### PR TITLE
[Feature] Traces/Services UI update

### DIFF
--- a/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
@@ -547,202 +547,206 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              />
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch euiFieldSearch--compressed"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -1804,202 +1808,206 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout euiFormControlLayout--compressed"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch euiFieldSearch--compressed"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--small"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            />
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -3000,202 +3008,206 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              />
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch euiFieldSearch--compressed"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -4171,202 +4183,206 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout euiFormControlLayout--compressed"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch euiFieldSearch--compressed"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--small"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            />
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -5435,202 +5451,206 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              />
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch euiFieldSearch--compressed"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -6606,202 +6626,206 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout euiFormControlLayout--compressed"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch euiFieldSearch--compressed"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--small"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            />
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -7797,202 +7821,206 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              />
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch euiFieldSearch--compressed"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -8929,202 +8957,206 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout euiFormControlLayout--compressed"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch euiFieldSearch--compressed"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--small"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            />
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -10123,202 +10155,206 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              />
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch euiFieldSearch--compressed"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -11260,202 +11296,206 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout euiFormControlLayout--compressed"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch euiFieldSearch--compressed"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--small"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            />
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -12488,202 +12528,206 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              />
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch euiFieldSearch--compressed"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -13659,202 +13703,206 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout euiFormControlLayout--compressed"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch euiFieldSearch--compressed"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--small"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            />
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -14855,202 +14903,206 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              />
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch euiFieldSearch--compressed"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -16026,202 +16078,206 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout euiFormControlLayout--compressed"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch euiFieldSearch--compressed"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--small"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            />
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>
@@ -17260,202 +17316,206 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiPage euiPage--paddingMedium euiPage--grow"
                         >
                           <div
-                            class="euiText euiText--medium"
-                          >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                          />
-                          <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                           >
                             <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                              class="euiText euiText--medium"
                             >
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
-                                >
-                                  <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
-                                    value=""
-                                  />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
-                          >
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
-                            >
-                              <h2
-                                class="euiTitle euiTitle--medium"
-                              >
-                                No matches
-                              </h2>
                               <span
-                                class="euiTextColor euiTextColor--subdued"
+                                class="panel-title"
                               >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
-                                />
-                                <div
-                                  class="euiText euiText--medium"
-                                >
-                                  <div
-                                    class="euiText euiText--small"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
-                                </div>
+                                Service map
                               </span>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--s"
+                              class="euiSpacer euiSpacer--m"
                             />
+                            <fieldset
+                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                            >
+                              <legend
+                                class="euiScreenReaderOnly"
+                              />
+                              <div
+                                class="euiButtonGroup__buttons"
+                              >
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Duration"
+                                      title="Duration"
+                                    >
+                                      <input
+                                        checked=""
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="latency"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Duration
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Errors"
+                                      title="Errors"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="error_rate"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Errors
+                                    </span>
+                                  </span>
+                                </label>
+                                <label
+                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  for="random_html_id"
+                                >
+                                  <span
+                                    class="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      class="euiButton__text euiButtonGroupButton__textShift"
+                                      data-text="Request Rate"
+                                      title="Request Rate"
+                                    >
+                                      <input
+                                        class="euiScreenReaderOnly"
+                                        data-test-subj="throughput"
+                                        id="random_html_id"
+                                        name="random_html_id"
+                                        type="radio"
+                                        value=""
+                                      />
+                                      Request Rate
+                                    </span>
+                                  </span>
+                                </label>
+                              </div>
+                            </fieldset>
+                            <hr
+                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            />
+                            <div
+                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <div
+                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              >
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Focus on
+                                </div>
+                              </div>
+                              <div
+                                class="euiFlexItem"
+                              >
+                                <div
+                                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                                >
+                                  <div
+                                    class="euiFormControlLayout__childrenWrapper"
+                                  >
+                                    <input
+                                      class="euiFieldSearch euiFieldSearch--compressed"
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                    <div
+                                      class="euiFormControlLayoutIcons"
+                                    >
+                                      <span
+                                        class="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--l"
+                            />
+                            <div
+                              style="min-height: 434px;"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                              <div
+                                class="euiEmptyPrompt"
+                              >
+                                <h2
+                                  class="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                                <span
+                                  class="euiTextColor euiTextColor--subdued"
+                                >
+                                  <div
+                                    class="euiSpacer euiSpacer--m"
+                                  />
+                                  <div
+                                    class="euiText euiText--medium"
+                                  >
+                                    <div
+                                      class="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </div>
+                                </span>
+                              </div>
+                              <div
+                                class="euiSpacer euiSpacer--s"
+                              />
+                            </div>
                           </div>
+                          <div
+                            class="euiSpacer euiSpacer--xl"
+                          />
                         </div>
-                        <div
-                          class="euiSpacer euiSpacer--xl"
-                        />
                       </div>
                     </div>
                   </div>
@@ -18517,202 +18577,206 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                        class="euiPage euiPage--paddingMedium euiPage--grow"
                       >
                         <div
-                          class="euiText euiText--medium"
-                        >
-                          <span
-                            class="panel-title"
-                          >
-                            Service map
-                          </span>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--m"
-                        />
-                        <fieldset
-                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                        >
-                          <legend
-                            class="euiScreenReaderOnly"
-                          />
-                          <div
-                            class="euiButtonGroup__buttons"
-                          >
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Duration"
-                                  title="Duration"
-                                >
-                                  <input
-                                    checked=""
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="latency"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Duration
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Errors"
-                                  title="Errors"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="error_rate"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Errors
-                                </span>
-                              </span>
-                            </label>
-                            <label
-                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                              for="random_html_id"
-                            >
-                              <span
-                                class="euiButtonContent euiButton__content"
-                              >
-                                <span
-                                  class="euiButton__text euiButtonGroupButton__textShift"
-                                  data-text="Request Rate"
-                                  title="Request Rate"
-                                >
-                                  <input
-                                    class="euiScreenReaderOnly"
-                                    data-test-subj="throughput"
-                                    id="random_html_id"
-                                    name="random_html_id"
-                                    type="radio"
-                                    value=""
-                                  />
-                                  Request Rate
-                                </span>
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <hr
-                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                        <div
-                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
-                            >
-                              Focus on
-                            </div>
-                          </div>
-                          <div
-                            class="euiFlexItem"
-                          >
-                            <div
-                              class="euiFormControlLayout euiFormControlLayout--compressed"
-                            >
-                              <div
-                                class="euiFormControlLayout__childrenWrapper"
-                              >
-                                <input
-                                  class="euiFieldSearch euiFieldSearch--compressed"
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                                <div
-                                  class="euiFormControlLayoutIcons"
-                                >
-                                  <span
-                                    class="euiFormControlLayoutCustomIcon"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiSpacer euiSpacer--l"
-                        />
-                        <div
-                          style="min-height: 434px;"
-                        >
-                          <div
-                            class="euiSpacer euiSpacer--s"
-                          />
-                          <div
-                            class="euiEmptyPrompt"
-                          >
-                            <h2
-                              class="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
                             <span
-                              class="euiTextColor euiTextColor--subdued"
+                              class="panel-title"
                             >
-                              <div
-                                class="euiSpacer euiSpacer--m"
-                              />
-                              <div
-                                class="euiText euiText--medium"
-                              >
-                                <div
-                                  class="euiText euiText--small"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </div>
+                              Service map
                             </span>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--s"
+                            class="euiSpacer euiSpacer--m"
                           />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
+                            />
+                            <div
+                              class="euiButtonGroup__buttons"
+                            >
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
+                              </div>
+                            </div>
+                            <div
+                              class="euiFlexItem"
+                            >
+                              <div
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                  <div
+                                    class="euiFormControlLayoutIcons"
+                                  >
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
-                      <div
-                        class="euiSpacer euiSpacer--xl"
-                      />
                     </div>
                   </div>
                 </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
@@ -547,206 +547,202 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPage euiPage--paddingMedium euiPage--grow"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
+                            <span
+                              class="panel-title"
                             >
-                              <span
-                                class="panel-title"
-                              >
-                                Service map
-                              </span>
-                            </div>
-                            <div
-                              class="euiSpacer euiSpacer--m"
-                            />
-                            <fieldset
-                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                            >
-                              <legend
-                                class="euiScreenReaderOnly"
-                              />
-                              <div
-                                class="euiButtonGroup__buttons"
-                              >
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Duration"
-                                      title="Duration"
-                                    >
-                                      <input
-                                        checked=""
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="latency"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Duration
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Errors"
-                                      title="Errors"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="error_rate"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Errors
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Request Rate"
-                                      title="Request Rate"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="throughput"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Request Rate
-                                    </span>
-                                  </span>
-                                </label>
-                              </div>
-                            </fieldset>
-                            <hr
-                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                              Service map
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--m"
+                          />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
                             />
                             <div
-                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                              class="euiButtonGroup__buttons"
                             >
-                              <div
-                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
                               >
-                                <div
-                                  class="euiText euiText--medium"
+                                <span
+                                  class="euiButtonContent euiButton__content"
                                 >
-                                  Focus on
-                                </div>
-                              </div>
-                              <div
-                                class="euiFlexItem"
-                              >
-                                <div
-                                  class="euiFormControlLayout euiFormControlLayout--compressed"
-                                >
-                                  <div
-                                    class="euiFormControlLayout__childrenWrapper"
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
                                   >
                                     <input
-                                      class="euiFieldSearch euiFieldSearch--compressed"
-                                      placeholder="Service name"
-                                      type="search"
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
                                       value=""
                                     />
-                                    <div
-                                      class="euiFormControlLayoutIcons"
-                                    >
-                                      <span
-                                        class="euiFormControlLayoutCustomIcon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          height="16"
-                                          role="img"
-                                          viewBox="0 0 16 16"
-                                          width="16"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
                               </div>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--l"
-                            />
-                            <div
-                              style="min-height: 434px;"
+                              class="euiFlexItem"
                             >
                               <div
-                                class="euiSpacer euiSpacer--s"
-                              />
-                              <div
-                                class="euiEmptyPrompt"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
                                 >
-                                  No matches
-                                </h2>
-                                <span
-                                  class="euiTextColor euiTextColor--subdued"
-                                >
-                                  <div
-                                    class="euiSpacer euiSpacer--m"
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
                                   />
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiFormControlLayoutIcons"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
                                     >
-                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                    </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
                                   </div>
-                                </span>
+                                </div>
                               </div>
-                              <div
-                                class="euiSpacer euiSpacer--s"
-                              />
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--xl"
+                            class="euiSpacer euiSpacer--l"
                           />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
                     </div>
                   </div>
@@ -1808,206 +1804,202 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPage euiPage--paddingMedium euiPage--grow"
+                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                       >
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--medium"
+                          <span
+                            class="panel-title"
                           >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            Service map
+                          </span>
+                        </div>
+                        <div
+                          class="euiSpacer euiSpacer--m"
+                        />
+                        <fieldset
+                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                        >
+                          <legend
+                            class="euiScreenReaderOnly"
                           />
                           <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiButtonGroup__buttons"
                           >
-                            <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              for="random_html_id"
                             >
-                              <div
-                                class="euiText euiText--medium"
+                              <span
+                                class="euiButtonContent euiButton__content"
                               >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Duration"
+                                  title="Duration"
                                 >
                                   <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
+                                    checked=""
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="latency"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
                                     value=""
                                   />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
+                                  Duration
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Errors"
+                                  title="Errors"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="error_rate"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Errors
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Request Rate"
+                                  title="Request Rate"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="throughput"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Request Rate
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </fieldset>
+                        <hr
+                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiText euiText--medium"
+                            >
+                              Focus on
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
+                            class="euiFlexItem"
                           >
                             <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
+                              <div
+                                class="euiFormControlLayout__childrenWrapper"
                               >
-                                No matches
-                              </h2>
-                              <span
-                                class="euiTextColor euiTextColor--subdued"
-                              >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
+                                <input
+                                  class="euiFieldSearch euiFieldSearch--compressed"
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
                                 />
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiFormControlLayoutIcons"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
+                                  <span
+                                    class="euiFormControlLayoutCustomIcon"
                                   >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                      />
+                                    </svg>
+                                  </span>
                                 </div>
-                              </span>
+                              </div>
                             </div>
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
                           </div>
                         </div>
                         <div
-                          class="euiSpacer euiSpacer--xl"
+                          class="euiSpacer euiSpacer--l"
                         />
+                        <div
+                          style="min-height: 434px;"
+                        >
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                          <div
+                            class="euiEmptyPrompt"
+                          >
+                            <h2
+                              class="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                            <span
+                              class="euiTextColor euiTextColor--subdued"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--m"
+                              />
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                <div
+                                  class="euiText euiText--small"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                        </div>
                       </div>
+                      <div
+                        class="euiSpacer euiSpacer--xl"
+                      />
                     </div>
                   </div>
                 </div>
@@ -3008,206 +3000,202 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPage euiPage--paddingMedium euiPage--grow"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
+                            <span
+                              class="panel-title"
                             >
-                              <span
-                                class="panel-title"
-                              >
-                                Service map
-                              </span>
-                            </div>
-                            <div
-                              class="euiSpacer euiSpacer--m"
-                            />
-                            <fieldset
-                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                            >
-                              <legend
-                                class="euiScreenReaderOnly"
-                              />
-                              <div
-                                class="euiButtonGroup__buttons"
-                              >
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Duration"
-                                      title="Duration"
-                                    >
-                                      <input
-                                        checked=""
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="latency"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Duration
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Errors"
-                                      title="Errors"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="error_rate"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Errors
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Request Rate"
-                                      title="Request Rate"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="throughput"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Request Rate
-                                    </span>
-                                  </span>
-                                </label>
-                              </div>
-                            </fieldset>
-                            <hr
-                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                              Service map
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--m"
+                          />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
                             />
                             <div
-                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                              class="euiButtonGroup__buttons"
                             >
-                              <div
-                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
                               >
-                                <div
-                                  class="euiText euiText--medium"
+                                <span
+                                  class="euiButtonContent euiButton__content"
                                 >
-                                  Focus on
-                                </div>
-                              </div>
-                              <div
-                                class="euiFlexItem"
-                              >
-                                <div
-                                  class="euiFormControlLayout euiFormControlLayout--compressed"
-                                >
-                                  <div
-                                    class="euiFormControlLayout__childrenWrapper"
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
                                   >
                                     <input
-                                      class="euiFieldSearch euiFieldSearch--compressed"
-                                      placeholder="Service name"
-                                      type="search"
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
                                       value=""
                                     />
-                                    <div
-                                      class="euiFormControlLayoutIcons"
-                                    >
-                                      <span
-                                        class="euiFormControlLayoutCustomIcon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          height="16"
-                                          role="img"
-                                          viewBox="0 0 16 16"
-                                          width="16"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
                               </div>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--l"
-                            />
-                            <div
-                              style="min-height: 434px;"
+                              class="euiFlexItem"
                             >
                               <div
-                                class="euiSpacer euiSpacer--s"
-                              />
-                              <div
-                                class="euiEmptyPrompt"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
                                 >
-                                  No matches
-                                </h2>
-                                <span
-                                  class="euiTextColor euiTextColor--subdued"
-                                >
-                                  <div
-                                    class="euiSpacer euiSpacer--m"
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
                                   />
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiFormControlLayoutIcons"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
                                     >
-                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                    </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
                                   </div>
-                                </span>
+                                </div>
                               </div>
-                              <div
-                                class="euiSpacer euiSpacer--s"
-                              />
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--xl"
+                            class="euiSpacer euiSpacer--l"
                           />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
                     </div>
                   </div>
@@ -4183,206 +4171,202 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPage euiPage--paddingMedium euiPage--grow"
+                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                       >
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--medium"
+                          <span
+                            class="panel-title"
                           >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            Service map
+                          </span>
+                        </div>
+                        <div
+                          class="euiSpacer euiSpacer--m"
+                        />
+                        <fieldset
+                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                        >
+                          <legend
+                            class="euiScreenReaderOnly"
                           />
                           <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiButtonGroup__buttons"
                           >
-                            <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              for="random_html_id"
                             >
-                              <div
-                                class="euiText euiText--medium"
+                              <span
+                                class="euiButtonContent euiButton__content"
                               >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Duration"
+                                  title="Duration"
                                 >
                                   <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
+                                    checked=""
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="latency"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
                                     value=""
                                   />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
+                                  Duration
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Errors"
+                                  title="Errors"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="error_rate"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Errors
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Request Rate"
+                                  title="Request Rate"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="throughput"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Request Rate
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </fieldset>
+                        <hr
+                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiText euiText--medium"
+                            >
+                              Focus on
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
+                            class="euiFlexItem"
                           >
                             <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
+                              <div
+                                class="euiFormControlLayout__childrenWrapper"
                               >
-                                No matches
-                              </h2>
-                              <span
-                                class="euiTextColor euiTextColor--subdued"
-                              >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
+                                <input
+                                  class="euiFieldSearch euiFieldSearch--compressed"
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
                                 />
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiFormControlLayoutIcons"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
+                                  <span
+                                    class="euiFormControlLayoutCustomIcon"
                                   >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                      />
+                                    </svg>
+                                  </span>
                                 </div>
-                              </span>
+                              </div>
                             </div>
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
                           </div>
                         </div>
                         <div
-                          class="euiSpacer euiSpacer--xl"
+                          class="euiSpacer euiSpacer--l"
                         />
+                        <div
+                          style="min-height: 434px;"
+                        >
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                          <div
+                            class="euiEmptyPrompt"
+                          >
+                            <h2
+                              class="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                            <span
+                              class="euiTextColor euiTextColor--subdued"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--m"
+                              />
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                <div
+                                  class="euiText euiText--small"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                        </div>
                       </div>
+                      <div
+                        class="euiSpacer euiSpacer--xl"
+                      />
                     </div>
                   </div>
                 </div>
@@ -5451,206 +5435,202 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPage euiPage--paddingMedium euiPage--grow"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
+                            <span
+                              class="panel-title"
                             >
-                              <span
-                                class="panel-title"
-                              >
-                                Service map
-                              </span>
-                            </div>
-                            <div
-                              class="euiSpacer euiSpacer--m"
-                            />
-                            <fieldset
-                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                            >
-                              <legend
-                                class="euiScreenReaderOnly"
-                              />
-                              <div
-                                class="euiButtonGroup__buttons"
-                              >
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Duration"
-                                      title="Duration"
-                                    >
-                                      <input
-                                        checked=""
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="latency"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Duration
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Errors"
-                                      title="Errors"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="error_rate"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Errors
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Request Rate"
-                                      title="Request Rate"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="throughput"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Request Rate
-                                    </span>
-                                  </span>
-                                </label>
-                              </div>
-                            </fieldset>
-                            <hr
-                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                              Service map
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--m"
+                          />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
                             />
                             <div
-                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                              class="euiButtonGroup__buttons"
                             >
-                              <div
-                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
                               >
-                                <div
-                                  class="euiText euiText--medium"
+                                <span
+                                  class="euiButtonContent euiButton__content"
                                 >
-                                  Focus on
-                                </div>
-                              </div>
-                              <div
-                                class="euiFlexItem"
-                              >
-                                <div
-                                  class="euiFormControlLayout euiFormControlLayout--compressed"
-                                >
-                                  <div
-                                    class="euiFormControlLayout__childrenWrapper"
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
                                   >
                                     <input
-                                      class="euiFieldSearch euiFieldSearch--compressed"
-                                      placeholder="Service name"
-                                      type="search"
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
                                       value=""
                                     />
-                                    <div
-                                      class="euiFormControlLayoutIcons"
-                                    >
-                                      <span
-                                        class="euiFormControlLayoutCustomIcon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          height="16"
-                                          role="img"
-                                          viewBox="0 0 16 16"
-                                          width="16"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
                               </div>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--l"
-                            />
-                            <div
-                              style="min-height: 434px;"
+                              class="euiFlexItem"
                             >
                               <div
-                                class="euiSpacer euiSpacer--s"
-                              />
-                              <div
-                                class="euiEmptyPrompt"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
                                 >
-                                  No matches
-                                </h2>
-                                <span
-                                  class="euiTextColor euiTextColor--subdued"
-                                >
-                                  <div
-                                    class="euiSpacer euiSpacer--m"
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
                                   />
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiFormControlLayoutIcons"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
                                     >
-                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                    </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
                                   </div>
-                                </span>
+                                </div>
                               </div>
-                              <div
-                                class="euiSpacer euiSpacer--s"
-                              />
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--xl"
+                            class="euiSpacer euiSpacer--l"
                           />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
                     </div>
                   </div>
@@ -6626,206 +6606,202 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPage euiPage--paddingMedium euiPage--grow"
+                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                       >
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--medium"
+                          <span
+                            class="panel-title"
                           >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            Service map
+                          </span>
+                        </div>
+                        <div
+                          class="euiSpacer euiSpacer--m"
+                        />
+                        <fieldset
+                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                        >
+                          <legend
+                            class="euiScreenReaderOnly"
                           />
                           <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiButtonGroup__buttons"
                           >
-                            <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              for="random_html_id"
                             >
-                              <div
-                                class="euiText euiText--medium"
+                              <span
+                                class="euiButtonContent euiButton__content"
                               >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Duration"
+                                  title="Duration"
                                 >
                                   <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
+                                    checked=""
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="latency"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
                                     value=""
                                   />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
+                                  Duration
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Errors"
+                                  title="Errors"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="error_rate"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Errors
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Request Rate"
+                                  title="Request Rate"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="throughput"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Request Rate
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </fieldset>
+                        <hr
+                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiText euiText--medium"
+                            >
+                              Focus on
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
+                            class="euiFlexItem"
                           >
                             <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
+                              <div
+                                class="euiFormControlLayout__childrenWrapper"
                               >
-                                No matches
-                              </h2>
-                              <span
-                                class="euiTextColor euiTextColor--subdued"
-                              >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
+                                <input
+                                  class="euiFieldSearch euiFieldSearch--compressed"
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
                                 />
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiFormControlLayoutIcons"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
+                                  <span
+                                    class="euiFormControlLayoutCustomIcon"
                                   >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                      />
+                                    </svg>
+                                  </span>
                                 </div>
-                              </span>
+                              </div>
                             </div>
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
                           </div>
                         </div>
                         <div
-                          class="euiSpacer euiSpacer--xl"
+                          class="euiSpacer euiSpacer--l"
                         />
+                        <div
+                          style="min-height: 434px;"
+                        >
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                          <div
+                            class="euiEmptyPrompt"
+                          >
+                            <h2
+                              class="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                            <span
+                              class="euiTextColor euiTextColor--subdued"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--m"
+                              />
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                <div
+                                  class="euiText euiText--small"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                        </div>
                       </div>
+                      <div
+                        class="euiSpacer euiSpacer--xl"
+                      />
                     </div>
                   </div>
                 </div>
@@ -7821,206 +7797,202 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPage euiPage--paddingMedium euiPage--grow"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
+                            <span
+                              class="panel-title"
                             >
-                              <span
-                                class="panel-title"
-                              >
-                                Service map
-                              </span>
-                            </div>
-                            <div
-                              class="euiSpacer euiSpacer--m"
-                            />
-                            <fieldset
-                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                            >
-                              <legend
-                                class="euiScreenReaderOnly"
-                              />
-                              <div
-                                class="euiButtonGroup__buttons"
-                              >
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Duration"
-                                      title="Duration"
-                                    >
-                                      <input
-                                        checked=""
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="latency"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Duration
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Errors"
-                                      title="Errors"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="error_rate"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Errors
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Request Rate"
-                                      title="Request Rate"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="throughput"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Request Rate
-                                    </span>
-                                  </span>
-                                </label>
-                              </div>
-                            </fieldset>
-                            <hr
-                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                              Service map
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--m"
+                          />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
                             />
                             <div
-                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                              class="euiButtonGroup__buttons"
                             >
-                              <div
-                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
                               >
-                                <div
-                                  class="euiText euiText--medium"
+                                <span
+                                  class="euiButtonContent euiButton__content"
                                 >
-                                  Focus on
-                                </div>
-                              </div>
-                              <div
-                                class="euiFlexItem"
-                              >
-                                <div
-                                  class="euiFormControlLayout euiFormControlLayout--compressed"
-                                >
-                                  <div
-                                    class="euiFormControlLayout__childrenWrapper"
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
                                   >
                                     <input
-                                      class="euiFieldSearch euiFieldSearch--compressed"
-                                      placeholder="Service name"
-                                      type="search"
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
                                       value=""
                                     />
-                                    <div
-                                      class="euiFormControlLayoutIcons"
-                                    >
-                                      <span
-                                        class="euiFormControlLayoutCustomIcon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          height="16"
-                                          role="img"
-                                          viewBox="0 0 16 16"
-                                          width="16"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
                               </div>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--l"
-                            />
-                            <div
-                              style="min-height: 434px;"
+                              class="euiFlexItem"
                             >
                               <div
-                                class="euiSpacer euiSpacer--s"
-                              />
-                              <div
-                                class="euiEmptyPrompt"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
                                 >
-                                  No matches
-                                </h2>
-                                <span
-                                  class="euiTextColor euiTextColor--subdued"
-                                >
-                                  <div
-                                    class="euiSpacer euiSpacer--m"
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
                                   />
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiFormControlLayoutIcons"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
                                     >
-                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                    </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                    </span>
                                   </div>
-                                </span>
+                                </div>
                               </div>
-                              <div
-                                class="euiSpacer euiSpacer--s"
-                              />
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--xl"
+                            class="euiSpacer euiSpacer--l"
                           />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
                     </div>
                   </div>
@@ -8957,206 +8929,202 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPage euiPage--paddingMedium euiPage--grow"
+                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                       >
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--medium"
+                          <span
+                            class="panel-title"
                           >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            Service map
+                          </span>
+                        </div>
+                        <div
+                          class="euiSpacer euiSpacer--m"
+                        />
+                        <fieldset
+                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                        >
+                          <legend
+                            class="euiScreenReaderOnly"
                           />
                           <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiButtonGroup__buttons"
                           >
-                            <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              for="random_html_id"
                             >
-                              <div
-                                class="euiText euiText--medium"
+                              <span
+                                class="euiButtonContent euiButton__content"
                               >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Duration"
+                                  title="Duration"
                                 >
                                   <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
+                                    checked=""
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="latency"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
                                     value=""
                                   />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
+                                  Duration
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Errors"
+                                  title="Errors"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="error_rate"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Errors
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Request Rate"
+                                  title="Request Rate"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="throughput"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Request Rate
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </fieldset>
+                        <hr
+                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiText euiText--medium"
+                            >
+                              Focus on
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
+                            class="euiFlexItem"
                           >
                             <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
+                              <div
+                                class="euiFormControlLayout__childrenWrapper"
                               >
-                                No matches
-                              </h2>
-                              <span
-                                class="euiTextColor euiTextColor--subdued"
-                              >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
+                                <input
+                                  class="euiFieldSearch euiFieldSearch--compressed"
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
                                 />
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiFormControlLayoutIcons"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
+                                  <span
+                                    class="euiFormControlLayoutCustomIcon"
                                   >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </span>
                                 </div>
-                              </span>
+                              </div>
                             </div>
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
                           </div>
                         </div>
                         <div
-                          class="euiSpacer euiSpacer--xl"
+                          class="euiSpacer euiSpacer--l"
                         />
+                        <div
+                          style="min-height: 434px;"
+                        >
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                          <div
+                            class="euiEmptyPrompt"
+                          >
+                            <h2
+                              class="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                            <span
+                              class="euiTextColor euiTextColor--subdued"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--m"
+                              />
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                <div
+                                  class="euiText euiText--small"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                        </div>
                       </div>
+                      <div
+                        class="euiSpacer euiSpacer--xl"
+                      />
                     </div>
                   </div>
                 </div>
@@ -10155,206 +10123,202 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPage euiPage--paddingMedium euiPage--grow"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
+                            <span
+                              class="panel-title"
                             >
-                              <span
-                                class="panel-title"
-                              >
-                                Service map
-                              </span>
-                            </div>
-                            <div
-                              class="euiSpacer euiSpacer--m"
-                            />
-                            <fieldset
-                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                            >
-                              <legend
-                                class="euiScreenReaderOnly"
-                              />
-                              <div
-                                class="euiButtonGroup__buttons"
-                              >
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Duration"
-                                      title="Duration"
-                                    >
-                                      <input
-                                        checked=""
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="latency"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Duration
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Errors"
-                                      title="Errors"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="error_rate"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Errors
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Request Rate"
-                                      title="Request Rate"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="throughput"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Request Rate
-                                    </span>
-                                  </span>
-                                </label>
-                              </div>
-                            </fieldset>
-                            <hr
-                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                              Service map
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--m"
+                          />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
                             />
                             <div
-                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                              class="euiButtonGroup__buttons"
                             >
-                              <div
-                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
                               >
-                                <div
-                                  class="euiText euiText--medium"
+                                <span
+                                  class="euiButtonContent euiButton__content"
                                 >
-                                  Focus on
-                                </div>
-                              </div>
-                              <div
-                                class="euiFlexItem"
-                              >
-                                <div
-                                  class="euiFormControlLayout euiFormControlLayout--compressed"
-                                >
-                                  <div
-                                    class="euiFormControlLayout__childrenWrapper"
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
                                   >
                                     <input
-                                      class="euiFieldSearch euiFieldSearch--compressed"
-                                      placeholder="Service name"
-                                      type="search"
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
                                       value=""
                                     />
-                                    <div
-                                      class="euiFormControlLayoutIcons"
-                                    >
-                                      <span
-                                        class="euiFormControlLayoutCustomIcon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          height="16"
-                                          role="img"
-                                          viewBox="0 0 16 16"
-                                          width="16"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
                               </div>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--l"
-                            />
-                            <div
-                              style="min-height: 434px;"
+                              class="euiFlexItem"
                             >
                               <div
-                                class="euiSpacer euiSpacer--s"
-                              />
-                              <div
-                                class="euiEmptyPrompt"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
                                 >
-                                  No matches
-                                </h2>
-                                <span
-                                  class="euiTextColor euiTextColor--subdued"
-                                >
-                                  <div
-                                    class="euiSpacer euiSpacer--m"
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
                                   />
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiFormControlLayoutIcons"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
                                     >
-                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                    </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
                                   </div>
-                                </span>
+                                </div>
                               </div>
-                              <div
-                                class="euiSpacer euiSpacer--s"
-                              />
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--xl"
+                            class="euiSpacer euiSpacer--l"
                           />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
                     </div>
                   </div>
@@ -11296,206 +11260,202 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPage euiPage--paddingMedium euiPage--grow"
+                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                       >
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--medium"
+                          <span
+                            class="panel-title"
                           >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            Service map
+                          </span>
+                        </div>
+                        <div
+                          class="euiSpacer euiSpacer--m"
+                        />
+                        <fieldset
+                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                        >
+                          <legend
+                            class="euiScreenReaderOnly"
                           />
                           <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiButtonGroup__buttons"
                           >
-                            <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              for="random_html_id"
                             >
-                              <div
-                                class="euiText euiText--medium"
+                              <span
+                                class="euiButtonContent euiButton__content"
                               >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Duration"
+                                  title="Duration"
                                 >
                                   <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
+                                    checked=""
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="latency"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
                                     value=""
                                   />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
+                                  Duration
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Errors"
+                                  title="Errors"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="error_rate"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Errors
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Request Rate"
+                                  title="Request Rate"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="throughput"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Request Rate
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </fieldset>
+                        <hr
+                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiText euiText--medium"
+                            >
+                              Focus on
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
+                            class="euiFlexItem"
                           >
                             <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
+                              <div
+                                class="euiFormControlLayout__childrenWrapper"
                               >
-                                No matches
-                              </h2>
-                              <span
-                                class="euiTextColor euiTextColor--subdued"
-                              >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
+                                <input
+                                  class="euiFieldSearch euiFieldSearch--compressed"
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
                                 />
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiFormControlLayoutIcons"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
+                                  <span
+                                    class="euiFormControlLayoutCustomIcon"
                                   >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                      />
+                                    </svg>
+                                  </span>
                                 </div>
-                              </span>
+                              </div>
                             </div>
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
                           </div>
                         </div>
                         <div
-                          class="euiSpacer euiSpacer--xl"
+                          class="euiSpacer euiSpacer--l"
                         />
+                        <div
+                          style="min-height: 434px;"
+                        >
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                          <div
+                            class="euiEmptyPrompt"
+                          >
+                            <h2
+                              class="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                            <span
+                              class="euiTextColor euiTextColor--subdued"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--m"
+                              />
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                <div
+                                  class="euiText euiText--small"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                        </div>
                       </div>
+                      <div
+                        class="euiSpacer euiSpacer--xl"
+                      />
                     </div>
                   </div>
                 </div>
@@ -12528,206 +12488,202 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPage euiPage--paddingMedium euiPage--grow"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
+                            <span
+                              class="panel-title"
                             >
-                              <span
-                                class="panel-title"
-                              >
-                                Service map
-                              </span>
-                            </div>
-                            <div
-                              class="euiSpacer euiSpacer--m"
-                            />
-                            <fieldset
-                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                            >
-                              <legend
-                                class="euiScreenReaderOnly"
-                              />
-                              <div
-                                class="euiButtonGroup__buttons"
-                              >
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Duration"
-                                      title="Duration"
-                                    >
-                                      <input
-                                        checked=""
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="latency"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Duration
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Errors"
-                                      title="Errors"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="error_rate"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Errors
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Request Rate"
-                                      title="Request Rate"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="throughput"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Request Rate
-                                    </span>
-                                  </span>
-                                </label>
-                              </div>
-                            </fieldset>
-                            <hr
-                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                              Service map
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--m"
+                          />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
                             />
                             <div
-                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                              class="euiButtonGroup__buttons"
                             >
-                              <div
-                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
                               >
-                                <div
-                                  class="euiText euiText--medium"
+                                <span
+                                  class="euiButtonContent euiButton__content"
                                 >
-                                  Focus on
-                                </div>
-                              </div>
-                              <div
-                                class="euiFlexItem"
-                              >
-                                <div
-                                  class="euiFormControlLayout euiFormControlLayout--compressed"
-                                >
-                                  <div
-                                    class="euiFormControlLayout__childrenWrapper"
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
                                   >
                                     <input
-                                      class="euiFieldSearch euiFieldSearch--compressed"
-                                      placeholder="Service name"
-                                      type="search"
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
                                       value=""
                                     />
-                                    <div
-                                      class="euiFormControlLayoutIcons"
-                                    >
-                                      <span
-                                        class="euiFormControlLayoutCustomIcon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          height="16"
-                                          role="img"
-                                          viewBox="0 0 16 16"
-                                          width="16"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
                               </div>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--l"
-                            />
-                            <div
-                              style="min-height: 434px;"
+                              class="euiFlexItem"
                             >
                               <div
-                                class="euiSpacer euiSpacer--s"
-                              />
-                              <div
-                                class="euiEmptyPrompt"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
                                 >
-                                  No matches
-                                </h2>
-                                <span
-                                  class="euiTextColor euiTextColor--subdued"
-                                >
-                                  <div
-                                    class="euiSpacer euiSpacer--m"
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
                                   />
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiFormControlLayoutIcons"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
                                     >
-                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                    </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
                                   </div>
-                                </span>
+                                </div>
                               </div>
-                              <div
-                                class="euiSpacer euiSpacer--s"
-                              />
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--xl"
+                            class="euiSpacer euiSpacer--l"
                           />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
                     </div>
                   </div>
@@ -13703,206 +13659,202 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPage euiPage--paddingMedium euiPage--grow"
+                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                       >
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--medium"
+                          <span
+                            class="panel-title"
                           >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            Service map
+                          </span>
+                        </div>
+                        <div
+                          class="euiSpacer euiSpacer--m"
+                        />
+                        <fieldset
+                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                        >
+                          <legend
+                            class="euiScreenReaderOnly"
                           />
                           <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiButtonGroup__buttons"
                           >
-                            <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              for="random_html_id"
                             >
-                              <div
-                                class="euiText euiText--medium"
+                              <span
+                                class="euiButtonContent euiButton__content"
                               >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Duration"
+                                  title="Duration"
                                 >
                                   <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
+                                    checked=""
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="latency"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
                                     value=""
                                   />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
+                                  Duration
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Errors"
+                                  title="Errors"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="error_rate"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Errors
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Request Rate"
+                                  title="Request Rate"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="throughput"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Request Rate
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </fieldset>
+                        <hr
+                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiText euiText--medium"
+                            >
+                              Focus on
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
+                            class="euiFlexItem"
                           >
                             <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
+                              <div
+                                class="euiFormControlLayout__childrenWrapper"
                               >
-                                No matches
-                              </h2>
-                              <span
-                                class="euiTextColor euiTextColor--subdued"
-                              >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
+                                <input
+                                  class="euiFieldSearch euiFieldSearch--compressed"
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
                                 />
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiFormControlLayoutIcons"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
+                                  <span
+                                    class="euiFormControlLayoutCustomIcon"
                                   >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                      />
+                                    </svg>
+                                  </span>
                                 </div>
-                              </span>
+                              </div>
                             </div>
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
                           </div>
                         </div>
                         <div
-                          class="euiSpacer euiSpacer--xl"
+                          class="euiSpacer euiSpacer--l"
                         />
+                        <div
+                          style="min-height: 434px;"
+                        >
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                          <div
+                            class="euiEmptyPrompt"
+                          >
+                            <h2
+                              class="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                            <span
+                              class="euiTextColor euiTextColor--subdued"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--m"
+                              />
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                <div
+                                  class="euiText euiText--small"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                        </div>
                       </div>
+                      <div
+                        class="euiSpacer euiSpacer--xl"
+                      />
                     </div>
                   </div>
                 </div>
@@ -14903,206 +14855,202 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPage euiPage--paddingMedium euiPage--grow"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
+                            <span
+                              class="panel-title"
                             >
-                              <span
-                                class="panel-title"
-                              >
-                                Service map
-                              </span>
-                            </div>
-                            <div
-                              class="euiSpacer euiSpacer--m"
-                            />
-                            <fieldset
-                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                            >
-                              <legend
-                                class="euiScreenReaderOnly"
-                              />
-                              <div
-                                class="euiButtonGroup__buttons"
-                              >
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Duration"
-                                      title="Duration"
-                                    >
-                                      <input
-                                        checked=""
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="latency"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Duration
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Errors"
-                                      title="Errors"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="error_rate"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Errors
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Request Rate"
-                                      title="Request Rate"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="throughput"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Request Rate
-                                    </span>
-                                  </span>
-                                </label>
-                              </div>
-                            </fieldset>
-                            <hr
-                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                              Service map
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--m"
+                          />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
                             />
                             <div
-                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                              class="euiButtonGroup__buttons"
                             >
-                              <div
-                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
                               >
-                                <div
-                                  class="euiText euiText--medium"
+                                <span
+                                  class="euiButtonContent euiButton__content"
                                 >
-                                  Focus on
-                                </div>
-                              </div>
-                              <div
-                                class="euiFlexItem"
-                              >
-                                <div
-                                  class="euiFormControlLayout euiFormControlLayout--compressed"
-                                >
-                                  <div
-                                    class="euiFormControlLayout__childrenWrapper"
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
                                   >
                                     <input
-                                      class="euiFieldSearch euiFieldSearch--compressed"
-                                      placeholder="Service name"
-                                      type="search"
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
                                       value=""
                                     />
-                                    <div
-                                      class="euiFormControlLayoutIcons"
-                                    >
-                                      <span
-                                        class="euiFormControlLayoutCustomIcon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          height="16"
-                                          role="img"
-                                          viewBox="0 0 16 16"
-                                          width="16"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
                               </div>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--l"
-                            />
-                            <div
-                              style="min-height: 434px;"
+                              class="euiFlexItem"
                             >
                               <div
-                                class="euiSpacer euiSpacer--s"
-                              />
-                              <div
-                                class="euiEmptyPrompt"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
                                 >
-                                  No matches
-                                </h2>
-                                <span
-                                  class="euiTextColor euiTextColor--subdued"
-                                >
-                                  <div
-                                    class="euiSpacer euiSpacer--m"
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
                                   />
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiFormControlLayoutIcons"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
                                     >
-                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                    </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
                                   </div>
-                                </span>
+                                </div>
                               </div>
-                              <div
-                                class="euiSpacer euiSpacer--s"
-                              />
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--xl"
+                            class="euiSpacer euiSpacer--l"
                           />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
                     </div>
                   </div>
@@ -16078,206 +16026,202 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPage euiPage--paddingMedium euiPage--grow"
+                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                       >
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--medium"
+                          <span
+                            class="panel-title"
                           >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            Service map
+                          </span>
+                        </div>
+                        <div
+                          class="euiSpacer euiSpacer--m"
+                        />
+                        <fieldset
+                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                        >
+                          <legend
+                            class="euiScreenReaderOnly"
                           />
                           <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiButtonGroup__buttons"
                           >
-                            <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              for="random_html_id"
                             >
-                              <div
-                                class="euiText euiText--medium"
+                              <span
+                                class="euiButtonContent euiButton__content"
                               >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Duration"
+                                  title="Duration"
                                 >
                                   <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
+                                    checked=""
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="latency"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
                                     value=""
                                   />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
+                                  Duration
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Errors"
+                                  title="Errors"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="error_rate"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Errors
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Request Rate"
+                                  title="Request Rate"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="throughput"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Request Rate
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </fieldset>
+                        <hr
+                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiText euiText--medium"
+                            >
+                              Focus on
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
+                            class="euiFlexItem"
                           >
                             <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
+                              <div
+                                class="euiFormControlLayout__childrenWrapper"
                               >
-                                No matches
-                              </h2>
-                              <span
-                                class="euiTextColor euiTextColor--subdued"
-                              >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
+                                <input
+                                  class="euiFieldSearch euiFieldSearch--compressed"
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
                                 />
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiFormControlLayoutIcons"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
+                                  <span
+                                    class="euiFormControlLayoutCustomIcon"
                                   >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                      />
+                                    </svg>
+                                  </span>
                                 </div>
-                              </span>
+                              </div>
                             </div>
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
                           </div>
                         </div>
                         <div
-                          class="euiSpacer euiSpacer--xl"
+                          class="euiSpacer euiSpacer--l"
                         />
+                        <div
+                          style="min-height: 434px;"
+                        >
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                          <div
+                            class="euiEmptyPrompt"
+                          >
+                            <h2
+                              class="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                            <span
+                              class="euiTextColor euiTextColor--subdued"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--m"
+                              />
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                <div
+                                  class="euiText euiText--small"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                        </div>
                       </div>
+                      <div
+                        class="euiSpacer euiSpacer--xl"
+                      />
                     </div>
                   </div>
                 </div>
@@ -17316,206 +17260,202 @@ Object {
                           class="euiSpacer euiSpacer--l"
                         />
                         <div
-                          class="euiPage euiPage--paddingMedium euiPage--grow"
+                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
                           <div
-                            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                            class="euiText euiText--medium"
                           >
-                            <div
-                              class="euiText euiText--medium"
+                            <span
+                              class="panel-title"
                             >
-                              <span
-                                class="panel-title"
-                              >
-                                Service map
-                              </span>
-                            </div>
-                            <div
-                              class="euiSpacer euiSpacer--m"
-                            />
-                            <fieldset
-                              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                            >
-                              <legend
-                                class="euiScreenReaderOnly"
-                              />
-                              <div
-                                class="euiButtonGroup__buttons"
-                              >
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Duration"
-                                      title="Duration"
-                                    >
-                                      <input
-                                        checked=""
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="latency"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Duration
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Errors"
-                                      title="Errors"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="error_rate"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Errors
-                                    </span>
-                                  </span>
-                                </label>
-                                <label
-                                  class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  for="random_html_id"
-                                >
-                                  <span
-                                    class="euiButtonContent euiButton__content"
-                                  >
-                                    <span
-                                      class="euiButton__text euiButtonGroupButton__textShift"
-                                      data-text="Request Rate"
-                                      title="Request Rate"
-                                    >
-                                      <input
-                                        class="euiScreenReaderOnly"
-                                        data-test-subj="throughput"
-                                        id="random_html_id"
-                                        name="random_html_id"
-                                        type="radio"
-                                        value=""
-                                      />
-                                      Request Rate
-                                    </span>
-                                  </span>
-                                </label>
-                              </div>
-                            </fieldset>
-                            <hr
-                              class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                              Service map
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--m"
+                          />
+                          <fieldset
+                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          >
+                            <legend
+                              class="euiScreenReaderOnly"
                             />
                             <div
-                              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                              class="euiButtonGroup__buttons"
                             >
-                              <div
-                                class="euiFlexItem euiFlexItem--flexGrowZero"
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                for="random_html_id"
                               >
-                                <div
-                                  class="euiText euiText--medium"
+                                <span
+                                  class="euiButtonContent euiButton__content"
                                 >
-                                  Focus on
-                                </div>
-                              </div>
-                              <div
-                                class="euiFlexItem"
-                              >
-                                <div
-                                  class="euiFormControlLayout euiFormControlLayout--compressed"
-                                >
-                                  <div
-                                    class="euiFormControlLayout__childrenWrapper"
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
                                   >
                                     <input
-                                      class="euiFieldSearch euiFieldSearch--compressed"
-                                      placeholder="Service name"
-                                      type="search"
+                                      checked=""
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
                                       value=""
                                     />
-                                    <div
-                                      class="euiFormControlLayoutIcons"
-                                    >
-                                      <span
-                                        class="euiFormControlLayoutCustomIcon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          height="16"
-                                          role="img"
-                                          viewBox="0 0 16 16"
-                                          width="16"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
+                                    Duration
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </label>
+                              <label
+                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                for="random_html_id"
+                              >
+                                <span
+                                  class="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    class="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      class="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      type="radio"
+                                      value=""
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <hr
+                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                          <div
+                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                          >
+                            <div
+                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Focus on
                               </div>
                             </div>
                             <div
-                              class="euiSpacer euiSpacer--l"
-                            />
-                            <div
-                              style="min-height: 434px;"
+                              class="euiFlexItem"
                             >
                               <div
-                                class="euiSpacer euiSpacer--s"
-                              />
-                              <div
-                                class="euiEmptyPrompt"
+                                class="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <h2
-                                  class="euiTitle euiTitle--medium"
+                                <div
+                                  class="euiFormControlLayout__childrenWrapper"
                                 >
-                                  No matches
-                                </h2>
-                                <span
-                                  class="euiTextColor euiTextColor--subdued"
-                                >
-                                  <div
-                                    class="euiSpacer euiSpacer--m"
+                                  <input
+                                    class="euiFieldSearch euiFieldSearch--compressed"
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
                                   />
                                   <div
-                                    class="euiText euiText--medium"
+                                    class="euiFormControlLayoutIcons"
                                   >
-                                    <div
-                                      class="euiText euiText--small"
+                                    <span
+                                      class="euiFormControlLayoutCustomIcon"
                                     >
-                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                    </div>
+                                      <svg
+                                        aria-hidden="true"
+                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                        focusable="false"
+                                        height="16"
+                                        role="img"
+                                        viewBox="0 0 16 16"
+                                        width="16"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                        />
+                                      </svg>
+                                    </span>
                                   </div>
-                                </span>
+                                </div>
                               </div>
-                              <div
-                                class="euiSpacer euiSpacer--s"
-                              />
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--xl"
+                            class="euiSpacer euiSpacer--l"
                           />
+                          <div
+                            style="min-height: 434px;"
+                          >
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                            <div
+                              class="euiEmptyPrompt"
+                            >
+                              <h2
+                                class="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                              <span
+                                class="euiTextColor euiTextColor--subdued"
+                              >
+                                <div
+                                  class="euiSpacer euiSpacer--m"
+                                />
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  <div
+                                    class="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </div>
+                              </span>
+                            </div>
+                            <div
+                              class="euiSpacer euiSpacer--s"
+                            />
+                          </div>
                         </div>
+                        <div
+                          class="euiSpacer euiSpacer--xl"
+                        />
                       </div>
                     </div>
                   </div>
@@ -18577,206 +18517,202 @@ Object {
                         class="euiSpacer euiSpacer--l"
                       />
                       <div
-                        class="euiPage euiPage--paddingMedium euiPage--grow"
+                        class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                       >
                         <div
-                          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                          class="euiText euiText--medium"
                         >
-                          <div
-                            class="euiText euiText--medium"
+                          <span
+                            class="panel-title"
                           >
-                            <span
-                              class="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                          <div
-                            class="euiSpacer euiSpacer--m"
-                          />
-                          <fieldset
-                            class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          >
-                            <legend
-                              class="euiScreenReaderOnly"
-                            />
-                            <div
-                              class="euiButtonGroup__buttons"
-                            >
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Duration"
-                                    title="Duration"
-                                  >
-                                    <input
-                                      checked=""
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="latency"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Duration
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Errors"
-                                    title="Errors"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="error_rate"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Errors
-                                  </span>
-                                </span>
-                              </label>
-                              <label
-                                class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                for="random_html_id"
-                              >
-                                <span
-                                  class="euiButtonContent euiButton__content"
-                                >
-                                  <span
-                                    class="euiButton__text euiButtonGroupButton__textShift"
-                                    data-text="Request Rate"
-                                    title="Request Rate"
-                                  >
-                                    <input
-                                      class="euiScreenReaderOnly"
-                                      data-test-subj="throughput"
-                                      id="random_html_id"
-                                      name="random_html_id"
-                                      type="radio"
-                                      value=""
-                                    />
-                                    Request Rate
-                                  </span>
-                                </span>
-                              </label>
-                            </div>
-                          </fieldset>
-                          <hr
-                            class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                            Service map
+                          </span>
+                        </div>
+                        <div
+                          class="euiSpacer euiSpacer--m"
+                        />
+                        <fieldset
+                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                        >
+                          <legend
+                            class="euiScreenReaderOnly"
                           />
                           <div
-                            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            class="euiButtonGroup__buttons"
                           >
-                            <div
-                              class="euiFlexItem euiFlexItem--flexGrowZero"
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              for="random_html_id"
                             >
-                              <div
-                                class="euiText euiText--medium"
+                              <span
+                                class="euiButtonContent euiButton__content"
                               >
-                                Focus on
-                              </div>
-                            </div>
-                            <div
-                              class="euiFlexItem"
-                            >
-                              <div
-                                class="euiFormControlLayout euiFormControlLayout--compressed"
-                              >
-                                <div
-                                  class="euiFormControlLayout__childrenWrapper"
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Duration"
+                                  title="Duration"
                                 >
                                   <input
-                                    class="euiFieldSearch euiFieldSearch--compressed"
-                                    placeholder="Service name"
-                                    type="search"
+                                    checked=""
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="latency"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
                                     value=""
                                   />
-                                  <div
-                                    class="euiFormControlLayoutIcons"
-                                  >
-                                    <span
-                                      class="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height="16"
-                                        role="img"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </div>
-                                </div>
-                              </div>
+                                  Duration
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Errors"
+                                  title="Errors"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="error_rate"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Errors
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Request Rate"
+                                  title="Request Rate"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="throughput"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Request Rate
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </fieldset>
+                        <hr
+                          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiText euiText--medium"
+                            >
+                              Focus on
                             </div>
                           </div>
                           <div
-                            class="euiSpacer euiSpacer--l"
-                          />
-                          <div
-                            style="min-height: 434px;"
+                            class="euiFlexItem"
                           >
                             <div
-                              class="euiSpacer euiSpacer--s"
-                            />
-                            <div
-                              class="euiEmptyPrompt"
+                              class="euiFormControlLayout euiFormControlLayout--compressed"
                             >
-                              <h2
-                                class="euiTitle euiTitle--medium"
+                              <div
+                                class="euiFormControlLayout__childrenWrapper"
                               >
-                                No matches
-                              </h2>
-                              <span
-                                class="euiTextColor euiTextColor--subdued"
-                              >
-                                <div
-                                  class="euiSpacer euiSpacer--m"
+                                <input
+                                  class="euiFieldSearch euiFieldSearch--compressed"
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
                                 />
                                 <div
-                                  class="euiText euiText--medium"
+                                  class="euiFormControlLayoutIcons"
                                 >
-                                  <div
-                                    class="euiText euiText--small"
+                                  <span
+                                    class="euiFormControlLayoutCustomIcon"
                                   >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </div>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                      />
+                                    </svg>
+                                  </span>
                                 </div>
-                              </span>
+                              </div>
                             </div>
-                            <div
-                              class="euiSpacer euiSpacer--s"
-                            />
                           </div>
                         </div>
                         <div
-                          class="euiSpacer euiSpacer--xl"
+                          class="euiSpacer euiSpacer--l"
                         />
+                        <div
+                          style="min-height: 434px;"
+                        >
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                          <div
+                            class="euiEmptyPrompt"
+                          >
+                            <h2
+                              class="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                            <span
+                              class="euiTextColor euiTextColor--subdued"
+                            >
+                              <div
+                                class="euiSpacer euiSpacer--m"
+                              />
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                <div
+                                  class="euiText euiText--small"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </div>
+                            </span>
+                          </div>
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                        </div>
                       </div>
+                      <div
+                        class="euiSpacer euiSpacer--xl"
+                      />
                     </div>
                   </div>
                 </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/flyout.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/flyout.test.tsx.snap
@@ -874,6 +874,7 @@ exports[`Trace Detail Render Flyout component render trace detail 1`] = `
                           >
                             <EuiButtonContent
                               className="euiButton__content"
+                              iconGap="m"
                               iconSide="left"
                               textProps={
                                 Object {
@@ -954,6 +955,7 @@ exports[`Trace Detail Render Flyout component render trace detail 1`] = `
                           >
                             <EuiButtonContent
                               className="euiButton__content"
+                              iconGap="m"
                               iconSide="left"
                               textProps={
                                 Object {

--- a/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
@@ -327,6 +327,7 @@ exports[`Log Config component renders empty log config 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -994,6 +995,7 @@ exports[`Log Config component renders with query 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {

--- a/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -669,535 +669,543 @@ exports[`Service Config component renders empty service config 1`] = `
                   serviceMap={Object {}}
                   setIdSelected={[Function]}
                 >
-                  <EuiPanel>
+                  <EuiPage
+                    paddingSize="m"
+                  >
                     <div
-                      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                      className="euiPage euiPage--paddingMedium euiPage--grow"
                     >
-                      <PanelTitle
-                        title="Service map"
-                      >
-                        <EuiText
-                          size="m"
-                        >
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            <span
-                              className="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                        </EuiText>
-                      </PanelTitle>
-                      <EuiSpacer
-                        size="m"
-                      >
+                      <EuiPanel>
                         <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiButtonGroup
-                        buttonSize="s"
-                        color="text"
-                        idSelected="latency"
-                        onChange={[Function]}
-                        options={
-                          Array [
-                            Object {
-                              "id": "latency",
-                              "label": "Duration",
-                            },
-                            Object {
-                              "id": "error_rate",
-                              "label": "Errors",
-                            },
-                            Object {
-                              "id": "throughput",
-                              "label": "Request Rate",
-                            },
-                          ]
-                        }
-                      >
-                        <fieldset
-                          className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          disabled={false}
+                          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
-                          <EuiScreenReaderOnly>
-                            <legend
-                              className="euiScreenReaderOnly"
-                            />
-                          </EuiScreenReaderOnly>
-                          <div
-                            className="euiButtonGroup__buttons"
+                          <PanelTitle
+                            title="Service map"
                           >
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="latency"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={true}
-                              key="0"
-                              label="Duration"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
+                            <EuiText
+                              size="m"
                             >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className="euiButtonGroupButton-isSelected"
-                                color="text"
-                                element="label"
-                                fill={true}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Duration",
-                                    "ref": [Function],
-                                    "title": "Duration",
-                                  }
-                                }
+                              <div
+                                className="euiText euiText--medium"
                               >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
+                                <span
+                                  className="panel-title"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
+                                  Service map
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                          <EuiSpacer
+                            size="m"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--m"
+                            />
+                          </EuiSpacer>
+                          <EuiButtonGroup
+                            buttonSize="s"
+                            color="text"
+                            idSelected="latency"
+                            onChange={[Function]}
+                            options={
+                              Array [
+                                Object {
+                                  "id": "latency",
+                                  "label": "Duration",
+                                },
+                                Object {
+                                  "id": "error_rate",
+                                  "label": "Errors",
+                                },
+                                Object {
+                                  "id": "throughput",
+                                  "label": "Request Rate",
+                                },
+                              ]
+                            }
+                          >
+                            <fieldset
+                              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                              disabled={false}
+                            >
+                              <EuiScreenReaderOnly>
+                                <legend
+                                  className="euiScreenReaderOnly"
+                                />
+                              </EuiScreenReaderOnly>
+                              <div
+                                className="euiButtonGroup__buttons"
+                              >
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="latency"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={true}
+                                  key="0"
+                                  label="Duration"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  size="s"
+                                >
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className="euiButtonGroupButton-isSelected"
+                                    color="text"
+                                    element="label"
+                                    fill={true}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
                                     textProps={
                                       Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
+                                        "className": "euiButtonGroupButton__textShift",
                                         "data-text": "Duration",
                                         "ref": [Function],
                                         "title": "Duration",
                                       }
                                     }
                                   >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
                                     >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Duration"
-                                        title="Duration"
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Duration",
+                                            "ref": [Function],
+                                            "title": "Duration",
+                                          }
+                                        }
                                       >
-                                        <input
-                                          checked={true}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="latency"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Duration
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="error_rate"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={false}
-                              key="1"
-                              label="Errors"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className=""
-                                color="text"
-                                element="label"
-                                fill={false}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Errors",
-                                    "ref": [Function],
-                                    "title": "Errors",
-                                  }
-                                }
-                              >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
+                                        <span
+                                          className="euiButtonContent euiButton__content"
+                                        >
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Duration"
+                                            title="Duration"
+                                          >
+                                            <input
+                                              checked={true}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="latency"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Duration
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="error_rate"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={false}
+                                  key="1"
+                                  label="Errors"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  size="s"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className=""
+                                    color="text"
+                                    element="label"
+                                    fill={false}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
                                     textProps={
                                       Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
+                                        "className": "euiButtonGroupButton__textShift",
                                         "data-text": "Errors",
                                         "ref": [Function],
                                         "title": "Errors",
                                       }
                                     }
                                   >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
                                     >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Errors"
-                                        title="Errors"
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Errors",
+                                            "ref": [Function],
+                                            "title": "Errors",
+                                          }
+                                        }
                                       >
-                                        <input
-                                          checked={false}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="error_rate"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Errors
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="throughput"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={false}
-                              key="2"
-                              label="Request Rate"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className=""
-                                color="text"
-                                element="label"
-                                fill={false}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Request Rate",
-                                    "ref": [Function],
-                                    "title": "Request Rate",
-                                  }
-                                }
-                              >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
+                                        <span
+                                          className="euiButtonContent euiButton__content"
+                                        >
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Errors"
+                                            title="Errors"
+                                          >
+                                            <input
+                                              checked={false}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="error_rate"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Errors
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="throughput"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={false}
+                                  key="2"
+                                  label="Request Rate"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  size="s"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className=""
+                                    color="text"
+                                    element="label"
+                                    fill={false}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
                                     textProps={
                                       Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
+                                        "className": "euiButtonGroupButton__textShift",
                                         "data-text": "Request Rate",
                                         "ref": [Function],
                                         "title": "Request Rate",
                                       }
                                     }
                                   >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
                                     >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Request Rate"
-                                        title="Request Rate"
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Request Rate",
+                                            "ref": [Function],
+                                            "title": "Request Rate",
+                                          }
+                                        }
                                       >
-                                        <input
-                                          checked={false}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="throughput"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Request Rate
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                          </div>
-                        </fieldset>
-                      </EuiButtonGroup>
-                      <EuiHorizontalRule
-                        margin="m"
-                      >
-                        <hr
-                          className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                      </EuiHorizontalRule>
-                      <EuiFlexGroup
-                        alignItems="center"
-                        gutterSize="s"
-                      >
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                        >
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                            >
-                              <EuiText>
-                                <div
-                                  className="euiText euiText--medium"
-                                >
-                                  Focus on
-                                </div>
-                              </EuiText>
-                            </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem>
-                            <div
-                              className="euiFlexItem"
-                            >
-                              <EuiCompressedFieldSearch
-                                compressed={true}
-                                fullWidth={false}
-                                incremental={false}
-                                isClearable={true}
-                                isInvalid={false}
-                                isLoading={false}
-                                onChange={[Function]}
-                                onSearch={[Function]}
-                                placeholder="Service name"
-                                value=""
-                              >
-                                <EuiFormControlLayout
-                                  compressed={true}
-                                  fullWidth={false}
-                                  icon="search"
-                                  isLoading={false}
-                                >
-                                  <div
-                                    className="euiFormControlLayout euiFormControlLayout--compressed"
-                                  >
-                                    <div
-                                      className="euiFormControlLayout__childrenWrapper"
-                                    >
-                                      <EuiValidatableControl
-                                        isInvalid={false}
-                                      >
-                                        <input
-                                          className="euiFieldSearch euiFieldSearch--compressed"
-                                          onChange={[Function]}
-                                          onKeyUp={[Function]}
-                                          placeholder="Service name"
-                                          type="search"
-                                          value=""
-                                        />
-                                      </EuiValidatableControl>
-                                      <EuiFormControlLayoutIcons
-                                        compressed={true}
-                                        icon="search"
-                                        isLoading={false}
-                                      >
-                                        <div
-                                          className="euiFormControlLayoutIcons"
+                                        <span
+                                          className="euiButtonContent euiButton__content"
                                         >
-                                          <EuiFormControlLayoutCustomIcon
-                                            size="s"
-                                            type="search"
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Request Rate"
+                                            title="Request Rate"
                                           >
-                                            <span
-                                              className="euiFormControlLayoutCustomIcon"
-                                            >
-                                              <EuiIcon
-                                                aria-hidden="true"
-                                                className="euiFormControlLayoutCustomIcon__icon"
-                                                size="s"
-                                                type="search"
-                                              >
-                                                <EuiIconBeaker
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconBeaker>
-                                              </EuiIcon>
-                                            </span>
-                                          </EuiFormControlLayoutCustomIcon>
-                                        </div>
-                                      </EuiFormControlLayoutIcons>
-                                    </div>
-                                  </div>
-                                </EuiFormControlLayout>
-                              </EuiCompressedFieldSearch>
-                            </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
-                      <EuiSpacer>
-                        <div
-                          className="euiSpacer euiSpacer--l"
-                        />
-                      </EuiSpacer>
-                      <div
-                        style={
-                          Object {
-                            "minHeight": 434,
-                          }
-                        }
-                      >
-                        <NoMatchMessage
-                          size="s"
-                        >
-                          <EuiSpacer
-                            size="s"
+                                            <input
+                                              checked={false}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="throughput"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Request Rate
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                              </div>
+                            </fieldset>
+                          </EuiButtonGroup>
+                          <EuiHorizontalRule
+                            margin="m"
                           >
-                            <div
-                              className="euiSpacer euiSpacer--s"
+                            <hr
+                              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
                             />
-                          </EuiSpacer>
-                          <EuiEmptyPrompt
-                            body={
-                              <EuiText
-                                size="s"
-                              >
-                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                              </EuiText>
-                            }
-                            title={
-                              <h2>
-                                No matches
-                              </h2>
-                            }
+                          </EuiHorizontalRule>
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="s"
                           >
                             <div
-                              className="euiEmptyPrompt"
+                              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
                             >
-                              <EuiTitle
-                                size="m"
+                              <EuiFlexItem
+                                grow={false}
                               >
-                                <h2
-                                  className="euiTitle euiTitle--medium"
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
                                 >
-                                  No matches
-                                </h2>
-                              </EuiTitle>
-                              <EuiTextColor
-                                color="subdued"
-                              >
-                                <span
-                                  className="euiTextColor euiTextColor--subdued"
-                                >
-                                  <EuiSpacer
-                                    size="m"
-                                  >
-                                    <div
-                                      className="euiSpacer euiSpacer--m"
-                                    />
-                                  </EuiSpacer>
                                   <EuiText>
                                     <div
                                       className="euiText euiText--medium"
                                     >
-                                      <EuiText
-                                        size="s"
-                                      >
-                                        <div
-                                          className="euiText euiText--small"
-                                        >
-                                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                        </div>
-                                      </EuiText>
+                                      Focus on
                                     </div>
                                   </EuiText>
-                                </span>
-                              </EuiTextColor>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiCompressedFieldSearch
+                                    compressed={true}
+                                    fullWidth={false}
+                                    incremental={false}
+                                    isClearable={true}
+                                    isInvalid={false}
+                                    isLoading={false}
+                                    onChange={[Function]}
+                                    onSearch={[Function]}
+                                    placeholder="Service name"
+                                    value=""
+                                  >
+                                    <EuiFormControlLayout
+                                      compressed={true}
+                                      fullWidth={false}
+                                      icon="search"
+                                      isLoading={false}
+                                    >
+                                      <div
+                                        className="euiFormControlLayout euiFormControlLayout--compressed"
+                                      >
+                                        <div
+                                          className="euiFormControlLayout__childrenWrapper"
+                                        >
+                                          <EuiValidatableControl
+                                            isInvalid={false}
+                                          >
+                                            <input
+                                              className="euiFieldSearch euiFieldSearch--compressed"
+                                              onChange={[Function]}
+                                              onKeyUp={[Function]}
+                                              placeholder="Service name"
+                                              type="search"
+                                              value=""
+                                            />
+                                          </EuiValidatableControl>
+                                          <EuiFormControlLayoutIcons
+                                            compressed={true}
+                                            icon="search"
+                                            isLoading={false}
+                                          >
+                                            <div
+                                              className="euiFormControlLayoutIcons"
+                                            >
+                                              <EuiFormControlLayoutCustomIcon
+                                                size="s"
+                                                type="search"
+                                              >
+                                                <span
+                                                  className="euiFormControlLayoutCustomIcon"
+                                                >
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiFormControlLayoutCustomIcon__icon"
+                                                    size="s"
+                                                    type="search"
+                                                  >
+                                                    <EuiIconBeaker
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
+                                                  </EuiIcon>
+                                                </span>
+                                              </EuiFormControlLayoutCustomIcon>
+                                            </div>
+                                          </EuiFormControlLayoutIcons>
+                                        </div>
+                                      </div>
+                                    </EuiFormControlLayout>
+                                  </EuiCompressedFieldSearch>
+                                </div>
+                              </EuiFlexItem>
                             </div>
-                          </EuiEmptyPrompt>
-                          <EuiSpacer
-                            size="s"
-                          >
+                          </EuiFlexGroup>
+                          <EuiSpacer>
                             <div
-                              className="euiSpacer euiSpacer--s"
+                              className="euiSpacer euiSpacer--l"
                             />
                           </EuiSpacer>
-                        </NoMatchMessage>
-                      </div>
+                          <div
+                            style={
+                              Object {
+                                "minHeight": 434,
+                              }
+                            }
+                          >
+                            <NoMatchMessage
+                              size="s"
+                            >
+                              <EuiSpacer
+                                size="s"
+                              >
+                                <div
+                                  className="euiSpacer euiSpacer--s"
+                                />
+                              </EuiSpacer>
+                              <EuiEmptyPrompt
+                                body={
+                                  <EuiText
+                                    size="s"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </EuiText>
+                                }
+                                title={
+                                  <h2>
+                                    No matches
+                                  </h2>
+                                }
+                              >
+                                <div
+                                  className="euiEmptyPrompt"
+                                >
+                                  <EuiTitle
+                                    size="m"
+                                  >
+                                    <h2
+                                      className="euiTitle euiTitle--medium"
+                                    >
+                                      No matches
+                                    </h2>
+                                  </EuiTitle>
+                                  <EuiTextColor
+                                    color="subdued"
+                                  >
+                                    <span
+                                      className="euiTextColor euiTextColor--subdued"
+                                    >
+                                      <EuiSpacer
+                                        size="m"
+                                      >
+                                        <div
+                                          className="euiSpacer euiSpacer--m"
+                                        />
+                                      </EuiSpacer>
+                                      <EuiText>
+                                        <div
+                                          className="euiText euiText--medium"
+                                        >
+                                          <EuiText
+                                            size="s"
+                                          >
+                                            <div
+                                              className="euiText euiText--small"
+                                            >
+                                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                            </div>
+                                          </EuiText>
+                                        </div>
+                                      </EuiText>
+                                    </span>
+                                  </EuiTextColor>
+                                </div>
+                              </EuiEmptyPrompt>
+                              <EuiSpacer
+                                size="s"
+                              >
+                                <div
+                                  className="euiSpacer euiSpacer--s"
+                                />
+                              </EuiSpacer>
+                            </NoMatchMessage>
+                          </div>
+                        </div>
+                      </EuiPanel>
+                      <EuiSpacer
+                        size="xl"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--xl"
+                        />
+                      </EuiSpacer>
                     </div>
-                  </EuiPanel>
-                  <EuiSpacer
-                    size="xl"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--xl"
-                    />
-                  </EuiSpacer>
+                  </EuiPage>
                 </ServiceMap>
               </div>
             </div>
@@ -1894,535 +1902,543 @@ exports[`Service Config component renders with one service selected 1`] = `
                   serviceMap={Object {}}
                   setIdSelected={[Function]}
                 >
-                  <EuiPanel>
+                  <EuiPage
+                    paddingSize="m"
+                  >
                     <div
-                      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                      className="euiPage euiPage--paddingMedium euiPage--grow"
                     >
-                      <PanelTitle
-                        title="Service map"
-                      >
-                        <EuiText
-                          size="m"
-                        >
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            <span
-                              className="panel-title"
-                            >
-                              Service map
-                            </span>
-                          </div>
-                        </EuiText>
-                      </PanelTitle>
-                      <EuiSpacer
-                        size="m"
-                      >
+                      <EuiPanel>
                         <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiButtonGroup
-                        buttonSize="s"
-                        color="text"
-                        idSelected="latency"
-                        onChange={[Function]}
-                        options={
-                          Array [
-                            Object {
-                              "id": "latency",
-                              "label": "Duration",
-                            },
-                            Object {
-                              "id": "error_rate",
-                              "label": "Errors",
-                            },
-                            Object {
-                              "id": "throughput",
-                              "label": "Request Rate",
-                            },
-                          ]
-                        }
-                      >
-                        <fieldset
-                          className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                          disabled={false}
+                          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                         >
-                          <EuiScreenReaderOnly>
-                            <legend
-                              className="euiScreenReaderOnly"
-                            />
-                          </EuiScreenReaderOnly>
-                          <div
-                            className="euiButtonGroup__buttons"
+                          <PanelTitle
+                            title="Service map"
                           >
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="latency"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={true}
-                              key="0"
-                              label="Duration"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
+                            <EuiText
+                              size="m"
                             >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className="euiButtonGroupButton-isSelected"
-                                color="text"
-                                element="label"
-                                fill={true}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Duration",
-                                    "ref": [Function],
-                                    "title": "Duration",
-                                  }
-                                }
+                              <div
+                                className="euiText euiText--medium"
                               >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
+                                <span
+                                  className="panel-title"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
+                                  Service map
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                          <EuiSpacer
+                            size="m"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--m"
+                            />
+                          </EuiSpacer>
+                          <EuiButtonGroup
+                            buttonSize="s"
+                            color="text"
+                            idSelected="latency"
+                            onChange={[Function]}
+                            options={
+                              Array [
+                                Object {
+                                  "id": "latency",
+                                  "label": "Duration",
+                                },
+                                Object {
+                                  "id": "error_rate",
+                                  "label": "Errors",
+                                },
+                                Object {
+                                  "id": "throughput",
+                                  "label": "Request Rate",
+                                },
+                              ]
+                            }
+                          >
+                            <fieldset
+                              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                              disabled={false}
+                            >
+                              <EuiScreenReaderOnly>
+                                <legend
+                                  className="euiScreenReaderOnly"
+                                />
+                              </EuiScreenReaderOnly>
+                              <div
+                                className="euiButtonGroup__buttons"
+                              >
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="latency"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={true}
+                                  key="0"
+                                  label="Duration"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  size="s"
+                                >
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className="euiButtonGroupButton-isSelected"
+                                    color="text"
+                                    element="label"
+                                    fill={true}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
                                     textProps={
                                       Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
+                                        "className": "euiButtonGroupButton__textShift",
                                         "data-text": "Duration",
                                         "ref": [Function],
                                         "title": "Duration",
                                       }
                                     }
                                   >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
                                     >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Duration"
-                                        title="Duration"
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Duration",
+                                            "ref": [Function],
+                                            "title": "Duration",
+                                          }
+                                        }
                                       >
-                                        <input
-                                          checked={true}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="latency"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Duration
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="error_rate"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={false}
-                              key="1"
-                              label="Errors"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className=""
-                                color="text"
-                                element="label"
-                                fill={false}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Errors",
-                                    "ref": [Function],
-                                    "title": "Errors",
-                                  }
-                                }
-                              >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
+                                        <span
+                                          className="euiButtonContent euiButton__content"
+                                        >
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Duration"
+                                            title="Duration"
+                                          >
+                                            <input
+                                              checked={true}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="latency"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Duration
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="error_rate"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={false}
+                                  key="1"
+                                  label="Errors"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  size="s"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className=""
+                                    color="text"
+                                    element="label"
+                                    fill={false}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
                                     textProps={
                                       Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
+                                        "className": "euiButtonGroupButton__textShift",
                                         "data-text": "Errors",
                                         "ref": [Function],
                                         "title": "Errors",
                                       }
                                     }
                                   >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
                                     >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Errors"
-                                        title="Errors"
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Errors",
+                                            "ref": [Function],
+                                            "title": "Errors",
+                                          }
+                                        }
                                       >
-                                        <input
-                                          checked={false}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="error_rate"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Errors
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                            <EuiButtonGroupButton
-                              color="text"
-                              element="label"
-                              id="throughput"
-                              isDisabled={false}
-                              isIconOnly={false}
-                              isSelected={false}
-                              key="2"
-                              label="Request Rate"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              size="s"
-                            >
-                              <EuiButtonDisplay
-                                baseClassName="euiButtonGroupButton"
-                                className=""
-                                color="text"
-                                element="label"
-                                fill={false}
-                                htmlFor="random_html_id"
-                                isDisabled={false}
-                                onClick={[Function]}
-                                size="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonGroupButton__textShift",
-                                    "data-text": "Request Rate",
-                                    "ref": [Function],
-                                    "title": "Request Rate",
-                                  }
-                                }
-                              >
-                                <label
-                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                  disabled={false}
-                                  htmlFor="random_html_id"
-                                  onClick={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": undefined,
-                                    }
-                                  }
+                                        <span
+                                          className="euiButtonContent euiButton__content"
+                                        >
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Errors"
+                                            title="Errors"
+                                          >
+                                            <input
+                                              checked={false}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="error_rate"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Errors
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                                <EuiButtonGroupButton
+                                  color="text"
+                                  element="label"
+                                  id="throughput"
+                                  isDisabled={false}
+                                  isIconOnly={false}
+                                  isSelected={false}
+                                  key="2"
+                                  label="Request Rate"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  size="s"
                                 >
-                                  <EuiButtonContent
-                                    className="euiButton__content"
-                                    iconSide="left"
+                                  <EuiButtonDisplay
+                                    baseClassName="euiButtonGroupButton"
+                                    className=""
+                                    color="text"
+                                    element="label"
+                                    fill={false}
+                                    htmlFor="random_html_id"
+                                    isDisabled={false}
+                                    onClick={[Function]}
+                                    size="s"
                                     textProps={
                                       Object {
-                                        "className": "euiButton__text euiButtonGroupButton__textShift",
+                                        "className": "euiButtonGroupButton__textShift",
                                         "data-text": "Request Rate",
                                         "ref": [Function],
                                         "title": "Request Rate",
                                       }
                                     }
                                   >
-                                    <span
-                                      className="euiButtonContent euiButton__content"
+                                    <label
+                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                      disabled={false}
+                                      htmlFor="random_html_id"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "minWidth": undefined,
+                                        }
+                                      }
                                     >
-                                      <span
-                                        className="euiButton__text euiButtonGroupButton__textShift"
-                                        data-text="Request Rate"
-                                        title="Request Rate"
+                                      <EuiButtonContent
+                                        className="euiButton__content"
+                                        iconSide="left"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                                            "data-text": "Request Rate",
+                                            "ref": [Function],
+                                            "title": "Request Rate",
+                                          }
+                                        }
                                       >
-                                        <input
-                                          checked={false}
-                                          className="euiScreenReaderOnly"
-                                          data-test-subj="throughput"
-                                          disabled={false}
-                                          id="random_html_id"
-                                          name="random_html_id"
-                                          onChange={[Function]}
-                                          type="radio"
-                                        />
-                                        Request Rate
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </label>
-                              </EuiButtonDisplay>
-                            </EuiButtonGroupButton>
-                          </div>
-                        </fieldset>
-                      </EuiButtonGroup>
-                      <EuiHorizontalRule
-                        margin="m"
-                      >
-                        <hr
-                          className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                        />
-                      </EuiHorizontalRule>
-                      <EuiFlexGroup
-                        alignItems="center"
-                        gutterSize="s"
-                      >
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                        >
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                            >
-                              <EuiText>
-                                <div
-                                  className="euiText euiText--medium"
-                                >
-                                  Focus on
-                                </div>
-                              </EuiText>
-                            </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem>
-                            <div
-                              className="euiFlexItem"
-                            >
-                              <EuiCompressedFieldSearch
-                                compressed={true}
-                                fullWidth={false}
-                                incremental={false}
-                                isClearable={true}
-                                isInvalid={false}
-                                isLoading={false}
-                                onChange={[Function]}
-                                onSearch={[Function]}
-                                placeholder="Service name"
-                                value=""
-                              >
-                                <EuiFormControlLayout
-                                  compressed={true}
-                                  fullWidth={false}
-                                  icon="search"
-                                  isLoading={false}
-                                >
-                                  <div
-                                    className="euiFormControlLayout euiFormControlLayout--compressed"
-                                  >
-                                    <div
-                                      className="euiFormControlLayout__childrenWrapper"
-                                    >
-                                      <EuiValidatableControl
-                                        isInvalid={false}
-                                      >
-                                        <input
-                                          className="euiFieldSearch euiFieldSearch--compressed"
-                                          onChange={[Function]}
-                                          onKeyUp={[Function]}
-                                          placeholder="Service name"
-                                          type="search"
-                                          value=""
-                                        />
-                                      </EuiValidatableControl>
-                                      <EuiFormControlLayoutIcons
-                                        compressed={true}
-                                        icon="search"
-                                        isLoading={false}
-                                      >
-                                        <div
-                                          className="euiFormControlLayoutIcons"
+                                        <span
+                                          className="euiButtonContent euiButton__content"
                                         >
-                                          <EuiFormControlLayoutCustomIcon
-                                            size="s"
-                                            type="search"
+                                          <span
+                                            className="euiButton__text euiButtonGroupButton__textShift"
+                                            data-text="Request Rate"
+                                            title="Request Rate"
                                           >
-                                            <span
-                                              className="euiFormControlLayoutCustomIcon"
-                                            >
-                                              <EuiIcon
-                                                aria-hidden="true"
-                                                className="euiFormControlLayoutCustomIcon__icon"
-                                                size="s"
-                                                type="search"
-                                              >
-                                                <EuiIconSearch
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconSearch>
-                                              </EuiIcon>
-                                            </span>
-                                          </EuiFormControlLayoutCustomIcon>
-                                        </div>
-                                      </EuiFormControlLayoutIcons>
-                                    </div>
-                                  </div>
-                                </EuiFormControlLayout>
-                              </EuiCompressedFieldSearch>
-                            </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
-                      <EuiSpacer>
-                        <div
-                          className="euiSpacer euiSpacer--l"
-                        />
-                      </EuiSpacer>
-                      <div
-                        style={
-                          Object {
-                            "minHeight": 434,
-                          }
-                        }
-                      >
-                        <NoMatchMessage
-                          size="s"
-                        >
-                          <EuiSpacer
-                            size="s"
+                                            <input
+                                              checked={false}
+                                              className="euiScreenReaderOnly"
+                                              data-test-subj="throughput"
+                                              disabled={false}
+                                              id="random_html_id"
+                                              name="random_html_id"
+                                              onChange={[Function]}
+                                              type="radio"
+                                            />
+                                            Request Rate
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </label>
+                                  </EuiButtonDisplay>
+                                </EuiButtonGroupButton>
+                              </div>
+                            </fieldset>
+                          </EuiButtonGroup>
+                          <EuiHorizontalRule
+                            margin="m"
                           >
-                            <div
-                              className="euiSpacer euiSpacer--s"
+                            <hr
+                              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
                             />
-                          </EuiSpacer>
-                          <EuiEmptyPrompt
-                            body={
-                              <EuiText
-                                size="s"
-                              >
-                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                              </EuiText>
-                            }
-                            title={
-                              <h2>
-                                No matches
-                              </h2>
-                            }
+                          </EuiHorizontalRule>
+                          <EuiFlexGroup
+                            alignItems="center"
+                            gutterSize="s"
                           >
                             <div
-                              className="euiEmptyPrompt"
+                              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
                             >
-                              <EuiTitle
-                                size="m"
+                              <EuiFlexItem
+                                grow={false}
                               >
-                                <h2
-                                  className="euiTitle euiTitle--medium"
+                                <div
+                                  className="euiFlexItem euiFlexItem--flexGrowZero"
                                 >
-                                  No matches
-                                </h2>
-                              </EuiTitle>
-                              <EuiTextColor
-                                color="subdued"
-                              >
-                                <span
-                                  className="euiTextColor euiTextColor--subdued"
-                                >
-                                  <EuiSpacer
-                                    size="m"
-                                  >
-                                    <div
-                                      className="euiSpacer euiSpacer--m"
-                                    />
-                                  </EuiSpacer>
                                   <EuiText>
                                     <div
                                       className="euiText euiText--medium"
                                     >
-                                      <EuiText
-                                        size="s"
-                                      >
-                                        <div
-                                          className="euiText euiText--small"
-                                        >
-                                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                        </div>
-                                      </EuiText>
+                                      Focus on
                                     </div>
                                   </EuiText>
-                                </span>
-                              </EuiTextColor>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiCompressedFieldSearch
+                                    compressed={true}
+                                    fullWidth={false}
+                                    incremental={false}
+                                    isClearable={true}
+                                    isInvalid={false}
+                                    isLoading={false}
+                                    onChange={[Function]}
+                                    onSearch={[Function]}
+                                    placeholder="Service name"
+                                    value=""
+                                  >
+                                    <EuiFormControlLayout
+                                      compressed={true}
+                                      fullWidth={false}
+                                      icon="search"
+                                      isLoading={false}
+                                    >
+                                      <div
+                                        className="euiFormControlLayout euiFormControlLayout--compressed"
+                                      >
+                                        <div
+                                          className="euiFormControlLayout__childrenWrapper"
+                                        >
+                                          <EuiValidatableControl
+                                            isInvalid={false}
+                                          >
+                                            <input
+                                              className="euiFieldSearch euiFieldSearch--compressed"
+                                              onChange={[Function]}
+                                              onKeyUp={[Function]}
+                                              placeholder="Service name"
+                                              type="search"
+                                              value=""
+                                            />
+                                          </EuiValidatableControl>
+                                          <EuiFormControlLayoutIcons
+                                            compressed={true}
+                                            icon="search"
+                                            isLoading={false}
+                                          >
+                                            <div
+                                              className="euiFormControlLayoutIcons"
+                                            >
+                                              <EuiFormControlLayoutCustomIcon
+                                                size="s"
+                                                type="search"
+                                              >
+                                                <span
+                                                  className="euiFormControlLayoutCustomIcon"
+                                                >
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiFormControlLayoutCustomIcon__icon"
+                                                    size="s"
+                                                    type="search"
+                                                  >
+                                                    <EuiIconSearch
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconSearch>
+                                                  </EuiIcon>
+                                                </span>
+                                              </EuiFormControlLayoutCustomIcon>
+                                            </div>
+                                          </EuiFormControlLayoutIcons>
+                                        </div>
+                                      </div>
+                                    </EuiFormControlLayout>
+                                  </EuiCompressedFieldSearch>
+                                </div>
+                              </EuiFlexItem>
                             </div>
-                          </EuiEmptyPrompt>
-                          <EuiSpacer
-                            size="s"
-                          >
+                          </EuiFlexGroup>
+                          <EuiSpacer>
                             <div
-                              className="euiSpacer euiSpacer--s"
+                              className="euiSpacer euiSpacer--l"
                             />
                           </EuiSpacer>
-                        </NoMatchMessage>
-                      </div>
+                          <div
+                            style={
+                              Object {
+                                "minHeight": 434,
+                              }
+                            }
+                          >
+                            <NoMatchMessage
+                              size="s"
+                            >
+                              <EuiSpacer
+                                size="s"
+                              >
+                                <div
+                                  className="euiSpacer euiSpacer--s"
+                                />
+                              </EuiSpacer>
+                              <EuiEmptyPrompt
+                                body={
+                                  <EuiText
+                                    size="s"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </EuiText>
+                                }
+                                title={
+                                  <h2>
+                                    No matches
+                                  </h2>
+                                }
+                              >
+                                <div
+                                  className="euiEmptyPrompt"
+                                >
+                                  <EuiTitle
+                                    size="m"
+                                  >
+                                    <h2
+                                      className="euiTitle euiTitle--medium"
+                                    >
+                                      No matches
+                                    </h2>
+                                  </EuiTitle>
+                                  <EuiTextColor
+                                    color="subdued"
+                                  >
+                                    <span
+                                      className="euiTextColor euiTextColor--subdued"
+                                    >
+                                      <EuiSpacer
+                                        size="m"
+                                      >
+                                        <div
+                                          className="euiSpacer euiSpacer--m"
+                                        />
+                                      </EuiSpacer>
+                                      <EuiText>
+                                        <div
+                                          className="euiText euiText--medium"
+                                        >
+                                          <EuiText
+                                            size="s"
+                                          >
+                                            <div
+                                              className="euiText euiText--small"
+                                            >
+                                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                            </div>
+                                          </EuiText>
+                                        </div>
+                                      </EuiText>
+                                    </span>
+                                  </EuiTextColor>
+                                </div>
+                              </EuiEmptyPrompt>
+                              <EuiSpacer
+                                size="s"
+                              >
+                                <div
+                                  className="euiSpacer euiSpacer--s"
+                                />
+                              </EuiSpacer>
+                            </NoMatchMessage>
+                          </div>
+                        </div>
+                      </EuiPanel>
+                      <EuiSpacer
+                        size="xl"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--xl"
+                        />
+                      </EuiSpacer>
                     </div>
-                  </EuiPanel>
-                  <EuiSpacer
-                    size="xl"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--xl"
-                    />
-                  </EuiSpacer>
+                  </EuiPage>
                 </ServiceMap>
               </div>
             </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -669,543 +669,535 @@ exports[`Service Config component renders empty service config 1`] = `
                   serviceMap={Object {}}
                   setIdSelected={[Function]}
                 >
-                  <EuiPage
-                    paddingSize="m"
-                  >
+                  <EuiPanel>
                     <div
-                      className="euiPage euiPage--paddingMedium euiPage--grow"
+                      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                     >
-                      <EuiPanel>
-                        <div
-                          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                      <PanelTitle
+                        title="Service map"
+                      >
+                        <EuiText
+                          size="m"
                         >
-                          <PanelTitle
-                            title="Service map"
+                          <div
+                            className="euiText euiText--medium"
                           >
-                            <EuiText
-                              size="m"
+                            <span
+                              className="panel-title"
                             >
-                              <div
-                                className="euiText euiText--medium"
-                              >
-                                <span
-                                  className="panel-title"
-                                >
-                                  Service map
-                                </span>
-                              </div>
-                            </EuiText>
-                          </PanelTitle>
-                          <EuiSpacer
-                            size="m"
-                          >
-                            <div
-                              className="euiSpacer euiSpacer--m"
+                              Service map
+                            </span>
+                          </div>
+                        </EuiText>
+                      </PanelTitle>
+                      <EuiSpacer
+                        size="m"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--m"
+                        />
+                      </EuiSpacer>
+                      <EuiButtonGroup
+                        buttonSize="s"
+                        color="text"
+                        idSelected="latency"
+                        onChange={[Function]}
+                        options={
+                          Array [
+                            Object {
+                              "id": "latency",
+                              "label": "Duration",
+                            },
+                            Object {
+                              "id": "error_rate",
+                              "label": "Errors",
+                            },
+                            Object {
+                              "id": "throughput",
+                              "label": "Request Rate",
+                            },
+                          ]
+                        }
+                      >
+                        <fieldset
+                          className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          disabled={false}
+                        >
+                          <EuiScreenReaderOnly>
+                            <legend
+                              className="euiScreenReaderOnly"
                             />
-                          </EuiSpacer>
-                          <EuiButtonGroup
-                            buttonSize="s"
-                            color="text"
-                            idSelected="latency"
-                            onChange={[Function]}
-                            options={
-                              Array [
-                                Object {
-                                  "id": "latency",
-                                  "label": "Duration",
-                                },
-                                Object {
-                                  "id": "error_rate",
-                                  "label": "Errors",
-                                },
-                                Object {
-                                  "id": "throughput",
-                                  "label": "Request Rate",
-                                },
-                              ]
-                            }
+                          </EuiScreenReaderOnly>
+                          <div
+                            className="euiButtonGroup__buttons"
                           >
-                            <fieldset
-                              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                              disabled={false}
+                            <EuiButtonGroupButton
+                              color="text"
+                              element="label"
+                              id="latency"
+                              isDisabled={false}
+                              isIconOnly={false}
+                              isSelected={true}
+                              key="0"
+                              label="Duration"
+                              name="random_html_id"
+                              onChange={[Function]}
+                              size="s"
                             >
-                              <EuiScreenReaderOnly>
-                                <legend
-                                  className="euiScreenReaderOnly"
-                                />
-                              </EuiScreenReaderOnly>
-                              <div
-                                className="euiButtonGroup__buttons"
+                              <EuiButtonDisplay
+                                baseClassName="euiButtonGroupButton"
+                                className="euiButtonGroupButton-isSelected"
+                                color="text"
+                                element="label"
+                                fill={true}
+                                htmlFor="random_html_id"
+                                isDisabled={false}
+                                onClick={[Function]}
+                                size="s"
+                                textProps={
+                                  Object {
+                                    "className": "euiButtonGroupButton__textShift",
+                                    "data-text": "Duration",
+                                    "ref": [Function],
+                                    "title": "Duration",
+                                  }
+                                }
                               >
-                                <EuiButtonGroupButton
-                                  color="text"
-                                  element="label"
-                                  id="latency"
-                                  isDisabled={false}
-                                  isIconOnly={false}
-                                  isSelected={true}
-                                  key="0"
-                                  label="Duration"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  size="s"
+                                <label
+                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  disabled={false}
+                                  htmlFor="random_html_id"
+                                  onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "minWidth": undefined,
+                                    }
+                                  }
                                 >
-                                  <EuiButtonDisplay
-                                    baseClassName="euiButtonGroupButton"
-                                    className="euiButtonGroupButton-isSelected"
-                                    color="text"
-                                    element="label"
-                                    fill={true}
-                                    htmlFor="random_html_id"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="s"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
                                     textProps={
                                       Object {
-                                        "className": "euiButtonGroupButton__textShift",
+                                        "className": "euiButton__text euiButtonGroupButton__textShift",
                                         "data-text": "Duration",
                                         "ref": [Function],
                                         "title": "Duration",
                                       }
                                     }
                                   >
-                                    <label
-                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                      disabled={false}
-                                      htmlFor="random_html_id"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "minWidth": undefined,
-                                        }
-                                      }
+                                    <span
+                                      className="euiButtonContent euiButton__content"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButton__content"
-                                        iconSide="left"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                                            "data-text": "Duration",
-                                            "ref": [Function],
-                                            "title": "Duration",
-                                          }
-                                        }
+                                      <span
+                                        className="euiButton__text euiButtonGroupButton__textShift"
+                                        data-text="Duration"
+                                        title="Duration"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButton__content"
-                                        >
-                                          <span
-                                            className="euiButton__text euiButtonGroupButton__textShift"
-                                            data-text="Duration"
-                                            title="Duration"
-                                          >
-                                            <input
-                                              checked={true}
-                                              className="euiScreenReaderOnly"
-                                              data-test-subj="latency"
-                                              disabled={false}
-                                              id="random_html_id"
-                                              name="random_html_id"
-                                              onChange={[Function]}
-                                              type="radio"
-                                            />
-                                            Duration
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </label>
-                                  </EuiButtonDisplay>
-                                </EuiButtonGroupButton>
-                                <EuiButtonGroupButton
-                                  color="text"
-                                  element="label"
-                                  id="error_rate"
-                                  isDisabled={false}
-                                  isIconOnly={false}
-                                  isSelected={false}
-                                  key="1"
-                                  label="Errors"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  size="s"
+                                        <input
+                                          checked={true}
+                                          className="euiScreenReaderOnly"
+                                          data-test-subj="latency"
+                                          disabled={false}
+                                          id="random_html_id"
+                                          name="random_html_id"
+                                          onChange={[Function]}
+                                          type="radio"
+                                        />
+                                        Duration
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </label>
+                              </EuiButtonDisplay>
+                            </EuiButtonGroupButton>
+                            <EuiButtonGroupButton
+                              color="text"
+                              element="label"
+                              id="error_rate"
+                              isDisabled={false}
+                              isIconOnly={false}
+                              isSelected={false}
+                              key="1"
+                              label="Errors"
+                              name="random_html_id"
+                              onChange={[Function]}
+                              size="s"
+                            >
+                              <EuiButtonDisplay
+                                baseClassName="euiButtonGroupButton"
+                                className=""
+                                color="text"
+                                element="label"
+                                fill={false}
+                                htmlFor="random_html_id"
+                                isDisabled={false}
+                                onClick={[Function]}
+                                size="s"
+                                textProps={
+                                  Object {
+                                    "className": "euiButtonGroupButton__textShift",
+                                    "data-text": "Errors",
+                                    "ref": [Function],
+                                    "title": "Errors",
+                                  }
+                                }
+                              >
+                                <label
+                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  disabled={false}
+                                  htmlFor="random_html_id"
+                                  onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "minWidth": undefined,
+                                    }
+                                  }
                                 >
-                                  <EuiButtonDisplay
-                                    baseClassName="euiButtonGroupButton"
-                                    className=""
-                                    color="text"
-                                    element="label"
-                                    fill={false}
-                                    htmlFor="random_html_id"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="s"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
                                     textProps={
                                       Object {
-                                        "className": "euiButtonGroupButton__textShift",
+                                        "className": "euiButton__text euiButtonGroupButton__textShift",
                                         "data-text": "Errors",
                                         "ref": [Function],
                                         "title": "Errors",
                                       }
                                     }
                                   >
-                                    <label
-                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                      disabled={false}
-                                      htmlFor="random_html_id"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "minWidth": undefined,
-                                        }
-                                      }
+                                    <span
+                                      className="euiButtonContent euiButton__content"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButton__content"
-                                        iconSide="left"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                                            "data-text": "Errors",
-                                            "ref": [Function],
-                                            "title": "Errors",
-                                          }
-                                        }
+                                      <span
+                                        className="euiButton__text euiButtonGroupButton__textShift"
+                                        data-text="Errors"
+                                        title="Errors"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButton__content"
-                                        >
-                                          <span
-                                            className="euiButton__text euiButtonGroupButton__textShift"
-                                            data-text="Errors"
-                                            title="Errors"
-                                          >
-                                            <input
-                                              checked={false}
-                                              className="euiScreenReaderOnly"
-                                              data-test-subj="error_rate"
-                                              disabled={false}
-                                              id="random_html_id"
-                                              name="random_html_id"
-                                              onChange={[Function]}
-                                              type="radio"
-                                            />
-                                            Errors
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </label>
-                                  </EuiButtonDisplay>
-                                </EuiButtonGroupButton>
-                                <EuiButtonGroupButton
-                                  color="text"
-                                  element="label"
-                                  id="throughput"
-                                  isDisabled={false}
-                                  isIconOnly={false}
-                                  isSelected={false}
-                                  key="2"
-                                  label="Request Rate"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  size="s"
+                                        <input
+                                          checked={false}
+                                          className="euiScreenReaderOnly"
+                                          data-test-subj="error_rate"
+                                          disabled={false}
+                                          id="random_html_id"
+                                          name="random_html_id"
+                                          onChange={[Function]}
+                                          type="radio"
+                                        />
+                                        Errors
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </label>
+                              </EuiButtonDisplay>
+                            </EuiButtonGroupButton>
+                            <EuiButtonGroupButton
+                              color="text"
+                              element="label"
+                              id="throughput"
+                              isDisabled={false}
+                              isIconOnly={false}
+                              isSelected={false}
+                              key="2"
+                              label="Request Rate"
+                              name="random_html_id"
+                              onChange={[Function]}
+                              size="s"
+                            >
+                              <EuiButtonDisplay
+                                baseClassName="euiButtonGroupButton"
+                                className=""
+                                color="text"
+                                element="label"
+                                fill={false}
+                                htmlFor="random_html_id"
+                                isDisabled={false}
+                                onClick={[Function]}
+                                size="s"
+                                textProps={
+                                  Object {
+                                    "className": "euiButtonGroupButton__textShift",
+                                    "data-text": "Request Rate",
+                                    "ref": [Function],
+                                    "title": "Request Rate",
+                                  }
+                                }
+                              >
+                                <label
+                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  disabled={false}
+                                  htmlFor="random_html_id"
+                                  onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "minWidth": undefined,
+                                    }
+                                  }
                                 >
-                                  <EuiButtonDisplay
-                                    baseClassName="euiButtonGroupButton"
-                                    className=""
-                                    color="text"
-                                    element="label"
-                                    fill={false}
-                                    htmlFor="random_html_id"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="s"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
                                     textProps={
                                       Object {
-                                        "className": "euiButtonGroupButton__textShift",
+                                        "className": "euiButton__text euiButtonGroupButton__textShift",
                                         "data-text": "Request Rate",
                                         "ref": [Function],
                                         "title": "Request Rate",
                                       }
                                     }
                                   >
-                                    <label
-                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                      disabled={false}
-                                      htmlFor="random_html_id"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "minWidth": undefined,
-                                        }
-                                      }
+                                    <span
+                                      className="euiButtonContent euiButton__content"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButton__content"
-                                        iconSide="left"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                                            "data-text": "Request Rate",
-                                            "ref": [Function],
-                                            "title": "Request Rate",
-                                          }
-                                        }
+                                      <span
+                                        className="euiButton__text euiButtonGroupButton__textShift"
+                                        data-text="Request Rate"
+                                        title="Request Rate"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButton__content"
-                                        >
-                                          <span
-                                            className="euiButton__text euiButtonGroupButton__textShift"
-                                            data-text="Request Rate"
-                                            title="Request Rate"
-                                          >
-                                            <input
-                                              checked={false}
-                                              className="euiScreenReaderOnly"
-                                              data-test-subj="throughput"
-                                              disabled={false}
-                                              id="random_html_id"
-                                              name="random_html_id"
-                                              onChange={[Function]}
-                                              type="radio"
-                                            />
-                                            Request Rate
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </label>
-                                  </EuiButtonDisplay>
-                                </EuiButtonGroupButton>
-                              </div>
-                            </fieldset>
-                          </EuiButtonGroup>
-                          <EuiHorizontalRule
-                            margin="m"
-                          >
-                            <hr
-                              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                            />
-                          </EuiHorizontalRule>
-                          <EuiFlexGroup
-                            alignItems="center"
-                            gutterSize="s"
+                                        <input
+                                          checked={false}
+                                          className="euiScreenReaderOnly"
+                                          data-test-subj="throughput"
+                                          disabled={false}
+                                          id="random_html_id"
+                                          name="random_html_id"
+                                          onChange={[Function]}
+                                          type="radio"
+                                        />
+                                        Request Rate
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </label>
+                              </EuiButtonDisplay>
+                            </EuiButtonGroupButton>
+                          </div>
+                        </fieldset>
+                      </EuiButtonGroup>
+                      <EuiHorizontalRule
+                        margin="m"
+                      >
+                        <hr
+                          className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                        />
+                      </EuiHorizontalRule>
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <EuiFlexItem
-                                grow={false}
-                              >
+                              <EuiText>
                                 <div
-                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                  className="euiText euiText--medium"
                                 >
+                                  Focus on
+                                </div>
+                              </EuiText>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                fullWidth={false}
+                                incremental={false}
+                                isClearable={true}
+                                isInvalid={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Service name"
+                                value=""
+                              >
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={false}
+                                  icon="search"
+                                  isLoading={false}
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed"
+                                  >
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl
+                                        isInvalid={false}
+                                      >
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--compressed"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <span
+                                              className="euiFormControlLayoutCustomIcon"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
+                                              >
+                                                <EuiIconBeaker
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconBeaker>
+                                              </EuiIcon>
+                                            </span>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                      <EuiSpacer>
+                        <div
+                          className="euiSpacer euiSpacer--l"
+                        />
+                      </EuiSpacer>
+                      <div
+                        style={
+                          Object {
+                            "minHeight": 434,
+                          }
+                        }
+                      >
+                        <NoMatchMessage
+                          size="s"
+                        >
+                          <EuiSpacer
+                            size="s"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--s"
+                            />
+                          </EuiSpacer>
+                          <EuiEmptyPrompt
+                            body={
+                              <EuiText
+                                size="s"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </EuiText>
+                            }
+                            title={
+                              <h2>
+                                No matches
+                              </h2>
+                            }
+                          >
+                            <div
+                              className="euiEmptyPrompt"
+                            >
+                              <EuiTitle
+                                size="m"
+                              >
+                                <h2
+                                  className="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                              </EuiTitle>
+                              <EuiTextColor
+                                color="subdued"
+                              >
+                                <span
+                                  className="euiTextColor euiTextColor--subdued"
+                                >
+                                  <EuiSpacer
+                                    size="m"
+                                  >
+                                    <div
+                                      className="euiSpacer euiSpacer--m"
+                                    />
+                                  </EuiSpacer>
                                   <EuiText>
                                     <div
                                       className="euiText euiText--medium"
                                     >
-                                      Focus on
-                                    </div>
-                                  </EuiText>
-                                </div>
-                              </EuiFlexItem>
-                              <EuiFlexItem>
-                                <div
-                                  className="euiFlexItem"
-                                >
-                                  <EuiCompressedFieldSearch
-                                    compressed={true}
-                                    fullWidth={false}
-                                    incremental={false}
-                                    isClearable={true}
-                                    isInvalid={false}
-                                    isLoading={false}
-                                    onChange={[Function]}
-                                    onSearch={[Function]}
-                                    placeholder="Service name"
-                                    value=""
-                                  >
-                                    <EuiFormControlLayout
-                                      compressed={true}
-                                      fullWidth={false}
-                                      icon="search"
-                                      isLoading={false}
-                                    >
-                                      <div
-                                        className="euiFormControlLayout euiFormControlLayout--compressed"
+                                      <EuiText
+                                        size="s"
                                       >
                                         <div
-                                          className="euiFormControlLayout__childrenWrapper"
+                                          className="euiText euiText--small"
                                         >
-                                          <EuiValidatableControl
-                                            isInvalid={false}
-                                          >
-                                            <input
-                                              className="euiFieldSearch euiFieldSearch--compressed"
-                                              onChange={[Function]}
-                                              onKeyUp={[Function]}
-                                              placeholder="Service name"
-                                              type="search"
-                                              value=""
-                                            />
-                                          </EuiValidatableControl>
-                                          <EuiFormControlLayoutIcons
-                                            compressed={true}
-                                            icon="search"
-                                            isLoading={false}
-                                          >
-                                            <div
-                                              className="euiFormControlLayoutIcons"
-                                            >
-                                              <EuiFormControlLayoutCustomIcon
-                                                size="s"
-                                                type="search"
-                                              >
-                                                <span
-                                                  className="euiFormControlLayoutCustomIcon"
-                                                >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiFormControlLayoutCustomIcon__icon"
-                                                    size="s"
-                                                    type="search"
-                                                  >
-                                                    <EuiIconBeaker
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
-                                                    >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                                        focusable="false"
-                                                        height={16}
-                                                        role="img"
-                                                        style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      >
-                                                        <path
-                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                        />
-                                                      </svg>
-                                                    </EuiIconBeaker>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiFormControlLayoutCustomIcon>
-                                            </div>
-                                          </EuiFormControlLayoutIcons>
-                                        </div>
-                                      </div>
-                                    </EuiFormControlLayout>
-                                  </EuiCompressedFieldSearch>
-                                </div>
-                              </EuiFlexItem>
-                            </div>
-                          </EuiFlexGroup>
-                          <EuiSpacer>
-                            <div
-                              className="euiSpacer euiSpacer--l"
-                            />
-                          </EuiSpacer>
-                          <div
-                            style={
-                              Object {
-                                "minHeight": 434,
-                              }
-                            }
-                          >
-                            <NoMatchMessage
-                              size="s"
-                            >
-                              <EuiSpacer
-                                size="s"
-                              >
-                                <div
-                                  className="euiSpacer euiSpacer--s"
-                                />
-                              </EuiSpacer>
-                              <EuiEmptyPrompt
-                                body={
-                                  <EuiText
-                                    size="s"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </EuiText>
-                                }
-                                title={
-                                  <h2>
-                                    No matches
-                                  </h2>
-                                }
-                              >
-                                <div
-                                  className="euiEmptyPrompt"
-                                >
-                                  <EuiTitle
-                                    size="m"
-                                  >
-                                    <h2
-                                      className="euiTitle euiTitle--medium"
-                                    >
-                                      No matches
-                                    </h2>
-                                  </EuiTitle>
-                                  <EuiTextColor
-                                    color="subdued"
-                                  >
-                                    <span
-                                      className="euiTextColor euiTextColor--subdued"
-                                    >
-                                      <EuiSpacer
-                                        size="m"
-                                      >
-                                        <div
-                                          className="euiSpacer euiSpacer--m"
-                                        />
-                                      </EuiSpacer>
-                                      <EuiText>
-                                        <div
-                                          className="euiText euiText--medium"
-                                        >
-                                          <EuiText
-                                            size="s"
-                                          >
-                                            <div
-                                              className="euiText euiText--small"
-                                            >
-                                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                            </div>
-                                          </EuiText>
+                                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                         </div>
                                       </EuiText>
-                                    </span>
-                                  </EuiTextColor>
-                                </div>
-                              </EuiEmptyPrompt>
-                              <EuiSpacer
-                                size="s"
-                              >
-                                <div
-                                  className="euiSpacer euiSpacer--s"
-                                />
-                              </EuiSpacer>
-                            </NoMatchMessage>
-                          </div>
-                        </div>
-                      </EuiPanel>
-                      <EuiSpacer
-                        size="xl"
-                      >
-                        <div
-                          className="euiSpacer euiSpacer--xl"
-                        />
-                      </EuiSpacer>
+                                    </div>
+                                  </EuiText>
+                                </span>
+                              </EuiTextColor>
+                            </div>
+                          </EuiEmptyPrompt>
+                          <EuiSpacer
+                            size="s"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--s"
+                            />
+                          </EuiSpacer>
+                        </NoMatchMessage>
+                      </div>
                     </div>
-                  </EuiPage>
+                  </EuiPanel>
+                  <EuiSpacer
+                    size="xl"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--xl"
+                    />
+                  </EuiSpacer>
                 </ServiceMap>
               </div>
             </div>
@@ -1902,543 +1894,535 @@ exports[`Service Config component renders with one service selected 1`] = `
                   serviceMap={Object {}}
                   setIdSelected={[Function]}
                 >
-                  <EuiPage
-                    paddingSize="m"
-                  >
+                  <EuiPanel>
                     <div
-                      className="euiPage euiPage--paddingMedium euiPage--grow"
+                      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                     >
-                      <EuiPanel>
-                        <div
-                          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                      <PanelTitle
+                        title="Service map"
+                      >
+                        <EuiText
+                          size="m"
                         >
-                          <PanelTitle
-                            title="Service map"
+                          <div
+                            className="euiText euiText--medium"
                           >
-                            <EuiText
-                              size="m"
+                            <span
+                              className="panel-title"
                             >
-                              <div
-                                className="euiText euiText--medium"
-                              >
-                                <span
-                                  className="panel-title"
-                                >
-                                  Service map
-                                </span>
-                              </div>
-                            </EuiText>
-                          </PanelTitle>
-                          <EuiSpacer
-                            size="m"
-                          >
-                            <div
-                              className="euiSpacer euiSpacer--m"
+                              Service map
+                            </span>
+                          </div>
+                        </EuiText>
+                      </PanelTitle>
+                      <EuiSpacer
+                        size="m"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--m"
+                        />
+                      </EuiSpacer>
+                      <EuiButtonGroup
+                        buttonSize="s"
+                        color="text"
+                        idSelected="latency"
+                        onChange={[Function]}
+                        options={
+                          Array [
+                            Object {
+                              "id": "latency",
+                              "label": "Duration",
+                            },
+                            Object {
+                              "id": "error_rate",
+                              "label": "Errors",
+                            },
+                            Object {
+                              "id": "throughput",
+                              "label": "Request Rate",
+                            },
+                          ]
+                        }
+                      >
+                        <fieldset
+                          className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                          disabled={false}
+                        >
+                          <EuiScreenReaderOnly>
+                            <legend
+                              className="euiScreenReaderOnly"
                             />
-                          </EuiSpacer>
-                          <EuiButtonGroup
-                            buttonSize="s"
-                            color="text"
-                            idSelected="latency"
-                            onChange={[Function]}
-                            options={
-                              Array [
-                                Object {
-                                  "id": "latency",
-                                  "label": "Duration",
-                                },
-                                Object {
-                                  "id": "error_rate",
-                                  "label": "Errors",
-                                },
-                                Object {
-                                  "id": "throughput",
-                                  "label": "Request Rate",
-                                },
-                              ]
-                            }
+                          </EuiScreenReaderOnly>
+                          <div
+                            className="euiButtonGroup__buttons"
                           >
-                            <fieldset
-                              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                              disabled={false}
+                            <EuiButtonGroupButton
+                              color="text"
+                              element="label"
+                              id="latency"
+                              isDisabled={false}
+                              isIconOnly={false}
+                              isSelected={true}
+                              key="0"
+                              label="Duration"
+                              name="random_html_id"
+                              onChange={[Function]}
+                              size="s"
                             >
-                              <EuiScreenReaderOnly>
-                                <legend
-                                  className="euiScreenReaderOnly"
-                                />
-                              </EuiScreenReaderOnly>
-                              <div
-                                className="euiButtonGroup__buttons"
+                              <EuiButtonDisplay
+                                baseClassName="euiButtonGroupButton"
+                                className="euiButtonGroupButton-isSelected"
+                                color="text"
+                                element="label"
+                                fill={true}
+                                htmlFor="random_html_id"
+                                isDisabled={false}
+                                onClick={[Function]}
+                                size="s"
+                                textProps={
+                                  Object {
+                                    "className": "euiButtonGroupButton__textShift",
+                                    "data-text": "Duration",
+                                    "ref": [Function],
+                                    "title": "Duration",
+                                  }
+                                }
                               >
-                                <EuiButtonGroupButton
-                                  color="text"
-                                  element="label"
-                                  id="latency"
-                                  isDisabled={false}
-                                  isIconOnly={false}
-                                  isSelected={true}
-                                  key="0"
-                                  label="Duration"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  size="s"
+                                <label
+                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                                  disabled={false}
+                                  htmlFor="random_html_id"
+                                  onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "minWidth": undefined,
+                                    }
+                                  }
                                 >
-                                  <EuiButtonDisplay
-                                    baseClassName="euiButtonGroupButton"
-                                    className="euiButtonGroupButton-isSelected"
-                                    color="text"
-                                    element="label"
-                                    fill={true}
-                                    htmlFor="random_html_id"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="s"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
                                     textProps={
                                       Object {
-                                        "className": "euiButtonGroupButton__textShift",
+                                        "className": "euiButton__text euiButtonGroupButton__textShift",
                                         "data-text": "Duration",
                                         "ref": [Function],
                                         "title": "Duration",
                                       }
                                     }
                                   >
-                                    <label
-                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                                      disabled={false}
-                                      htmlFor="random_html_id"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "minWidth": undefined,
-                                        }
-                                      }
+                                    <span
+                                      className="euiButtonContent euiButton__content"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButton__content"
-                                        iconSide="left"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                                            "data-text": "Duration",
-                                            "ref": [Function],
-                                            "title": "Duration",
-                                          }
-                                        }
+                                      <span
+                                        className="euiButton__text euiButtonGroupButton__textShift"
+                                        data-text="Duration"
+                                        title="Duration"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButton__content"
-                                        >
-                                          <span
-                                            className="euiButton__text euiButtonGroupButton__textShift"
-                                            data-text="Duration"
-                                            title="Duration"
-                                          >
-                                            <input
-                                              checked={true}
-                                              className="euiScreenReaderOnly"
-                                              data-test-subj="latency"
-                                              disabled={false}
-                                              id="random_html_id"
-                                              name="random_html_id"
-                                              onChange={[Function]}
-                                              type="radio"
-                                            />
-                                            Duration
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </label>
-                                  </EuiButtonDisplay>
-                                </EuiButtonGroupButton>
-                                <EuiButtonGroupButton
-                                  color="text"
-                                  element="label"
-                                  id="error_rate"
-                                  isDisabled={false}
-                                  isIconOnly={false}
-                                  isSelected={false}
-                                  key="1"
-                                  label="Errors"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  size="s"
+                                        <input
+                                          checked={true}
+                                          className="euiScreenReaderOnly"
+                                          data-test-subj="latency"
+                                          disabled={false}
+                                          id="random_html_id"
+                                          name="random_html_id"
+                                          onChange={[Function]}
+                                          type="radio"
+                                        />
+                                        Duration
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </label>
+                              </EuiButtonDisplay>
+                            </EuiButtonGroupButton>
+                            <EuiButtonGroupButton
+                              color="text"
+                              element="label"
+                              id="error_rate"
+                              isDisabled={false}
+                              isIconOnly={false}
+                              isSelected={false}
+                              key="1"
+                              label="Errors"
+                              name="random_html_id"
+                              onChange={[Function]}
+                              size="s"
+                            >
+                              <EuiButtonDisplay
+                                baseClassName="euiButtonGroupButton"
+                                className=""
+                                color="text"
+                                element="label"
+                                fill={false}
+                                htmlFor="random_html_id"
+                                isDisabled={false}
+                                onClick={[Function]}
+                                size="s"
+                                textProps={
+                                  Object {
+                                    "className": "euiButtonGroupButton__textShift",
+                                    "data-text": "Errors",
+                                    "ref": [Function],
+                                    "title": "Errors",
+                                  }
+                                }
+                              >
+                                <label
+                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  disabled={false}
+                                  htmlFor="random_html_id"
+                                  onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "minWidth": undefined,
+                                    }
+                                  }
                                 >
-                                  <EuiButtonDisplay
-                                    baseClassName="euiButtonGroupButton"
-                                    className=""
-                                    color="text"
-                                    element="label"
-                                    fill={false}
-                                    htmlFor="random_html_id"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="s"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
                                     textProps={
                                       Object {
-                                        "className": "euiButtonGroupButton__textShift",
+                                        "className": "euiButton__text euiButtonGroupButton__textShift",
                                         "data-text": "Errors",
                                         "ref": [Function],
                                         "title": "Errors",
                                       }
                                     }
                                   >
-                                    <label
-                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                      disabled={false}
-                                      htmlFor="random_html_id"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "minWidth": undefined,
-                                        }
-                                      }
+                                    <span
+                                      className="euiButtonContent euiButton__content"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButton__content"
-                                        iconSide="left"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                                            "data-text": "Errors",
-                                            "ref": [Function],
-                                            "title": "Errors",
-                                          }
-                                        }
+                                      <span
+                                        className="euiButton__text euiButtonGroupButton__textShift"
+                                        data-text="Errors"
+                                        title="Errors"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButton__content"
-                                        >
-                                          <span
-                                            className="euiButton__text euiButtonGroupButton__textShift"
-                                            data-text="Errors"
-                                            title="Errors"
-                                          >
-                                            <input
-                                              checked={false}
-                                              className="euiScreenReaderOnly"
-                                              data-test-subj="error_rate"
-                                              disabled={false}
-                                              id="random_html_id"
-                                              name="random_html_id"
-                                              onChange={[Function]}
-                                              type="radio"
-                                            />
-                                            Errors
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </label>
-                                  </EuiButtonDisplay>
-                                </EuiButtonGroupButton>
-                                <EuiButtonGroupButton
-                                  color="text"
-                                  element="label"
-                                  id="throughput"
-                                  isDisabled={false}
-                                  isIconOnly={false}
-                                  isSelected={false}
-                                  key="2"
-                                  label="Request Rate"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  size="s"
+                                        <input
+                                          checked={false}
+                                          className="euiScreenReaderOnly"
+                                          data-test-subj="error_rate"
+                                          disabled={false}
+                                          id="random_html_id"
+                                          name="random_html_id"
+                                          onChange={[Function]}
+                                          type="radio"
+                                        />
+                                        Errors
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </label>
+                              </EuiButtonDisplay>
+                            </EuiButtonGroupButton>
+                            <EuiButtonGroupButton
+                              color="text"
+                              element="label"
+                              id="throughput"
+                              isDisabled={false}
+                              isIconOnly={false}
+                              isSelected={false}
+                              key="2"
+                              label="Request Rate"
+                              name="random_html_id"
+                              onChange={[Function]}
+                              size="s"
+                            >
+                              <EuiButtonDisplay
+                                baseClassName="euiButtonGroupButton"
+                                className=""
+                                color="text"
+                                element="label"
+                                fill={false}
+                                htmlFor="random_html_id"
+                                isDisabled={false}
+                                onClick={[Function]}
+                                size="s"
+                                textProps={
+                                  Object {
+                                    "className": "euiButtonGroupButton__textShift",
+                                    "data-text": "Request Rate",
+                                    "ref": [Function],
+                                    "title": "Request Rate",
+                                  }
+                                }
+                              >
+                                <label
+                                  className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                                  disabled={false}
+                                  htmlFor="random_html_id"
+                                  onClick={[Function]}
+                                  style={
+                                    Object {
+                                      "minWidth": undefined,
+                                    }
+                                  }
                                 >
-                                  <EuiButtonDisplay
-                                    baseClassName="euiButtonGroupButton"
-                                    className=""
-                                    color="text"
-                                    element="label"
-                                    fill={false}
-                                    htmlFor="random_html_id"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="s"
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
                                     textProps={
                                       Object {
-                                        "className": "euiButtonGroupButton__textShift",
+                                        "className": "euiButton__text euiButtonGroupButton__textShift",
                                         "data-text": "Request Rate",
                                         "ref": [Function],
                                         "title": "Request Rate",
                                       }
                                     }
                                   >
-                                    <label
-                                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                                      disabled={false}
-                                      htmlFor="random_html_id"
-                                      onClick={[Function]}
-                                      style={
-                                        Object {
-                                          "minWidth": undefined,
-                                        }
-                                      }
+                                    <span
+                                      className="euiButtonContent euiButton__content"
                                     >
-                                      <EuiButtonContent
-                                        className="euiButton__content"
-                                        iconSide="left"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                                            "data-text": "Request Rate",
-                                            "ref": [Function],
-                                            "title": "Request Rate",
-                                          }
-                                        }
+                                      <span
+                                        className="euiButton__text euiButtonGroupButton__textShift"
+                                        data-text="Request Rate"
+                                        title="Request Rate"
                                       >
-                                        <span
-                                          className="euiButtonContent euiButton__content"
-                                        >
-                                          <span
-                                            className="euiButton__text euiButtonGroupButton__textShift"
-                                            data-text="Request Rate"
-                                            title="Request Rate"
-                                          >
-                                            <input
-                                              checked={false}
-                                              className="euiScreenReaderOnly"
-                                              data-test-subj="throughput"
-                                              disabled={false}
-                                              id="random_html_id"
-                                              name="random_html_id"
-                                              onChange={[Function]}
-                                              type="radio"
-                                            />
-                                            Request Rate
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </label>
-                                  </EuiButtonDisplay>
-                                </EuiButtonGroupButton>
-                              </div>
-                            </fieldset>
-                          </EuiButtonGroup>
-                          <EuiHorizontalRule
-                            margin="m"
-                          >
-                            <hr
-                              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                            />
-                          </EuiHorizontalRule>
-                          <EuiFlexGroup
-                            alignItems="center"
-                            gutterSize="s"
+                                        <input
+                                          checked={false}
+                                          className="euiScreenReaderOnly"
+                                          data-test-subj="throughput"
+                                          disabled={false}
+                                          id="random_html_id"
+                                          name="random_html_id"
+                                          onChange={[Function]}
+                                          type="radio"
+                                        />
+                                        Request Rate
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </label>
+                              </EuiButtonDisplay>
+                            </EuiButtonGroupButton>
+                          </div>
+                        </fieldset>
+                      </EuiButtonGroup>
+                      <EuiHorizontalRule
+                        margin="m"
+                      >
+                        <hr
+                          className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                        />
+                      </EuiHorizontalRule>
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <EuiFlexItem
-                                grow={false}
-                              >
+                              <EuiText>
                                 <div
-                                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                                  className="euiText euiText--medium"
                                 >
+                                  Focus on
+                                </div>
+                              </EuiText>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                fullWidth={false}
+                                incremental={false}
+                                isClearable={true}
+                                isInvalid={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Service name"
+                                value=""
+                              >
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={false}
+                                  icon="search"
+                                  isLoading={false}
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed"
+                                  >
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl
+                                        isInvalid={false}
+                                      >
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--compressed"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <span
+                                              className="euiFormControlLayoutCustomIcon"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
+                                              >
+                                                <EuiIconSearch
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconSearch>
+                                              </EuiIcon>
+                                            </span>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                      <EuiSpacer>
+                        <div
+                          className="euiSpacer euiSpacer--l"
+                        />
+                      </EuiSpacer>
+                      <div
+                        style={
+                          Object {
+                            "minHeight": 434,
+                          }
+                        }
+                      >
+                        <NoMatchMessage
+                          size="s"
+                        >
+                          <EuiSpacer
+                            size="s"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--s"
+                            />
+                          </EuiSpacer>
+                          <EuiEmptyPrompt
+                            body={
+                              <EuiText
+                                size="s"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </EuiText>
+                            }
+                            title={
+                              <h2>
+                                No matches
+                              </h2>
+                            }
+                          >
+                            <div
+                              className="euiEmptyPrompt"
+                            >
+                              <EuiTitle
+                                size="m"
+                              >
+                                <h2
+                                  className="euiTitle euiTitle--medium"
+                                >
+                                  No matches
+                                </h2>
+                              </EuiTitle>
+                              <EuiTextColor
+                                color="subdued"
+                              >
+                                <span
+                                  className="euiTextColor euiTextColor--subdued"
+                                >
+                                  <EuiSpacer
+                                    size="m"
+                                  >
+                                    <div
+                                      className="euiSpacer euiSpacer--m"
+                                    />
+                                  </EuiSpacer>
                                   <EuiText>
                                     <div
                                       className="euiText euiText--medium"
                                     >
-                                      Focus on
-                                    </div>
-                                  </EuiText>
-                                </div>
-                              </EuiFlexItem>
-                              <EuiFlexItem>
-                                <div
-                                  className="euiFlexItem"
-                                >
-                                  <EuiCompressedFieldSearch
-                                    compressed={true}
-                                    fullWidth={false}
-                                    incremental={false}
-                                    isClearable={true}
-                                    isInvalid={false}
-                                    isLoading={false}
-                                    onChange={[Function]}
-                                    onSearch={[Function]}
-                                    placeholder="Service name"
-                                    value=""
-                                  >
-                                    <EuiFormControlLayout
-                                      compressed={true}
-                                      fullWidth={false}
-                                      icon="search"
-                                      isLoading={false}
-                                    >
-                                      <div
-                                        className="euiFormControlLayout euiFormControlLayout--compressed"
+                                      <EuiText
+                                        size="s"
                                       >
                                         <div
-                                          className="euiFormControlLayout__childrenWrapper"
+                                          className="euiText euiText--small"
                                         >
-                                          <EuiValidatableControl
-                                            isInvalid={false}
-                                          >
-                                            <input
-                                              className="euiFieldSearch euiFieldSearch--compressed"
-                                              onChange={[Function]}
-                                              onKeyUp={[Function]}
-                                              placeholder="Service name"
-                                              type="search"
-                                              value=""
-                                            />
-                                          </EuiValidatableControl>
-                                          <EuiFormControlLayoutIcons
-                                            compressed={true}
-                                            icon="search"
-                                            isLoading={false}
-                                          >
-                                            <div
-                                              className="euiFormControlLayoutIcons"
-                                            >
-                                              <EuiFormControlLayoutCustomIcon
-                                                size="s"
-                                                type="search"
-                                              >
-                                                <span
-                                                  className="euiFormControlLayoutCustomIcon"
-                                                >
-                                                  <EuiIcon
-                                                    aria-hidden="true"
-                                                    className="euiFormControlLayoutCustomIcon__icon"
-                                                    size="s"
-                                                    type="search"
-                                                  >
-                                                    <EuiIconSearch
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                                      focusable="false"
-                                                      role="img"
-                                                      style={null}
-                                                    >
-                                                      <svg
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                                        focusable="false"
-                                                        height={16}
-                                                        role="img"
-                                                        style={null}
-                                                        viewBox="0 0 16 16"
-                                                        width={16}
-                                                        xmlns="http://www.w3.org/2000/svg"
-                                                      >
-                                                        <path
-                                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                                        />
-                                                      </svg>
-                                                    </EuiIconSearch>
-                                                  </EuiIcon>
-                                                </span>
-                                              </EuiFormControlLayoutCustomIcon>
-                                            </div>
-                                          </EuiFormControlLayoutIcons>
-                                        </div>
-                                      </div>
-                                    </EuiFormControlLayout>
-                                  </EuiCompressedFieldSearch>
-                                </div>
-                              </EuiFlexItem>
-                            </div>
-                          </EuiFlexGroup>
-                          <EuiSpacer>
-                            <div
-                              className="euiSpacer euiSpacer--l"
-                            />
-                          </EuiSpacer>
-                          <div
-                            style={
-                              Object {
-                                "minHeight": 434,
-                              }
-                            }
-                          >
-                            <NoMatchMessage
-                              size="s"
-                            >
-                              <EuiSpacer
-                                size="s"
-                              >
-                                <div
-                                  className="euiSpacer euiSpacer--s"
-                                />
-                              </EuiSpacer>
-                              <EuiEmptyPrompt
-                                body={
-                                  <EuiText
-                                    size="s"
-                                  >
-                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                  </EuiText>
-                                }
-                                title={
-                                  <h2>
-                                    No matches
-                                  </h2>
-                                }
-                              >
-                                <div
-                                  className="euiEmptyPrompt"
-                                >
-                                  <EuiTitle
-                                    size="m"
-                                  >
-                                    <h2
-                                      className="euiTitle euiTitle--medium"
-                                    >
-                                      No matches
-                                    </h2>
-                                  </EuiTitle>
-                                  <EuiTextColor
-                                    color="subdued"
-                                  >
-                                    <span
-                                      className="euiTextColor euiTextColor--subdued"
-                                    >
-                                      <EuiSpacer
-                                        size="m"
-                                      >
-                                        <div
-                                          className="euiSpacer euiSpacer--m"
-                                        />
-                                      </EuiSpacer>
-                                      <EuiText>
-                                        <div
-                                          className="euiText euiText--medium"
-                                        >
-                                          <EuiText
-                                            size="s"
-                                          >
-                                            <div
-                                              className="euiText euiText--small"
-                                            >
-                                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                            </div>
-                                          </EuiText>
+                                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                                         </div>
                                       </EuiText>
-                                    </span>
-                                  </EuiTextColor>
-                                </div>
-                              </EuiEmptyPrompt>
-                              <EuiSpacer
-                                size="s"
-                              >
-                                <div
-                                  className="euiSpacer euiSpacer--s"
-                                />
-                              </EuiSpacer>
-                            </NoMatchMessage>
-                          </div>
-                        </div>
-                      </EuiPanel>
-                      <EuiSpacer
-                        size="xl"
-                      >
-                        <div
-                          className="euiSpacer euiSpacer--xl"
-                        />
-                      </EuiSpacer>
+                                    </div>
+                                  </EuiText>
+                                </span>
+                              </EuiTextColor>
+                            </div>
+                          </EuiEmptyPrompt>
+                          <EuiSpacer
+                            size="s"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--s"
+                            />
+                          </EuiSpacer>
+                        </NoMatchMessage>
+                      </div>
                     </div>
-                  </EuiPage>
+                  </EuiPanel>
+                  <EuiSpacer
+                    size="xl"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--xl"
+                    />
+                  </EuiSpacer>
                 </ServiceMap>
               </div>
             </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -371,6 +371,7 @@ exports[`Service Config component renders empty service config 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -776,6 +777,7 @@ exports[`Service Config component renders empty service config 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {
@@ -856,6 +858,7 @@ exports[`Service Config component renders empty service config 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {
@@ -936,6 +939,7 @@ exports[`Service Config component renders empty service config 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {
@@ -1595,6 +1599,7 @@ exports[`Service Config component renders with one service selected 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -2001,6 +2006,7 @@ exports[`Service Config component renders with one service selected 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {
@@ -2081,6 +2087,7 @@ exports[`Service Config component renders with one service selected 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {
@@ -2161,6 +2168,7 @@ exports[`Service Config component renders with one service selected 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {

--- a/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
@@ -367,6 +367,7 @@ exports[`Trace Config component renders empty trace config 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -1304,6 +1305,7 @@ exports[`Trace Config component renders with one trace selected 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {

--- a/public/components/common/live_tail/__tests__/__snapshots__/live_tail_button.test.tsx.snap
+++ b/public/components/common/live_tail/__tests__/__snapshots__/live_tail_button.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`Live tail button change live tail to 10s interval 1`] = `
         >
           <EuiButtonContent
             className="euiButton__content"
+            iconGap="m"
             iconSide="left"
             iconType="stop"
             textProps={
@@ -150,6 +151,7 @@ exports[`Live tail button starts live tail with 5s interval 1`] = `
         >
           <EuiButtonContent
             className="euiButton__content"
+            iconGap="m"
             iconSide="left"
             iconType="stop"
             textProps={
@@ -249,6 +251,7 @@ exports[`Live tail off button stop live tail 1`] = `
         >
           <EuiButtonContent
             className="euiButton__content"
+            iconGap="m"
             iconSide="left"
             iconType="stop"
             textProps={

--- a/public/components/common/search/__tests__/__snapshots__/search.test.tsx.snap
+++ b/public/components/common/search/__tests__/__snapshots__/search.test.tsx.snap
@@ -111,6 +111,7 @@ exports[`Explorer Search component renders basic component 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButton__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconType="arrowDown"
                                       textProps={
@@ -645,6 +646,7 @@ exports[`Explorer Search component renders basic component 1`] = `
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButtonEmpty__content"
+                                                    iconGap="m"
                                                     iconSide="right"
                                                     iconSize="s"
                                                     iconType="arrowDown"
@@ -840,6 +842,7 @@ exports[`Explorer Search component renders basic component 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     iconType="play"
                                     textProps={
@@ -963,6 +966,7 @@ exports[`Explorer Search component renders basic component 1`] = `
                                     >
                                       <EuiButtonContent
                                         className="euiButton__content"
+                                        iconGap="m"
                                         iconSide="left"
                                         iconType="clock"
                                         textProps={

--- a/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
+++ b/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
@@ -1440,6 +1440,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                     >
                                       <EuiButtonContent
                                         className="euiButton__content"
+                                        iconGap="m"
                                         iconSide="left"
                                         iconType="pencil"
                                         textProps={
@@ -1569,6 +1570,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                           >
                                             <EuiButtonContent
                                               className="euiButton__content"
+                                              iconGap="m"
                                               iconSide="right"
                                               iconType="arrowDown"
                                               textProps={
@@ -1706,6 +1708,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                             >
                                               <EuiButtonContent
                                                 className="euiButton__content"
+                                                iconGap="m"
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 textProps={
@@ -2276,6 +2279,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                                   >
                                                     <EuiButtonContent
                                                       className="euiButtonEmpty__content"
+                                                      iconGap="m"
                                                       iconSide="right"
                                                       iconSize="s"
                                                       iconType="arrowDown"
@@ -2479,6 +2483,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   iconType="refresh"
                                                   isLoading={false}
@@ -2706,6 +2711,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                             >
                                               <EuiButtonContent
                                                 className="euiButton__content"
+                                                iconGap="m"
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 textProps={
@@ -3794,6 +3800,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                     >
                                       <EuiButtonContent
                                         className="euiButton__content"
+                                        iconGap="m"
                                         iconSide="left"
                                         iconType="pencil"
                                         textProps={
@@ -3923,6 +3930,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                           >
                                             <EuiButtonContent
                                               className="euiButton__content"
+                                              iconGap="m"
                                               iconSide="right"
                                               iconType="arrowDown"
                                               textProps={
@@ -4059,6 +4067,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                             >
                                               <EuiButtonContent
                                                 className="euiButton__content"
+                                                iconGap="m"
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 textProps={
@@ -4628,6 +4637,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                                   >
                                                     <EuiButtonContent
                                                       className="euiButtonEmpty__content"
+                                                      iconGap="m"
                                                       iconSide="right"
                                                       iconSize="s"
                                                       iconType="arrowDown"
@@ -4829,6 +4839,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   iconType="refresh"
                                                   isLoading={false}
@@ -5056,6 +5067,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                             >
                                               <EuiButtonContent
                                                 className="euiButton__content"
+                                                iconGap="m"
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 textProps={

--- a/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`Empty panel view component renders empty panel view with disabled popov
                           >
                             <EuiButtonContent
                               className="euiButton__content"
+                              iconGap="m"
                               iconSide="right"
                               iconType="arrowDown"
                               textProps={
@@ -375,6 +376,7 @@ exports[`Empty panel view component renders empty panel view with enabled popove
                           >
                             <EuiButtonContent
                               className="euiButton__content"
+                              iconGap="m"
                               iconSide="right"
                               iconType="arrowDown"
                               textProps={

--- a/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
@@ -1127,6 +1127,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   textProps={
                                                     Object {
@@ -1192,6 +1193,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   textProps={
                                                     Object {
@@ -2446,6 +2448,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   textProps={
                                                     Object {
@@ -2511,6 +2514,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   textProps={
                                                     Object {

--- a/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout_so.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout_so.test.tsx.snap
@@ -1138,6 +1138,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButton__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     textProps={
                                                       Object {
@@ -1203,6 +1204,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButton__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     textProps={
                                                       Object {
@@ -2452,6 +2454,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButton__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     textProps={
                                                       Object {
@@ -2517,6 +2520,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButton__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     textProps={
                                                       Object {

--- a/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
@@ -264,6 +264,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             iconType="refresh"
                             isLoading={false}
@@ -364,6 +365,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             textProps={
                               Object {
@@ -1277,6 +1279,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButtonEmpty__content"
+                                                    iconGap="m"
                                                     iconSide="right"
                                                     iconSize="m"
                                                     iconType="arrowDown"
@@ -1634,6 +1637,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                   >
                                                     <EuiButtonContent
                                                       className="euiButtonEmpty__content"
+                                                      iconGap="m"
                                                       iconSide="right"
                                                       iconSize="s"
                                                       iconType="arrowDown"
@@ -4576,6 +4580,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               >
                                                 <EuiButtonContent
                                                   className="euiButtonEmpty__content"
+                                                  iconGap="m"
                                                   iconSide="right"
                                                   iconSize="s"
                                                   iconType="arrowDown"
@@ -4779,6 +4784,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButtonEmpty__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             iconSize="m"
                                                             textProps={
@@ -5160,6 +5166,7 @@ exports[`AssociatedObjectsTab Component renders tab with no databases or objects
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             iconType="refresh"
                             isLoading={false}
@@ -5260,6 +5267,7 @@ exports[`AssociatedObjectsTab Component renders tab with no databases or objects
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             textProps={
                               Object {
@@ -5389,6 +5397,7 @@ exports[`AssociatedObjectsTab Component renders tab with no databases or objects
                   >
                     <EuiButtonContent
                       className="euiButton__content"
+                      iconGap="m"
                       iconSide="right"
                       iconType="popout"
                       textProps={

--- a/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
@@ -140,6 +140,7 @@ exports[`Installed Integrations Table test Renders the empty installed integrati
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             textProps={
                               Object {
@@ -368,6 +369,7 @@ exports[`Installed Integrations Table test Renders the installed integrations ta
                       >
                         <EuiButtonContent
                           className="euiButton__content"
+                          iconGap="m"
                           iconSide="left"
                           textProps={
                             Object {

--- a/public/components/datasources/components/__tests__/__snapshots__/manage_data_connections_description.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/manage_data_connections_description.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`Manage Data Connections Description test Renders manage data connection
                   >
                     <EuiButtonContent
                       className="euiButton__content"
+                      iconGap="m"
                       iconSide="left"
                       iconType="refresh"
                       textProps={

--- a/public/components/datasources/components/__tests__/__snapshots__/no_access.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/no_access.test.tsx.snap
@@ -146,6 +146,7 @@ exports[`No access test Renders no access view of data source 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {

--- a/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_header.test.tsx.snap
+++ b/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_header.test.tsx.snap
@@ -689,6 +689,7 @@ exports[`Patterns header component Renders header of log patterns 1`] = `
                                                     >
                                                       <EuiButtonContent
                                                         className="euiButtonEmpty__content"
+                                                        iconGap="m"
                                                         iconSide="left"
                                                         iconSize="m"
                                                         textProps={
@@ -745,6 +746,7 @@ exports[`Patterns header component Renders header of log patterns 1`] = `
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {

--- a/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_table.test.tsx.snap
+++ b/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_table.test.tsx.snap
@@ -331,6 +331,7 @@ exports[`Pattern table component Renders pattern table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -1001,6 +1002,7 @@ exports[`Pattern table component Renders pattern table 1`] = `
                               >
                                 <EuiButtonContent
                                   className="euiButtonEmpty__content"
+                                  iconGap="m"
                                   iconSide="right"
                                   iconSize="s"
                                   iconType="arrowDown"
@@ -1204,6 +1206,7 @@ exports[`Pattern table component Renders pattern table 1`] = `
                                         >
                                           <EuiButtonContent
                                             className="euiButtonEmpty__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconSize="m"
                                             textProps={

--- a/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/__snapshots__/config_panel.test.tsx.snap
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/__snapshots__/config_panel.test.tsx.snap
@@ -9270,6 +9270,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButton__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             textProps={
                                                               Object {
@@ -9350,6 +9351,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButton__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             textProps={
                                                               Object {
@@ -9563,6 +9565,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButton__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             textProps={
                                                               Object {
@@ -9643,6 +9646,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButton__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             textProps={
                                                               Object {
@@ -9723,6 +9727,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButton__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             textProps={
                                                               Object {
@@ -10748,6 +10753,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -10828,6 +10834,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -11022,6 +11029,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -11102,6 +11110,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -12262,6 +12271,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -12342,6 +12352,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -15242,6 +15253,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                             >
                                               <EuiButtonContent
                                                 className="euiButton__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 textProps={
                                                   Object {

--- a/public/components/event_analytics/home/__tests__/__snapshots__/saved_query_table.test.tsx.snap
+++ b/public/components/event_analytics/home/__tests__/__snapshots__/saved_query_table.test.tsx.snap
@@ -496,6 +496,7 @@ exports[`Saved query table component Renders saved query table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="m"
                                       iconType="arrowDown"
@@ -1467,6 +1468,7 @@ exports[`Saved query table component Renders saved query table 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
                                     iconSize="s"
                                     iconType="arrowDown"
@@ -1670,6 +1672,7 @@ exports[`Saved query table component Renders saved query table 1`] = `
                                           >
                                             <EuiButtonContent
                                               className="euiButtonEmpty__content"
+                                              iconGap="m"
                                               iconSide="left"
                                               iconSize="m"
                                               textProps={

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -824,6 +824,7 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                                               >
                                                 <EuiButtonContent
                                                   className="euiButtonEmpty__content"
+                                                  iconGap="m"
                                                   iconSide="right"
                                                   iconSize="m"
                                                   iconType="arrowDown"

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration_flyout.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration_flyout.test.tsx.snap
@@ -1792,6 +1792,7 @@ exports[`Add Integration Flyout Test Renders add integration flyout with dummy i
                                                           >
                                                             <EuiButtonContent
                                                               className="euiButton__content"
+                                                              iconGap="m"
                                                               iconSide="left"
                                                               textProps={
                                                                 Object {
@@ -1986,6 +1987,7 @@ exports[`Add Integration Flyout Test Renders add integration flyout with dummy i
                                           >
                                             <EuiButtonContent
                                               className="euiButton__content"
+                                              iconGap="m"
                                               iconSide="left"
                                               textProps={
                                                 Object {
@@ -2055,6 +2057,7 @@ exports[`Add Integration Flyout Test Renders add integration flyout with dummy i
                                           >
                                             <EuiButtonContent
                                               className="euiButton__content"
+                                              iconGap="m"
                                               iconSide="left"
                                               textProps={
                                                 Object {

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration_table.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration_table.test.tsx.snap
@@ -477,6 +477,7 @@ exports[`Added Integration Table View Test Renders added integration table view 
                                         >
                                           <EuiButtonContent
                                             className="euiButtonEmpty__content"
+                                            iconGap="m"
                                             iconSide="right"
                                             iconSize="m"
                                             iconType="arrowDown"
@@ -1189,6 +1190,7 @@ exports[`Added Integration Table View Test Renders added integration table view 
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -1392,6 +1394,7 @@ exports[`Added Integration Table View Test Renders added integration table view 
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButtonEmpty__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     iconSize="m"
                                                     textProps={

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
@@ -257,6 +257,7 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             iconType="list"
                             textProps={
@@ -379,6 +380,7 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             iconType="grid"
                             textProps={

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
@@ -457,6 +457,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                         >
                                           <EuiButtonContent
                                             className="euiButton__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconType="list"
                                             textProps={
@@ -579,6 +580,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                         >
                                           <EuiButtonContent
                                             className="euiButton__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconType="grid"
                                             textProps={
@@ -1222,6 +1224,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -1425,6 +1428,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButtonEmpty__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     iconSize="m"
                                                     textProps={

--- a/public/components/integrations/components/__tests__/__snapshots__/integration_header.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/integration_header.test.tsx.snap
@@ -94,6 +94,7 @@ exports[`Integration Header Test Renders integration header as expected 1`] = `
                           >
                             <EuiButtonContent
                               className="euiButton__content"
+                              iconGap="m"
                               iconSide="left"
                               iconType="arrowDown"
                               textProps={

--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -982,6 +982,7 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                                     >
                                       <EuiButtonContent
                                         className="euiButtonEmpty__content"
+                                        iconGap="m"
                                         iconSide="left"
                                         iconSize="m"
                                         iconType="cross"
@@ -1089,6 +1090,7 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                                       >
                                         <EuiButtonContent
                                           className="euiButton__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconType="arrowRight"
                                           isLoading={false}

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`Export Metrics Panel Component renders Export Metrics Panel Component 1
                     >
                       <EuiButtonContent
                         className="euiButton__content"
+                        iconGap="m"
                         iconSide="right"
                         iconType="arrowDown"
                         textProps={

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/top_menu.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/top_menu.test.tsx.snap
@@ -645,6 +645,7 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="right"
                                                 iconSize="s"
                                                 iconType="arrowDown"
@@ -846,6 +847,7 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                                         >
                                           <EuiButtonContent
                                             className="euiButton__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconType="refresh"
                                             isLoading={false}
@@ -980,6 +982,7 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                                       >
                                         <EuiButtonContent
                                           className="euiButton__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconType="arrowDown"
                                           textProps={

--- a/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -399,10 +399,11 @@ exports[`Search bar components renders search bar 1`] = `
   startTime="now-5m"
 >
   <EuiFlexGroup
+    alignItems="center"
     gutterSize="s"
   >
     <div
-      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <EuiFlexItem>
         <div
@@ -418,6 +419,12 @@ exports[`Search bar components renders search bar 1`] = `
             onChange={[Function]}
             onSearch={[MockFunction]}
             placeholder="Trace ID, trace group name, service name"
+            prepend={
+              <GlobalFilterButton
+                filters={Array []}
+                setFilters={[MockFunction]}
+              />
+            }
             value="test"
           >
             <EuiFormControlLayout
@@ -425,16 +432,112 @@ exports[`Search bar components renders search bar 1`] = `
               fullWidth={true}
               icon="search"
               isLoading={false}
+              prepend={
+                <GlobalFilterButton
+                  filters={Array []}
+                  setFilters={[MockFunction]}
+                />
+              }
             >
               <div
-                className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
               >
+                <GlobalFilterButton
+                  className="euiFormControlLayout__prepend"
+                  filters={Array []}
+                  key="0/.0"
+                  setFilters={[MockFunction]}
+                >
+                  <EuiPopover
+                    anchorPosition="rightUp"
+                    button={
+                      <EuiSmallButtonIcon
+                        aria-label="Change all filters"
+                        iconType="filter"
+                        onClick={[Function]}
+                        title="Change all filters"
+                      />
+                    }
+                    closePopover={[Function]}
+                    data-test-subj="global-filter-button"
+                    display="inlineBlock"
+                    hasArrow={true}
+                    isOpen={false}
+                    ownFocus={true}
+                    panelPaddingSize="none"
+                  >
+                    <div
+                      className="euiPopover euiPopover--anchorRightUp"
+                      data-test-subj="global-filter-button"
+                    >
+                      <div
+                        className="euiPopover__anchor"
+                      >
+                        <EuiSmallButtonIcon
+                          aria-label="Change all filters"
+                          iconType="filter"
+                          onClick={[Function]}
+                          title="Change all filters"
+                        >
+                          <EuiButtonIcon
+                            aria-label="Change all filters"
+                            iconType="filter"
+                            onClick={[Function]}
+                            size="s"
+                            title="Change all filters"
+                          >
+                            <button
+                              aria-label="Change all filters"
+                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                              disabled={false}
+                              onClick={[Function]}
+                              title="Change all filters"
+                              type="button"
+                            >
+                              <EuiIcon
+                                aria-hidden="true"
+                                className="euiButtonIcon__icon"
+                                color="inherit"
+                                size="m"
+                                type="filter"
+                              >
+                                <EuiIconBeaker
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  role="img"
+                                  style={null}
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
+                                </EuiIconBeaker>
+                              </EuiIcon>
+                            </button>
+                          </EuiButtonIcon>
+                        </EuiSmallButtonIcon>
+                      </div>
+                    </div>
+                  </EuiPopover>
+                </GlobalFilterButton>
                 <div
                   className="euiFormControlLayout__childrenWrapper"
                 >
                   <EuiValidatableControl>
                     <input
-                      className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
+                      className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
                       data-test-subj="search-bar-input-box"
                       onChange={[Function]}
                       onKeyUp={[Function]}
@@ -502,7 +605,7 @@ exports[`Search bar components renders search bar 1`] = `
         grow={false}
         style={
           Object {
-            "maxWidth": "40vw",
+            "maxWidth": "30vw",
           }
         }
       >
@@ -510,7 +613,7 @@ exports[`Search bar components renders search bar 1`] = `
           className="euiFlexItem euiFlexItem--flexGrowZero"
           style={
             Object {
-              "maxWidth": "40vw",
+              "maxWidth": "30vw",
             }
           }
         >
@@ -559,8 +662,8 @@ exports[`Search bar components renders search bar 1`] = `
                 },
               ]
             }
-            compressed={false}
-            dateFormat=""
+            compressed={true}
+            dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
             end="now"
             isAutoRefreshOnly={false}
             isDisabled={false}
@@ -586,7 +689,7 @@ exports[`Search bar components renders search bar 1`] = `
                   >
                     <EuiFormControlLayout
                       className="euiSuperDatePicker"
-                      compressed={false}
+                      compressed={true}
                       isDisabled={false}
                       prepend={
                         <EuiQuickSelectPopover
@@ -635,7 +738,7 @@ exports[`Search bar components renders search bar 1`] = `
                               },
                             ]
                           }
-                          dateFormat=""
+                          dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
                           end="now"
                           isAutoRefreshOnly={false}
                           isDisabled={false}
@@ -647,7 +750,7 @@ exports[`Search bar components renders search bar 1`] = `
                       }
                     >
                       <div
-                        className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                        className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
                       >
                         <EuiQuickSelectPopover
                           applyTime={[Function]}
@@ -696,7 +799,7 @@ exports[`Search bar components renders search bar 1`] = `
                               },
                             ]
                           }
-                          dateFormat=""
+                          dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
                           end="now"
                           isAutoRefreshOnly={false}
                           isDisabled={false}
@@ -865,7 +968,7 @@ exports[`Search bar components renders search bar 1`] = `
                               className="euiDatePickerRange euiDatePickerRange--inGroup"
                             >
                               <button
-                                className="euiSuperDatePicker__prettyFormat"
+                                className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
                                 data-test-subj="superDatePickerShowDatesButton"
                                 disabled={false}
                                 onClick={[Function]}
@@ -885,7 +988,7 @@ exports[`Search bar components renders search bar 1`] = `
                             </div>
                           </EuiDatePickerRange>
                           <EuiFormControlLayoutIcons
-                            compressed={false}
+                            compressed={true}
                           />
                         </div>
                       </div>
@@ -903,304 +1006,60 @@ exports[`Search bar components renders search bar 1`] = `
         <div
           className="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <EuiSmallButton
+          <EuiButtonIcon
+            aria-label="Refresh"
             data-click-metric-element="trace_analytics.refresh_button"
             data-test-subj="superDatePickerApplyTimeButton"
+            display="base"
             iconType="refresh"
             onClick={[Function]}
+            size="s"
           >
-            <EuiButton
+            <button
+              aria-label="Refresh"
+              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
               data-click-metric-element="trace_analytics.refresh_button"
               data-test-subj="superDatePickerApplyTimeButton"
-              iconType="refresh"
+              disabled={false}
               onClick={[Function]}
-              size="s"
+              type="button"
             >
-              <EuiButtonDisplay
-                baseClassName="euiButton"
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                disabled={false}
-                element="button"
-                iconType="refresh"
-                isDisabled={false}
-                onClick={[Function]}
-                size="s"
-                type="button"
+              <EuiIcon
+                aria-hidden="true"
+                className="euiButtonIcon__icon"
+                color="inherit"
+                size="m"
+                type="refresh"
               >
-                <button
-                  className="euiButton euiButton--primary euiButton--small"
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  disabled={false}
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "minWidth": undefined,
-                    }
-                  }
-                  type="button"
+                <EuiIconBeaker
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                  focusable="false"
+                  role="img"
+                  style={null}
                 >
-                  <EuiButtonContent
-                    className="euiButton__content"
-                    iconSide="left"
-                    iconType="refresh"
-                    textProps={
-                      Object {
-                        "className": "euiButton__text",
-                      }
-                    }
+                  <svg
+                    aria-hidden={true}
+                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                    focusable="false"
+                    height={16}
+                    role="img"
+                    style={null}
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <span
-                      className="euiButtonContent euiButton__content"
-                    >
-                      <EuiIcon
-                        className="euiButtonContent__icon"
-                        color="inherit"
-                        size="m"
-                        type="refresh"
-                      >
-                        <EuiIconBeaker
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                          focusable="false"
-                          role="img"
-                          style={null}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                            focusable="false"
-                            height={16}
-                            role="img"
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                            />
-                          </svg>
-                        </EuiIconBeaker>
-                      </EuiIcon>
-                      <span
-                        className="euiButton__text"
-                      >
-                        Refresh
-                      </span>
-                    </span>
-                  </EuiButtonContent>
-                </button>
-              </EuiButtonDisplay>
-            </EuiButton>
-          </EuiSmallButton>
+                    <path
+                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                    />
+                  </svg>
+                </EuiIconBeaker>
+              </EuiIcon>
+            </button>
+          </EuiButtonIcon>
         </div>
       </EuiFlexItem>
     </div>
   </EuiFlexGroup>
-  <EuiSpacer
-    size="s"
-  >
-    <div
-      className="euiSpacer euiSpacer--s"
-    />
-  </EuiSpacer>
-  <Filters
-    appConfigs={Array []}
-    attributesFilterFields={Array []}
-    filters={Array []}
-    mode="data_prepper"
-    page="dashboard"
-    setFilters={[MockFunction]}
-  >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="xs"
-      responsive={false}
-      style={
-        Object {
-          "minHeight": 32,
-        }
-      }
-    >
-      <div
-        className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-        style={
-          Object {
-            "minHeight": 32,
-          }
-        }
-      >
-        <EuiFlexItem
-          grow={false}
-        >
-          <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <GlobalFilterButton>
-              <EuiPopover
-                anchorPosition="rightUp"
-                button={
-                  <EuiSmallButtonIcon
-                    aria-label="Change all filters"
-                    iconType="filter"
-                    onClick={[Function]}
-                    title="Change all filters"
-                  />
-                }
-                closePopover={[Function]}
-                data-test-subj="global-filter-button"
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="none"
-                withTitle={true}
-              >
-                <div
-                  className="euiPopover euiPopover--anchorRightUp"
-                  data-test-subj="global-filter-button"
-                  withTitle={true}
-                >
-                  <div
-                    className="euiPopover__anchor"
-                  >
-                    <EuiSmallButtonIcon
-                      aria-label="Change all filters"
-                      iconType="filter"
-                      onClick={[Function]}
-                      title="Change all filters"
-                    >
-                      <EuiButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        size="s"
-                        title="Change all filters"
-                      >
-                        <button
-                          aria-label="Change all filters"
-                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                          disabled={false}
-                          onClick={[Function]}
-                          title="Change all filters"
-                          type="button"
-                        >
-                          <EuiIcon
-                            aria-hidden="true"
-                            className="euiButtonIcon__icon"
-                            color="inherit"
-                            size="m"
-                            type="filter"
-                          >
-                            <EuiIconBeaker
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                />
-                              </svg>
-                            </EuiIconBeaker>
-                          </EuiIcon>
-                        </button>
-                      </EuiButtonIcon>
-                    </EuiSmallButtonIcon>
-                  </div>
-                </div>
-              </EuiPopover>
-            </GlobalFilterButton>
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem
-          grow={false}
-        >
-          <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <AddFilterButton>
-              <EuiPopover
-                anchorPosition="downLeft"
-                button={
-                  <EuiButtonEmpty
-                    onClick={[Function]}
-                    size="xs"
-                  >
-                    + Add filter
-                  </EuiButtonEmpty>
-                }
-                closePopover={[Function]}
-                data-test-subj="addfilter"
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="m"
-                withTitle={true}
-              >
-                <div
-                  className="euiPopover euiPopover--anchorDownLeft"
-                  data-test-subj="addfilter"
-                  withTitle={true}
-                >
-                  <div
-                    className="euiPopover__anchor"
-                  >
-                    <EuiButtonEmpty
-                      onClick={[Function]}
-                      size="xs"
-                    >
-                      <button
-                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                        disabled={false}
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <EuiButtonContent
-                          className="euiButtonEmpty__content"
-                          iconSide="left"
-                          iconSize="s"
-                          textProps={
-                            Object {
-                              "className": "euiButtonEmpty__text",
-                            }
-                          }
-                        >
-                          <span
-                            className="euiButtonContent euiButtonEmpty__content"
-                          >
-                            <span
-                              className="euiButtonEmpty__text"
-                            >
-                              + Add filter
-                            </span>
-                          </span>
-                        </EuiButtonContent>
-                      </button>
-                    </EuiButtonEmpty>
-                  </div>
-                </div>
-              </EuiPopover>
-            </AddFilterButton>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
-  </Filters>
 </ForwardRef>
 `;

--- a/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -255,6 +255,7 @@ exports[`Search bar components renders date picker 1`] = `
                         >
                           <EuiButtonContent
                             className="euiButtonEmpty__content"
+                            iconGap="m"
                             iconSide="right"
                             iconSize="s"
                             iconType="arrowDown"
@@ -871,6 +872,7 @@ exports[`Search bar components renders search bar 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
@@ -637,6 +637,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButtonEmpty__content"
+                    iconGap="m"
                     iconSide="left"
                     iconSize="m"
                     textProps={
@@ -700,6 +701,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                   >
                     <EuiButtonContent
                       className="euiButton__content"
+                      iconGap="m"
                       iconSide="left"
                       textProps={
                         Object {

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Filter component renders filters 1`] = `
     style={
       Object {
         "minHeight": 32,
+        "padding": "0 16px",
       }
     }
   >
@@ -22,104 +23,10 @@ exports[`Filter component renders filters 1`] = `
       style={
         Object {
           "minHeight": 32,
+          "padding": "0 16px",
         }
       }
     >
-      <EuiFlexItem
-        grow={false}
-      >
-        <div
-          className="euiFlexItem euiFlexItem--flexGrowZero"
-        >
-          <GlobalFilterButton>
-            <EuiPopover
-              anchorPosition="rightUp"
-              button={
-                <EuiSmallButtonIcon
-                  aria-label="Change all filters"
-                  iconType="filter"
-                  onClick={[Function]}
-                  title="Change all filters"
-                />
-              }
-              closePopover={[Function]}
-              data-test-subj="global-filter-button"
-              display="inlineBlock"
-              hasArrow={true}
-              isOpen={false}
-              ownFocus={true}
-              panelPaddingSize="none"
-              withTitle={true}
-            >
-              <div
-                className="euiPopover euiPopover--anchorRightUp"
-                data-test-subj="global-filter-button"
-                withTitle={true}
-              >
-                <div
-                  className="euiPopover__anchor"
-                >
-                  <EuiSmallButtonIcon
-                    aria-label="Change all filters"
-                    iconType="filter"
-                    onClick={[Function]}
-                    title="Change all filters"
-                  >
-                    <EuiButtonIcon
-                      aria-label="Change all filters"
-                      iconType="filter"
-                      onClick={[Function]}
-                      size="s"
-                      title="Change all filters"
-                    >
-                      <button
-                        aria-label="Change all filters"
-                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                        disabled={false}
-                        onClick={[Function]}
-                        title="Change all filters"
-                        type="button"
-                      >
-                        <EuiIcon
-                          aria-hidden="true"
-                          className="euiButtonIcon__icon"
-                          color="inherit"
-                          size="m"
-                          type="filter"
-                        >
-                          <EuiIconBeaker
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                              />
-                            </svg>
-                          </EuiIconBeaker>
-                        </EuiIcon>
-                      </button>
-                    </EuiButtonIcon>
-                  </EuiSmallButtonIcon>
-                </div>
-              </div>
-            </EuiPopover>
-          </GlobalFilterButton>
-        </div>
-      </EuiFlexItem>
       <EuiFlexItem
         grow={false}
       >
@@ -144,12 +51,10 @@ exports[`Filter component renders filters 1`] = `
               isOpen={false}
               ownFocus={true}
               panelPaddingSize="m"
-              withTitle={true}
             >
               <div
                 className="euiPopover euiPopover--anchorDownLeft"
                 data-test-subj="addfilter"
-                withTitle={true}
               >
                 <div
                   className="euiPopover__anchor"

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`Filter component renders filters 1`] = `
               anchorPosition="downLeft"
               button={
                 <EuiButtonEmpty
+                  flush="left"
                   onClick={[Function]}
                   size="xs"
                 >
@@ -48,11 +49,12 @@ exports[`Filter component renders filters 1`] = `
                   className="euiPopover__anchor"
                 >
                   <EuiButtonEmpty
+                    flush="left"
                     onClick={[Function]}
                     size="xs"
                   >
                     <button
-                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                       disabled={false}
                       onClick={[Function]}
                       type="button"

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
@@ -11,21 +11,9 @@ exports[`Filter component renders filters 1`] = `
     alignItems="center"
     gutterSize="xs"
     responsive={false}
-    style={
-      Object {
-        "minHeight": 32,
-        "padding": "0 16px",
-      }
-    }
   >
     <div
       className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-      style={
-        Object {
-          "minHeight": 32,
-          "padding": "0 16px",
-        }
-      }
     >
       <EuiFlexItem
         grow={false}

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`Filter component renders filters 1`] = `
                     >
                       <EuiButtonContent
                         className="euiButtonEmpty__content"
+                        iconGap="m"
                         iconSide="left"
                         iconSize="s"
                         textProps={

--- a/public/components/trace_analytics/components/common/filters/filters.tsx
+++ b/public/components/trace_analytics/components/common/filters/filters.tsx
@@ -224,12 +224,7 @@ export function Filters(props: FiltersOwnProps) {
   const filterComponents = useMemo(() => renderFilters(), [props.filters]);
 
   return (
-    <EuiFlexGroup
-      gutterSize="xs"
-      alignItems="center"
-      responsive={false}
-      style={{ minHeight: 32, padding: '0 16px' }}
-    >
+    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
       {filterComponents}
       <EuiFlexItem grow={false}>
         <AddFilterButton />

--- a/public/components/trace_analytics/components/common/filters/filters.tsx
+++ b/public/components/trace_analytics/components/common/filters/filters.tsx
@@ -65,75 +65,6 @@ export function Filters(props: FiltersOwnProps) {
     [props.page, props.mode, props.attributesFilterFields]
   );
 
-  const globalPopoverPanels = [
-    {
-      id: 0,
-      title: 'Change all filters',
-      items: [
-        {
-          name: 'Enable all',
-          icon: <EuiIcon type="eye" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              props.filters.map((filter) => ({
-                ...filter,
-                disabled: filter.locked ? filter.disabled : false,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Disable all',
-          icon: <EuiIcon type="eyeClosed" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              props.filters.map((filter) => ({
-                ...filter,
-                disabled: filter.locked ? filter.disabled : true,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Invert inclusion',
-          icon: <EuiIcon type="invert" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              // if filter.custom.query exists, it's a customized filter and "inverted" is alwasy false
-              props.filters.map((filter) => ({
-                ...filter,
-                inverted: filter.locked
-                  ? filter.inverted
-                  : filter.custom?.query
-                  ? false
-                  : !filter.inverted,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Invert enabled/disabled',
-          icon: <EuiIcon type="eye" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              props.filters.map((filter) => ({
-                ...filter,
-                disabled: filter.locked ? filter.disabled : !filter.disabled,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Remove all',
-          icon: <EuiIcon type="trash" size="m" />,
-          onClick: () => {
-            props.setFilters([]);
-          },
-        },
-      ],
-    },
-  ];
-
   const getFilterPopoverPanels = (
     filter: FilterType,
     index: number,
@@ -191,30 +122,6 @@ export function Filters(props: FiltersOwnProps) {
     },
   ];
 
-  const GlobalFilterButton = () => {
-    const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-    return (
-      <EuiPopover
-        isOpen={isPopoverOpen}
-        closePopover={() => setIsPopoverOpen(false)}
-        button={
-          <EuiSmallButtonIcon
-            onClick={() => setIsPopoverOpen(true)}
-            iconType="filter"
-            title="Change all filters"
-            aria-label="Change all filters"
-          />
-        }
-        anchorPosition="rightUp"
-        panelPaddingSize="none"
-        withTitle
-        data-test-subj="global-filter-button"
-      >
-        <EuiContextMenu initialPanelId={0} panels={globalPopoverPanels} />
-      </EuiPopover>
-    );
-  };
-
   const AddFilterButton = () => {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
     const button = (
@@ -235,7 +142,6 @@ export function Filters(props: FiltersOwnProps) {
         closePopover={() => setIsPopoverOpen(false)}
         anchorPosition="downLeft"
         data-test-subj="addfilter"
-        withTitle
       >
         <EuiPopoverTitle>{'Add filter'}</EuiPopoverTitle>
         <FilterEditPopover
@@ -318,10 +224,12 @@ export function Filters(props: FiltersOwnProps) {
   const filterComponents = useMemo(() => renderFilters(), [props.filters]);
 
   return (
-    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} style={{ minHeight: 32 }}>
-      <EuiFlexItem grow={false}>
-        <GlobalFilterButton />
-      </EuiFlexItem>
+    <EuiFlexGroup
+      gutterSize="xs"
+      alignItems="center"
+      responsive={false}
+      style={{ minHeight: 32, padding: '0 16px' }}
+    >
       {filterComponents}
       <EuiFlexItem grow={false}>
         <AddFilterButton />
@@ -329,3 +237,104 @@ export function Filters(props: FiltersOwnProps) {
     </EuiFlexGroup>
   );
 }
+
+export const GlobalFilterButton = ({ filters, setFilters }) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const togglePopover = () => {
+    setIsPopoverOpen(!isPopoverOpen);
+  };
+
+  const globalPopoverPanels = [
+    {
+      id: 0,
+      title: 'Change all filters',
+      items: [
+        {
+          name: 'Enable all',
+          icon: <EuiIcon type="eye" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                disabled: filter.locked ? filter.disabled : false,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Disable all',
+          icon: <EuiIcon type="eyeClosed" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                disabled: filter.locked ? filter.disabled : true,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Invert inclusion',
+          icon: <EuiIcon type="invert" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                inverted: filter.locked
+                  ? filter.inverted
+                  : filter.custom?.query
+                  ? false
+                  : !filter.inverted,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Invert enabled/disabled',
+          icon: <EuiIcon type="eye" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                disabled: filter.locked ? filter.disabled : !filter.disabled,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Remove all',
+          icon: <EuiIcon type="trash" size="m" />,
+          onClick: () => {
+            setFilters([]);
+            togglePopover();
+          },
+        },
+      ],
+    },
+  ];
+
+  return (
+    <EuiPopover
+      isOpen={isPopoverOpen}
+      closePopover={() => setIsPopoverOpen(false)}
+      button={
+        <EuiSmallButtonIcon
+          onClick={togglePopover}
+          iconType="filter"
+          title="Change all filters"
+          aria-label="Change all filters"
+        />
+      }
+      anchorPosition="rightUp"
+      panelPaddingSize="none"
+      data-test-subj="global-filter-button"
+    >
+      <EuiContextMenu initialPanelId={0} panels={globalPopoverPanels} size="s" />
+    </EuiPopover>
+  );
+};

--- a/public/components/trace_analytics/components/common/filters/filters.tsx
+++ b/public/components/trace_analytics/components/common/filters/filters.tsx
@@ -127,6 +127,7 @@ export function Filters(props: FiltersOwnProps) {
     const button = (
       <EuiButtonEmpty
         size="xs"
+        flush="left"
         onClick={() => {
           setIsPopoverOpen(true);
         }}

--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map.test.tsx.snap
@@ -2,371 +2,375 @@
 
 exports[`Service map component renders service map 1`] = `
 <Fragment>
-  <EuiPanel>
-    <PanelTitle
-      title="Service map"
-    />
+  <EuiPage
+    paddingSize="m"
+  >
+    <EuiPanel>
+      <PanelTitle
+        title="Service map"
+      />
+      <EuiSpacer
+        size="m"
+      />
+      <EuiButtonGroup
+        buttonSize="s"
+        color="text"
+        idSelected="latency"
+        onChange={[Function]}
+        options={
+          Array [
+            Object {
+              "id": "latency",
+              "label": "Duration",
+            },
+            Object {
+              "id": "error_rate",
+              "label": "Errors",
+            },
+            Object {
+              "id": "throughput",
+              "label": "Request Rate",
+            },
+          ]
+        }
+      />
+      <EuiHorizontalRule
+        margin="m"
+      />
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="s"
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <EuiText>
+            Focus on
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCompressedFieldSearch
+            compressed={true}
+            fullWidth={false}
+            incremental={false}
+            isClearable={true}
+            isInvalid={false}
+            isLoading={false}
+            onChange={[Function]}
+            onSearch={[Function]}
+            placeholder="Service name"
+            value=""
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer />
+      <EuiFlexGroup
+        gutterSize="none"
+        responsive={false}
+      >
+        <EuiFlexItem>
+          <div
+            style={
+              Object {
+                "position": "relative",
+              }
+            }
+          />
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={false}
+        >
+          <ServiceMapScale
+            idSelected="latency"
+            serviceMap={
+              Object {
+                "analytics-service": Object {
+                  "destServices": Array [
+                    "order",
+                    "inventory",
+                    "authentication",
+                    "payment",
+                    "recommendation",
+                  ],
+                  "error_rate": 0,
+                  "id": 2,
+                  "latency": 12.99,
+                  "serviceName": "analytics-service",
+                  "targetServices": Array [],
+                  "throughput": 37,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "client_cancel_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "client_checkout",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "client_create_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "client_delivery_status",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "client_pay_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "/logs",
+                      ],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+                "authentication": Object {
+                  "destServices": Array [
+                    "frontend-client",
+                  ],
+                  "error_rate": 8.33,
+                  "id": 6,
+                  "latency": 139.09,
+                  "serviceName": "authentication",
+                  "targetServices": Array [
+                    "analytics-service",
+                    "recommendation",
+                  ],
+                  "throughput": 12,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "server_request_login",
+                      ],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+                "database": Object {
+                  "destServices": Array [
+                    "order",
+                    "inventory",
+                  ],
+                  "error_rate": 3.77,
+                  "id": 3,
+                  "latency": 49.54,
+                  "serviceName": "database",
+                  "targetServices": Array [],
+                  "throughput": 53,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "cartEmpty",
+                      ],
+                      "traceGroup": "client_cancel_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "updateItem",
+                      ],
+                      "traceGroup": "client_checkout",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "addItemToCart",
+                      ],
+                      "traceGroup": "client_create_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "getCart",
+                      ],
+                      "traceGroup": "client_delivery_status",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "cartSold",
+                      ],
+                      "traceGroup": "client_pay_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "getIntentory",
+                      ],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+                "frontend-client": Object {
+                  "destServices": Array [],
+                  "error_rate": 7.41,
+                  "id": 4,
+                  "latency": 207.71,
+                  "serviceName": "frontend-client",
+                  "targetServices": Array [
+                    "order",
+                    "payment",
+                    "authentication",
+                  ],
+                  "throughput": 27,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "client_cancel_order",
+                    },
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "client_checkout",
+                    },
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "client_create_order",
+                    },
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "client_delivery_status",
+                    },
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "client_pay_order",
+                    },
+                    Object {
+                      "targetResource": Array [],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+                "inventory": Object {
+                  "destServices": Array [
+                    "payment",
+                    "recommendation",
+                  ],
+                  "error_rate": 3.23,
+                  "id": 5,
+                  "latency": 183.52,
+                  "serviceName": "inventory",
+                  "targetServices": Array [
+                    "analytics-service",
+                    "database",
+                  ],
+                  "throughput": 31,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "update_inventory",
+                      ],
+                      "traceGroup": "client_checkout",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "read_inventory",
+                      ],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+                "order": Object {
+                  "destServices": Array [
+                    "frontend-client",
+                  ],
+                  "error_rate": 4.17,
+                  "id": 1,
+                  "latency": 90.1,
+                  "serviceName": "order",
+                  "targetServices": Array [
+                    "analytics-service",
+                    "database",
+                  ],
+                  "throughput": 48,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "clear_order",
+                      ],
+                      "traceGroup": "client_cancel_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "update_order",
+                      ],
+                      "traceGroup": "client_create_order",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "get_order",
+                      ],
+                      "traceGroup": "client_delivery_status",
+                    },
+                    Object {
+                      "targetResource": Array [
+                        "pay_order",
+                      ],
+                      "traceGroup": "client_pay_order",
+                    },
+                  ],
+                },
+                "payment": Object {
+                  "destServices": Array [
+                    "frontend-client",
+                  ],
+                  "error_rate": 9.09,
+                  "id": 7,
+                  "latency": 134.36,
+                  "serviceName": "payment",
+                  "targetServices": Array [
+                    "analytics-service",
+                    "inventory",
+                  ],
+                  "throughput": 11,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "payment",
+                      ],
+                      "traceGroup": "client_checkout",
+                    },
+                  ],
+                },
+                "recommendation": Object {
+                  "destServices": Array [
+                    "authentication",
+                  ],
+                  "error_rate": 6.25,
+                  "id": 8,
+                  "latency": 176.97,
+                  "serviceName": "recommendation",
+                  "targetServices": Array [
+                    "analytics-service",
+                    "inventory",
+                  ],
+                  "throughput": 16,
+                  "traceGroups": Array [
+                    Object {
+                      "targetResource": Array [
+                        "recommend",
+                      ],
+                      "traceGroup": "load_main_screen",
+                    },
+                  ],
+                },
+              }
+            }
+            ticks={Array []}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
     <EuiSpacer
-      size="m"
+      size="xl"
     />
-    <EuiButtonGroup
-      buttonSize="s"
-      color="text"
-      idSelected="latency"
-      onChange={[Function]}
-      options={
-        Array [
-          Object {
-            "id": "latency",
-            "label": "Duration",
-          },
-          Object {
-            "id": "error_rate",
-            "label": "Errors",
-          },
-          Object {
-            "id": "throughput",
-            "label": "Request Rate",
-          },
-        ]
-      }
-    />
-    <EuiHorizontalRule
-      margin="m"
-    />
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="s"
-    >
-      <EuiFlexItem
-        grow={false}
-      >
-        <EuiText>
-          Focus on
-        </EuiText>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiCompressedFieldSearch
-          compressed={true}
-          fullWidth={false}
-          incremental={false}
-          isClearable={true}
-          isInvalid={false}
-          isLoading={false}
-          onChange={[Function]}
-          onSearch={[Function]}
-          placeholder="Service name"
-          value=""
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-    <EuiSpacer />
-    <EuiFlexGroup
-      gutterSize="none"
-      responsive={false}
-    >
-      <EuiFlexItem>
-        <div
-          style={
-            Object {
-              "position": "relative",
-            }
-          }
-        />
-      </EuiFlexItem>
-      <EuiFlexItem
-        grow={false}
-      >
-        <ServiceMapScale
-          idSelected="latency"
-          serviceMap={
-            Object {
-              "analytics-service": Object {
-                "destServices": Array [
-                  "order",
-                  "inventory",
-                  "authentication",
-                  "payment",
-                  "recommendation",
-                ],
-                "error_rate": 0,
-                "id": 2,
-                "latency": 12.99,
-                "serviceName": "analytics-service",
-                "targetServices": Array [],
-                "throughput": 37,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "client_cancel_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "client_checkout",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "client_create_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "client_delivery_status",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "client_pay_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "/logs",
-                    ],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-              "authentication": Object {
-                "destServices": Array [
-                  "frontend-client",
-                ],
-                "error_rate": 8.33,
-                "id": 6,
-                "latency": 139.09,
-                "serviceName": "authentication",
-                "targetServices": Array [
-                  "analytics-service",
-                  "recommendation",
-                ],
-                "throughput": 12,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "server_request_login",
-                    ],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-              "database": Object {
-                "destServices": Array [
-                  "order",
-                  "inventory",
-                ],
-                "error_rate": 3.77,
-                "id": 3,
-                "latency": 49.54,
-                "serviceName": "database",
-                "targetServices": Array [],
-                "throughput": 53,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "cartEmpty",
-                    ],
-                    "traceGroup": "client_cancel_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "updateItem",
-                    ],
-                    "traceGroup": "client_checkout",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "addItemToCart",
-                    ],
-                    "traceGroup": "client_create_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "getCart",
-                    ],
-                    "traceGroup": "client_delivery_status",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "cartSold",
-                    ],
-                    "traceGroup": "client_pay_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "getIntentory",
-                    ],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-              "frontend-client": Object {
-                "destServices": Array [],
-                "error_rate": 7.41,
-                "id": 4,
-                "latency": 207.71,
-                "serviceName": "frontend-client",
-                "targetServices": Array [
-                  "order",
-                  "payment",
-                  "authentication",
-                ],
-                "throughput": 27,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "client_cancel_order",
-                  },
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "client_checkout",
-                  },
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "client_create_order",
-                  },
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "client_delivery_status",
-                  },
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "client_pay_order",
-                  },
-                  Object {
-                    "targetResource": Array [],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-              "inventory": Object {
-                "destServices": Array [
-                  "payment",
-                  "recommendation",
-                ],
-                "error_rate": 3.23,
-                "id": 5,
-                "latency": 183.52,
-                "serviceName": "inventory",
-                "targetServices": Array [
-                  "analytics-service",
-                  "database",
-                ],
-                "throughput": 31,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "update_inventory",
-                    ],
-                    "traceGroup": "client_checkout",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "read_inventory",
-                    ],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-              "order": Object {
-                "destServices": Array [
-                  "frontend-client",
-                ],
-                "error_rate": 4.17,
-                "id": 1,
-                "latency": 90.1,
-                "serviceName": "order",
-                "targetServices": Array [
-                  "analytics-service",
-                  "database",
-                ],
-                "throughput": 48,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "clear_order",
-                    ],
-                    "traceGroup": "client_cancel_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "update_order",
-                    ],
-                    "traceGroup": "client_create_order",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "get_order",
-                    ],
-                    "traceGroup": "client_delivery_status",
-                  },
-                  Object {
-                    "targetResource": Array [
-                      "pay_order",
-                    ],
-                    "traceGroup": "client_pay_order",
-                  },
-                ],
-              },
-              "payment": Object {
-                "destServices": Array [
-                  "frontend-client",
-                ],
-                "error_rate": 9.09,
-                "id": 7,
-                "latency": 134.36,
-                "serviceName": "payment",
-                "targetServices": Array [
-                  "analytics-service",
-                  "inventory",
-                ],
-                "throughput": 11,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "payment",
-                    ],
-                    "traceGroup": "client_checkout",
-                  },
-                ],
-              },
-              "recommendation": Object {
-                "destServices": Array [
-                  "authentication",
-                ],
-                "error_rate": 6.25,
-                "id": 8,
-                "latency": 176.97,
-                "serviceName": "recommendation",
-                "targetServices": Array [
-                  "analytics-service",
-                  "inventory",
-                ],
-                "throughput": 16,
-                "traceGroups": Array [
-                  Object {
-                    "targetResource": Array [
-                      "recommend",
-                    ],
-                    "traceGroup": "load_main_screen",
-                  },
-                ],
-              },
-            }
-          }
-          ticks={Array []}
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </EuiPanel>
-  <EuiSpacer
-    size="xl"
-  />
+  </EuiPage>
 </Fragment>
 `;

--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map.test.tsx.snap
@@ -2,375 +2,371 @@
 
 exports[`Service map component renders service map 1`] = `
 <Fragment>
-  <EuiPage
-    paddingSize="m"
-  >
-    <EuiPanel>
-      <PanelTitle
-        title="Service map"
-      />
-      <EuiSpacer
-        size="m"
-      />
-      <EuiButtonGroup
-        buttonSize="s"
-        color="text"
-        idSelected="latency"
-        onChange={[Function]}
-        options={
-          Array [
-            Object {
-              "id": "latency",
-              "label": "Duration",
-            },
-            Object {
-              "id": "error_rate",
-              "label": "Errors",
-            },
-            Object {
-              "id": "throughput",
-              "label": "Request Rate",
-            },
-          ]
-        }
-      />
-      <EuiHorizontalRule
-        margin="m"
-      />
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="s"
-      >
-        <EuiFlexItem
-          grow={false}
-        >
-          <EuiText>
-            Focus on
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCompressedFieldSearch
-            compressed={true}
-            fullWidth={false}
-            incremental={false}
-            isClearable={true}
-            isInvalid={false}
-            isLoading={false}
-            onChange={[Function]}
-            onSearch={[Function]}
-            placeholder="Service name"
-            value=""
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer />
-      <EuiFlexGroup
-        gutterSize="none"
-        responsive={false}
-      >
-        <EuiFlexItem>
-          <div
-            style={
-              Object {
-                "position": "relative",
-              }
-            }
-          />
-        </EuiFlexItem>
-        <EuiFlexItem
-          grow={false}
-        >
-          <ServiceMapScale
-            idSelected="latency"
-            serviceMap={
-              Object {
-                "analytics-service": Object {
-                  "destServices": Array [
-                    "order",
-                    "inventory",
-                    "authentication",
-                    "payment",
-                    "recommendation",
-                  ],
-                  "error_rate": 0,
-                  "id": 2,
-                  "latency": 12.99,
-                  "serviceName": "analytics-service",
-                  "targetServices": Array [],
-                  "throughput": 37,
-                  "traceGroups": Array [
-                    Object {
-                      "targetResource": Array [
-                        "/logs",
-                      ],
-                      "traceGroup": "client_cancel_order",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "/logs",
-                      ],
-                      "traceGroup": "client_checkout",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "/logs",
-                      ],
-                      "traceGroup": "client_create_order",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "/logs",
-                      ],
-                      "traceGroup": "client_delivery_status",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "/logs",
-                      ],
-                      "traceGroup": "client_pay_order",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "/logs",
-                      ],
-                      "traceGroup": "load_main_screen",
-                    },
-                  ],
-                },
-                "authentication": Object {
-                  "destServices": Array [
-                    "frontend-client",
-                  ],
-                  "error_rate": 8.33,
-                  "id": 6,
-                  "latency": 139.09,
-                  "serviceName": "authentication",
-                  "targetServices": Array [
-                    "analytics-service",
-                    "recommendation",
-                  ],
-                  "throughput": 12,
-                  "traceGroups": Array [
-                    Object {
-                      "targetResource": Array [
-                        "server_request_login",
-                      ],
-                      "traceGroup": "load_main_screen",
-                    },
-                  ],
-                },
-                "database": Object {
-                  "destServices": Array [
-                    "order",
-                    "inventory",
-                  ],
-                  "error_rate": 3.77,
-                  "id": 3,
-                  "latency": 49.54,
-                  "serviceName": "database",
-                  "targetServices": Array [],
-                  "throughput": 53,
-                  "traceGroups": Array [
-                    Object {
-                      "targetResource": Array [
-                        "cartEmpty",
-                      ],
-                      "traceGroup": "client_cancel_order",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "updateItem",
-                      ],
-                      "traceGroup": "client_checkout",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "addItemToCart",
-                      ],
-                      "traceGroup": "client_create_order",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "getCart",
-                      ],
-                      "traceGroup": "client_delivery_status",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "cartSold",
-                      ],
-                      "traceGroup": "client_pay_order",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "getIntentory",
-                      ],
-                      "traceGroup": "load_main_screen",
-                    },
-                  ],
-                },
-                "frontend-client": Object {
-                  "destServices": Array [],
-                  "error_rate": 7.41,
-                  "id": 4,
-                  "latency": 207.71,
-                  "serviceName": "frontend-client",
-                  "targetServices": Array [
-                    "order",
-                    "payment",
-                    "authentication",
-                  ],
-                  "throughput": 27,
-                  "traceGroups": Array [
-                    Object {
-                      "targetResource": Array [],
-                      "traceGroup": "client_cancel_order",
-                    },
-                    Object {
-                      "targetResource": Array [],
-                      "traceGroup": "client_checkout",
-                    },
-                    Object {
-                      "targetResource": Array [],
-                      "traceGroup": "client_create_order",
-                    },
-                    Object {
-                      "targetResource": Array [],
-                      "traceGroup": "client_delivery_status",
-                    },
-                    Object {
-                      "targetResource": Array [],
-                      "traceGroup": "client_pay_order",
-                    },
-                    Object {
-                      "targetResource": Array [],
-                      "traceGroup": "load_main_screen",
-                    },
-                  ],
-                },
-                "inventory": Object {
-                  "destServices": Array [
-                    "payment",
-                    "recommendation",
-                  ],
-                  "error_rate": 3.23,
-                  "id": 5,
-                  "latency": 183.52,
-                  "serviceName": "inventory",
-                  "targetServices": Array [
-                    "analytics-service",
-                    "database",
-                  ],
-                  "throughput": 31,
-                  "traceGroups": Array [
-                    Object {
-                      "targetResource": Array [
-                        "update_inventory",
-                      ],
-                      "traceGroup": "client_checkout",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "read_inventory",
-                      ],
-                      "traceGroup": "load_main_screen",
-                    },
-                  ],
-                },
-                "order": Object {
-                  "destServices": Array [
-                    "frontend-client",
-                  ],
-                  "error_rate": 4.17,
-                  "id": 1,
-                  "latency": 90.1,
-                  "serviceName": "order",
-                  "targetServices": Array [
-                    "analytics-service",
-                    "database",
-                  ],
-                  "throughput": 48,
-                  "traceGroups": Array [
-                    Object {
-                      "targetResource": Array [
-                        "clear_order",
-                      ],
-                      "traceGroup": "client_cancel_order",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "update_order",
-                      ],
-                      "traceGroup": "client_create_order",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "get_order",
-                      ],
-                      "traceGroup": "client_delivery_status",
-                    },
-                    Object {
-                      "targetResource": Array [
-                        "pay_order",
-                      ],
-                      "traceGroup": "client_pay_order",
-                    },
-                  ],
-                },
-                "payment": Object {
-                  "destServices": Array [
-                    "frontend-client",
-                  ],
-                  "error_rate": 9.09,
-                  "id": 7,
-                  "latency": 134.36,
-                  "serviceName": "payment",
-                  "targetServices": Array [
-                    "analytics-service",
-                    "inventory",
-                  ],
-                  "throughput": 11,
-                  "traceGroups": Array [
-                    Object {
-                      "targetResource": Array [
-                        "payment",
-                      ],
-                      "traceGroup": "client_checkout",
-                    },
-                  ],
-                },
-                "recommendation": Object {
-                  "destServices": Array [
-                    "authentication",
-                  ],
-                  "error_rate": 6.25,
-                  "id": 8,
-                  "latency": 176.97,
-                  "serviceName": "recommendation",
-                  "targetServices": Array [
-                    "analytics-service",
-                    "inventory",
-                  ],
-                  "throughput": 16,
-                  "traceGroups": Array [
-                    Object {
-                      "targetResource": Array [
-                        "recommend",
-                      ],
-                      "traceGroup": "load_main_screen",
-                    },
-                  ],
-                },
-              }
-            }
-            ticks={Array []}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiPanel>
-    <EuiSpacer
-      size="xl"
+  <EuiPanel>
+    <PanelTitle
+      title="Service map"
     />
-  </EuiPage>
+    <EuiSpacer
+      size="m"
+    />
+    <EuiButtonGroup
+      buttonSize="s"
+      color="text"
+      idSelected="latency"
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "id": "latency",
+            "label": "Duration",
+          },
+          Object {
+            "id": "error_rate",
+            "label": "Errors",
+          },
+          Object {
+            "id": "throughput",
+            "label": "Request Rate",
+          },
+        ]
+      }
+    />
+    <EuiHorizontalRule
+      margin="m"
+    />
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+    >
+      <EuiFlexItem
+        grow={false}
+      >
+        <EuiText>
+          Focus on
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiCompressedFieldSearch
+          compressed={true}
+          fullWidth={false}
+          incremental={false}
+          isClearable={true}
+          isInvalid={false}
+          isLoading={false}
+          onChange={[Function]}
+          onSearch={[Function]}
+          placeholder="Service name"
+          value=""
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiSpacer />
+    <EuiFlexGroup
+      gutterSize="none"
+      responsive={false}
+    >
+      <EuiFlexItem>
+        <div
+          style={
+            Object {
+              "position": "relative",
+            }
+          }
+        />
+      </EuiFlexItem>
+      <EuiFlexItem
+        grow={false}
+      >
+        <ServiceMapScale
+          idSelected="latency"
+          serviceMap={
+            Object {
+              "analytics-service": Object {
+                "destServices": Array [
+                  "order",
+                  "inventory",
+                  "authentication",
+                  "payment",
+                  "recommendation",
+                ],
+                "error_rate": 0,
+                "id": 2,
+                "latency": 12.99,
+                "serviceName": "analytics-service",
+                "targetServices": Array [],
+                "throughput": 37,
+                "traceGroups": Array [
+                  Object {
+                    "targetResource": Array [
+                      "/logs",
+                    ],
+                    "traceGroup": "client_cancel_order",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "/logs",
+                    ],
+                    "traceGroup": "client_checkout",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "/logs",
+                    ],
+                    "traceGroup": "client_create_order",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "/logs",
+                    ],
+                    "traceGroup": "client_delivery_status",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "/logs",
+                    ],
+                    "traceGroup": "client_pay_order",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "/logs",
+                    ],
+                    "traceGroup": "load_main_screen",
+                  },
+                ],
+              },
+              "authentication": Object {
+                "destServices": Array [
+                  "frontend-client",
+                ],
+                "error_rate": 8.33,
+                "id": 6,
+                "latency": 139.09,
+                "serviceName": "authentication",
+                "targetServices": Array [
+                  "analytics-service",
+                  "recommendation",
+                ],
+                "throughput": 12,
+                "traceGroups": Array [
+                  Object {
+                    "targetResource": Array [
+                      "server_request_login",
+                    ],
+                    "traceGroup": "load_main_screen",
+                  },
+                ],
+              },
+              "database": Object {
+                "destServices": Array [
+                  "order",
+                  "inventory",
+                ],
+                "error_rate": 3.77,
+                "id": 3,
+                "latency": 49.54,
+                "serviceName": "database",
+                "targetServices": Array [],
+                "throughput": 53,
+                "traceGroups": Array [
+                  Object {
+                    "targetResource": Array [
+                      "cartEmpty",
+                    ],
+                    "traceGroup": "client_cancel_order",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "updateItem",
+                    ],
+                    "traceGroup": "client_checkout",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "addItemToCart",
+                    ],
+                    "traceGroup": "client_create_order",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "getCart",
+                    ],
+                    "traceGroup": "client_delivery_status",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "cartSold",
+                    ],
+                    "traceGroup": "client_pay_order",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "getIntentory",
+                    ],
+                    "traceGroup": "load_main_screen",
+                  },
+                ],
+              },
+              "frontend-client": Object {
+                "destServices": Array [],
+                "error_rate": 7.41,
+                "id": 4,
+                "latency": 207.71,
+                "serviceName": "frontend-client",
+                "targetServices": Array [
+                  "order",
+                  "payment",
+                  "authentication",
+                ],
+                "throughput": 27,
+                "traceGroups": Array [
+                  Object {
+                    "targetResource": Array [],
+                    "traceGroup": "client_cancel_order",
+                  },
+                  Object {
+                    "targetResource": Array [],
+                    "traceGroup": "client_checkout",
+                  },
+                  Object {
+                    "targetResource": Array [],
+                    "traceGroup": "client_create_order",
+                  },
+                  Object {
+                    "targetResource": Array [],
+                    "traceGroup": "client_delivery_status",
+                  },
+                  Object {
+                    "targetResource": Array [],
+                    "traceGroup": "client_pay_order",
+                  },
+                  Object {
+                    "targetResource": Array [],
+                    "traceGroup": "load_main_screen",
+                  },
+                ],
+              },
+              "inventory": Object {
+                "destServices": Array [
+                  "payment",
+                  "recommendation",
+                ],
+                "error_rate": 3.23,
+                "id": 5,
+                "latency": 183.52,
+                "serviceName": "inventory",
+                "targetServices": Array [
+                  "analytics-service",
+                  "database",
+                ],
+                "throughput": 31,
+                "traceGroups": Array [
+                  Object {
+                    "targetResource": Array [
+                      "update_inventory",
+                    ],
+                    "traceGroup": "client_checkout",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "read_inventory",
+                    ],
+                    "traceGroup": "load_main_screen",
+                  },
+                ],
+              },
+              "order": Object {
+                "destServices": Array [
+                  "frontend-client",
+                ],
+                "error_rate": 4.17,
+                "id": 1,
+                "latency": 90.1,
+                "serviceName": "order",
+                "targetServices": Array [
+                  "analytics-service",
+                  "database",
+                ],
+                "throughput": 48,
+                "traceGroups": Array [
+                  Object {
+                    "targetResource": Array [
+                      "clear_order",
+                    ],
+                    "traceGroup": "client_cancel_order",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "update_order",
+                    ],
+                    "traceGroup": "client_create_order",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "get_order",
+                    ],
+                    "traceGroup": "client_delivery_status",
+                  },
+                  Object {
+                    "targetResource": Array [
+                      "pay_order",
+                    ],
+                    "traceGroup": "client_pay_order",
+                  },
+                ],
+              },
+              "payment": Object {
+                "destServices": Array [
+                  "frontend-client",
+                ],
+                "error_rate": 9.09,
+                "id": 7,
+                "latency": 134.36,
+                "serviceName": "payment",
+                "targetServices": Array [
+                  "analytics-service",
+                  "inventory",
+                ],
+                "throughput": 11,
+                "traceGroups": Array [
+                  Object {
+                    "targetResource": Array [
+                      "payment",
+                    ],
+                    "traceGroup": "client_checkout",
+                  },
+                ],
+              },
+              "recommendation": Object {
+                "destServices": Array [
+                  "authentication",
+                ],
+                "error_rate": 6.25,
+                "id": 8,
+                "latency": 176.97,
+                "serviceName": "recommendation",
+                "targetServices": Array [
+                  "analytics-service",
+                  "inventory",
+                ],
+                "throughput": 16,
+                "traceGroups": Array [
+                  Object {
+                    "targetResource": Array [
+                      "recommend",
+                    ],
+                    "traceGroup": "load_main_screen",
+                  },
+                ],
+              },
+            }
+          }
+          ticks={Array []}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </EuiPanel>
+  <EuiSpacer
+    size="xl"
+  />
 </Fragment>
 `;

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -5,13 +5,14 @@
 
 import {
   EuiButtonGroup,
-  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
   EuiPanel,
   EuiSpacer,
   EuiText,
+  EuiPage,
+  EuiCompressedFieldSearch,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 // @ts-ignore
@@ -202,85 +203,87 @@ export function ServiceMap({
 
   return (
     <>
-      <EuiPanel>
-        {page === 'app' ? (
-          <PanelTitle title="Application Composition Map" />
-        ) : (
-          <PanelTitle title="Service map" />
-        )}
-        <EuiSpacer size="m" />
-        <EuiButtonGroup
-          options={toggleButtons}
-          idSelected={idSelected}
-          onChange={(id) => setIdSelected(id as 'latency' | 'error_rate' | 'throughput')}
-          buttonSize="s"
-          color="text"
-        />
-        <EuiHorizontalRule margin="m" />
-        <EuiFlexGroup alignItems="center" gutterSize="s">
-          <EuiFlexItem grow={false}>
-            <EuiText>Focus on</EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiCompressedFieldSearch
-              placeholder="Service name"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onSearch={(service) => onFocus(service)}
-              isInvalid={query.length > 0 && invalid}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer />
-
-        {Object.keys(serviceMap).length > 0 ? (
-          <EuiFlexGroup gutterSize="none" responsive={false}>
-            <EuiFlexItem>
-              <div style={{ position: 'relative' }}>
-                {items?.graph && (
-                  <Graph
-                    graph={items.graph}
-                    options={options}
-                    events={events}
-                    getNetwork={(networkInstance: any) => {
-                      setNetwork(networkInstance);
-                      if (currService) onFocus(currService, networkInstance);
-                    }}
-                  />
-                )}
-                {selectedNodeDetails && (
-                  <div
-                    style={{
-                      position: 'absolute',
-                      top: 20,
-                      right: 20,
-                      zIndex: 1000,
-                    }}
-                  >
-                    <ServiceMapNodeDetails
-                      selectedNodeDetails={selectedNodeDetails}
-                      setSelectedNodeDetails={setSelectedNodeDetails}
-                      addServiceFilter={addServiceFilter}
-                      setCurrentSelectedService={setCurrentSelectedService}
-                    />
-                  </div>
-                )}
-              </div>
-            </EuiFlexItem>
+      <EuiPage paddingSize="m">
+        <EuiPanel>
+          {page === 'app' ? (
+            <PanelTitle title="Application Composition Map" />
+          ) : (
+            <PanelTitle title="Service map" />
+          )}
+          <EuiSpacer size="m" />
+          <EuiButtonGroup
+            options={toggleButtons}
+            idSelected={idSelected}
+            onChange={(id) => setIdSelected(id as 'latency' | 'error_rate' | 'throughput')}
+            buttonSize="s"
+            color="text"
+          />
+          <EuiHorizontalRule margin="m" />
+          <EuiFlexGroup alignItems="center" gutterSize="s">
             <EuiFlexItem grow={false}>
-              <ServiceMapScale idSelected={idSelected} serviceMap={serviceMap} ticks={ticks} />
+              <EuiText>Focus on</EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCompressedFieldSearch
+                placeholder="Service name"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onSearch={(service) => onFocus(service)}
+                isInvalid={query.length > 0 && invalid}
+              />
             </EuiFlexItem>
           </EuiFlexGroup>
-        ) : (
-          <div style={{ minHeight: 434 }}>
-            <NoMatchMessage size="s" />
-          </div>
+          <EuiSpacer />
+
+          {Object.keys(serviceMap).length > 0 ? (
+            <EuiFlexGroup gutterSize="none" responsive={false}>
+              <EuiFlexItem>
+                <div style={{ position: 'relative' }}>
+                  {items?.graph && (
+                    <Graph
+                      graph={items.graph}
+                      options={options}
+                      events={events}
+                      getNetwork={(networkInstance: any) => {
+                        setNetwork(networkInstance);
+                        if (currService) onFocus(currService, networkInstance);
+                      }}
+                    />
+                  )}
+                  {selectedNodeDetails && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: 20,
+                        right: 20,
+                        zIndex: 1000,
+                      }}
+                    >
+                      <ServiceMapNodeDetails
+                        selectedNodeDetails={selectedNodeDetails}
+                        setSelectedNodeDetails={setSelectedNodeDetails}
+                        addServiceFilter={addServiceFilter}
+                        setCurrentSelectedService={setCurrentSelectedService}
+                      />
+                    </div>
+                  )}
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <ServiceMapScale idSelected={idSelected} serviceMap={serviceMap} ticks={ticks} />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            <div style={{ minHeight: 434 }}>
+              <NoMatchMessage size="s" />
+            </div>
+          )}
+        </EuiPanel>
+        <EuiSpacer size="xl" />
+        {filterByCurrService && items?.graph && (
+          <ServiceDependenciesTable serviceMap={serviceMap} graph={items?.graph} />
         )}
-      </EuiPanel>
-      <EuiSpacer size="xl" />
-      {filterByCurrService && items?.graph && (
-        <ServiceDependenciesTable serviceMap={serviceMap} graph={items?.graph} />
-      )}
+      </EuiPage>
     </>
   );
 }

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -11,7 +11,6 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
-  EuiPage,
   EuiCompressedFieldSearch,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
@@ -203,87 +202,85 @@ export function ServiceMap({
 
   return (
     <>
-      <EuiPage paddingSize="m">
-        <EuiPanel>
-          {page === 'app' ? (
-            <PanelTitle title="Application Composition Map" />
-          ) : (
-            <PanelTitle title="Service map" />
-          )}
-          <EuiSpacer size="m" />
-          <EuiButtonGroup
-            options={toggleButtons}
-            idSelected={idSelected}
-            onChange={(id) => setIdSelected(id as 'latency' | 'error_rate' | 'throughput')}
-            buttonSize="s"
-            color="text"
-          />
-          <EuiHorizontalRule margin="m" />
-          <EuiFlexGroup alignItems="center" gutterSize="s">
-            <EuiFlexItem grow={false}>
-              <EuiText>Focus on</EuiText>
-            </EuiFlexItem>
+      <EuiPanel>
+        {page === 'app' ? (
+          <PanelTitle title="Application Composition Map" />
+        ) : (
+          <PanelTitle title="Service map" />
+        )}
+        <EuiSpacer size="m" />
+        <EuiButtonGroup
+          options={toggleButtons}
+          idSelected={idSelected}
+          onChange={(id) => setIdSelected(id as 'latency' | 'error_rate' | 'throughput')}
+          buttonSize="s"
+          color="text"
+        />
+        <EuiHorizontalRule margin="m" />
+        <EuiFlexGroup alignItems="center" gutterSize="s">
+          <EuiFlexItem grow={false}>
+            <EuiText>Focus on</EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiCompressedFieldSearch
+              placeholder="Service name"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onSearch={(service) => onFocus(service)}
+              isInvalid={query.length > 0 && invalid}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer />
+
+        {Object.keys(serviceMap).length > 0 ? (
+          <EuiFlexGroup gutterSize="none" responsive={false}>
             <EuiFlexItem>
-              <EuiCompressedFieldSearch
-                placeholder="Service name"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                onSearch={(service) => onFocus(service)}
-                isInvalid={query.length > 0 && invalid}
-              />
+              <div style={{ position: 'relative' }}>
+                {items?.graph && (
+                  <Graph
+                    graph={items.graph}
+                    options={options}
+                    events={events}
+                    getNetwork={(networkInstance: any) => {
+                      setNetwork(networkInstance);
+                      if (currService) onFocus(currService, networkInstance);
+                    }}
+                  />
+                )}
+                {selectedNodeDetails && (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      top: 20,
+                      right: 20,
+                      zIndex: 1000,
+                    }}
+                  >
+                    <ServiceMapNodeDetails
+                      selectedNodeDetails={selectedNodeDetails}
+                      setSelectedNodeDetails={setSelectedNodeDetails}
+                      addServiceFilter={addServiceFilter}
+                      setCurrentSelectedService={setCurrentSelectedService}
+                    />
+                  </div>
+                )}
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <ServiceMapScale idSelected={idSelected} serviceMap={serviceMap} ticks={ticks} />
             </EuiFlexItem>
           </EuiFlexGroup>
-          <EuiSpacer />
-
-          {Object.keys(serviceMap).length > 0 ? (
-            <EuiFlexGroup gutterSize="none" responsive={false}>
-              <EuiFlexItem>
-                <div style={{ position: 'relative' }}>
-                  {items?.graph && (
-                    <Graph
-                      graph={items.graph}
-                      options={options}
-                      events={events}
-                      getNetwork={(networkInstance: any) => {
-                        setNetwork(networkInstance);
-                        if (currService) onFocus(currService, networkInstance);
-                      }}
-                    />
-                  )}
-                  {selectedNodeDetails && (
-                    <div
-                      style={{
-                        position: 'absolute',
-                        top: 20,
-                        right: 20,
-                        zIndex: 1000,
-                      }}
-                    >
-                      <ServiceMapNodeDetails
-                        selectedNodeDetails={selectedNodeDetails}
-                        setSelectedNodeDetails={setSelectedNodeDetails}
-                        addServiceFilter={addServiceFilter}
-                        setCurrentSelectedService={setCurrentSelectedService}
-                      />
-                    </div>
-                  )}
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <ServiceMapScale idSelected={idSelected} serviceMap={serviceMap} ticks={ticks} />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          ) : (
-            <div style={{ minHeight: 434 }}>
-              <NoMatchMessage size="s" />
-            </div>
-          )}
-        </EuiPanel>
-        <EuiSpacer size="xl" />
-        {filterByCurrService && items?.graph && (
-          <ServiceDependenciesTable serviceMap={serviceMap} graph={items?.graph} />
+        ) : (
+          <div style={{ minHeight: 434 }}>
+            <NoMatchMessage size="s" />
+          </div>
         )}
-      </EuiPage>
+      </EuiPanel>
+      <EuiSpacer size="xl" />
+      {filterByCurrService && items?.graph && (
+        <ServiceDependenciesTable serviceMap={serviceMap} graph={items?.graph} />
+      )}
     </>
   );
 }

--- a/public/components/trace_analytics/components/common/search_bar.tsx
+++ b/public/components/trace_analytics/components/common/search_bar.tsx
@@ -4,17 +4,18 @@
  */
 
 import {
-  EuiSmallButton,
-  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSpacer,
   EuiSuperDatePicker,
+  EuiButtonIcon,
+  EuiCompressedFieldSearch,
 } from '@elastic/eui';
 import debounce from 'lodash/debounce';
 import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import { i18n } from '@osd/i18n';
 import { uiSettingsService } from '../../../../../common/utils';
-import { Filters, FiltersProps } from './filters/filters';
+import { FiltersProps } from './filters/filters';
+import { GlobalFilterButton } from './filters/filters';
 
 export const renderDatePicker = (
   startTime: string,
@@ -69,13 +70,17 @@ export const SearchBar = forwardRef((props: SearchBarOwnProps, ref) => {
 
   return (
     <>
-      <EuiFlexGroup gutterSize="s">
+      <EuiFlexGroup gutterSize="s" alignItems="center">
         {!props.datepickerOnly && (
           <EuiFlexItem>
             <EuiCompressedFieldSearch
+              prepend={<GlobalFilterButton filters={props.filters} setFilters={props.setFilters} />}
+              compressed
               fullWidth
               isClearable={false}
-              placeholder="Trace ID, trace group name, service name"
+              placeholder={i18n.translate('traceAnalytics.searchBar.placeholder', {
+                defaultMessage: 'Trace ID, trace group name, service name',
+              })}
               data-test-subj="search-bar-input-box"
               value={query}
               onChange={(e) => {
@@ -86,34 +91,30 @@ export const SearchBar = forwardRef((props: SearchBarOwnProps, ref) => {
             />
           </EuiFlexItem>
         )}
-        <EuiFlexItem grow={false} style={{ maxWidth: '40vw' }}>
-          {renderDatePicker(props.startTime, props.setStartTime, props.endTime, props.setEndTime)}
+        <EuiFlexItem grow={false} style={{ maxWidth: '30vw' }}>
+          <EuiSuperDatePicker
+            compressed
+            start={props.startTime}
+            end={props.endTime}
+            onTimeChange={(e) => {
+              props.setStartTime(e.start);
+              props.setEndTime(e.end);
+            }}
+            showUpdateButton={false}
+          />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSmallButton
+          <EuiButtonIcon
+            iconType="refresh"
+            aria-label="Refresh"
+            display="base"
+            onClick={() => props.refresh()}
+            size="s"
             data-test-subj="superDatePickerApplyTimeButton"
             data-click-metric-element="trace_analytics.refresh_button"
-            iconType="refresh"
-            onClick={() => props.refresh()}
-          >
-            Refresh
-          </EuiSmallButton>
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
-
-      {!props.datepickerOnly && (
-        <>
-          <EuiSpacer size="s" />
-          <Filters
-            page={props.page}
-            filters={props.filters}
-            setFilters={props.setFilters}
-            appConfigs={props.appConfigs}
-            mode={props.mode}
-            attributesFilterFields={props.attributesFilterFields}
-          />
-        </>
-      )}
     </>
   );
 });

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -327,6 +327,7 @@ exports[`Dashboard component renders dashboard 1`] = `
               >
                 <EuiButtonContent
                   className="euiButtonEmpty__content"
+                  iconGap="m"
                   iconSide="right"
                   iconSize="m"
                   iconType="arrowDown"
@@ -1572,6 +1573,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
               >
                 <EuiButtonContent
                   className="euiButtonEmpty__content"
+                  iconGap="m"
                   iconSide="right"
                   iconSize="m"
                   iconType="arrowDown"
@@ -2817,6 +2819,7 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
               >
                 <EuiButtonContent
                   className="euiButtonEmpty__content"
+                  iconGap="m"
                   iconSide="right"
                   iconSize="m"
                   iconType="arrowDown"
@@ -3292,6 +3295,7 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButton__content"
+                                iconGap="m"
                                 iconSide="left"
                                 textProps={
                                   Object {
@@ -3375,6 +3379,7 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButton__content"
+                                iconGap="m"
                                 iconSide="left"
                                 textProps={
                                   Object {

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
@@ -966,6 +966,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -2962,6 +2963,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -3165,6 +3167,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/mode_picker.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/mode_picker.test.tsx.snap
@@ -79,6 +79,7 @@ exports[`Mode picker component renders mode picker 1`] = `
             >
               <EuiButtonContent
                 className="euiButtonEmpty__content"
+                iconGap="m"
                 iconSide="right"
                 iconSize="m"
                 iconType="arrowDown"
@@ -216,6 +217,7 @@ exports[`Mode picker component renders mode picker 2`] = `
             >
               <EuiButtonContent
                 className="euiButtonEmpty__content"
+                iconGap="m"
                 iconSide="right"
                 iconSize="m"
                 iconType="arrowDown"

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_error_rates_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_error_rates_table.test.tsx.snap
@@ -791,6 +791,7 @@ exports[`Error Rates Table component renders top error rates table with data 1`]
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -1936,6 +1937,7 @@ exports[`Error Rates Table component renders top error rates table with data 1`]
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -2139,6 +2141,7 @@ exports[`Error Rates Table component renders top error rates table with data 1`]
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_latency_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_latency_table.test.tsx.snap
@@ -1150,6 +1150,7 @@ exports[`Latency Table component renders top error rates table with data 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -2928,6 +2929,7 @@ exports[`Latency Table component renders top error rates table with data 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -3131,6 +3133,7 @@ exports[`Latency Table component renders top error rates table with data 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -558,6 +558,7 @@ exports[`Services component renders empty services page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
                                     iconSize="m"
                                     iconType="arrowDown"
@@ -1165,6 +1166,7 @@ exports[`Services component renders empty services page 1`] = `
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButtonEmpty__content"
+                                                          iconGap="m"
                                                           iconSide="right"
                                                           iconSize="s"
                                                           iconType="arrowDown"
@@ -1434,6 +1436,7 @@ exports[`Services component renders empty services page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     iconSize="s"
                                     textProps={
@@ -1568,6 +1571,7 @@ exports[`Services component renders empty services page 1`] = `
                                         >
                                           <EuiButtonContent
                                             className="euiButtonEmpty__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconSize="s"
                                             textProps={
@@ -1608,6 +1612,7 @@ exports[`Services component renders empty services page 1`] = `
                                     >
                                       <EuiButtonContent
                                         className="euiButtonEmpty__content"
+                                        iconGap="m"
                                         iconSide="left"
                                         iconSize="s"
                                         textProps={
@@ -1851,6 +1856,7 @@ exports[`Services component renders empty services page 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButton__content"
+                                iconGap="m"
                                 iconSide="left"
                                 textProps={
                                   Object {
@@ -1931,6 +1937,7 @@ exports[`Services component renders empty services page 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButton__content"
+                                iconGap="m"
                                 iconSide="left"
                                 textProps={
                                   Object {
@@ -2011,6 +2018,7 @@ exports[`Services component renders empty services page 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButton__content"
+                                iconGap="m"
                                 iconSide="left"
                                 textProps={
                                   Object {
@@ -2840,6 +2848,7 @@ exports[`Services component renders jaeger services page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
                                     iconSize="m"
                                     iconType="arrowDown"
@@ -3449,6 +3458,7 @@ exports[`Services component renders jaeger services page 1`] = `
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButtonEmpty__content"
+                                                          iconGap="m"
                                                           iconSide="right"
                                                           iconSize="s"
                                                           iconType="arrowDown"
@@ -3720,6 +3730,7 @@ exports[`Services component renders jaeger services page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     iconSize="s"
                                     textProps={
@@ -3855,6 +3866,7 @@ exports[`Services component renders jaeger services page 1`] = `
                                         >
                                           <EuiButtonContent
                                             className="euiButtonEmpty__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconSize="s"
                                             textProps={
@@ -4550,6 +4562,7 @@ exports[`Services component renders services page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
                                     iconSize="m"
                                     iconType="arrowDown"
@@ -5159,6 +5172,7 @@ exports[`Services component renders services page 1`] = `
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButtonEmpty__content"
+                                                          iconGap="m"
                                                           iconSide="right"
                                                           iconSize="s"
                                                           iconType="arrowDown"
@@ -5430,6 +5444,7 @@ exports[`Services component renders services page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     iconSize="s"
                                     textProps={
@@ -5564,6 +5579,7 @@ exports[`Services component renders services page 1`] = `
                                         >
                                           <EuiButtonContent
                                             className="euiButtonEmpty__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconSize="s"
                                             textProps={
@@ -5604,6 +5620,7 @@ exports[`Services component renders services page 1`] = `
                                     >
                                       <EuiButtonContent
                                         className="euiButtonEmpty__content"
+                                        iconGap="m"
                                         iconSide="left"
                                         iconSize="s"
                                         textProps={
@@ -5847,6 +5864,7 @@ exports[`Services component renders services page 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButton__content"
+                                iconGap="m"
                                 iconSide="left"
                                 textProps={
                                   Object {
@@ -5927,6 +5945,7 @@ exports[`Services component renders services page 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButton__content"
+                                iconGap="m"
                                 iconSide="left"
                                 textProps={
                                   Object {
@@ -6007,6 +6026,7 @@ exports[`Services component renders services page 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButton__content"
+                                iconGap="m"
                                 iconSide="left"
                                 textProps={
                                   Object {

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -1399,6 +1399,7 @@ exports[`Services component renders empty services page 1`] = `
                           anchorPosition="downLeft"
                           button={
                             <EuiButtonEmpty
+                              flush="left"
                               onClick={[Function]}
                               size="xs"
                             >
@@ -1421,11 +1422,12 @@ exports[`Services component renders empty services page 1`] = `
                               className="euiPopover__anchor"
                             >
                               <EuiButtonEmpty
+                                flush="left"
                                 onClick={[Function]}
                                 size="xs"
                               >
                                 <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                                   disabled={false}
                                   onClick={[Function]}
                                   type="button"
@@ -3683,6 +3685,7 @@ exports[`Services component renders jaeger services page 1`] = `
                           anchorPosition="downLeft"
                           button={
                             <EuiButtonEmpty
+                              flush="left"
                               onClick={[Function]}
                               size="xs"
                             >
@@ -3705,11 +3708,12 @@ exports[`Services component renders jaeger services page 1`] = `
                               className="euiPopover__anchor"
                             >
                               <EuiButtonEmpty
+                                flush="left"
                                 onClick={[Function]}
                                 size="xs"
                               >
                                 <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                                   disabled={false}
                                   onClick={[Function]}
                                   type="button"
@@ -5391,6 +5395,7 @@ exports[`Services component renders services page 1`] = `
                           anchorPosition="downLeft"
                           button={
                             <EuiButtonEmpty
+                              flush="left"
                               onClick={[Function]}
                               size="xs"
                             >
@@ -5413,11 +5418,12 @@ exports[`Services component renders services page 1`] = `
                               className="euiPopover__anchor"
                             >
                               <EuiButtonEmpty
+                                flush="left"
                                 onClick={[Function]}
                                 size="xs"
                               >
                                 <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                                   disabled={false}
                                   onClick={[Function]}
                                   type="button"

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -457,180 +457,913 @@ exports[`Services component renders empty services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="s"
-      justifyContent="spaceBetween"
-      style={
-        Object {
-          "padding": "0 24px",
-        }
-      }
+    <EuiPage
+      paddingSize="m"
     >
       <div
-        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-        style={
-          Object {
-            "padding": "0 24px",
-          }
-        }
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <EuiFlexItem
-          grow={false}
-        >
+        <EuiPageBody>
           <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
+            className="euiPageBody euiPageBody--borderRadiusNone"
           >
-            <DataSourcePicker
-              modes={
-                Array [
-                  Object {
-                    "id": "jaeger",
-                    "title": "Jaeger",
-                  },
-                  Object {
-                    "id": "data_prepper",
-                    "title": "Data Prepper",
-                  },
-                ]
-              }
-              selectedMode="data_prepper"
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiPopover
-                anchorClassName="eui-textTruncate"
-                anchorPosition="downCenter"
-                button={
-                  <EuiSmallButtonEmpty
-                    className="dscIndexPattern__triggerButton"
-                    color="text"
-                    data-test-subj="indexPattern-switch-link"
-                    flush="left"
-                    iconSide="right"
-                    iconType="arrowDown"
-                    onClick={[Function]}
-                    title="data_prepper"
-                  >
-                    Data Prepper
-                  </EuiSmallButtonEmpty>
-                }
-                className="eui-textTruncate"
-                closePopover={[Function]}
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="s"
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <div
-                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiPopover__anchor eui-textTruncate"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <EuiSmallButtonEmpty
-                      className="dscIndexPattern__triggerButton"
-                      color="text"
-                      data-test-subj="indexPattern-switch-link"
-                      flush="left"
-                      iconSide="right"
-                      iconType="arrowDown"
-                      onClick={[Function]}
-                      title="data_prepper"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="data_prepper"
                     >
-                      <EuiButtonEmpty
-                        className="dscIndexPattern__triggerButton"
-                        color="text"
-                        data-test-subj="indexPattern-switch-link"
-                        flush="left"
-                        iconSide="right"
-                        iconType="arrowDown"
-                        onClick={[Function]}
-                        size="s"
-                        title="data_prepper"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                          data-test-subj="indexPattern-switch-link"
-                          disabled={false}
-                          onClick={[Function]}
-                          title="data_prepper"
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
                             iconSide="right"
-                            iconSize="m"
                             iconType="arrowDown"
-                            textProps={
+                            onClick={[Function]}
+                            title="data_prepper"
+                          >
+                            Data Prepper
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
+                      >
+                        <div
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                        >
+                          <div
+                            className="euiPopover__anchor eui-textTruncate"
+                          >
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="data_prepper"
+                            >
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="data_prepper"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="data_prepper"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="right"
+                                    iconSize="m"
+                                    iconType="arrowDown"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Data Prepper
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="data_prepper"
+                      page="services"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
+                                }
+                                value=""
+                              >
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                                  >
+                                    <GlobalFilterButton
+                                      className="euiFormControlLayout__prepend"
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    >
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor"
+                                          >
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
+                                            >
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
+                                              >
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
+                                                >
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconBeaker
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <span
+                                              className="euiFormControlLayoutCustomIcon"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
+                                              >
+                                                <EuiIconBeaker
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconBeaker>
+                                              </EuiIcon>
+                                            </span>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
                               Object {
-                                "className": "euiButtonEmpty__text",
+                                "maxWidth": "30vw",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
+                                Object {
+                                  "maxWidth": "30vw",
+                                }
+                              }
                             >
-                              <EuiIcon
-                                className="euiButtonContent__icon"
-                                color="inherit"
-                                size="m"
-                                type="arrowDown"
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
                                   >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                              <span
-                                className="euiButtonEmpty__text"
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
+                                      >
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconBeaker
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconBeaker>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconBeaker
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconBeaker>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
                               >
-                                Data Prepper
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </EuiSmallButtonEmpty>
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconBeaker
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                    </EuiIconBeaker>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
                   </div>
-                </div>
-              </EuiPopover>
-            </DataSourcePicker>
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem
-          grow={true}
-        >
-          <div
-            className="euiFlexItem"
-          >
-            <ForwardRef
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
+              appConfigs={Array []}
               attributesFilterFields={Array []}
-              endTime="now"
               filters={Array []}
               mode="data_prepper"
               page="services"
-              query=""
-              refresh={[Function]}
-              setEndTime={[MockFunction]}
               setFilters={
                 [MockFunction] {
                   "calls": Array [
@@ -646,971 +1379,46 @@ exports[`Services component renders empty services page 1`] = `
                   ],
                 }
               }
-              setQuery={[MockFunction]}
-              setStartTime={[MockFunction]}
-              startTime="now-5m"
             >
               <EuiFlexGroup
                 alignItems="center"
-                gutterSize="s"
+                gutterSize="xs"
+                responsive={false}
               >
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
                 >
-                  <EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
                     <div
-                      className="euiFlexItem"
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiCompressedFieldSearch
-                        compressed={true}
-                        data-test-subj="search-bar-input-box"
-                        fullWidth={true}
-                        incremental={false}
-                        isClearable={false}
-                        isLoading={false}
-                        onChange={[Function]}
-                        onSearch={[Function]}
-                        placeholder="Trace ID, trace group name, service name"
-                        prepend={
-                          <GlobalFilterButton
-                            filters={Array []}
-                            setFilters={
-                              [MockFunction] {
-                                "calls": Array [
-                                  Array [
-                                    Array [],
-                                  ],
-                                ],
-                                "results": Array [
-                                  Object {
-                                    "type": "return",
-                                    "value": undefined,
-                                  },
-                                ],
-                              }
-                            }
-                          />
-                        }
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          compressed={true}
-                          fullWidth={true}
-                          icon="search"
-                          isLoading={false}
-                          prepend={
-                            <GlobalFilterButton
-                              filters={Array []}
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            />
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
                           }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
                           >
-                            <GlobalFilterButton
-                              className="euiFormControlLayout__prepend"
-                              filters={Array []}
-                              key="0/.0"
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <EuiSmallButtonIcon
-                                    aria-label="Change all filters"
-                                    iconType="filter"
-                                    onClick={[Function]}
-                                    title="Change all filters"
-                                  />
-                                }
-                                closePopover={[Function]}
-                                data-test-subj="global-filter-button"
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="none"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp"
-                                  data-test-subj="global-filter-button"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
-                                    <EuiSmallButtonIcon
-                                      aria-label="Change all filters"
-                                      iconType="filter"
-                                      onClick={[Function]}
-                                      title="Change all filters"
-                                    >
-                                      <EuiButtonIcon
-                                        aria-label="Change all filters"
-                                        iconType="filter"
-                                        onClick={[Function]}
-                                        size="s"
-                                        title="Change all filters"
-                                      >
-                                        <button
-                                          aria-label="Change all filters"
-                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          title="Change all filters"
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="filter"
-                                          >
-                                            <EuiIconBeaker
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                />
-                                              </svg>
-                                            </EuiIconBeaker>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiSmallButtonIcon>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </GlobalFilterButton>
                             <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiValidatableControl>
-                                <input
-                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
-                                  data-test-subj="search-bar-input-box"
-                                  onChange={[Function]}
-                                  onKeyUp={[Function]}
-                                  placeholder="Trace ID, trace group name, service name"
-                                  type="search"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons
-                                compressed={true}
-                                icon="search"
-                                isLoading={false}
-                              >
-                                <div
-                                  className="euiFormControlLayoutIcons"
-                                >
-                                  <EuiFormControlLayoutCustomIcon
-                                    size="s"
-                                    type="search"
-                                  >
-                                    <span
-                                      className="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiFormControlLayoutCustomIcon__icon"
-                                        size="s"
-                                        type="search"
-                                      >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </span>
-                                  </EuiFormControlLayoutCustomIcon>
-                                </div>
-                              </EuiFormControlLayoutIcons>
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </EuiCompressedFieldSearch>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                    style={
-                      Object {
-                        "maxWidth": "30vw",
-                      }
-                    }
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                      style={
-                        Object {
-                          "maxWidth": "30vw",
-                        }
-                      }
-                    >
-                      <EuiSuperDatePicker
-                        commonlyUsedRanges={
-                          Array [
-                            Object {
-                              "end": "now/d",
-                              "label": "Today",
-                              "start": "now/d",
-                            },
-                            Object {
-                              "end": "now/w",
-                              "label": "This week",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now/M",
-                              "label": "This month",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now/y",
-                              "label": "This year",
-                              "start": "now/y",
-                            },
-                            Object {
-                              "end": "now-1d/d",
-                              "label": "Yesterday",
-                              "start": "now-1d/d",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Week to date",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Month to date",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Year to date",
-                              "start": "now/y",
-                            },
-                          ]
-                        }
-                        compressed={true}
-                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                        end="now"
-                        isAutoRefreshOnly={false}
-                        isDisabled={false}
-                        isPaused={true}
-                        onTimeChange={[Function]}
-                        recentlyUsedRanges={Array []}
-                        refreshInterval={0}
-                        showUpdateButton={false}
-                        start="now-5m"
-                        timeFormat="HH:mm"
-                      >
-                        <EuiFlexGroup
-                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          gutterSize="s"
-                          responsive={false}
-                        >
-                          <div
-                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          >
-                            <EuiFlexItem>
-                              <div
-                                className="euiFlexItem"
-                              >
-                                <EuiFormControlLayout
-                                  className="euiSuperDatePicker"
-                                  compressed={true}
-                                  isDisabled={false}
-                                  prepend={
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    />
-                                  }
-                                >
-                                  <div
-                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
-                                  >
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      className="euiFormControlLayout__prepend"
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      key="0/.0"
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    >
-                                      <EuiPopover
-                                        anchorClassName="euiQuickSelectPopover__anchor"
-                                        anchorPosition="downLeft"
-                                        button={
-                                          <EuiButtonEmpty
-                                            aria-label="Date quick select"
-                                            className="euiFormControlLayout__prepend"
-                                            data-test-subj="superDatePickerToggleQuickMenuButton"
-                                            iconSide="right"
-                                            iconType="arrowDown"
-                                            isDisabled={false}
-                                            onClick={[Function]}
-                                            size="xs"
-                                            textProps={
-                                              Object {
-                                                "className": "euiQuickSelectPopover__buttonText",
-                                              }
-                                            }
-                                          >
-                                            <EuiIcon
-                                              type="calendar"
-                                            />
-                                          </EuiButtonEmpty>
-                                        }
-                                        closePopover={[Function]}
-                                        display="inlineBlock"
-                                        hasArrow={true}
-                                        isOpen={false}
-                                        ownFocus={true}
-                                        panelPaddingSize="s"
-                                      >
-                                        <div
-                                          className="euiPopover euiPopover--anchorDownLeft"
-                                        >
-                                          <div
-                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                          >
-                                            <EuiButtonEmpty
-                                              aria-label="Date quick select"
-                                              className="euiFormControlLayout__prepend"
-                                              data-test-subj="superDatePickerToggleQuickMenuButton"
-                                              iconSide="right"
-                                              iconType="arrowDown"
-                                              isDisabled={false}
-                                              onClick={[Function]}
-                                              size="xs"
-                                              textProps={
-                                                Object {
-                                                  "className": "euiQuickSelectPopover__buttonText",
-                                                }
-                                              }
-                                            >
-                                              <button
-                                                aria-label="Date quick select"
-                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                                data-test-subj="superDatePickerToggleQuickMenuButton"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <EuiButtonContent
-                                                  className="euiButtonEmpty__content"
-                                                  iconSide="right"
-                                                  iconSize="s"
-                                                  iconType="arrowDown"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                                    }
-                                                  }
-                                                >
-                                                  <span
-                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                                  >
-                                                    <EuiIcon
-                                                      className="euiButtonContent__icon"
-                                                      color="inherit"
-                                                      size="s"
-                                                      type="arrowDown"
-                                                    >
-                                                      <EuiIconBeaker
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                        focusable="false"
-                                                        role="img"
-                                                        style={null}
-                                                      >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                          focusable="false"
-                                                          height={16}
-                                                          role="img"
-                                                          style={null}
-                                                          viewBox="0 0 16 16"
-                                                          width={16}
-                                                          xmlns="http://www.w3.org/2000/svg"
-                                                        >
-                                                          <path
-                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                          />
-                                                        </svg>
-                                                      </EuiIconBeaker>
-                                                    </EuiIcon>
-                                                    <span
-                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                                    >
-                                                      <EuiIcon
-                                                        type="calendar"
-                                                      >
-                                                        <EuiIconBeaker
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                          focusable="false"
-                                                          role="img"
-                                                          style={null}
-                                                        >
-                                                          <svg
-                                                            aria-hidden={true}
-                                                            className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                            focusable="false"
-                                                            height={16}
-                                                            role="img"
-                                                            style={null}
-                                                            viewBox="0 0 16 16"
-                                                            width={16}
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                          >
-                                                            <path
-                                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                            />
-                                                          </svg>
-                                                        </EuiIconBeaker>
-                                                      </EuiIcon>
-                                                    </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonEmpty>
-                                          </div>
-                                        </div>
-                                      </EuiPopover>
-                                    </EuiQuickSelectPopover>
-                                    <div
-                                      className="euiFormControlLayout__childrenWrapper"
-                                    >
-                                      <EuiDatePickerRange
-                                        className="euiDatePickerRange--inGroup"
-                                        endDateControl={<div />}
-                                        iconType={false}
-                                        isCustom={true}
-                                        startDateControl={<div />}
-                                      >
-                                        <div
-                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                        >
-                                          <button
-                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
-                                            data-test-subj="superDatePickerShowDatesButton"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                          >
-                                            Last 5 minutes
-                                            <span
-                                              className="euiSuperDatePicker__prettyFormatLink"
-                                            >
-                                              <EuiI18n
-                                                default="Show dates"
-                                                token="euiSuperDatePicker.showDatesButtonLabel"
-                                              >
-                                                Show dates
-                                              </EuiI18n>
-                                            </span>
-                                          </button>
-                                        </div>
-                                      </EuiDatePickerRange>
-                                      <EuiFormControlLayoutIcons
-                                        compressed={true}
-                                      />
-                                    </div>
-                                  </div>
-                                </EuiFormControlLayout>
-                              </div>
-                            </EuiFlexItem>
-                          </div>
-                        </EuiFlexGroup>
-                      </EuiSuperDatePicker>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiButtonIcon
-                        aria-label="Refresh"
-                        data-click-metric-element="trace_analytics.refresh_button"
-                        data-test-subj="superDatePickerApplyTimeButton"
-                        display="base"
-                        iconType="refresh"
-                        onClick={[Function]}
-                        size="s"
-                      >
-                        <button
-                          aria-label="Refresh"
-                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
-                          data-click-metric-element="trace_analytics.refresh_button"
-                          data-test-subj="superDatePickerApplyTimeButton"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiIcon
-                            aria-hidden="true"
-                            className="euiButtonIcon__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
-                          >
-                            <EuiIconBeaker
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                />
-                              </svg>
-                            </EuiIconBeaker>
-                          </EuiIcon>
-                        </button>
-                      </EuiButtonIcon>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </ForwardRef>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
-    <Filters
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      filters={Array []}
-      mode="data_prepper"
-      page="services"
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-    >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="xs"
-        responsive={false}
-        style={
-          Object {
-            "minHeight": 32,
-            "padding": "0 16px",
-          }
-        }
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-          style={
-            Object {
-              "minHeight": 32,
-              "padding": "0 16px",
-            }
-          }
-        >
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <AddFilterButton>
-                <EuiPopover
-                  anchorPosition="downLeft"
-                  button={
-                    <EuiButtonEmpty
-                      onClick={[Function]}
-                      size="xs"
-                    >
-                      + Add filter
-                    </EuiButtonEmpty>
-                  }
-                  closePopover={[Function]}
-                  data-test-subj="addfilter"
-                  display="inlineBlock"
-                  hasArrow={true}
-                  isOpen={false}
-                  ownFocus={true}
-                  panelPaddingSize="m"
-                >
-                  <div
-                    className="euiPopover euiPopover--anchorDownLeft"
-                    data-test-subj="addfilter"
-                  >
-                    <div
-                      className="euiPopover__anchor"
-                    >
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
-                            iconSide="left"
-                            iconSize="s"
-                            textProps={
-                              Object {
-                                "className": "euiButtonEmpty__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButtonEmpty__content"
-                            >
-                              <span
-                                className="euiButtonEmpty__text"
-                              >
-                                + Add filter
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </div>
-                  </div>
-                </EuiPopover>
-              </AddFilterButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-    </Filters>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <ServicesTable
-      addFilter={[Function]}
-      addServicesGroupFilter={[Function]}
-      dataPrepperIndicesExist={true}
-      isServiceTrendEnabled={false}
-      items={Array []}
-      loading={true}
-      mode="data_prepper"
-      selectedItems={Array []}
-      serviceTrends={Object {}}
-      setIsServiceTrendEnabled={[Function]}
-      setRedirect={[Function]}
-      setSelectedItems={[Function]}
-      traceColumnAction={[Function]}
-    >
-      <EuiPage
-        paddingSize="m"
-      >
-        <div
-          className="euiPage euiPage--paddingMedium euiPage--grow"
-        >
-          <EuiPanel>
-            <div
-              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-            >
-              <EuiFlexGroup
-                justifyContent="spaceBetween"
-              >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <PanelTitle
-                        title="Services"
-                        totalItems={0}
-                      >
-                        <EuiText
-                          size="m"
-                        >
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            <span
-                              className="panel-title"
-                            >
-                              Services
-                            </span>
-                            <span
-                              className="panel-title-count"
-                            >
-                               (0)
-                            </span>
-                          </div>
-                        </EuiText>
-                      </PanelTitle>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiFlexGroup>
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                        >
-                          <EuiFlexItem>
-                            <div
-                              className="euiFlexItem"
-                            >
-                              <EuiToolTip
-                                content="Select services to filter"
-                                delay="regular"
-                                position="top"
-                              >
-                                <span
-                                  className="euiToolTipAnchor"
-                                  onKeyUp={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                >
-                                  <EuiButtonEmpty
-                                    isDisabled={true}
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    size="xs"
-                                  >
-                                    <button
-                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                      disabled={true}
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onFocus={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiButtonContent
-                                        className="euiButtonEmpty__content"
-                                        iconSide="left"
-                                        iconSize="s"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButtonEmpty__text",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiButtonContent euiButtonEmpty__content"
-                                        >
-                                          <span
-                                            className="euiButtonEmpty__text"
-                                          >
-                                            Filter services
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonEmpty>
-                                </span>
-                              </EuiToolTip>
-                            </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem>
-                            <div
-                              className="euiFlexItem"
+                              className="euiPopover__anchor"
                             >
                               <EuiButtonEmpty
                                 onClick={[Function]}
@@ -1638,668 +1446,836 @@ exports[`Services component renders empty services page 1`] = `
                                       <span
                                         className="euiButtonEmpty__text"
                                       >
-                                        Show 24 hour trends
+                                        + Add filter
                                       </span>
                                     </span>
                                   </EuiButtonContent>
                                 </button>
                               </EuiButtonEmpty>
                             </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
+                          </div>
+                        </EuiPopover>
+                      </AddFilterButton>
                     </div>
                   </EuiFlexItem>
                 </div>
               </EuiFlexGroup>
-              <EuiSpacer
-                size="m"
-              >
+            </Filters>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <ServicesTable
+              addFilter={[Function]}
+              addServicesGroupFilter={[Function]}
+              dataPrepperIndicesExist={true}
+              isServiceTrendEnabled={false}
+              items={Array []}
+              loading={true}
+              mode="data_prepper"
+              selectedItems={Array []}
+              serviceTrends={Object {}}
+              setIsServiceTrendEnabled={[Function]}
+              setRedirect={[Function]}
+              setSelectedItems={[Function]}
+              traceColumnAction={[Function]}
+            >
+              <EuiPanel>
                 <div
-                  className="euiSpacer euiSpacer--m"
-                />
-              </EuiSpacer>
-              <EuiHorizontalRule
-                margin="none"
-              >
-                <hr
-                  className="euiHorizontalRule euiHorizontalRule--full"
-                />
-              </EuiHorizontalRule>
-              <NoMatchMessage
-                size="xl"
-              >
-                <EuiSpacer
-                  size="xl"
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                 >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-                <EuiEmptyPrompt
-                  body={
-                    <EuiText
-                      size="s"
-                    >
-                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                    </EuiText>
-                  }
-                  title={
-                    <h2>
-                      No matches
-                    </h2>
-                  }
-                >
-                  <div
-                    className="euiEmptyPrompt"
+                  <EuiFlexGroup
+                    justifyContent="spaceBetween"
                   >
-                    <EuiTitle
-                      size="m"
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                     >
-                      <h2
-                        className="euiTitle euiTitle--medium"
+                      <EuiFlexItem
+                        grow={false}
                       >
-                        No matches
-                      </h2>
-                    </EuiTitle>
-                    <EuiTextColor
-                      color="subdued"
-                    >
-                      <span
-                        className="euiTextColor euiTextColor--subdued"
-                      >
-                        <EuiSpacer
-                          size="m"
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
                         >
-                          <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
+                          <PanelTitle
+                            title="Services"
+                            totalItems={0}
                           >
                             <EuiText
-                              size="s"
+                              size="m"
                             >
                               <div
-                                className="euiText euiText--small"
+                                className="euiText euiText--medium"
                               >
-                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                <span
+                                  className="panel-title"
+                                >
+                                  Services
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
                               </div>
                             </EuiText>
-                          </div>
-                        </EuiText>
-                      </span>
-                    </EuiTextColor>
-                  </div>
-                </EuiEmptyPrompt>
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-              </NoMatchMessage>
-            </div>
-          </EuiPanel>
-        </div>
-      </EuiPage>
-    </ServicesTable>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <ServiceMap
-      addFilter={[Function]}
-      currService=""
-      idSelected="latency"
-      page="services"
-      serviceMap={Object {}}
-      setIdSelected={[Function]}
-    >
-      <EuiPage
-        paddingSize="m"
-      >
-        <div
-          className="euiPage euiPage--paddingMedium euiPage--grow"
-        >
-          <EuiPanel>
-            <div
-              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-            >
-              <PanelTitle
-                title="Service map"
-              >
-                <EuiText
-                  size="m"
-                >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Service map
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-              <EuiSpacer
-                size="m"
-              >
-                <div
-                  className="euiSpacer euiSpacer--m"
-                />
-              </EuiSpacer>
-              <EuiButtonGroup
-                buttonSize="s"
-                color="text"
-                idSelected="latency"
-                onChange={[Function]}
-                options={
-                  Array [
-                    Object {
-                      "id": "latency",
-                      "label": "Duration",
-                    },
-                    Object {
-                      "id": "error_rate",
-                      "label": "Errors",
-                    },
-                    Object {
-                      "id": "throughput",
-                      "label": "Request Rate",
-                    },
-                  ]
-                }
-              >
-                <fieldset
-                  className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                  disabled={false}
-                >
-                  <EuiScreenReaderOnly>
-                    <legend
-                      className="euiScreenReaderOnly"
-                    />
-                  </EuiScreenReaderOnly>
-                  <div
-                    className="euiButtonGroup__buttons"
-                  >
-                    <EuiButtonGroupButton
-                      color="text"
-                      element="label"
-                      id="latency"
-                      isDisabled={false}
-                      isIconOnly={false}
-                      isSelected={true}
-                      key="0"
-                      label="Duration"
-                      name="random_html_id"
-                      onChange={[Function]}
-                      size="s"
-                    >
-                      <EuiButtonDisplay
-                        baseClassName="euiButtonGroupButton"
-                        className="euiButtonGroupButton-isSelected"
-                        color="text"
-                        element="label"
-                        fill={true}
-                        htmlFor="random_html_id"
-                        isDisabled={false}
-                        onClick={[Function]}
-                        size="s"
-                        textProps={
-                          Object {
-                            "className": "euiButtonGroupButton__textShift",
-                            "data-text": "Duration",
-                            "ref": [Function],
-                            "title": "Duration",
-                          }
-                        }
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
                       >
-                        <label
-                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                          disabled={false}
-                          htmlFor="random_html_id"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "minWidth": undefined,
-                            }
-                          }
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
                         >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
+                          <EuiFlexGroup>
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiToolTip
+                                    content="Select services to filter"
+                                    delay="regular"
+                                    position="top"
+                                  >
+                                    <span
+                                      className="euiToolTipAnchor"
+                                      onKeyUp={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                    >
+                                      <EuiButtonEmpty
+                                        isDisabled={true}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        size="xs"
+                                      >
+                                        <button
+                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                          disabled={true}
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          type="button"
+                                        >
+                                          <EuiButtonContent
+                                            className="euiButtonEmpty__content"
+                                            iconSide="left"
+                                            iconSize="s"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButtonEmpty__text",
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              className="euiButtonContent euiButtonEmpty__content"
+                                            >
+                                              <span
+                                                className="euiButtonEmpty__text"
+                                              >
+                                                Filter services
+                                              </span>
+                                            </span>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonEmpty>
+                                    </span>
+                                  </EuiToolTip>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiButtonEmpty
+                                    onClick={[Function]}
+                                    size="xs"
+                                  >
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="s"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonEmpty__content"
+                                        >
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            Show 24 hour trends
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
+                  >
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                    <EuiEmptyPrompt
+                      body={
+                        <EuiText
+                          size="s"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
+                      </div>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </ServicesTable>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <ServiceMap
+              addFilter={[Function]}
+              currService=""
+              idSelected="latency"
+              page="services"
+              serviceMap={Object {}}
+              setIdSelected={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <PanelTitle
+                    title="Service map"
+                  >
+                    <EuiText
+                      size="m"
+                    >
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <span
+                          className="panel-title"
+                        >
+                          Service map
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiButtonGroup
+                    buttonSize="s"
+                    color="text"
+                    idSelected="latency"
+                    onChange={[Function]}
+                    options={
+                      Array [
+                        Object {
+                          "id": "latency",
+                          "label": "Duration",
+                        },
+                        Object {
+                          "id": "error_rate",
+                          "label": "Errors",
+                        },
+                        Object {
+                          "id": "throughput",
+                          "label": "Request Rate",
+                        },
+                      ]
+                    }
+                  >
+                    <fieldset
+                      className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                      disabled={false}
+                    >
+                      <EuiScreenReaderOnly>
+                        <legend
+                          className="euiScreenReaderOnly"
+                        />
+                      </EuiScreenReaderOnly>
+                      <div
+                        className="euiButtonGroup__buttons"
+                      >
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="latency"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={true}
+                          key="0"
+                          label="Duration"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
+                        >
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className="euiButtonGroupButton-isSelected"
+                            color="text"
+                            element="label"
+                            fill={true}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
                             textProps={
                               Object {
-                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "className": "euiButtonGroupButton__textShift",
                                 "data-text": "Duration",
                                 "ref": [Function],
                                 "title": "Duration",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButton__content"
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
                             >
-                              <span
-                                className="euiButton__text euiButtonGroupButton__textShift"
-                                data-text="Duration"
-                                title="Duration"
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Duration",
+                                    "ref": [Function],
+                                    "title": "Duration",
+                                  }
+                                }
                               >
-                                <input
-                                  checked={true}
-                                  className="euiScreenReaderOnly"
-                                  data-test-subj="latency"
-                                  disabled={false}
-                                  id="random_html_id"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  type="radio"
-                                />
-                                Duration
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </label>
-                      </EuiButtonDisplay>
-                    </EuiButtonGroupButton>
-                    <EuiButtonGroupButton
-                      color="text"
-                      element="label"
-                      id="error_rate"
-                      isDisabled={false}
-                      isIconOnly={false}
-                      isSelected={false}
-                      key="1"
-                      label="Errors"
-                      name="random_html_id"
-                      onChange={[Function]}
-                      size="s"
-                    >
-                      <EuiButtonDisplay
-                        baseClassName="euiButtonGroupButton"
-                        className=""
-                        color="text"
-                        element="label"
-                        fill={false}
-                        htmlFor="random_html_id"
-                        isDisabled={false}
-                        onClick={[Function]}
-                        size="s"
-                        textProps={
-                          Object {
-                            "className": "euiButtonGroupButton__textShift",
-                            "data-text": "Errors",
-                            "ref": [Function],
-                            "title": "Errors",
-                          }
-                        }
-                      >
-                        <label
-                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                          disabled={false}
-                          htmlFor="random_html_id"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "minWidth": undefined,
-                            }
-                          }
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked={true}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="error_rate"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={false}
+                          key="1"
+                          label="Errors"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
                         >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className=""
+                            color="text"
+                            element="label"
+                            fill={false}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
                             textProps={
                               Object {
-                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "className": "euiButtonGroupButton__textShift",
                                 "data-text": "Errors",
                                 "ref": [Function],
                                 "title": "Errors",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButton__content"
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
                             >
-                              <span
-                                className="euiButton__text euiButtonGroupButton__textShift"
-                                data-text="Errors"
-                                title="Errors"
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Errors",
+                                    "ref": [Function],
+                                    "title": "Errors",
+                                  }
+                                }
                               >
-                                <input
-                                  checked={false}
-                                  className="euiScreenReaderOnly"
-                                  data-test-subj="error_rate"
-                                  disabled={false}
-                                  id="random_html_id"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  type="radio"
-                                />
-                                Errors
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </label>
-                      </EuiButtonDisplay>
-                    </EuiButtonGroupButton>
-                    <EuiButtonGroupButton
-                      color="text"
-                      element="label"
-                      id="throughput"
-                      isDisabled={false}
-                      isIconOnly={false}
-                      isSelected={false}
-                      key="2"
-                      label="Request Rate"
-                      name="random_html_id"
-                      onChange={[Function]}
-                      size="s"
-                    >
-                      <EuiButtonDisplay
-                        baseClassName="euiButtonGroupButton"
-                        className=""
-                        color="text"
-                        element="label"
-                        fill={false}
-                        htmlFor="random_html_id"
-                        isDisabled={false}
-                        onClick={[Function]}
-                        size="s"
-                        textProps={
-                          Object {
-                            "className": "euiButtonGroupButton__textShift",
-                            "data-text": "Request Rate",
-                            "ref": [Function],
-                            "title": "Request Rate",
-                          }
-                        }
-                      >
-                        <label
-                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                          disabled={false}
-                          htmlFor="random_html_id"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "minWidth": undefined,
-                            }
-                          }
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      checked={false}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="throughput"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={false}
+                          key="2"
+                          label="Request Rate"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
                         >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className=""
+                            color="text"
+                            element="label"
+                            fill={false}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
                             textProps={
                               Object {
-                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "className": "euiButtonGroupButton__textShift",
                                 "data-text": "Request Rate",
                                 "ref": [Function],
                                 "title": "Request Rate",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButton__content"
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
                             >
-                              <span
-                                className="euiButton__text euiButtonGroupButton__textShift"
-                                data-text="Request Rate"
-                                title="Request Rate"
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Request Rate",
+                                    "ref": [Function],
+                                    "title": "Request Rate",
+                                  }
+                                }
                               >
-                                <input
-                                  checked={false}
-                                  className="euiScreenReaderOnly"
-                                  data-test-subj="throughput"
-                                  disabled={false}
-                                  id="random_html_id"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  type="radio"
-                                />
-                                Request Rate
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </label>
-                      </EuiButtonDisplay>
-                    </EuiButtonGroupButton>
-                  </div>
-                </fieldset>
-              </EuiButtonGroup>
-              <EuiHorizontalRule
-                margin="m"
-              >
-                <hr
-                  className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                />
-              </EuiHorizontalRule>
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-              >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          Focus on
-                        </div>
-                      </EuiText>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
-                    >
-                      <EuiCompressedFieldSearch
-                        compressed={true}
-                        fullWidth={false}
-                        incremental={false}
-                        isClearable={true}
-                        isInvalid={false}
-                        isLoading={false}
-                        onChange={[Function]}
-                        onSearch={[Function]}
-                        placeholder="Service name"
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          compressed={true}
-                          fullWidth={false}
-                          icon="search"
-                          isLoading={false}
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--compressed"
-                          >
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiValidatableControl
-                                isInvalid={false}
-                              >
-                                <input
-                                  className="euiFieldSearch euiFieldSearch--compressed"
-                                  onChange={[Function]}
-                                  onKeyUp={[Function]}
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons
-                                compressed={true}
-                                icon="search"
-                                isLoading={false}
-                              >
-                                <div
-                                  className="euiFormControlLayoutIcons"
+                                <span
+                                  className="euiButtonContent euiButton__content"
                                 >
-                                  <EuiFormControlLayoutCustomIcon
-                                    size="s"
-                                    type="search"
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
                                   >
-                                    <span
-                                      className="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiFormControlLayoutCustomIcon__icon"
-                                        size="s"
-                                        type="search"
-                                      >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </span>
-                                  </EuiFormControlLayoutCustomIcon>
-                                </div>
-                              </EuiFormControlLayoutIcons>
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </EuiCompressedFieldSearch>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-              <EuiSpacer>
-                <div
-                  className="euiSpacer euiSpacer--l"
-                />
-              </EuiSpacer>
-              <div
-                style={
-                  Object {
-                    "minHeight": 434,
-                  }
-                }
-              >
-                <NoMatchMessage
-                  size="s"
-                >
-                  <EuiSpacer
-                    size="s"
+                                    <input
+                                      checked={false}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                      </div>
+                    </fieldset>
+                  </EuiButtonGroup>
+                  <EuiHorizontalRule
+                    margin="m"
                   >
-                    <div
-                      className="euiSpacer euiSpacer--s"
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
                     />
-                  </EuiSpacer>
-                  <EuiEmptyPrompt
-                    body={
-                      <EuiText
-                        size="s"
-                      >
-                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                      </EuiText>
-                    }
-                    title={
-                      <h2>
-                        No matches
-                      </h2>
-                    }
+                  </EuiHorizontalRule>
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
                   >
                     <div
-                      className="euiEmptyPrompt"
+                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
                     >
-                      <EuiTitle
-                        size="m"
+                      <EuiFlexItem
+                        grow={false}
                       >
-                        <h2
-                          className="euiTitle euiTitle--medium"
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
                         >
-                          No matches
-                        </h2>
-                      </EuiTitle>
-                      <EuiTextColor
-                        color="subdued"
-                      >
-                        <span
-                          className="euiTextColor euiTextColor--subdued"
-                        >
-                          <EuiSpacer
-                            size="m"
-                          >
-                            <div
-                              className="euiSpacer euiSpacer--m"
-                            />
-                          </EuiSpacer>
                           <EuiText>
                             <div
                               className="euiText euiText--medium"
                             >
-                              <EuiText
-                                size="s"
-                              >
-                                <div
-                                  className="euiText euiText--small"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </EuiText>
+                              Focus on
                             </div>
                           </EuiText>
-                        </span>
-                      </EuiTextColor>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiCompressedFieldSearch
+                            compressed={true}
+                            fullWidth={false}
+                            incremental={false}
+                            isClearable={true}
+                            isInvalid={false}
+                            isLoading={false}
+                            onChange={[Function]}
+                            onSearch={[Function]}
+                            placeholder="Service name"
+                            value=""
+                          >
+                            <EuiFormControlLayout
+                              compressed={true}
+                              fullWidth={false}
+                              icon="search"
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  className="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <EuiValidatableControl
+                                    isInvalid={false}
+                                  >
+                                    <input
+                                      className="euiFieldSearch euiFieldSearch--compressed"
+                                      onChange={[Function]}
+                                      onKeyUp={[Function]}
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                  </EuiValidatableControl>
+                                  <EuiFormControlLayoutIcons
+                                    compressed={true}
+                                    icon="search"
+                                    isLoading={false}
+                                  >
+                                    <div
+                                      className="euiFormControlLayoutIcons"
+                                    >
+                                      <EuiFormControlLayoutCustomIcon
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <span
+                                          className="euiFormControlLayoutCustomIcon"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiFormControlLayoutCustomIcon__icon"
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <EuiIconBeaker
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                        </span>
+                                      </EuiFormControlLayoutCustomIcon>
+                                    </div>
+                                  </EuiFormControlLayoutIcons>
+                                </div>
+                              </div>
+                            </EuiFormControlLayout>
+                          </EuiCompressedFieldSearch>
+                        </div>
+                      </EuiFlexItem>
                     </div>
-                  </EuiEmptyPrompt>
-                  <EuiSpacer
-                    size="s"
-                  >
+                  </EuiFlexGroup>
+                  <EuiSpacer>
                     <div
-                      className="euiSpacer euiSpacer--s"
+                      className="euiSpacer euiSpacer--l"
                     />
                   </EuiSpacer>
-                </NoMatchMessage>
-              </div>
-            </div>
-          </EuiPanel>
-          <EuiSpacer
-            size="xl"
-          >
-            <div
-              className="euiSpacer euiSpacer--xl"
-            />
-          </EuiSpacer>
-        </div>
-      </EuiPage>
-    </ServiceMap>
+                  <div
+                    style={
+                      Object {
+                        "minHeight": 434,
+                      }
+                    }
+                  >
+                    <NoMatchMessage
+                      size="s"
+                    >
+                      <EuiSpacer
+                        size="s"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--s"
+                        />
+                      </EuiSpacer>
+                      <EuiEmptyPrompt
+                        body={
+                          <EuiText
+                            size="s"
+                          >
+                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                          </EuiText>
+                        }
+                        title={
+                          <h2>
+                            No matches
+                          </h2>
+                        }
+                      >
+                        <div
+                          className="euiEmptyPrompt"
+                        >
+                          <EuiTitle
+                            size="m"
+                          >
+                            <h2
+                              className="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                          </EuiTitle>
+                          <EuiTextColor
+                            color="subdued"
+                          >
+                            <span
+                              className="euiTextColor euiTextColor--subdued"
+                            >
+                              <EuiSpacer
+                                size="m"
+                              >
+                                <div
+                                  className="euiSpacer euiSpacer--m"
+                                />
+                              </EuiSpacer>
+                              <EuiText>
+                                <div
+                                  className="euiText euiText--medium"
+                                >
+                                  <EuiText
+                                    size="s"
+                                  >
+                                    <div
+                                      className="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </EuiText>
+                                </div>
+                              </EuiText>
+                            </span>
+                          </EuiTextColor>
+                        </div>
+                      </EuiEmptyPrompt>
+                      <EuiSpacer
+                        size="s"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--s"
+                        />
+                      </EuiSpacer>
+                    </NoMatchMessage>
+                  </div>
+                </div>
+              </EuiPanel>
+              <EuiSpacer
+                size="xl"
+              >
+                <div
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+            </ServiceMap>
+          </div>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </ServicesContent>
 </Services>
 `;
@@ -2761,181 +2737,917 @@ exports[`Services component renders jaeger services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="s"
-      justifyContent="spaceBetween"
-      style={
-        Object {
-          "padding": "0 24px",
-        }
-      }
+    <EuiPage
+      paddingSize="m"
     >
       <div
-        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-        style={
-          Object {
-            "padding": "0 24px",
-          }
-        }
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <EuiFlexItem
-          grow={false}
-        >
+        <EuiPageBody>
           <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
+            className="euiPageBody euiPageBody--borderRadiusNone"
           >
-            <DataSourcePicker
-              modes={
-                Array [
-                  Object {
-                    "id": "jaeger",
-                    "title": "Jaeger",
-                  },
-                  Object {
-                    "id": "data_prepper",
-                    "title": "Data Prepper",
-                  },
-                ]
-              }
-              selectedMode="jaeger"
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiPopover
-                anchorClassName="eui-textTruncate"
-                anchorPosition="downCenter"
-                button={
-                  <EuiSmallButtonEmpty
-                    className="dscIndexPattern__triggerButton"
-                    color="text"
-                    data-test-subj="indexPattern-switch-link"
-                    flush="left"
-                    iconSide="right"
-                    iconType="arrowDown"
-                    onClick={[Function]}
-                    title="jaeger"
-                  >
-                    Jaeger
-                  </EuiSmallButtonEmpty>
-                }
-                className="eui-textTruncate"
-                closePopover={[Function]}
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="s"
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <div
-                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiPopover__anchor eui-textTruncate"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <EuiSmallButtonEmpty
-                      className="dscIndexPattern__triggerButton"
-                      color="text"
-                      data-test-subj="indexPattern-switch-link"
-                      flush="left"
-                      iconSide="right"
-                      iconType="arrowDown"
-                      onClick={[Function]}
-                      title="jaeger"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="jaeger"
                     >
-                      <EuiButtonEmpty
-                        className="dscIndexPattern__triggerButton"
-                        color="text"
-                        data-test-subj="indexPattern-switch-link"
-                        flush="left"
-                        iconSide="right"
-                        iconType="arrowDown"
-                        onClick={[Function]}
-                        size="s"
-                        title="jaeger"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                          data-test-subj="indexPattern-switch-link"
-                          disabled={false}
-                          onClick={[Function]}
-                          title="jaeger"
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
                             iconSide="right"
-                            iconSize="m"
                             iconType="arrowDown"
-                            textProps={
+                            onClick={[Function]}
+                            title="jaeger"
+                          >
+                            Jaeger
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
+                      >
+                        <div
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                        >
+                          <div
+                            className="euiPopover__anchor eui-textTruncate"
+                          >
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="jaeger"
+                            >
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="jaeger"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="jaeger"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="right"
+                                    iconSize="m"
+                                    iconType="arrowDown"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconArrowDown
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                              fillRule="non-zero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowDown>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Jaeger
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="jaeger"
+                      page="services"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
+                                }
+                                value=""
+                              >
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                                  >
+                                    <GlobalFilterButton
+                                      className="euiFormControlLayout__prepend"
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    >
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor"
+                                          >
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
+                                            >
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
+                                              >
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
+                                                >
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconFilter
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                          fillRule="evenodd"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconFilter>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <span
+                                              className="euiFormControlLayoutCustomIcon"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
+                                              >
+                                                <EuiIconSearch
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconSearch>
+                                              </EuiIcon>
+                                            </span>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
                               Object {
-                                "className": "euiButtonEmpty__text",
+                                "maxWidth": "30vw",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
+                                Object {
+                                  "maxWidth": "30vw",
+                                }
+                              }
                             >
-                              <EuiIcon
-                                className="euiButtonContent__icon"
-                                color="inherit"
-                                size="m"
-                                type="arrowDown"
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <EuiIconArrowDown
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
                                   >
-                                    <path
-                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                      fillRule="non-zero"
-                                    />
-                                  </svg>
-                                </EuiIconArrowDown>
-                              </EuiIcon>
-                              <span
-                                className="euiButtonEmpty__text"
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
+                                      >
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconArrowDown
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                                    fillRule="non-zero"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconArrowDown>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconCalendar
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                                      fillRule="evenodd"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconCalendar>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
                               >
-                                Jaeger
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </EuiSmallButtonEmpty>
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconRefresh
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                        />
+                                      </svg>
+                                    </EuiIconRefresh>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
                   </div>
-                </div>
-              </EuiPopover>
-            </DataSourcePicker>
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem
-          grow={true}
-        >
-          <div
-            className="euiFlexItem"
-          >
-            <ForwardRef
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
+              appConfigs={Array []}
               attributesFilterFields={Array []}
-              endTime="now"
               filters={Array []}
               mode="jaeger"
               page="services"
-              query=""
-              refresh={[Function]}
-              setEndTime={[MockFunction]}
               setFilters={
                 [MockFunction] {
                   "calls": Array [
@@ -2951,1081 +3663,329 @@ exports[`Services component renders jaeger services page 1`] = `
                   ],
                 }
               }
-              setQuery={[MockFunction]}
-              setStartTime={[MockFunction]}
-              startTime="now-5m"
             >
               <EuiFlexGroup
                 alignItems="center"
-                gutterSize="s"
+                gutterSize="xs"
+                responsive={false}
               >
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
                 >
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
-                    >
-                      <EuiCompressedFieldSearch
-                        compressed={true}
-                        data-test-subj="search-bar-input-box"
-                        fullWidth={true}
-                        incremental={false}
-                        isClearable={false}
-                        isLoading={false}
-                        onChange={[Function]}
-                        onSearch={[Function]}
-                        placeholder="Trace ID, trace group name, service name"
-                        prepend={
-                          <GlobalFilterButton
-                            filters={Array []}
-                            setFilters={
-                              [MockFunction] {
-                                "calls": Array [
-                                  Array [
-                                    Array [],
-                                  ],
-                                ],
-                                "results": Array [
-                                  Object {
-                                    "type": "return",
-                                    "value": undefined,
-                                  },
-                                ],
-                              }
-                            }
-                          />
-                        }
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          compressed={true}
-                          fullWidth={true}
-                          icon="search"
-                          isLoading={false}
-                          prepend={
-                            <GlobalFilterButton
-                              filters={Array []}
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
-                          >
-                            <GlobalFilterButton
-                              className="euiFormControlLayout__prepend"
-                              filters={Array []}
-                              key="0/.0"
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <EuiSmallButtonIcon
-                                    aria-label="Change all filters"
-                                    iconType="filter"
-                                    onClick={[Function]}
-                                    title="Change all filters"
-                                  />
-                                }
-                                closePopover={[Function]}
-                                data-test-subj="global-filter-button"
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="none"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp"
-                                  data-test-subj="global-filter-button"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
-                                    <EuiSmallButtonIcon
-                                      aria-label="Change all filters"
-                                      iconType="filter"
-                                      onClick={[Function]}
-                                      title="Change all filters"
-                                    >
-                                      <EuiButtonIcon
-                                        aria-label="Change all filters"
-                                        iconType="filter"
-                                        onClick={[Function]}
-                                        size="s"
-                                        title="Change all filters"
-                                      >
-                                        <button
-                                          aria-label="Change all filters"
-                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          title="Change all filters"
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="filter"
-                                          >
-                                            <EuiIconFilter
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                                  fillRule="evenodd"
-                                                />
-                                              </svg>
-                                            </EuiIconFilter>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiSmallButtonIcon>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </GlobalFilterButton>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiValidatableControl>
-                                <input
-                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
-                                  data-test-subj="search-bar-input-box"
-                                  onChange={[Function]}
-                                  onKeyUp={[Function]}
-                                  placeholder="Trace ID, trace group name, service name"
-                                  type="search"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons
-                                compressed={true}
-                                icon="search"
-                                isLoading={false}
-                              >
-                                <div
-                                  className="euiFormControlLayoutIcons"
-                                >
-                                  <EuiFormControlLayoutCustomIcon
-                                    size="s"
-                                    type="search"
-                                  >
-                                    <span
-                                      className="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiFormControlLayoutCustomIcon__icon"
-                                        size="s"
-                                        type="search"
-                                      >
-                                        <EuiIconSearch
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                            />
-                                          </svg>
-                                        </EuiIconSearch>
-                                      </EuiIcon>
-                                    </span>
-                                  </EuiFormControlLayoutCustomIcon>
-                                </div>
-                              </EuiFormControlLayoutIcons>
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </EuiCompressedFieldSearch>
-                    </div>
-                  </EuiFlexItem>
                   <EuiFlexItem
                     grow={false}
-                    style={
-                      Object {
-                        "maxWidth": "30vw",
-                      }
-                    }
                   >
                     <div
                       className="euiFlexItem euiFlexItem--flexGrowZero"
-                      style={
-                        Object {
-                          "maxWidth": "30vw",
-                        }
-                      }
                     >
-                      <EuiSuperDatePicker
-                        commonlyUsedRanges={
-                          Array [
-                            Object {
-                              "end": "now/d",
-                              "label": "Today",
-                              "start": "now/d",
-                            },
-                            Object {
-                              "end": "now/w",
-                              "label": "This week",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now/M",
-                              "label": "This month",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now/y",
-                              "label": "This year",
-                              "start": "now/y",
-                            },
-                            Object {
-                              "end": "now-1d/d",
-                              "label": "Yesterday",
-                              "start": "now-1d/d",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Week to date",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Month to date",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Year to date",
-                              "start": "now/y",
-                            },
-                          ]
-                        }
-                        compressed={true}
-                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                        end="now"
-                        isAutoRefreshOnly={false}
-                        isDisabled={false}
-                        isPaused={true}
-                        onTimeChange={[Function]}
-                        recentlyUsedRanges={Array []}
-                        refreshInterval={0}
-                        showUpdateButton={false}
-                        start="now-5m"
-                        timeFormat="HH:mm"
-                      >
-                        <EuiFlexGroup
-                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          gutterSize="s"
-                          responsive={false}
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
+                          }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
                         >
                           <div
-                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
                           >
-                            <EuiFlexItem>
-                              <div
-                                className="euiFlexItem"
+                            <div
+                              className="euiPopover__anchor"
+                            >
+                              <EuiButtonEmpty
+                                onClick={[Function]}
+                                size="xs"
                               >
-                                <EuiFormControlLayout
-                                  className="euiSuperDatePicker"
-                                  compressed={true}
-                                  isDisabled={false}
-                                  prepend={
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    />
-                                  }
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <div
-                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
-                                  >
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      className="euiFormControlLayout__prepend"
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
                                       }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      key="0/.0"
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      <EuiPopover
-                                        anchorClassName="euiQuickSelectPopover__anchor"
-                                        anchorPosition="downLeft"
-                                        button={
-                                          <EuiButtonEmpty
-                                            aria-label="Date quick select"
-                                            className="euiFormControlLayout__prepend"
-                                            data-test-subj="superDatePickerToggleQuickMenuButton"
-                                            iconSide="right"
-                                            iconType="arrowDown"
-                                            isDisabled={false}
-                                            onClick={[Function]}
-                                            size="xs"
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        + Add filter
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </div>
+                          </div>
+                        </EuiPopover>
+                      </AddFilterButton>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </Filters>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <ServicesTable
+              addFilter={[Function]}
+              addServicesGroupFilter={[Function]}
+              dataPrepperIndicesExist={false}
+              isServiceTrendEnabled={false}
+              items={Array []}
+              jaegerIndicesExist={true}
+              loading={true}
+              mode="jaeger"
+              selectedItems={Array []}
+              serviceTrends={Object {}}
+              setIsServiceTrendEnabled={[Function]}
+              setRedirect={[Function]}
+              setSelectedItems={[Function]}
+              traceColumnAction={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <EuiFlexGroup
+                    justifyContent="spaceBetween"
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <PanelTitle
+                            title="Services"
+                            totalItems={0}
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <span
+                                  className="panel-title"
+                                >
+                                  Services
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiFlexGroup>
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiToolTip
+                                    content="Select services to filter"
+                                    delay="regular"
+                                    position="top"
+                                  >
+                                    <span
+                                      className="euiToolTipAnchor"
+                                      onKeyUp={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                    >
+                                      <EuiButtonEmpty
+                                        isDisabled={true}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        size="xs"
+                                      >
+                                        <button
+                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                          disabled={true}
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          type="button"
+                                        >
+                                          <EuiButtonContent
+                                            className="euiButtonEmpty__content"
+                                            iconSide="left"
+                                            iconSize="s"
                                             textProps={
                                               Object {
-                                                "className": "euiQuickSelectPopover__buttonText",
+                                                "className": "euiButtonEmpty__text",
                                               }
                                             }
                                           >
-                                            <EuiIcon
-                                              type="calendar"
-                                            />
-                                          </EuiButtonEmpty>
-                                        }
-                                        closePopover={[Function]}
-                                        display="inlineBlock"
-                                        hasArrow={true}
-                                        isOpen={false}
-                                        ownFocus={true}
-                                        panelPaddingSize="s"
-                                      >
-                                        <div
-                                          className="euiPopover euiPopover--anchorDownLeft"
-                                        >
-                                          <div
-                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                          >
-                                            <EuiButtonEmpty
-                                              aria-label="Date quick select"
-                                              className="euiFormControlLayout__prepend"
-                                              data-test-subj="superDatePickerToggleQuickMenuButton"
-                                              iconSide="right"
-                                              iconType="arrowDown"
-                                              isDisabled={false}
-                                              onClick={[Function]}
-                                              size="xs"
-                                              textProps={
-                                                Object {
-                                                  "className": "euiQuickSelectPopover__buttonText",
-                                                }
-                                              }
-                                            >
-                                              <button
-                                                aria-label="Date quick select"
-                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                                data-test-subj="superDatePickerToggleQuickMenuButton"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <EuiButtonContent
-                                                  className="euiButtonEmpty__content"
-                                                  iconSide="right"
-                                                  iconSize="s"
-                                                  iconType="arrowDown"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                                    }
-                                                  }
-                                                >
-                                                  <span
-                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                                  >
-                                                    <EuiIcon
-                                                      className="euiButtonContent__icon"
-                                                      color="inherit"
-                                                      size="s"
-                                                      type="arrowDown"
-                                                    >
-                                                      <EuiIconArrowDown
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                        focusable="false"
-                                                        role="img"
-                                                        style={null}
-                                                      >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                          focusable="false"
-                                                          height={16}
-                                                          role="img"
-                                                          style={null}
-                                                          viewBox="0 0 16 16"
-                                                          width={16}
-                                                          xmlns="http://www.w3.org/2000/svg"
-                                                        >
-                                                          <path
-                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                            fillRule="non-zero"
-                                                          />
-                                                        </svg>
-                                                      </EuiIconArrowDown>
-                                                    </EuiIcon>
-                                                    <span
-                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                                    >
-                                                      <EuiIcon
-                                                        type="calendar"
-                                                      >
-                                                        <EuiIconCalendar
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--medium"
-                                                          focusable="false"
-                                                          role="img"
-                                                          style={null}
-                                                        >
-                                                          <svg
-                                                            aria-hidden={true}
-                                                            className="euiIcon euiIcon--medium"
-                                                            focusable="false"
-                                                            height={16}
-                                                            role="img"
-                                                            style={null}
-                                                            viewBox="0 0 16 16"
-                                                            width={16}
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                          >
-                                                            <path
-                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                              fillRule="evenodd"
-                                                            />
-                                                          </svg>
-                                                        </EuiIconCalendar>
-                                                      </EuiIcon>
-                                                    </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonEmpty>
-                                          </div>
-                                        </div>
-                                      </EuiPopover>
-                                    </EuiQuickSelectPopover>
-                                    <div
-                                      className="euiFormControlLayout__childrenWrapper"
-                                    >
-                                      <EuiDatePickerRange
-                                        className="euiDatePickerRange--inGroup"
-                                        endDateControl={<div />}
-                                        iconType={false}
-                                        isCustom={true}
-                                        startDateControl={<div />}
-                                      >
-                                        <div
-                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                        >
-                                          <button
-                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
-                                            data-test-subj="superDatePickerShowDatesButton"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                          >
-                                            Last 5 minutes
                                             <span
-                                              className="euiSuperDatePicker__prettyFormatLink"
+                                              className="euiButtonContent euiButtonEmpty__content"
                                             >
-                                              <EuiI18n
-                                                default="Show dates"
-                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              <span
+                                                className="euiButtonEmpty__text"
                                               >
-                                                Show dates
-                                              </EuiI18n>
+                                                Filter services
+                                              </span>
                                             </span>
-                                          </button>
-                                        </div>
-                                      </EuiDatePickerRange>
-                                      <EuiFormControlLayoutIcons
-                                        compressed={true}
-                                      />
-                                    </div>
-                                  </div>
-                                </EuiFormControlLayout>
-                              </div>
-                            </EuiFlexItem>
-                          </div>
-                        </EuiFlexGroup>
-                      </EuiSuperDatePicker>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiButtonIcon
-                        aria-label="Refresh"
-                        data-click-metric-element="trace_analytics.refresh_button"
-                        data-test-subj="superDatePickerApplyTimeButton"
-                        display="base"
-                        iconType="refresh"
-                        onClick={[Function]}
-                        size="s"
-                      >
-                        <button
-                          aria-label="Refresh"
-                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
-                          data-click-metric-element="trace_analytics.refresh_button"
-                          data-test-subj="superDatePickerApplyTimeButton"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiIcon
-                            aria-hidden="true"
-                            className="euiButtonIcon__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
-                          >
-                            <EuiIconRefresh
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                                />
-                              </svg>
-                            </EuiIconRefresh>
-                          </EuiIcon>
-                        </button>
-                      </EuiButtonIcon>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </ForwardRef>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
-    <Filters
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      filters={Array []}
-      mode="jaeger"
-      page="services"
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-    >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="xs"
-        responsive={false}
-        style={
-          Object {
-            "minHeight": 32,
-            "padding": "0 16px",
-          }
-        }
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-          style={
-            Object {
-              "minHeight": 32,
-              "padding": "0 16px",
-            }
-          }
-        >
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <AddFilterButton>
-                <EuiPopover
-                  anchorPosition="downLeft"
-                  button={
-                    <EuiButtonEmpty
-                      onClick={[Function]}
-                      size="xs"
-                    >
-                      + Add filter
-                    </EuiButtonEmpty>
-                  }
-                  closePopover={[Function]}
-                  data-test-subj="addfilter"
-                  display="inlineBlock"
-                  hasArrow={true}
-                  isOpen={false}
-                  ownFocus={true}
-                  panelPaddingSize="m"
-                >
-                  <div
-                    className="euiPopover euiPopover--anchorDownLeft"
-                    data-test-subj="addfilter"
-                  >
-                    <div
-                      className="euiPopover__anchor"
-                    >
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
-                            iconSide="left"
-                            iconSize="s"
-                            textProps={
-                              Object {
-                                "className": "euiButtonEmpty__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButtonEmpty__content"
-                            >
-                              <span
-                                className="euiButtonEmpty__text"
-                              >
-                                + Add filter
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </div>
-                  </div>
-                </EuiPopover>
-              </AddFilterButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-    </Filters>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <ServicesTable
-      addFilter={[Function]}
-      addServicesGroupFilter={[Function]}
-      dataPrepperIndicesExist={false}
-      isServiceTrendEnabled={false}
-      items={Array []}
-      jaegerIndicesExist={true}
-      loading={true}
-      mode="jaeger"
-      selectedItems={Array []}
-      serviceTrends={Object {}}
-      setIsServiceTrendEnabled={[Function]}
-      setRedirect={[Function]}
-      setSelectedItems={[Function]}
-      traceColumnAction={[Function]}
-    >
-      <EuiPage
-        paddingSize="m"
-      >
-        <div
-          className="euiPage euiPage--paddingMedium euiPage--grow"
-        >
-          <EuiPanel>
-            <div
-              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-            >
-              <EuiFlexGroup
-                justifyContent="spaceBetween"
-              >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <PanelTitle
-                        title="Services"
-                        totalItems={0}
-                      >
-                        <EuiText
-                          size="m"
-                        >
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            <span
-                              className="panel-title"
-                            >
-                              Services
-                            </span>
-                            <span
-                              className="panel-title-count"
-                            >
-                               (0)
-                            </span>
-                          </div>
-                        </EuiText>
-                      </PanelTitle>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiFlexGroup>
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                        >
-                          <EuiFlexItem>
-                            <div
-                              className="euiFlexItem"
-                            >
-                              <EuiToolTip
-                                content="Select services to filter"
-                                delay="regular"
-                                position="top"
-                              >
-                                <span
-                                  className="euiToolTipAnchor"
-                                  onKeyUp={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                >
-                                  <EuiButtonEmpty
-                                    isDisabled={true}
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    size="xs"
-                                  >
-                                    <button
-                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                      disabled={true}
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onFocus={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiButtonContent
-                                        className="euiButtonEmpty__content"
-                                        iconSide="left"
-                                        iconSize="s"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButtonEmpty__text",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiButtonContent euiButtonEmpty__content"
-                                        >
-                                          <span
-                                            className="euiButtonEmpty__text"
-                                          >
-                                            Filter services
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonEmpty>
-                                </span>
-                              </EuiToolTip>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonEmpty>
+                                    </span>
+                                  </EuiToolTip>
+                                </div>
+                              </EuiFlexItem>
                             </div>
-                          </EuiFlexItem>
+                          </EuiFlexGroup>
                         </div>
-                      </EuiFlexGroup>
+                      </EuiFlexItem>
                     </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-              <EuiSpacer
-                size="m"
-              >
-                <div
-                  className="euiSpacer euiSpacer--m"
-                />
-              </EuiSpacer>
-              <EuiHorizontalRule
-                margin="none"
-              >
-                <hr
-                  className="euiHorizontalRule euiHorizontalRule--full"
-                />
-              </EuiHorizontalRule>
-              <NoMatchMessage
-                size="xl"
-              >
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-                <EuiEmptyPrompt
-                  body={
-                    <EuiText
-                      size="s"
-                    >
-                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                    </EuiText>
-                  }
-                  title={
-                    <h2>
-                      No matches
-                    </h2>
-                  }
-                >
-                  <div
-                    className="euiEmptyPrompt"
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
                   >
-                    <EuiTitle
-                      size="m"
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
+                  >
+                    <EuiSpacer
+                      size="xl"
                     >
-                      <h2
-                        className="euiTitle euiTitle--medium"
-                      >
-                        No matches
-                      </h2>
-                    </EuiTitle>
-                    <EuiTextColor
-                      color="subdued"
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                    <EuiEmptyPrompt
+                      body={
+                        <EuiText
+                          size="s"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
                     >
-                      <span
-                        className="euiTextColor euiTextColor--subdued"
+                      <div
+                        className="euiEmptyPrompt"
                       >
-                        <EuiSpacer
+                        <EuiTitle
                           size="m"
                         >
-                          <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
+                          <h2
+                            className="euiTitle euiTitle--medium"
                           >
-                            <EuiText
-                              size="s"
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
                             >
                               <div
-                                className="euiText euiText--small"
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
                               >
-                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
                               </div>
                             </EuiText>
-                          </div>
-                        </EuiText>
-                      </span>
-                    </EuiTextColor>
-                  </div>
-                </EuiEmptyPrompt>
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-              </NoMatchMessage>
-            </div>
-          </EuiPanel>
-        </div>
-      </EuiPage>
-    </ServicesTable>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <div />
+                          </span>
+                        </EuiTextColor>
+                      </div>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </ServicesTable>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <div />
+          </div>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </ServicesContent>
 </Services>
 `;
@@ -4485,181 +4445,917 @@ exports[`Services component renders services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="s"
-      justifyContent="spaceBetween"
-      style={
-        Object {
-          "padding": "0 24px",
-        }
-      }
+    <EuiPage
+      paddingSize="m"
     >
       <div
-        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-        style={
-          Object {
-            "padding": "0 24px",
-          }
-        }
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <EuiFlexItem
-          grow={false}
-        >
+        <EuiPageBody>
           <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
+            className="euiPageBody euiPageBody--borderRadiusNone"
           >
-            <DataSourcePicker
-              modes={
-                Array [
-                  Object {
-                    "id": "jaeger",
-                    "title": "Jaeger",
-                  },
-                  Object {
-                    "id": "data_prepper",
-                    "title": "Data Prepper",
-                  },
-                ]
-              }
-              selectedMode="data_prepper"
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiPopover
-                anchorClassName="eui-textTruncate"
-                anchorPosition="downCenter"
-                button={
-                  <EuiSmallButtonEmpty
-                    className="dscIndexPattern__triggerButton"
-                    color="text"
-                    data-test-subj="indexPattern-switch-link"
-                    flush="left"
-                    iconSide="right"
-                    iconType="arrowDown"
-                    onClick={[Function]}
-                    title="data_prepper"
-                  >
-                    Data Prepper
-                  </EuiSmallButtonEmpty>
-                }
-                className="eui-textTruncate"
-                closePopover={[Function]}
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="s"
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <div
-                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiPopover__anchor eui-textTruncate"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <EuiSmallButtonEmpty
-                      className="dscIndexPattern__triggerButton"
-                      color="text"
-                      data-test-subj="indexPattern-switch-link"
-                      flush="left"
-                      iconSide="right"
-                      iconType="arrowDown"
-                      onClick={[Function]}
-                      title="data_prepper"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="data_prepper"
                     >
-                      <EuiButtonEmpty
-                        className="dscIndexPattern__triggerButton"
-                        color="text"
-                        data-test-subj="indexPattern-switch-link"
-                        flush="left"
-                        iconSide="right"
-                        iconType="arrowDown"
-                        onClick={[Function]}
-                        size="s"
-                        title="data_prepper"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                          data-test-subj="indexPattern-switch-link"
-                          disabled={false}
-                          onClick={[Function]}
-                          title="data_prepper"
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
                             iconSide="right"
-                            iconSize="m"
                             iconType="arrowDown"
-                            textProps={
+                            onClick={[Function]}
+                            title="data_prepper"
+                          >
+                            Data Prepper
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
+                      >
+                        <div
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                        >
+                          <div
+                            className="euiPopover__anchor eui-textTruncate"
+                          >
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="data_prepper"
+                            >
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="data_prepper"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="data_prepper"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="right"
+                                    iconSize="m"
+                                    iconType="arrowDown"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconArrowDown
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                              fillRule="non-zero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowDown>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Data Prepper
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="data_prepper"
+                      page="services"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
+                                }
+                                value=""
+                              >
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                                  >
+                                    <GlobalFilterButton
+                                      className="euiFormControlLayout__prepend"
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    >
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor"
+                                          >
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
+                                            >
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
+                                              >
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
+                                                >
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconFilter
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                          fillRule="evenodd"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconFilter>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <span
+                                              className="euiFormControlLayoutCustomIcon"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
+                                              >
+                                                <EuiIconSearch
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconSearch>
+                                              </EuiIcon>
+                                            </span>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
                               Object {
-                                "className": "euiButtonEmpty__text",
+                                "maxWidth": "30vw",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
+                                Object {
+                                  "maxWidth": "30vw",
+                                }
+                              }
                             >
-                              <EuiIcon
-                                className="euiButtonContent__icon"
-                                color="inherit"
-                                size="m"
-                                type="arrowDown"
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <EuiIconArrowDown
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
                                   >
-                                    <path
-                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                      fillRule="non-zero"
-                                    />
-                                  </svg>
-                                </EuiIconArrowDown>
-                              </EuiIcon>
-                              <span
-                                className="euiButtonEmpty__text"
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
+                                      >
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconArrowDown
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                                    fillRule="non-zero"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconArrowDown>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconCalendar
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                                      fillRule="evenodd"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconCalendar>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
                               >
-                                Data Prepper
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </EuiSmallButtonEmpty>
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconRefresh
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                        />
+                                      </svg>
+                                    </EuiIconRefresh>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
                   </div>
-                </div>
-              </EuiPopover>
-            </DataSourcePicker>
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem
-          grow={true}
-        >
-          <div
-            className="euiFlexItem"
-          >
-            <ForwardRef
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
+              appConfigs={Array []}
               attributesFilterFields={Array []}
-              endTime="now"
               filters={Array []}
               mode="data_prepper"
               page="services"
-              query=""
-              refresh={[Function]}
-              setEndTime={[MockFunction]}
               setFilters={
                 [MockFunction] {
                   "calls": Array [
@@ -4675,974 +5371,46 @@ exports[`Services component renders services page 1`] = `
                   ],
                 }
               }
-              setQuery={[MockFunction]}
-              setStartTime={[MockFunction]}
-              startTime="now-5m"
             >
               <EuiFlexGroup
                 alignItems="center"
-                gutterSize="s"
+                gutterSize="xs"
+                responsive={false}
               >
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
                 >
-                  <EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
                     <div
-                      className="euiFlexItem"
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiCompressedFieldSearch
-                        compressed={true}
-                        data-test-subj="search-bar-input-box"
-                        fullWidth={true}
-                        incremental={false}
-                        isClearable={false}
-                        isLoading={false}
-                        onChange={[Function]}
-                        onSearch={[Function]}
-                        placeholder="Trace ID, trace group name, service name"
-                        prepend={
-                          <GlobalFilterButton
-                            filters={Array []}
-                            setFilters={
-                              [MockFunction] {
-                                "calls": Array [
-                                  Array [
-                                    Array [],
-                                  ],
-                                ],
-                                "results": Array [
-                                  Object {
-                                    "type": "return",
-                                    "value": undefined,
-                                  },
-                                ],
-                              }
-                            }
-                          />
-                        }
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          compressed={true}
-                          fullWidth={true}
-                          icon="search"
-                          isLoading={false}
-                          prepend={
-                            <GlobalFilterButton
-                              filters={Array []}
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            />
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
                           }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
                           >
-                            <GlobalFilterButton
-                              className="euiFormControlLayout__prepend"
-                              filters={Array []}
-                              key="0/.0"
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <EuiSmallButtonIcon
-                                    aria-label="Change all filters"
-                                    iconType="filter"
-                                    onClick={[Function]}
-                                    title="Change all filters"
-                                  />
-                                }
-                                closePopover={[Function]}
-                                data-test-subj="global-filter-button"
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="none"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp"
-                                  data-test-subj="global-filter-button"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
-                                    <EuiSmallButtonIcon
-                                      aria-label="Change all filters"
-                                      iconType="filter"
-                                      onClick={[Function]}
-                                      title="Change all filters"
-                                    >
-                                      <EuiButtonIcon
-                                        aria-label="Change all filters"
-                                        iconType="filter"
-                                        onClick={[Function]}
-                                        size="s"
-                                        title="Change all filters"
-                                      >
-                                        <button
-                                          aria-label="Change all filters"
-                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          title="Change all filters"
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="filter"
-                                          >
-                                            <EuiIconFilter
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                                  fillRule="evenodd"
-                                                />
-                                              </svg>
-                                            </EuiIconFilter>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiSmallButtonIcon>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </GlobalFilterButton>
                             <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiValidatableControl>
-                                <input
-                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
-                                  data-test-subj="search-bar-input-box"
-                                  onChange={[Function]}
-                                  onKeyUp={[Function]}
-                                  placeholder="Trace ID, trace group name, service name"
-                                  type="search"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons
-                                compressed={true}
-                                icon="search"
-                                isLoading={false}
-                              >
-                                <div
-                                  className="euiFormControlLayoutIcons"
-                                >
-                                  <EuiFormControlLayoutCustomIcon
-                                    size="s"
-                                    type="search"
-                                  >
-                                    <span
-                                      className="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiFormControlLayoutCustomIcon__icon"
-                                        size="s"
-                                        type="search"
-                                      >
-                                        <EuiIconSearch
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                            />
-                                          </svg>
-                                        </EuiIconSearch>
-                                      </EuiIcon>
-                                    </span>
-                                  </EuiFormControlLayoutCustomIcon>
-                                </div>
-                              </EuiFormControlLayoutIcons>
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </EuiCompressedFieldSearch>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                    style={
-                      Object {
-                        "maxWidth": "30vw",
-                      }
-                    }
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                      style={
-                        Object {
-                          "maxWidth": "30vw",
-                        }
-                      }
-                    >
-                      <EuiSuperDatePicker
-                        commonlyUsedRanges={
-                          Array [
-                            Object {
-                              "end": "now/d",
-                              "label": "Today",
-                              "start": "now/d",
-                            },
-                            Object {
-                              "end": "now/w",
-                              "label": "This week",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now/M",
-                              "label": "This month",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now/y",
-                              "label": "This year",
-                              "start": "now/y",
-                            },
-                            Object {
-                              "end": "now-1d/d",
-                              "label": "Yesterday",
-                              "start": "now-1d/d",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Week to date",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Month to date",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Year to date",
-                              "start": "now/y",
-                            },
-                          ]
-                        }
-                        compressed={true}
-                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                        end="now"
-                        isAutoRefreshOnly={false}
-                        isDisabled={false}
-                        isPaused={true}
-                        onTimeChange={[Function]}
-                        recentlyUsedRanges={Array []}
-                        refreshInterval={0}
-                        showUpdateButton={false}
-                        start="now-5m"
-                        timeFormat="HH:mm"
-                      >
-                        <EuiFlexGroup
-                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          gutterSize="s"
-                          responsive={false}
-                        >
-                          <div
-                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          >
-                            <EuiFlexItem>
-                              <div
-                                className="euiFlexItem"
-                              >
-                                <EuiFormControlLayout
-                                  className="euiSuperDatePicker"
-                                  compressed={true}
-                                  isDisabled={false}
-                                  prepend={
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    />
-                                  }
-                                >
-                                  <div
-                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
-                                  >
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      className="euiFormControlLayout__prepend"
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      key="0/.0"
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    >
-                                      <EuiPopover
-                                        anchorClassName="euiQuickSelectPopover__anchor"
-                                        anchorPosition="downLeft"
-                                        button={
-                                          <EuiButtonEmpty
-                                            aria-label="Date quick select"
-                                            className="euiFormControlLayout__prepend"
-                                            data-test-subj="superDatePickerToggleQuickMenuButton"
-                                            iconSide="right"
-                                            iconType="arrowDown"
-                                            isDisabled={false}
-                                            onClick={[Function]}
-                                            size="xs"
-                                            textProps={
-                                              Object {
-                                                "className": "euiQuickSelectPopover__buttonText",
-                                              }
-                                            }
-                                          >
-                                            <EuiIcon
-                                              type="calendar"
-                                            />
-                                          </EuiButtonEmpty>
-                                        }
-                                        closePopover={[Function]}
-                                        display="inlineBlock"
-                                        hasArrow={true}
-                                        isOpen={false}
-                                        ownFocus={true}
-                                        panelPaddingSize="s"
-                                      >
-                                        <div
-                                          className="euiPopover euiPopover--anchorDownLeft"
-                                        >
-                                          <div
-                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                          >
-                                            <EuiButtonEmpty
-                                              aria-label="Date quick select"
-                                              className="euiFormControlLayout__prepend"
-                                              data-test-subj="superDatePickerToggleQuickMenuButton"
-                                              iconSide="right"
-                                              iconType="arrowDown"
-                                              isDisabled={false}
-                                              onClick={[Function]}
-                                              size="xs"
-                                              textProps={
-                                                Object {
-                                                  "className": "euiQuickSelectPopover__buttonText",
-                                                }
-                                              }
-                                            >
-                                              <button
-                                                aria-label="Date quick select"
-                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                                data-test-subj="superDatePickerToggleQuickMenuButton"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <EuiButtonContent
-                                                  className="euiButtonEmpty__content"
-                                                  iconSide="right"
-                                                  iconSize="s"
-                                                  iconType="arrowDown"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                                    }
-                                                  }
-                                                >
-                                                  <span
-                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                                  >
-                                                    <EuiIcon
-                                                      className="euiButtonContent__icon"
-                                                      color="inherit"
-                                                      size="s"
-                                                      type="arrowDown"
-                                                    >
-                                                      <EuiIconArrowDown
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                        focusable="false"
-                                                        role="img"
-                                                        style={null}
-                                                      >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                          focusable="false"
-                                                          height={16}
-                                                          role="img"
-                                                          style={null}
-                                                          viewBox="0 0 16 16"
-                                                          width={16}
-                                                          xmlns="http://www.w3.org/2000/svg"
-                                                        >
-                                                          <path
-                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                            fillRule="non-zero"
-                                                          />
-                                                        </svg>
-                                                      </EuiIconArrowDown>
-                                                    </EuiIcon>
-                                                    <span
-                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                                    >
-                                                      <EuiIcon
-                                                        type="calendar"
-                                                      >
-                                                        <EuiIconCalendar
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--medium"
-                                                          focusable="false"
-                                                          role="img"
-                                                          style={null}
-                                                        >
-                                                          <svg
-                                                            aria-hidden={true}
-                                                            className="euiIcon euiIcon--medium"
-                                                            focusable="false"
-                                                            height={16}
-                                                            role="img"
-                                                            style={null}
-                                                            viewBox="0 0 16 16"
-                                                            width={16}
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                          >
-                                                            <path
-                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                              fillRule="evenodd"
-                                                            />
-                                                          </svg>
-                                                        </EuiIconCalendar>
-                                                      </EuiIcon>
-                                                    </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonEmpty>
-                                          </div>
-                                        </div>
-                                      </EuiPopover>
-                                    </EuiQuickSelectPopover>
-                                    <div
-                                      className="euiFormControlLayout__childrenWrapper"
-                                    >
-                                      <EuiDatePickerRange
-                                        className="euiDatePickerRange--inGroup"
-                                        endDateControl={<div />}
-                                        iconType={false}
-                                        isCustom={true}
-                                        startDateControl={<div />}
-                                      >
-                                        <div
-                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                        >
-                                          <button
-                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
-                                            data-test-subj="superDatePickerShowDatesButton"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                          >
-                                            Last 5 minutes
-                                            <span
-                                              className="euiSuperDatePicker__prettyFormatLink"
-                                            >
-                                              <EuiI18n
-                                                default="Show dates"
-                                                token="euiSuperDatePicker.showDatesButtonLabel"
-                                              >
-                                                Show dates
-                                              </EuiI18n>
-                                            </span>
-                                          </button>
-                                        </div>
-                                      </EuiDatePickerRange>
-                                      <EuiFormControlLayoutIcons
-                                        compressed={true}
-                                      />
-                                    </div>
-                                  </div>
-                                </EuiFormControlLayout>
-                              </div>
-                            </EuiFlexItem>
-                          </div>
-                        </EuiFlexGroup>
-                      </EuiSuperDatePicker>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiButtonIcon
-                        aria-label="Refresh"
-                        data-click-metric-element="trace_analytics.refresh_button"
-                        data-test-subj="superDatePickerApplyTimeButton"
-                        display="base"
-                        iconType="refresh"
-                        onClick={[Function]}
-                        size="s"
-                      >
-                        <button
-                          aria-label="Refresh"
-                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
-                          data-click-metric-element="trace_analytics.refresh_button"
-                          data-test-subj="superDatePickerApplyTimeButton"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiIcon
-                            aria-hidden="true"
-                            className="euiButtonIcon__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
-                          >
-                            <EuiIconRefresh
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                                />
-                              </svg>
-                            </EuiIconRefresh>
-                          </EuiIcon>
-                        </button>
-                      </EuiButtonIcon>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </ForwardRef>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
-    <Filters
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      filters={Array []}
-      mode="data_prepper"
-      page="services"
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-    >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="xs"
-        responsive={false}
-        style={
-          Object {
-            "minHeight": 32,
-            "padding": "0 16px",
-          }
-        }
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-          style={
-            Object {
-              "minHeight": 32,
-              "padding": "0 16px",
-            }
-          }
-        >
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <AddFilterButton>
-                <EuiPopover
-                  anchorPosition="downLeft"
-                  button={
-                    <EuiButtonEmpty
-                      onClick={[Function]}
-                      size="xs"
-                    >
-                      + Add filter
-                    </EuiButtonEmpty>
-                  }
-                  closePopover={[Function]}
-                  data-test-subj="addfilter"
-                  display="inlineBlock"
-                  hasArrow={true}
-                  isOpen={false}
-                  ownFocus={true}
-                  panelPaddingSize="m"
-                >
-                  <div
-                    className="euiPopover euiPopover--anchorDownLeft"
-                    data-test-subj="addfilter"
-                  >
-                    <div
-                      className="euiPopover__anchor"
-                    >
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
-                            iconSide="left"
-                            iconSize="s"
-                            textProps={
-                              Object {
-                                "className": "euiButtonEmpty__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButtonEmpty__content"
-                            >
-                              <span
-                                className="euiButtonEmpty__text"
-                              >
-                                + Add filter
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </div>
-                  </div>
-                </EuiPopover>
-              </AddFilterButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-    </Filters>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <ServicesTable
-      addFilter={[Function]}
-      addServicesGroupFilter={[Function]}
-      dataPrepperIndicesExist={true}
-      isServiceTrendEnabled={false}
-      items={Array []}
-      loading={true}
-      mode="data_prepper"
-      selectedItems={Array []}
-      serviceTrends={Object {}}
-      setIsServiceTrendEnabled={[Function]}
-      setRedirect={[Function]}
-      setSelectedItems={[Function]}
-      traceColumnAction={[Function]}
-    >
-      <EuiPage
-        paddingSize="m"
-      >
-        <div
-          className="euiPage euiPage--paddingMedium euiPage--grow"
-        >
-          <EuiPanel>
-            <div
-              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-            >
-              <EuiFlexGroup
-                justifyContent="spaceBetween"
-              >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <PanelTitle
-                        title="Services"
-                        totalItems={0}
-                      >
-                        <EuiText
-                          size="m"
-                        >
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            <span
-                              className="panel-title"
-                            >
-                              Services
-                            </span>
-                            <span
-                              className="panel-title-count"
-                            >
-                               (0)
-                            </span>
-                          </div>
-                        </EuiText>
-                      </PanelTitle>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiFlexGroup>
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                        >
-                          <EuiFlexItem>
-                            <div
-                              className="euiFlexItem"
-                            >
-                              <EuiToolTip
-                                content="Select services to filter"
-                                delay="regular"
-                                position="top"
-                              >
-                                <span
-                                  className="euiToolTipAnchor"
-                                  onKeyUp={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                >
-                                  <EuiButtonEmpty
-                                    isDisabled={true}
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    size="xs"
-                                  >
-                                    <button
-                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                      disabled={true}
-                                      onBlur={[Function]}
-                                      onClick={[Function]}
-                                      onFocus={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiButtonContent
-                                        className="euiButtonEmpty__content"
-                                        iconSide="left"
-                                        iconSize="s"
-                                        textProps={
-                                          Object {
-                                            "className": "euiButtonEmpty__text",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiButtonContent euiButtonEmpty__content"
-                                        >
-                                          <span
-                                            className="euiButtonEmpty__text"
-                                          >
-                                            Filter services
-                                          </span>
-                                        </span>
-                                      </EuiButtonContent>
-                                    </button>
-                                  </EuiButtonEmpty>
-                                </span>
-                              </EuiToolTip>
-                            </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem>
-                            <div
-                              className="euiFlexItem"
+                              className="euiPopover__anchor"
                             >
                               <EuiButtonEmpty
                                 onClick={[Function]}
@@ -5670,668 +5438,836 @@ exports[`Services component renders services page 1`] = `
                                       <span
                                         className="euiButtonEmpty__text"
                                       >
-                                        Show 24 hour trends
+                                        + Add filter
                                       </span>
                                     </span>
                                   </EuiButtonContent>
                                 </button>
                               </EuiButtonEmpty>
                             </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
+                          </div>
+                        </EuiPopover>
+                      </AddFilterButton>
                     </div>
                   </EuiFlexItem>
                 </div>
               </EuiFlexGroup>
-              <EuiSpacer
-                size="m"
-              >
+            </Filters>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <ServicesTable
+              addFilter={[Function]}
+              addServicesGroupFilter={[Function]}
+              dataPrepperIndicesExist={true}
+              isServiceTrendEnabled={false}
+              items={Array []}
+              loading={true}
+              mode="data_prepper"
+              selectedItems={Array []}
+              serviceTrends={Object {}}
+              setIsServiceTrendEnabled={[Function]}
+              setRedirect={[Function]}
+              setSelectedItems={[Function]}
+              traceColumnAction={[Function]}
+            >
+              <EuiPanel>
                 <div
-                  className="euiSpacer euiSpacer--m"
-                />
-              </EuiSpacer>
-              <EuiHorizontalRule
-                margin="none"
-              >
-                <hr
-                  className="euiHorizontalRule euiHorizontalRule--full"
-                />
-              </EuiHorizontalRule>
-              <NoMatchMessage
-                size="xl"
-              >
-                <EuiSpacer
-                  size="xl"
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                 >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-                <EuiEmptyPrompt
-                  body={
-                    <EuiText
-                      size="s"
-                    >
-                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                    </EuiText>
-                  }
-                  title={
-                    <h2>
-                      No matches
-                    </h2>
-                  }
-                >
-                  <div
-                    className="euiEmptyPrompt"
+                  <EuiFlexGroup
+                    justifyContent="spaceBetween"
                   >
-                    <EuiTitle
-                      size="m"
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                     >
-                      <h2
-                        className="euiTitle euiTitle--medium"
+                      <EuiFlexItem
+                        grow={false}
                       >
-                        No matches
-                      </h2>
-                    </EuiTitle>
-                    <EuiTextColor
-                      color="subdued"
-                    >
-                      <span
-                        className="euiTextColor euiTextColor--subdued"
-                      >
-                        <EuiSpacer
-                          size="m"
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
                         >
-                          <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
+                          <PanelTitle
+                            title="Services"
+                            totalItems={0}
                           >
                             <EuiText
-                              size="s"
+                              size="m"
                             >
                               <div
-                                className="euiText euiText--small"
+                                className="euiText euiText--medium"
                               >
-                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                <span
+                                  className="panel-title"
+                                >
+                                  Services
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
                               </div>
                             </EuiText>
-                          </div>
-                        </EuiText>
-                      </span>
-                    </EuiTextColor>
-                  </div>
-                </EuiEmptyPrompt>
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-              </NoMatchMessage>
-            </div>
-          </EuiPanel>
-        </div>
-      </EuiPage>
-    </ServicesTable>
-    <EuiSpacer
-      size="s"
-    >
-      <div
-        className="euiSpacer euiSpacer--s"
-      />
-    </EuiSpacer>
-    <ServiceMap
-      addFilter={[Function]}
-      currService=""
-      idSelected="latency"
-      page="services"
-      serviceMap={Object {}}
-      setIdSelected={[Function]}
-    >
-      <EuiPage
-        paddingSize="m"
-      >
-        <div
-          className="euiPage euiPage--paddingMedium euiPage--grow"
-        >
-          <EuiPanel>
-            <div
-              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-            >
-              <PanelTitle
-                title="Service map"
-              >
-                <EuiText
-                  size="m"
-                >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Service map
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-              <EuiSpacer
-                size="m"
-              >
-                <div
-                  className="euiSpacer euiSpacer--m"
-                />
-              </EuiSpacer>
-              <EuiButtonGroup
-                buttonSize="s"
-                color="text"
-                idSelected="latency"
-                onChange={[Function]}
-                options={
-                  Array [
-                    Object {
-                      "id": "latency",
-                      "label": "Duration",
-                    },
-                    Object {
-                      "id": "error_rate",
-                      "label": "Errors",
-                    },
-                    Object {
-                      "id": "throughput",
-                      "label": "Request Rate",
-                    },
-                  ]
-                }
-              >
-                <fieldset
-                  className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-                  disabled={false}
-                >
-                  <EuiScreenReaderOnly>
-                    <legend
-                      className="euiScreenReaderOnly"
-                    />
-                  </EuiScreenReaderOnly>
-                  <div
-                    className="euiButtonGroup__buttons"
-                  >
-                    <EuiButtonGroupButton
-                      color="text"
-                      element="label"
-                      id="latency"
-                      isDisabled={false}
-                      isIconOnly={false}
-                      isSelected={true}
-                      key="0"
-                      label="Duration"
-                      name="random_html_id"
-                      onChange={[Function]}
-                      size="s"
-                    >
-                      <EuiButtonDisplay
-                        baseClassName="euiButtonGroupButton"
-                        className="euiButtonGroupButton-isSelected"
-                        color="text"
-                        element="label"
-                        fill={true}
-                        htmlFor="random_html_id"
-                        isDisabled={false}
-                        onClick={[Function]}
-                        size="s"
-                        textProps={
-                          Object {
-                            "className": "euiButtonGroupButton__textShift",
-                            "data-text": "Duration",
-                            "ref": [Function],
-                            "title": "Duration",
-                          }
-                        }
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
                       >
-                        <label
-                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                          disabled={false}
-                          htmlFor="random_html_id"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "minWidth": undefined,
-                            }
-                          }
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
                         >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
+                          <EuiFlexGroup>
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiToolTip
+                                    content="Select services to filter"
+                                    delay="regular"
+                                    position="top"
+                                  >
+                                    <span
+                                      className="euiToolTipAnchor"
+                                      onKeyUp={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                    >
+                                      <EuiButtonEmpty
+                                        isDisabled={true}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        size="xs"
+                                      >
+                                        <button
+                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                          disabled={true}
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          type="button"
+                                        >
+                                          <EuiButtonContent
+                                            className="euiButtonEmpty__content"
+                                            iconSide="left"
+                                            iconSize="s"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButtonEmpty__text",
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              className="euiButtonContent euiButtonEmpty__content"
+                                            >
+                                              <span
+                                                className="euiButtonEmpty__text"
+                                              >
+                                                Filter services
+                                              </span>
+                                            </span>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonEmpty>
+                                    </span>
+                                  </EuiToolTip>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiButtonEmpty
+                                    onClick={[Function]}
+                                    size="xs"
+                                  >
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="s"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonEmpty__content"
+                                        >
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            Show 24 hour trends
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
+                  >
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                    <EuiEmptyPrompt
+                      body={
+                        <EuiText
+                          size="s"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
+                      </div>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </ServicesTable>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <ServiceMap
+              addFilter={[Function]}
+              currService=""
+              idSelected="latency"
+              page="services"
+              serviceMap={Object {}}
+              setIdSelected={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <PanelTitle
+                    title="Service map"
+                  >
+                    <EuiText
+                      size="m"
+                    >
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <span
+                          className="panel-title"
+                        >
+                          Service map
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiButtonGroup
+                    buttonSize="s"
+                    color="text"
+                    idSelected="latency"
+                    onChange={[Function]}
+                    options={
+                      Array [
+                        Object {
+                          "id": "latency",
+                          "label": "Duration",
+                        },
+                        Object {
+                          "id": "error_rate",
+                          "label": "Errors",
+                        },
+                        Object {
+                          "id": "throughput",
+                          "label": "Request Rate",
+                        },
+                      ]
+                    }
+                  >
+                    <fieldset
+                      className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                      disabled={false}
+                    >
+                      <EuiScreenReaderOnly>
+                        <legend
+                          className="euiScreenReaderOnly"
+                        />
+                      </EuiScreenReaderOnly>
+                      <div
+                        className="euiButtonGroup__buttons"
+                      >
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="latency"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={true}
+                          key="0"
+                          label="Duration"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
+                        >
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className="euiButtonGroupButton-isSelected"
+                            color="text"
+                            element="label"
+                            fill={true}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
                             textProps={
                               Object {
-                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "className": "euiButtonGroupButton__textShift",
                                 "data-text": "Duration",
                                 "ref": [Function],
                                 "title": "Duration",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButton__content"
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
                             >
-                              <span
-                                className="euiButton__text euiButtonGroupButton__textShift"
-                                data-text="Duration"
-                                title="Duration"
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Duration",
+                                    "ref": [Function],
+                                    "title": "Duration",
+                                  }
+                                }
                               >
-                                <input
-                                  checked={true}
-                                  className="euiScreenReaderOnly"
-                                  data-test-subj="latency"
-                                  disabled={false}
-                                  id="random_html_id"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  type="radio"
-                                />
-                                Duration
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </label>
-                      </EuiButtonDisplay>
-                    </EuiButtonGroupButton>
-                    <EuiButtonGroupButton
-                      color="text"
-                      element="label"
-                      id="error_rate"
-                      isDisabled={false}
-                      isIconOnly={false}
-                      isSelected={false}
-                      key="1"
-                      label="Errors"
-                      name="random_html_id"
-                      onChange={[Function]}
-                      size="s"
-                    >
-                      <EuiButtonDisplay
-                        baseClassName="euiButtonGroupButton"
-                        className=""
-                        color="text"
-                        element="label"
-                        fill={false}
-                        htmlFor="random_html_id"
-                        isDisabled={false}
-                        onClick={[Function]}
-                        size="s"
-                        textProps={
-                          Object {
-                            "className": "euiButtonGroupButton__textShift",
-                            "data-text": "Errors",
-                            "ref": [Function],
-                            "title": "Errors",
-                          }
-                        }
-                      >
-                        <label
-                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                          disabled={false}
-                          htmlFor="random_html_id"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "minWidth": undefined,
-                            }
-                          }
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked={true}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="error_rate"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={false}
+                          key="1"
+                          label="Errors"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
                         >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className=""
+                            color="text"
+                            element="label"
+                            fill={false}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
                             textProps={
                               Object {
-                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "className": "euiButtonGroupButton__textShift",
                                 "data-text": "Errors",
                                 "ref": [Function],
                                 "title": "Errors",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButton__content"
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
                             >
-                              <span
-                                className="euiButton__text euiButtonGroupButton__textShift"
-                                data-text="Errors"
-                                title="Errors"
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Errors",
+                                    "ref": [Function],
+                                    "title": "Errors",
+                                  }
+                                }
                               >
-                                <input
-                                  checked={false}
-                                  className="euiScreenReaderOnly"
-                                  data-test-subj="error_rate"
-                                  disabled={false}
-                                  id="random_html_id"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  type="radio"
-                                />
-                                Errors
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </label>
-                      </EuiButtonDisplay>
-                    </EuiButtonGroupButton>
-                    <EuiButtonGroupButton
-                      color="text"
-                      element="label"
-                      id="throughput"
-                      isDisabled={false}
-                      isIconOnly={false}
-                      isSelected={false}
-                      key="2"
-                      label="Request Rate"
-                      name="random_html_id"
-                      onChange={[Function]}
-                      size="s"
-                    >
-                      <EuiButtonDisplay
-                        baseClassName="euiButtonGroupButton"
-                        className=""
-                        color="text"
-                        element="label"
-                        fill={false}
-                        htmlFor="random_html_id"
-                        isDisabled={false}
-                        onClick={[Function]}
-                        size="s"
-                        textProps={
-                          Object {
-                            "className": "euiButtonGroupButton__textShift",
-                            "data-text": "Request Rate",
-                            "ref": [Function],
-                            "title": "Request Rate",
-                          }
-                        }
-                      >
-                        <label
-                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                          disabled={false}
-                          htmlFor="random_html_id"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "minWidth": undefined,
-                            }
-                          }
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      checked={false}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="throughput"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={false}
+                          key="2"
+                          label="Request Rate"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
                         >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className=""
+                            color="text"
+                            element="label"
+                            fill={false}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
                             textProps={
                               Object {
-                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "className": "euiButtonGroupButton__textShift",
                                 "data-text": "Request Rate",
                                 "ref": [Function],
                                 "title": "Request Rate",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButton__content"
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
                             >
-                              <span
-                                className="euiButton__text euiButtonGroupButton__textShift"
-                                data-text="Request Rate"
-                                title="Request Rate"
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Request Rate",
+                                    "ref": [Function],
+                                    "title": "Request Rate",
+                                  }
+                                }
                               >
-                                <input
-                                  checked={false}
-                                  className="euiScreenReaderOnly"
-                                  data-test-subj="throughput"
-                                  disabled={false}
-                                  id="random_html_id"
-                                  name="random_html_id"
-                                  onChange={[Function]}
-                                  type="radio"
-                                />
-                                Request Rate
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </label>
-                      </EuiButtonDisplay>
-                    </EuiButtonGroupButton>
-                  </div>
-                </fieldset>
-              </EuiButtonGroup>
-              <EuiHorizontalRule
-                margin="m"
-              >
-                <hr
-                  className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                />
-              </EuiHorizontalRule>
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-              >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
-                        >
-                          Focus on
-                        </div>
-                      </EuiText>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
-                    >
-                      <EuiCompressedFieldSearch
-                        compressed={true}
-                        fullWidth={false}
-                        incremental={false}
-                        isClearable={true}
-                        isInvalid={false}
-                        isLoading={false}
-                        onChange={[Function]}
-                        onSearch={[Function]}
-                        placeholder="Service name"
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          compressed={true}
-                          fullWidth={false}
-                          icon="search"
-                          isLoading={false}
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--compressed"
-                          >
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiValidatableControl
-                                isInvalid={false}
-                              >
-                                <input
-                                  className="euiFieldSearch euiFieldSearch--compressed"
-                                  onChange={[Function]}
-                                  onKeyUp={[Function]}
-                                  placeholder="Service name"
-                                  type="search"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons
-                                compressed={true}
-                                icon="search"
-                                isLoading={false}
-                              >
-                                <div
-                                  className="euiFormControlLayoutIcons"
+                                <span
+                                  className="euiButtonContent euiButton__content"
                                 >
-                                  <EuiFormControlLayoutCustomIcon
-                                    size="s"
-                                    type="search"
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
                                   >
-                                    <span
-                                      className="euiFormControlLayoutCustomIcon"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiFormControlLayoutCustomIcon__icon"
-                                        size="s"
-                                        type="search"
-                                      >
-                                        <EuiIconSearch
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                            />
-                                          </svg>
-                                        </EuiIconSearch>
-                                      </EuiIcon>
-                                    </span>
-                                  </EuiFormControlLayoutCustomIcon>
-                                </div>
-                              </EuiFormControlLayoutIcons>
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </EuiCompressedFieldSearch>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-              <EuiSpacer>
-                <div
-                  className="euiSpacer euiSpacer--l"
-                />
-              </EuiSpacer>
-              <div
-                style={
-                  Object {
-                    "minHeight": 434,
-                  }
-                }
-              >
-                <NoMatchMessage
-                  size="s"
-                >
-                  <EuiSpacer
-                    size="s"
+                                    <input
+                                      checked={false}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                      </div>
+                    </fieldset>
+                  </EuiButtonGroup>
+                  <EuiHorizontalRule
+                    margin="m"
                   >
-                    <div
-                      className="euiSpacer euiSpacer--s"
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
                     />
-                  </EuiSpacer>
-                  <EuiEmptyPrompt
-                    body={
-                      <EuiText
-                        size="s"
-                      >
-                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                      </EuiText>
-                    }
-                    title={
-                      <h2>
-                        No matches
-                      </h2>
-                    }
+                  </EuiHorizontalRule>
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
                   >
                     <div
-                      className="euiEmptyPrompt"
+                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
                     >
-                      <EuiTitle
-                        size="m"
+                      <EuiFlexItem
+                        grow={false}
                       >
-                        <h2
-                          className="euiTitle euiTitle--medium"
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
                         >
-                          No matches
-                        </h2>
-                      </EuiTitle>
-                      <EuiTextColor
-                        color="subdued"
-                      >
-                        <span
-                          className="euiTextColor euiTextColor--subdued"
-                        >
-                          <EuiSpacer
-                            size="m"
-                          >
-                            <div
-                              className="euiSpacer euiSpacer--m"
-                            />
-                          </EuiSpacer>
                           <EuiText>
                             <div
                               className="euiText euiText--medium"
                             >
-                              <EuiText
-                                size="s"
-                              >
-                                <div
-                                  className="euiText euiText--small"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </EuiText>
+                              Focus on
                             </div>
                           </EuiText>
-                        </span>
-                      </EuiTextColor>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiCompressedFieldSearch
+                            compressed={true}
+                            fullWidth={false}
+                            incremental={false}
+                            isClearable={true}
+                            isInvalid={false}
+                            isLoading={false}
+                            onChange={[Function]}
+                            onSearch={[Function]}
+                            placeholder="Service name"
+                            value=""
+                          >
+                            <EuiFormControlLayout
+                              compressed={true}
+                              fullWidth={false}
+                              icon="search"
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  className="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <EuiValidatableControl
+                                    isInvalid={false}
+                                  >
+                                    <input
+                                      className="euiFieldSearch euiFieldSearch--compressed"
+                                      onChange={[Function]}
+                                      onKeyUp={[Function]}
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                  </EuiValidatableControl>
+                                  <EuiFormControlLayoutIcons
+                                    compressed={true}
+                                    icon="search"
+                                    isLoading={false}
+                                  >
+                                    <div
+                                      className="euiFormControlLayoutIcons"
+                                    >
+                                      <EuiFormControlLayoutCustomIcon
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <span
+                                          className="euiFormControlLayoutCustomIcon"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiFormControlLayoutCustomIcon__icon"
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <EuiIconSearch
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                />
+                                              </svg>
+                                            </EuiIconSearch>
+                                          </EuiIcon>
+                                        </span>
+                                      </EuiFormControlLayoutCustomIcon>
+                                    </div>
+                                  </EuiFormControlLayoutIcons>
+                                </div>
+                              </div>
+                            </EuiFormControlLayout>
+                          </EuiCompressedFieldSearch>
+                        </div>
+                      </EuiFlexItem>
                     </div>
-                  </EuiEmptyPrompt>
-                  <EuiSpacer
-                    size="s"
-                  >
+                  </EuiFlexGroup>
+                  <EuiSpacer>
                     <div
-                      className="euiSpacer euiSpacer--s"
+                      className="euiSpacer euiSpacer--l"
                     />
                   </EuiSpacer>
-                </NoMatchMessage>
-              </div>
-            </div>
-          </EuiPanel>
-          <EuiSpacer
-            size="xl"
-          >
-            <div
-              className="euiSpacer euiSpacer--xl"
-            />
-          </EuiSpacer>
-        </div>
-      </EuiPage>
-    </ServiceMap>
+                  <div
+                    style={
+                      Object {
+                        "minHeight": 434,
+                      }
+                    }
+                  >
+                    <NoMatchMessage
+                      size="s"
+                    >
+                      <EuiSpacer
+                        size="s"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--s"
+                        />
+                      </EuiSpacer>
+                      <EuiEmptyPrompt
+                        body={
+                          <EuiText
+                            size="s"
+                          >
+                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                          </EuiText>
+                        }
+                        title={
+                          <h2>
+                            No matches
+                          </h2>
+                        }
+                      >
+                        <div
+                          className="euiEmptyPrompt"
+                        >
+                          <EuiTitle
+                            size="m"
+                          >
+                            <h2
+                              className="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                          </EuiTitle>
+                          <EuiTextColor
+                            color="subdued"
+                          >
+                            <span
+                              className="euiTextColor euiTextColor--subdued"
+                            >
+                              <EuiSpacer
+                                size="m"
+                              >
+                                <div
+                                  className="euiSpacer euiSpacer--m"
+                                />
+                              </EuiSpacer>
+                              <EuiText>
+                                <div
+                                  className="euiText euiText--medium"
+                                >
+                                  <EuiText
+                                    size="s"
+                                  >
+                                    <div
+                                      className="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </EuiText>
+                                </div>
+                              </EuiText>
+                            </span>
+                          </EuiTextColor>
+                        </div>
+                      </EuiEmptyPrompt>
+                      <EuiSpacer
+                        size="s"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--s"
+                        />
+                      </EuiSpacer>
+                    </NoMatchMessage>
+                  </div>
+                </div>
+              </EuiPanel>
+              <EuiSpacer
+                size="xl"
+              >
+                <div
+                  className="euiSpacer euiSpacer--xl"
+                />
+              </EuiSpacer>
+            </ServiceMap>
+          </div>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </ServicesContent>
 </Services>
 `;

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -229,139 +229,6 @@ exports[`Services component renders empty services page 1`] = `
   startTime="now-5m"
   traceColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="data_prepper"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="data_prepper"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconBeaker
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                          />
-                        </svg>
-                      </EuiIconBeaker>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Data Prepper
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <ServicesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -590,16 +457,913 @@ exports[`Services component renders empty services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 24px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 24px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="data_prepper"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiSmallButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="data_prepper"
+                  >
+                    Data Prepper
+                  </EuiSmallButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiSmallButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="data_prepper"
+                    >
+                      <EuiButtonEmpty
+                        className="dscIndexPattern__triggerButton"
+                        color="text"
+                        data-test-subj="indexPattern-switch-link"
+                        flush="left"
+                        iconSide="right"
+                        iconType="arrowDown"
+                        onClick={[Function]}
+                        size="s"
+                        title="data_prepper"
+                      >
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                          data-test-subj="indexPattern-switch-link"
+                          disabled={false}
+                          onClick={[Function]}
+                          title="data_prepper"
+                          type="button"
+                        >
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="right"
+                            iconSize="m"
+                            iconType="arrowDown"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            >
+                              <EuiIcon
+                                className="euiButtonContent__icon"
+                                color="inherit"
+                                size="m"
+                                type="arrowDown"
+                              >
+                                <EuiIconBeaker
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                  focusable="false"
+                                  role="img"
+                                  style={null}
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
+                                </EuiIconBeaker>
+                              </EuiIcon>
+                              <span
+                                className="euiButtonEmpty__text"
+                              >
+                                Data Prepper
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </EuiSmallButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="data_prepper"
+              page="services"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiCompressedFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiSmallButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiSmallButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <EuiButtonIcon
+                                        aria-label="Change all filters"
+                                        iconType="filter"
+                                        onClick={[Function]}
+                                        size="s"
+                                        title="Change all filters"
+                                      >
+                                        <button
+                                          aria-label="Change all filters"
+                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          title="Change all filters"
+                                          type="button"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="filter"
+                                          >
+                                            <EuiIconBeaker
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiSmallButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiCompressedFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconBeaker
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconBeaker>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconBeaker
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconBeaker>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconBeaker
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </EuiIconBeaker>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="data_prepper"
       page="services"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -615,832 +1379,105 @@ exports[`Services component renders empty services page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconBeaker
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconBeaker>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconBeaker
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconBeaker>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
-                  >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
-                          >
-                            <EuiIconBeaker
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                />
-                              </svg>
-                            </EuiIconBeaker>
-                          </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="services"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <ServicesTable
@@ -1458,85 +1495,131 @@ exports[`Services component renders empty services page 1`] = `
       setSelectedItems={[Function]}
       traceColumnAction={[Function]}
     >
-      <EuiPanel>
+      <EuiPage
+        paddingSize="m"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiPage euiPage--paddingMedium euiPage--grow"
         >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
-          >
+          <EuiPanel>
             <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <EuiFlexItem
-                grow={false}
+              <EuiFlexGroup
+                justifyContent="spaceBetween"
               >
                 <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
+                  <EuiFlexItem
+                    grow={false}
                   >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
                     <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
+                      <PanelTitle
+                        title="Services"
+                        totalItems={0}
+                      >
+                        <EuiText
+                          size="m"
                         >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
+                          <div
+                            className="euiText euiText--medium"
                           >
                             <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
+                              className="panel-title"
+                            >
+                              Services
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
+                          </div>
+                        </EuiText>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiFlexGroup>
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiToolTip
+                                content="Select services to filter"
+                                delay="regular"
+                                position="top"
+                              >
+                                <span
+                                  className="euiToolTipAnchor"
+                                  onKeyUp={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                >
+                                  <EuiButtonEmpty
+                                    isDisabled={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    size="xs"
+                                  >
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                      disabled={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="s"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonEmpty__content"
+                                        >
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            Filter services
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </span>
+                              </EuiToolTip>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
                             >
                               <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
                                 onClick={[Function]}
-                                onFocus={[Function]}
                                 size="xs"
                               >
                                 <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
-                                  onBlur={[Function]}
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  disabled={false}
                                   onClick={[Function]}
-                                  onFocus={[Function]}
                                   type="button"
                                 >
                                   <EuiButtonContent
@@ -1555,158 +1638,120 @@ exports[`Services component renders empty services page 1`] = `
                                       <span
                                         className="euiButtonEmpty__text"
                                       >
-                                        Filter services
+                                        Show 24 hour trends
                                       </span>
                                     </span>
                                   </EuiButtonContent>
                                 </button>
                               </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
+                            </div>
+                          </EuiFlexItem>
                         </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiButtonEmpty
-                            onClick={[Function]}
-                            size="xs"
-                          >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
-                                }
-                              >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
-                                >
-                                  <span
-                                    className="euiButtonEmpty__text"
-                                  >
-                                    Show 24 hour trends
-                                  </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </div>
-                      </EuiFlexItem>
+                      </EuiFlexGroup>
                     </div>
-                  </EuiFlexGroup>
+                  </EuiFlexItem>
                 </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
+              </EuiFlexGroup>
+              <EuiSpacer
+                size="m"
               >
-                <EuiTitle
-                  size="m"
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
+              <NoMatchMessage
+                size="xl"
+              >
+                <EuiSpacer
+                  size="xl"
                 >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText
+                      size="s"
+                    >
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                    </EuiText>
+                  }
+                  title={
+                    <h2>
+                      No matches
+                    </h2>
+                  }
                 >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                  <div
+                    className="euiEmptyPrompt"
                   >
-                    <EuiSpacer
+                    <EuiTitle
                       size="m"
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                      <h2
+                        className="euiTitle euiTitle--medium"
                       >
-                        <EuiText
-                          size="s"
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
                         >
                           <div
-                            className="euiText euiText--small"
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
                           >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                            <EuiText
+                              size="s"
+                            >
+                              <div
+                                className="euiText euiText--small"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
                           </div>
                         </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </EuiPanel>
         </div>
-      </EuiPanel>
+      </EuiPage>
     </ServicesTable>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <ServiceMap
@@ -1717,535 +1762,543 @@ exports[`Services component renders empty services page 1`] = `
       serviceMap={Object {}}
       setIdSelected={[Function]}
     >
-      <EuiPanel>
+      <EuiPage
+        paddingSize="m"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiPage euiPage--paddingMedium euiPage--grow"
         >
-          <PanelTitle
-            title="Service map"
-          >
-            <EuiText
-              size="m"
-            >
-              <div
-                className="euiText euiText--medium"
-              >
-                <span
-                  className="panel-title"
-                >
-                  Service map
-                </span>
-              </div>
-            </EuiText>
-          </PanelTitle>
-          <EuiSpacer
-            size="m"
-          >
+          <EuiPanel>
             <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiButtonGroup
-            buttonSize="s"
-            color="text"
-            idSelected="latency"
-            onChange={[Function]}
-            options={
-              Array [
-                Object {
-                  "id": "latency",
-                  "label": "Duration",
-                },
-                Object {
-                  "id": "error_rate",
-                  "label": "Errors",
-                },
-                Object {
-                  "id": "throughput",
-                  "label": "Request Rate",
-                },
-              ]
-            }
-          >
-            <fieldset
-              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-              disabled={false}
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <EuiScreenReaderOnly>
-                <legend
-                  className="euiScreenReaderOnly"
-                />
-              </EuiScreenReaderOnly>
-              <div
-                className="euiButtonGroup__buttons"
+              <PanelTitle
+                title="Service map"
               >
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="latency"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={true}
-                  key="0"
-                  label="Duration"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
+                <EuiText
+                  size="m"
                 >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className="euiButtonGroupButton-isSelected"
-                    color="text"
-                    element="label"
-                    fill={true}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Duration",
-                        "ref": [Function],
-                        "title": "Duration",
-                      }
-                    }
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
+                    <span
+                      className="panel-title"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
+                      Service map
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiButtonGroup
+                buttonSize="s"
+                color="text"
+                idSelected="latency"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "id": "latency",
+                      "label": "Duration",
+                    },
+                    Object {
+                      "id": "error_rate",
+                      "label": "Errors",
+                    },
+                    Object {
+                      "id": "throughput",
+                      "label": "Request Rate",
+                    },
+                  ]
+                }
+              >
+                <fieldset
+                  className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                  disabled={false}
+                >
+                  <EuiScreenReaderOnly>
+                    <legend
+                      className="euiScreenReaderOnly"
+                    />
+                  </EuiScreenReaderOnly>
+                  <div
+                    className="euiButtonGroup__buttons"
+                  >
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="latency"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={true}
+                      key="0"
+                      label="Duration"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className="euiButtonGroupButton-isSelected"
+                        color="text"
+                        element="label"
+                        fill={true}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
                         textProps={
                           Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                            "className": "euiButtonGroupButton__textShift",
                             "data-text": "Duration",
                             "ref": [Function],
                             "title": "Duration",
                           }
                         }
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
                         >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Duration"
-                            title="Duration"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Duration",
+                                "ref": [Function],
+                                "title": "Duration",
+                              }
+                            }
                           >
-                            <input
-                              checked={true}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="latency"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Duration
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="error_rate"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="1"
-                  label="Errors"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Errors",
-                        "ref": [Function],
-                        "title": "Errors",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Duration"
+                                title="Duration"
+                              >
+                                <input
+                                  checked={true}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="latency"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Duration
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="error_rate"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={false}
+                      key="1"
+                      label="Errors"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className=""
+                        color="text"
+                        element="label"
+                        fill={false}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
                         textProps={
                           Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                            "className": "euiButtonGroupButton__textShift",
                             "data-text": "Errors",
                             "ref": [Function],
                             "title": "Errors",
                           }
                         }
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
                         >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Errors"
-                            title="Errors"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Errors",
+                                "ref": [Function],
+                                "title": "Errors",
+                              }
+                            }
                           >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="error_rate"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Errors
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="throughput"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="2"
-                  label="Request Rate"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Request Rate",
-                        "ref": [Function],
-                        "title": "Request Rate",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Errors"
+                                title="Errors"
+                              >
+                                <input
+                                  checked={false}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="error_rate"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Errors
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="throughput"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={false}
+                      key="2"
+                      label="Request Rate"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className=""
+                        color="text"
+                        element="label"
+                        fill={false}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
                         textProps={
                           Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                            "className": "euiButtonGroupButton__textShift",
                             "data-text": "Request Rate",
                             "ref": [Function],
                             "title": "Request Rate",
                           }
                         }
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
                         >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Request Rate"
-                            title="Request Rate"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Request Rate",
+                                "ref": [Function],
+                                "title": "Request Rate",
+                              }
+                            }
                           >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="throughput"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Request Rate
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-              </div>
-            </fieldset>
-          </EuiButtonGroup>
-          <EuiHorizontalRule
-            margin="m"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-            />
-          </EuiHorizontalRule>
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiText>
-                    <div
-                      className="euiText euiText--medium"
-                    >
-                      Focus on
-                    </div>
-                  </EuiText>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiCompressedFieldSearch
-                    compressed={true}
-                    fullWidth={false}
-                    incremental={false}
-                    isClearable={true}
-                    isInvalid={false}
-                    isLoading={false}
-                    onChange={[Function]}
-                    onSearch={[Function]}
-                    placeholder="Service name"
-                    value=""
-                  >
-                    <EuiFormControlLayout
-                      compressed={true}
-                      fullWidth={false}
-                      icon="search"
-                      isLoading={false}
-                    >
-                      <div
-                        className="euiFormControlLayout euiFormControlLayout--compressed"
-                      >
-                        <div
-                          className="euiFormControlLayout__childrenWrapper"
-                        >
-                          <EuiValidatableControl
-                            isInvalid={false}
-                          >
-                            <input
-                              className="euiFieldSearch euiFieldSearch--compressed"
-                              onChange={[Function]}
-                              onKeyUp={[Function]}
-                              placeholder="Service name"
-                              type="search"
-                              value=""
-                            />
-                          </EuiValidatableControl>
-                          <EuiFormControlLayoutIcons
-                            compressed={true}
-                            icon="search"
-                            isLoading={false}
-                          >
-                            <div
-                              className="euiFormControlLayoutIcons"
+                            <span
+                              className="euiButtonContent euiButton__content"
                             >
-                              <EuiFormControlLayoutCustomIcon
-                                size="s"
-                                type="search"
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Request Rate"
+                                title="Request Rate"
                               >
-                                <span
-                                  className="euiFormControlLayoutCustomIcon"
-                                >
-                                  <EuiIcon
-                                    aria-hidden="true"
-                                    className="euiFormControlLayoutCustomIcon__icon"
-                                    size="s"
-                                    type="search"
-                                  >
-                                    <EuiIconBeaker
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                        />
-                                      </svg>
-                                    </EuiIconBeaker>
-                                  </EuiIcon>
-                                </span>
-                              </EuiFormControlLayoutCustomIcon>
-                            </div>
-                          </EuiFormControlLayoutIcons>
-                        </div>
-                      </div>
-                    </EuiFormControlLayout>
-                  </EuiCompressedFieldSearch>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer>
-            <div
-              className="euiSpacer euiSpacer--l"
-            />
-          </EuiSpacer>
-          <div
-            style={
-              Object {
-                "minHeight": 434,
-              }
-            }
-          >
-            <NoMatchMessage
-              size="s"
-            >
-              <EuiSpacer
-                size="s"
+                                <input
+                                  checked={false}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="throughput"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Request Rate
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                  </div>
+                </fieldset>
+              </EuiButtonGroup>
+              <EuiHorizontalRule
+                margin="m"
               >
-                <div
-                  className="euiSpacer euiSpacer--s"
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
                 />
-              </EuiSpacer>
-              <EuiEmptyPrompt
-                body={
-                  <EuiText
-                    size="s"
-                  >
-                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                  </EuiText>
-                }
-                title={
-                  <h2>
-                    No matches
-                  </h2>
-                }
+              </EuiHorizontalRule>
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
               >
                 <div
-                  className="euiEmptyPrompt"
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <EuiTitle
-                    size="m"
+                  <EuiFlexItem
+                    grow={false}
                   >
-                    <h2
-                      className="euiTitle euiTitle--medium"
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      No matches
-                    </h2>
-                  </EuiTitle>
-                  <EuiTextColor
-                    color="subdued"
-                  >
-                    <span
-                      className="euiTextColor euiTextColor--subdued"
-                    >
-                      <EuiSpacer
-                        size="m"
-                      >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
                       <EuiText>
                         <div
                           className="euiText euiText--medium"
                         >
-                          <EuiText
-                            size="s"
-                          >
-                            <div
-                              className="euiText euiText--small"
-                            >
-                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                            </div>
-                          </EuiText>
+                          Focus on
                         </div>
                       </EuiText>
-                    </span>
-                  </EuiTextColor>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiCompressedFieldSearch
+                        compressed={true}
+                        fullWidth={false}
+                        incremental={false}
+                        isClearable={true}
+                        isInvalid={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Service name"
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={false}
+                          icon="search"
+                          isLoading={false}
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--compressed"
+                          >
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl
+                                isInvalid={false}
+                              >
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--compressed"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiCompressedFieldSearch>
+                    </div>
+                  </EuiFlexItem>
                 </div>
-              </EuiEmptyPrompt>
-              <EuiSpacer
-                size="s"
-              >
+              </EuiFlexGroup>
+              <EuiSpacer>
                 <div
-                  className="euiSpacer euiSpacer--s"
+                  className="euiSpacer euiSpacer--l"
                 />
               </EuiSpacer>
-            </NoMatchMessage>
-          </div>
+              <div
+                style={
+                  Object {
+                    "minHeight": 434,
+                  }
+                }
+              >
+                <NoMatchMessage
+                  size="s"
+                >
+                  <EuiSpacer
+                    size="s"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--s"
+                    />
+                  </EuiSpacer>
+                  <EuiEmptyPrompt
+                    body={
+                      <EuiText
+                        size="s"
+                      >
+                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                      </EuiText>
+                    }
+                    title={
+                      <h2>
+                        No matches
+                      </h2>
+                    }
+                  >
+                    <div
+                      className="euiEmptyPrompt"
+                    >
+                      <EuiTitle
+                        size="m"
+                      >
+                        <h2
+                          className="euiTitle euiTitle--medium"
+                        >
+                          No matches
+                        </h2>
+                      </EuiTitle>
+                      <EuiTextColor
+                        color="subdued"
+                      >
+                        <span
+                          className="euiTextColor euiTextColor--subdued"
+                        >
+                          <EuiSpacer
+                            size="m"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--m"
+                            />
+                          </EuiSpacer>
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              <EuiText
+                                size="s"
+                              >
+                                <div
+                                  className="euiText euiText--small"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </EuiText>
+                            </div>
+                          </EuiText>
+                        </span>
+                      </EuiTextColor>
+                    </div>
+                  </EuiEmptyPrompt>
+                  <EuiSpacer
+                    size="s"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--s"
+                    />
+                  </EuiSpacer>
+                </NoMatchMessage>
+              </div>
+            </div>
+          </EuiPanel>
+          <EuiSpacer
+            size="xl"
+          >
+            <div
+              className="euiSpacer euiSpacer--xl"
+            />
+          </EuiSpacer>
         </div>
-      </EuiPanel>
-      <EuiSpacer
-        size="xl"
-      >
-        <div
-          className="euiSpacer euiSpacer--xl"
-        />
-      </EuiSpacer>
+      </EuiPage>
     </ServiceMap>
   </ServicesContent>
 </Services>
@@ -2480,140 +2533,6 @@ exports[`Services component renders jaeger services page 1`] = `
   startTime="now-5m"
   traceColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="jaeger"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="jaeger"
-        >
-          Jaeger
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="jaeger"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="jaeger"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="jaeger"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconArrowDown
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                            fillRule="non-zero"
-                          />
-                        </svg>
-                      </EuiIconArrowDown>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Jaeger
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <ServicesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -2842,16 +2761,917 @@ exports[`Services component renders jaeger services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 24px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 24px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="jaeger"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiSmallButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="jaeger"
+                  >
+                    Jaeger
+                  </EuiSmallButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiSmallButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="jaeger"
+                    >
+                      <EuiButtonEmpty
+                        className="dscIndexPattern__triggerButton"
+                        color="text"
+                        data-test-subj="indexPattern-switch-link"
+                        flush="left"
+                        iconSide="right"
+                        iconType="arrowDown"
+                        onClick={[Function]}
+                        size="s"
+                        title="jaeger"
+                      >
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                          data-test-subj="indexPattern-switch-link"
+                          disabled={false}
+                          onClick={[Function]}
+                          title="jaeger"
+                          type="button"
+                        >
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="right"
+                            iconSize="m"
+                            iconType="arrowDown"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            >
+                              <EuiIcon
+                                className="euiButtonContent__icon"
+                                color="inherit"
+                                size="m"
+                                type="arrowDown"
+                              >
+                                <EuiIconArrowDown
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                  focusable="false"
+                                  role="img"
+                                  style={null}
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                      fillRule="non-zero"
+                                    />
+                                  </svg>
+                                </EuiIconArrowDown>
+                              </EuiIcon>
+                              <span
+                                className="euiButtonEmpty__text"
+                              >
+                                Jaeger
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </EuiSmallButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="jaeger"
+              page="services"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiCompressedFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiSmallButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiSmallButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <EuiButtonIcon
+                                        aria-label="Change all filters"
+                                        iconType="filter"
+                                        onClick={[Function]}
+                                        size="s"
+                                        title="Change all filters"
+                                      >
+                                        <button
+                                          aria-label="Change all filters"
+                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          title="Change all filters"
+                                          type="button"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="filter"
+                                          >
+                                            <EuiIconFilter
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                  fillRule="evenodd"
+                                                />
+                                              </svg>
+                                            </EuiIconFilter>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiSmallButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconSearch
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSearch>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiCompressedFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconArrowDown
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                            fillRule="non-zero"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconArrowDown>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconCalendar
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                              fillRule="evenodd"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconCalendar>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconRefresh
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                />
+                              </svg>
+                            </EuiIconRefresh>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="jaeger"
       page="services"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -2867,835 +3687,105 @@ exports[`Services component renders jaeger services page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconCalendar
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
-                                                    />
-                                                  </svg>
-                                                </EuiIconCalendar>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
-                  >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
-                          >
-                            <EuiIconRefresh
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                                />
-                              </svg>
-                            </EuiIconRefresh>
-                          </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="jaeger"
-        page="services"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconFilter
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                      fillRule="evenodd"
-                                    />
-                                  </svg>
-                                </EuiIconFilter>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <ServicesTable
@@ -3714,217 +3804,225 @@ exports[`Services component renders jaeger services page 1`] = `
       setSelectedItems={[Function]}
       traceColumnAction={[Function]}
     >
-      <EuiPanel>
+      <EuiPage
+        paddingSize="m"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiPage euiPage--paddingMedium euiPage--grow"
         >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
-          >
+          <EuiPanel>
             <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <EuiFlexItem
-                grow={false}
+              <EuiFlexGroup
+                justifyContent="spaceBetween"
               >
                 <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
+                  <EuiFlexItem
+                    grow={false}
                   >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
                     <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                size="xs"
-                              >
-                                <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  type="button"
-                                >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="s"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
-                                    >
-                                      <span
-                                        className="euiButtonEmpty__text"
-                                      >
-                                        Filter services
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                      <PanelTitle
+                        title="Services"
+                        totalItems={0}
                       >
                         <EuiText
-                          size="s"
+                          size="m"
                         >
                           <div
-                            className="euiText euiText--small"
+                            className="euiText euiText--medium"
                           >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                            <span
+                              className="panel-title"
+                            >
+                              Services
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
                           </div>
                         </EuiText>
-                      </div>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiFlexGroup>
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiToolTip
+                                content="Select services to filter"
+                                delay="regular"
+                                position="top"
+                              >
+                                <span
+                                  className="euiToolTipAnchor"
+                                  onKeyUp={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                >
+                                  <EuiButtonEmpty
+                                    isDisabled={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    size="xs"
+                                  >
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                      disabled={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="s"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonEmpty__content"
+                                        >
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            Filter services
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </span>
+                              </EuiToolTip>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
+              <NoMatchMessage
+                size="xl"
+              >
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText
+                      size="s"
+                    >
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                     </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
+                  }
+                  title={
+                    <h2>
+                      No matches
+                    </h2>
+                  }
+                >
+                  <div
+                    className="euiEmptyPrompt"
+                  >
+                    <EuiTitle
+                      size="m"
+                    >
+                      <h2
+                        className="euiTitle euiTitle--medium"
+                      >
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <EuiText
+                              size="s"
+                            >
+                              <div
+                                className="euiText euiText--small"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiText>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </EuiPanel>
         </div>
-      </EuiPanel>
+      </EuiPage>
     </ServicesTable>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <div />
@@ -4160,140 +4258,6 @@ exports[`Services component renders services page 1`] = `
   startTime="now-5m"
   traceColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="data_prepper"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="data_prepper"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconArrowDown
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                            fillRule="non-zero"
-                          />
-                        </svg>
-                      </EuiIconArrowDown>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Data Prepper
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <ServicesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -4521,16 +4485,917 @@ exports[`Services component renders services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 24px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 24px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="data_prepper"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiSmallButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="data_prepper"
+                  >
+                    Data Prepper
+                  </EuiSmallButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiSmallButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="data_prepper"
+                    >
+                      <EuiButtonEmpty
+                        className="dscIndexPattern__triggerButton"
+                        color="text"
+                        data-test-subj="indexPattern-switch-link"
+                        flush="left"
+                        iconSide="right"
+                        iconType="arrowDown"
+                        onClick={[Function]}
+                        size="s"
+                        title="data_prepper"
+                      >
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                          data-test-subj="indexPattern-switch-link"
+                          disabled={false}
+                          onClick={[Function]}
+                          title="data_prepper"
+                          type="button"
+                        >
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="right"
+                            iconSize="m"
+                            iconType="arrowDown"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            >
+                              <EuiIcon
+                                className="euiButtonContent__icon"
+                                color="inherit"
+                                size="m"
+                                type="arrowDown"
+                              >
+                                <EuiIconArrowDown
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                  focusable="false"
+                                  role="img"
+                                  style={null}
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                      fillRule="non-zero"
+                                    />
+                                  </svg>
+                                </EuiIconArrowDown>
+                              </EuiIcon>
+                              <span
+                                className="euiButtonEmpty__text"
+                              >
+                                Data Prepper
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </EuiSmallButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="data_prepper"
+              page="services"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiCompressedFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiSmallButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiSmallButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <EuiButtonIcon
+                                        aria-label="Change all filters"
+                                        iconType="filter"
+                                        onClick={[Function]}
+                                        size="s"
+                                        title="Change all filters"
+                                      >
+                                        <button
+                                          aria-label="Change all filters"
+                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          title="Change all filters"
+                                          type="button"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="filter"
+                                          >
+                                            <EuiIconFilter
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                  fillRule="evenodd"
+                                                />
+                                              </svg>
+                                            </EuiIconFilter>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiSmallButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconSearch
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSearch>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiCompressedFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconArrowDown
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                            fillRule="non-zero"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconArrowDown>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconCalendar
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                              fillRule="evenodd"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconCalendar>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconRefresh
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                />
+                              </svg>
+                            </EuiIconRefresh>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="data_prepper"
       page="services"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -4546,835 +5411,105 @@ exports[`Services component renders services page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconCalendar
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
-                                                    />
-                                                  </svg>
-                                                </EuiIconCalendar>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
-                  >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
-                          >
-                            <EuiIconRefresh
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                                />
-                              </svg>
-                            </EuiIconRefresh>
-                          </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="services"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconFilter
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                      fillRule="evenodd"
-                                    />
-                                  </svg>
-                                </EuiIconFilter>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <ServicesTable
@@ -5392,85 +5527,131 @@ exports[`Services component renders services page 1`] = `
       setSelectedItems={[Function]}
       traceColumnAction={[Function]}
     >
-      <EuiPanel>
+      <EuiPage
+        paddingSize="m"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiPage euiPage--paddingMedium euiPage--grow"
         >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
-          >
+          <EuiPanel>
             <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <EuiFlexItem
-                grow={false}
+              <EuiFlexGroup
+                justifyContent="spaceBetween"
               >
                 <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
+                  <EuiFlexItem
+                    grow={false}
                   >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
                     <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
+                      <PanelTitle
+                        title="Services"
+                        totalItems={0}
+                      >
+                        <EuiText
+                          size="m"
                         >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
+                          <div
+                            className="euiText euiText--medium"
                           >
                             <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
+                              className="panel-title"
+                            >
+                              Services
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
+                          </div>
+                        </EuiText>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiFlexGroup>
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiToolTip
+                                content="Select services to filter"
+                                delay="regular"
+                                position="top"
+                              >
+                                <span
+                                  className="euiToolTipAnchor"
+                                  onKeyUp={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                >
+                                  <EuiButtonEmpty
+                                    isDisabled={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    size="xs"
+                                  >
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                      disabled={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconSide="left"
+                                        iconSize="s"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonEmpty__content"
+                                        >
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            Filter services
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </span>
+                              </EuiToolTip>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
                             >
                               <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
                                 onClick={[Function]}
-                                onFocus={[Function]}
                                 size="xs"
                               >
                                 <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
-                                  onBlur={[Function]}
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  disabled={false}
                                   onClick={[Function]}
-                                  onFocus={[Function]}
                                   type="button"
                                 >
                                   <EuiButtonContent
@@ -5489,158 +5670,120 @@ exports[`Services component renders services page 1`] = `
                                       <span
                                         className="euiButtonEmpty__text"
                                       >
-                                        Filter services
+                                        Show 24 hour trends
                                       </span>
                                     </span>
                                   </EuiButtonContent>
                                 </button>
                               </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
+                            </div>
+                          </EuiFlexItem>
                         </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiButtonEmpty
-                            onClick={[Function]}
-                            size="xs"
-                          >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
-                                }
-                              >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
-                                >
-                                  <span
-                                    className="euiButtonEmpty__text"
-                                  >
-                                    Show 24 hour trends
-                                  </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </div>
-                      </EuiFlexItem>
+                      </EuiFlexGroup>
                     </div>
-                  </EuiFlexGroup>
+                  </EuiFlexItem>
                 </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
+              </EuiFlexGroup>
+              <EuiSpacer
+                size="m"
               >
-                <EuiTitle
-                  size="m"
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
+              <NoMatchMessage
+                size="xl"
+              >
+                <EuiSpacer
+                  size="xl"
                 >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText
+                      size="s"
+                    >
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                    </EuiText>
+                  }
+                  title={
+                    <h2>
+                      No matches
+                    </h2>
+                  }
                 >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                  <div
+                    className="euiEmptyPrompt"
                   >
-                    <EuiSpacer
+                    <EuiTitle
                       size="m"
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                      <h2
+                        className="euiTitle euiTitle--medium"
                       >
-                        <EuiText
-                          size="s"
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
                         >
                           <div
-                            className="euiText euiText--small"
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
                           >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                            <EuiText
+                              size="s"
+                            >
+                              <div
+                                className="euiText euiText--small"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
                           </div>
                         </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </EuiPanel>
         </div>
-      </EuiPanel>
+      </EuiPage>
     </ServicesTable>
     <EuiSpacer
-      size="m"
+      size="s"
     >
       <div
-        className="euiSpacer euiSpacer--m"
+        className="euiSpacer euiSpacer--s"
       />
     </EuiSpacer>
     <ServiceMap
@@ -5651,535 +5794,543 @@ exports[`Services component renders services page 1`] = `
       serviceMap={Object {}}
       setIdSelected={[Function]}
     >
-      <EuiPanel>
+      <EuiPage
+        paddingSize="m"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiPage euiPage--paddingMedium euiPage--grow"
         >
-          <PanelTitle
-            title="Service map"
-          >
-            <EuiText
-              size="m"
-            >
-              <div
-                className="euiText euiText--medium"
-              >
-                <span
-                  className="panel-title"
-                >
-                  Service map
-                </span>
-              </div>
-            </EuiText>
-          </PanelTitle>
-          <EuiSpacer
-            size="m"
-          >
+          <EuiPanel>
             <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiButtonGroup
-            buttonSize="s"
-            color="text"
-            idSelected="latency"
-            onChange={[Function]}
-            options={
-              Array [
-                Object {
-                  "id": "latency",
-                  "label": "Duration",
-                },
-                Object {
-                  "id": "error_rate",
-                  "label": "Errors",
-                },
-                Object {
-                  "id": "throughput",
-                  "label": "Request Rate",
-                },
-              ]
-            }
-          >
-            <fieldset
-              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-              disabled={false}
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <EuiScreenReaderOnly>
-                <legend
-                  className="euiScreenReaderOnly"
-                />
-              </EuiScreenReaderOnly>
-              <div
-                className="euiButtonGroup__buttons"
+              <PanelTitle
+                title="Service map"
               >
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="latency"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={true}
-                  key="0"
-                  label="Duration"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
+                <EuiText
+                  size="m"
                 >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className="euiButtonGroupButton-isSelected"
-                    color="text"
-                    element="label"
-                    fill={true}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Duration",
-                        "ref": [Function],
-                        "title": "Duration",
-                      }
-                    }
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
+                    <span
+                      className="panel-title"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
+                      Service map
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiButtonGroup
+                buttonSize="s"
+                color="text"
+                idSelected="latency"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "id": "latency",
+                      "label": "Duration",
+                    },
+                    Object {
+                      "id": "error_rate",
+                      "label": "Errors",
+                    },
+                    Object {
+                      "id": "throughput",
+                      "label": "Request Rate",
+                    },
+                  ]
+                }
+              >
+                <fieldset
+                  className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                  disabled={false}
+                >
+                  <EuiScreenReaderOnly>
+                    <legend
+                      className="euiScreenReaderOnly"
+                    />
+                  </EuiScreenReaderOnly>
+                  <div
+                    className="euiButtonGroup__buttons"
+                  >
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="latency"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={true}
+                      key="0"
+                      label="Duration"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
+                    >
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className="euiButtonGroupButton-isSelected"
+                        color="text"
+                        element="label"
+                        fill={true}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
                         textProps={
                           Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                            "className": "euiButtonGroupButton__textShift",
                             "data-text": "Duration",
                             "ref": [Function],
                             "title": "Duration",
                           }
                         }
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
                         >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Duration"
-                            title="Duration"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Duration",
+                                "ref": [Function],
+                                "title": "Duration",
+                              }
+                            }
                           >
-                            <input
-                              checked={true}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="latency"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Duration
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="error_rate"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="1"
-                  label="Errors"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Errors",
-                        "ref": [Function],
-                        "title": "Errors",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Duration"
+                                title="Duration"
+                              >
+                                <input
+                                  checked={true}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="latency"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Duration
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="error_rate"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={false}
+                      key="1"
+                      label="Errors"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className=""
+                        color="text"
+                        element="label"
+                        fill={false}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
                         textProps={
                           Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                            "className": "euiButtonGroupButton__textShift",
                             "data-text": "Errors",
                             "ref": [Function],
                             "title": "Errors",
                           }
                         }
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
                         >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Errors"
-                            title="Errors"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Errors",
+                                "ref": [Function],
+                                "title": "Errors",
+                              }
+                            }
                           >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="error_rate"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Errors
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="throughput"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="2"
-                  label="Request Rate"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Request Rate",
-                        "ref": [Function],
-                        "title": "Request Rate",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
+                            <span
+                              className="euiButtonContent euiButton__content"
+                            >
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Errors"
+                                title="Errors"
+                              >
+                                <input
+                                  checked={false}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="error_rate"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Errors
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                    <EuiButtonGroupButton
+                      color="text"
+                      element="label"
+                      id="throughput"
+                      isDisabled={false}
+                      isIconOnly={false}
+                      isSelected={false}
+                      key="2"
+                      label="Request Rate"
+                      name="random_html_id"
+                      onChange={[Function]}
+                      size="s"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
+                      <EuiButtonDisplay
+                        baseClassName="euiButtonGroupButton"
+                        className=""
+                        color="text"
+                        element="label"
+                        fill={false}
+                        htmlFor="random_html_id"
+                        isDisabled={false}
+                        onClick={[Function]}
+                        size="s"
                         textProps={
                           Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
+                            "className": "euiButtonGroupButton__textShift",
                             "data-text": "Request Rate",
                             "ref": [Function],
                             "title": "Request Rate",
                           }
                         }
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <label
+                          className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                          disabled={false}
+                          htmlFor="random_html_id"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "minWidth": undefined,
+                            }
+                          }
                         >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Request Rate"
-                            title="Request Rate"
+                          <EuiButtonContent
+                            className="euiButton__content"
+                            iconSide="left"
+                            textProps={
+                              Object {
+                                "className": "euiButton__text euiButtonGroupButton__textShift",
+                                "data-text": "Request Rate",
+                                "ref": [Function],
+                                "title": "Request Rate",
+                              }
+                            }
                           >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="throughput"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Request Rate
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-              </div>
-            </fieldset>
-          </EuiButtonGroup>
-          <EuiHorizontalRule
-            margin="m"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-            />
-          </EuiHorizontalRule>
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiText>
-                    <div
-                      className="euiText euiText--medium"
-                    >
-                      Focus on
-                    </div>
-                  </EuiText>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiCompressedFieldSearch
-                    compressed={true}
-                    fullWidth={false}
-                    incremental={false}
-                    isClearable={true}
-                    isInvalid={false}
-                    isLoading={false}
-                    onChange={[Function]}
-                    onSearch={[Function]}
-                    placeholder="Service name"
-                    value=""
-                  >
-                    <EuiFormControlLayout
-                      compressed={true}
-                      fullWidth={false}
-                      icon="search"
-                      isLoading={false}
-                    >
-                      <div
-                        className="euiFormControlLayout euiFormControlLayout--compressed"
-                      >
-                        <div
-                          className="euiFormControlLayout__childrenWrapper"
-                        >
-                          <EuiValidatableControl
-                            isInvalid={false}
-                          >
-                            <input
-                              className="euiFieldSearch euiFieldSearch--compressed"
-                              onChange={[Function]}
-                              onKeyUp={[Function]}
-                              placeholder="Service name"
-                              type="search"
-                              value=""
-                            />
-                          </EuiValidatableControl>
-                          <EuiFormControlLayoutIcons
-                            compressed={true}
-                            icon="search"
-                            isLoading={false}
-                          >
-                            <div
-                              className="euiFormControlLayoutIcons"
+                            <span
+                              className="euiButtonContent euiButton__content"
                             >
-                              <EuiFormControlLayoutCustomIcon
-                                size="s"
-                                type="search"
+                              <span
+                                className="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Request Rate"
+                                title="Request Rate"
                               >
-                                <span
-                                  className="euiFormControlLayoutCustomIcon"
-                                >
-                                  <EuiIcon
-                                    aria-hidden="true"
-                                    className="euiFormControlLayoutCustomIcon__icon"
-                                    size="s"
-                                    type="search"
-                                  >
-                                    <EuiIconSearch
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </EuiIconSearch>
-                                  </EuiIcon>
-                                </span>
-                              </EuiFormControlLayoutCustomIcon>
-                            </div>
-                          </EuiFormControlLayoutIcons>
-                        </div>
-                      </div>
-                    </EuiFormControlLayout>
-                  </EuiCompressedFieldSearch>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer>
-            <div
-              className="euiSpacer euiSpacer--l"
-            />
-          </EuiSpacer>
-          <div
-            style={
-              Object {
-                "minHeight": 434,
-              }
-            }
-          >
-            <NoMatchMessage
-              size="s"
-            >
-              <EuiSpacer
-                size="s"
+                                <input
+                                  checked={false}
+                                  className="euiScreenReaderOnly"
+                                  data-test-subj="throughput"
+                                  disabled={false}
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  onChange={[Function]}
+                                  type="radio"
+                                />
+                                Request Rate
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </label>
+                      </EuiButtonDisplay>
+                    </EuiButtonGroupButton>
+                  </div>
+                </fieldset>
+              </EuiButtonGroup>
+              <EuiHorizontalRule
+                margin="m"
               >
-                <div
-                  className="euiSpacer euiSpacer--s"
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
                 />
-              </EuiSpacer>
-              <EuiEmptyPrompt
-                body={
-                  <EuiText
-                    size="s"
-                  >
-                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                  </EuiText>
-                }
-                title={
-                  <h2>
-                    No matches
-                  </h2>
-                }
+              </EuiHorizontalRule>
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
               >
                 <div
-                  className="euiEmptyPrompt"
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <EuiTitle
-                    size="m"
+                  <EuiFlexItem
+                    grow={false}
                   >
-                    <h2
-                      className="euiTitle euiTitle--medium"
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      No matches
-                    </h2>
-                  </EuiTitle>
-                  <EuiTextColor
-                    color="subdued"
-                  >
-                    <span
-                      className="euiTextColor euiTextColor--subdued"
-                    >
-                      <EuiSpacer
-                        size="m"
-                      >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
                       <EuiText>
                         <div
                           className="euiText euiText--medium"
                         >
-                          <EuiText
-                            size="s"
-                          >
-                            <div
-                              className="euiText euiText--small"
-                            >
-                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                            </div>
-                          </EuiText>
+                          Focus on
                         </div>
                       </EuiText>
-                    </span>
-                  </EuiTextColor>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiCompressedFieldSearch
+                        compressed={true}
+                        fullWidth={false}
+                        incremental={false}
+                        isClearable={true}
+                        isInvalid={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Service name"
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={false}
+                          icon="search"
+                          isLoading={false}
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--compressed"
+                          >
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl
+                                isInvalid={false}
+                              >
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--compressed"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconSearch
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSearch>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiCompressedFieldSearch>
+                    </div>
+                  </EuiFlexItem>
                 </div>
-              </EuiEmptyPrompt>
-              <EuiSpacer
-                size="s"
-              >
+              </EuiFlexGroup>
+              <EuiSpacer>
                 <div
-                  className="euiSpacer euiSpacer--s"
+                  className="euiSpacer euiSpacer--l"
                 />
               </EuiSpacer>
-            </NoMatchMessage>
-          </div>
+              <div
+                style={
+                  Object {
+                    "minHeight": 434,
+                  }
+                }
+              >
+                <NoMatchMessage
+                  size="s"
+                >
+                  <EuiSpacer
+                    size="s"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--s"
+                    />
+                  </EuiSpacer>
+                  <EuiEmptyPrompt
+                    body={
+                      <EuiText
+                        size="s"
+                      >
+                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                      </EuiText>
+                    }
+                    title={
+                      <h2>
+                        No matches
+                      </h2>
+                    }
+                  >
+                    <div
+                      className="euiEmptyPrompt"
+                    >
+                      <EuiTitle
+                        size="m"
+                      >
+                        <h2
+                          className="euiTitle euiTitle--medium"
+                        >
+                          No matches
+                        </h2>
+                      </EuiTitle>
+                      <EuiTextColor
+                        color="subdued"
+                      >
+                        <span
+                          className="euiTextColor euiTextColor--subdued"
+                        >
+                          <EuiSpacer
+                            size="m"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--m"
+                            />
+                          </EuiSpacer>
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              <EuiText
+                                size="s"
+                              >
+                                <div
+                                  className="euiText euiText--small"
+                                >
+                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                </div>
+                              </EuiText>
+                            </div>
+                          </EuiText>
+                        </span>
+                      </EuiTextColor>
+                    </div>
+                  </EuiEmptyPrompt>
+                  <EuiSpacer
+                    size="s"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--s"
+                    />
+                  </EuiSpacer>
+                </NoMatchMessage>
+              </div>
+            </div>
+          </EuiPanel>
+          <EuiSpacer
+            size="xl"
+          >
+            <div
+              className="euiSpacer euiSpacer--xl"
+            />
+          </EuiSpacer>
         </div>
-      </EuiPanel>
-      <EuiSpacer
-        size="xl"
-      >
-        <div
-          className="euiSpacer euiSpacer--xl"
-        />
-      </EuiSpacer>
+      </EuiPage>
     </ServiceMap>
   </ServicesContent>
 </Services>

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
@@ -12,355 +12,83 @@ exports[`Services table component renders empty jaeger services table message 1`
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPage
-    paddingSize="m"
-  >
+  <EuiPanel>
     <div
-      className="euiPage euiPage--paddingMedium euiPage--grow"
+      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     >
-      <EuiPanel>
+      <EuiFlexGroup
+        justifyContent="spaceBetween"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
+          <EuiFlexItem
+            grow={false}
           >
             <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <EuiFlexItem
-                grow={false}
+              <PanelTitle
+                title="Services"
+                totalItems={0}
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                size="xs"
-                              >
-                                <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  type="button"
-                                >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="s"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
-                                    >
-                                      <span
-                                        className="euiButtonEmpty__text"
-                                      >
-                                        Filter services
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
                 <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
                   size="m"
                 >
-                  <h2
-                    className="euiTitle euiTitle--medium"
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
+                    <span
+                      className="panel-title"
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <EuiText
-                          size="s"
-                        >
-                          <div
-                            className="euiText euiText--small"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
-                        </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
-    </div>
-  </EuiPage>
-</ServicesTable>
-`;
-
-exports[`Services table component renders empty services table message 1`] = `
-<ServicesTable
-  addFilter={[MockFunction]}
-  dataPrepperIndicesExist={true}
-  items={Array []}
-  jaegerIndicesExist={false}
-  loading={false}
-  mode="data_prepper"
-  selectedItems={Array []}
-  setRedirect={[MockFunction]}
-  traceColumnAction={[Function]}
->
-  <EuiPage
-    paddingSize="m"
-  >
-    <div
-      className="euiPage euiPage--paddingMedium euiPage--grow"
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
+                      Services
+                    </span>
+                    <span
+                      className="panel-title-count"
+                    >
+                       (0)
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
           >
             <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <EuiFlexItem
-                grow={false}
-              >
+              <EuiFlexGroup>
                 <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
                     >
-                      <div
-                        className="euiText euiText--medium"
+                      <EuiToolTip
+                        content="Select services to filter"
+                        delay="regular"
+                        position="top"
                       >
                         <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                size="xs"
-                              >
-                                <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  type="button"
-                                >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="s"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
-                                    >
-                                      <span
-                                        className="euiButtonEmpty__text"
-                                      >
-                                        Filter services
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
+                          className="euiToolTipAnchor"
+                          onKeyUp={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
                         >
                           <EuiButtonEmpty
-                            onClick={[Function]}
+                            isDisabled={true}
+                            onBlur={[Function]}
+                            onFocus={[Function]}
                             size="xs"
                           >
                             <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                              disabled={false}
-                              onClick={[Function]}
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                              disabled={true}
+                              onBlur={[Function]}
+                              onFocus={[Function]}
                               type="button"
                             >
                               <EuiButtonContent
@@ -379,114 +107,370 @@ exports[`Services table component renders empty services table message 1`] = `
                                   <span
                                     className="euiButtonEmpty__text"
                                   >
-                                    Show 24 hour trends
+                                    Filter services
                                   </span>
                                 </span>
                               </EuiButtonContent>
                             </button>
                           </EuiButtonEmpty>
-                        </div>
-                      </EuiFlexItem>
+                        </span>
+                      </EuiToolTip>
                     </div>
-                  </EuiFlexGroup>
+                  </EuiFlexItem>
                 </div>
-              </EuiFlexItem>
+              </EuiFlexGroup>
             </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+      <EuiSpacer
+        size="m"
+      >
+        <div
+          className="euiSpacer euiSpacer--m"
+        />
+      </EuiSpacer>
+      <EuiHorizontalRule
+        margin="none"
+      >
+        <hr
+          className="euiHorizontalRule euiHorizontalRule--full"
+        />
+      </EuiHorizontalRule>
+      <NoMatchMessage
+        size="xl"
+      >
+        <EuiSpacer
+          size="xl"
+        >
+          <div
+            className="euiSpacer euiSpacer--xl"
+          />
+        </EuiSpacer>
+        <EuiEmptyPrompt
+          body={
+            <EuiText
+              size="s"
             >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
+              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+            </EuiText>
+          }
+          title={
+            <h2>
+              No matches
+            </h2>
+          }
+        >
+          <div
+            className="euiEmptyPrompt"
+          >
+            <EuiTitle
+              size="m"
             >
-              <div
-                className="euiEmptyPrompt"
+              <h2
+                className="euiTitle euiTitle--medium"
               >
-                <EuiTitle
+                No matches
+              </h2>
+            </EuiTitle>
+            <EuiTextColor
+              color="subdued"
+            >
+              <span
+                className="euiTextColor euiTextColor--subdued"
+              >
+                <EuiSpacer
                   size="m"
                 >
-                  <h2
-                    className="euiTitle euiTitle--medium"
+                  <div
+                    className="euiSpacer euiSpacer--m"
+                  />
+                </EuiSpacer>
+                <EuiText>
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
+                    <EuiText
+                      size="s"
                     >
                       <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                        className="euiText euiText--small"
                       >
-                        <EuiText
-                          size="s"
-                        >
-                          <div
-                            className="euiText euiText--small"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
-                        </EuiText>
+                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                       </div>
                     </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
+                  </div>
+                </EuiText>
+              </span>
+            </EuiTextColor>
+          </div>
+        </EuiEmptyPrompt>
+        <EuiSpacer
+          size="xl"
+        >
+          <div
+            className="euiSpacer euiSpacer--xl"
+          />
+        </EuiSpacer>
+      </NoMatchMessage>
     </div>
-  </EuiPage>
+  </EuiPanel>
+</ServicesTable>
+`;
+
+exports[`Services table component renders empty services table message 1`] = `
+<ServicesTable
+  addFilter={[MockFunction]}
+  dataPrepperIndicesExist={true}
+  items={Array []}
+  jaegerIndicesExist={false}
+  loading={false}
+  mode="data_prepper"
+  selectedItems={Array []}
+  setRedirect={[MockFunction]}
+  traceColumnAction={[Function]}
+>
+  <EuiPanel>
+    <div
+      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+    >
+      <EuiFlexGroup
+        justifyContent="spaceBetween"
+      >
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        >
+          <EuiFlexItem
+            grow={false}
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <PanelTitle
+                title="Services"
+                totalItems={0}
+              >
+                <EuiText
+                  size="m"
+                >
+                  <div
+                    className="euiText euiText--medium"
+                  >
+                    <span
+                      className="panel-title"
+                    >
+                      Services
+                    </span>
+                    <span
+                      className="panel-title-count"
+                    >
+                       (0)
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <EuiFlexGroup>
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiToolTip
+                        content="Select services to filter"
+                        delay="regular"
+                        position="top"
+                      >
+                        <span
+                          className="euiToolTipAnchor"
+                          onKeyUp={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                        >
+                          <EuiButtonEmpty
+                            isDisabled={true}
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            size="xs"
+                          >
+                            <button
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                              disabled={true}
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              type="button"
+                            >
+                              <EuiButtonContent
+                                className="euiButtonEmpty__content"
+                                iconSide="left"
+                                iconSize="s"
+                                textProps={
+                                  Object {
+                                    "className": "euiButtonEmpty__text",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButtonEmpty__content"
+                                >
+                                  <span
+                                    className="euiButtonEmpty__text"
+                                  >
+                                    Filter services
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </button>
+                          </EuiButtonEmpty>
+                        </span>
+                      </EuiToolTip>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiButtonEmpty
+                        onClick={[Function]}
+                        size="xs"
+                      >
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
+                            >
+                              <span
+                                className="euiButtonEmpty__text"
+                              >
+                                Show 24 hour trends
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+      <EuiSpacer
+        size="m"
+      >
+        <div
+          className="euiSpacer euiSpacer--m"
+        />
+      </EuiSpacer>
+      <EuiHorizontalRule
+        margin="none"
+      >
+        <hr
+          className="euiHorizontalRule euiHorizontalRule--full"
+        />
+      </EuiHorizontalRule>
+      <NoMatchMessage
+        size="xl"
+      >
+        <EuiSpacer
+          size="xl"
+        >
+          <div
+            className="euiSpacer euiSpacer--xl"
+          />
+        </EuiSpacer>
+        <EuiEmptyPrompt
+          body={
+            <EuiText
+              size="s"
+            >
+              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+            </EuiText>
+          }
+          title={
+            <h2>
+              No matches
+            </h2>
+          }
+        >
+          <div
+            className="euiEmptyPrompt"
+          >
+            <EuiTitle
+              size="m"
+            >
+              <h2
+                className="euiTitle euiTitle--medium"
+              >
+                No matches
+              </h2>
+            </EuiTitle>
+            <EuiTextColor
+              color="subdued"
+            >
+              <span
+                className="euiTextColor euiTextColor--subdued"
+              >
+                <EuiSpacer
+                  size="m"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--m"
+                  />
+                </EuiSpacer>
+                <EuiText>
+                  <div
+                    className="euiText euiText--medium"
+                  >
+                    <EuiText
+                      size="s"
+                    >
+                      <div
+                        className="euiText euiText--small"
+                      >
+                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                      </div>
+                    </EuiText>
+                  </div>
+                </EuiText>
+              </span>
+            </EuiTextColor>
+          </div>
+        </EuiEmptyPrompt>
+        <EuiSpacer
+          size="xl"
+        >
+          <div
+            className="euiSpacer euiSpacer--xl"
+          />
+        </EuiSpacer>
+      </NoMatchMessage>
+    </div>
+  </EuiPanel>
 </ServicesTable>
 `;
 
@@ -512,1582 +496,439 @@ exports[`Services table component renders jaeger services table 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPage
-    paddingSize="m"
-  >
+  <EuiPanel>
     <div
-      className="euiPage euiPage--paddingMedium euiPage--grow"
+      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     >
-      <EuiPanel>
+      <EuiFlexGroup
+        justifyContent="spaceBetween"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
+          <EuiFlexItem
+            grow={false}
           >
             <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <EuiFlexItem
-                grow={false}
+              <PanelTitle
+                title="Services"
+                totalItems={1}
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                <EuiText
+                  size="m"
                 >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={1}
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    <EuiText
-                      size="m"
+                    <span
+                      className="panel-title"
                     >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (1)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                      Services
+                    </span>
+                    <span
+                      className="panel-title-count"
                     >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                size="xs"
-                              >
-                                <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  type="button"
-                                >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="s"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
-                                    >
-                                      <span
-                                        className="euiButtonEmpty__text"
-                                      >
-                                        Filter services
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
+                       (1)
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
             </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
           >
             <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <EuiInMemoryTable
-            columns={
-              Array [
-                Object {
-                  "align": "left",
-                  "field": "name",
-                  "name": "Name",
-                  "render": [Function],
-                  "sortable": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "average_latency",
-                  "name": "Average duration (ms)",
-                  "render": [Function],
-                  "sortable": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "error_rate",
-                  "name": "Error rate",
-                  "render": [Function],
-                  "sortable": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "throughput",
-                  "name": "Request rate",
-                  "render": [Function],
-                  "sortable": true,
-                  "truncateText": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "traces",
-                  "name": "Traces",
-                  "render": [Function],
-                  "sortable": true,
-                  "truncateText": true,
-                },
-                Object {
-                  "align": "center",
-                  "field": "actions",
-                  "name": "Actions",
-                  "render": [Function],
-                },
-              ]
-            }
-            isSelectable={true}
-            itemId="itemId"
-            items={
-              Array [
-                Object {
-                  "average_latency": 49.54,
-                  "error_rate": 3.77,
-                  "name": "database",
-                  "throughput": 53,
-                  "traces": 31,
-                },
-              ]
-            }
-            loading={false}
-            pagination={
-              Object {
-                "initialPageSize": 10,
-                "pageSizeOptions": Array [
-                  5,
-                  10,
-                  15,
-                ],
-              }
-            }
-            responsive={true}
-            selection={
-              Object {
-                "onSelectionChange": [Function],
-              }
-            }
-            sorting={
-              Object {
-                "sort": Object {
-                  "direction": "asc",
-                  "field": "name",
-                },
-              }
-            }
-            tableLayout="auto"
-          >
-            <EuiBasicTable
-              columns={
-                Array [
-                  Object {
-                    "align": "left",
-                    "field": "name",
-                    "name": "Name",
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "average_latency",
-                    "name": "Average duration (ms)",
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "error_rate",
-                    "name": "Error rate",
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "throughput",
-                    "name": "Request rate",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "traces",
-                    "name": "Traces",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                  },
-                  Object {
-                    "align": "center",
-                    "field": "actions",
-                    "name": "Actions",
-                    "render": [Function],
-                  },
-                ]
-              }
-              isSelectable={true}
-              itemId="itemId"
-              items={
-                Array [
-                  Object {
-                    "average_latency": 49.54,
-                    "error_rate": 3.77,
-                    "name": "database",
-                    "throughput": 53,
-                    "traces": 31,
-                  },
-                ]
-              }
-              loading={false}
-              noItemsMessage="No items found"
-              onChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-              responsive={true}
-              selection={
-                Object {
-                  "onSelectionChange": [Function],
-                }
-              }
-              sorting={
-                Object {
-                  "allowNeutralSort": true,
-                  "sort": Object {
-                    "direction": "asc",
-                    "field": "Name",
-                  },
-                }
-              }
-              tableLayout="auto"
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiBasicTable"
-              >
-                <div>
-                  <EuiTableHeaderMobile>
+              <EuiFlexGroup>
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
                     <div
-                      className="euiTableHeaderMobile"
+                      className="euiFlexItem"
                     >
-                      <EuiFlexGroup
-                        alignItems="baseline"
-                        justifyContent="spaceBetween"
-                        responsive={false}
+                      <EuiToolTip
+                        content="Select services to filter"
+                        delay="regular"
+                        position="top"
                       >
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        <span
+                          className="euiToolTipAnchor"
+                          onKeyUp={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
                         >
-                          <EuiFlexItem
-                            grow={false}
+                          <EuiButtonEmpty
+                            isDisabled={true}
+                            onBlur={[Function]}
+                            onFocus={[Function]}
+                            size="xs"
                           >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            <button
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                              disabled={true}
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              type="button"
                             >
-                              <EuiI18n
-                                default="Select all rows"
-                                token="euiBasicTable.selectAllRows"
-                              >
-                                <EuiCheckbox
-                                  aria-label="Select all rows"
-                                  checked={false}
-                                  compressed={false}
-                                  disabled={false}
-                                  id="_selection_column-checkbox_random_html_id"
-                                  indeterminate={false}
-                                  label="Select all rows"
-                                  onChange={[Function]}
-                                >
-                                  <div
-                                    className="euiCheckbox"
-                                  >
-                                    <input
-                                      aria-label="Select all rows"
-                                      checked={false}
-                                      className="euiCheckbox__input"
-                                      disabled={false}
-                                      id="_selection_column-checkbox_random_html_id"
-                                      onChange={[Function]}
-                                      type="checkbox"
-                                    />
-                                    <div
-                                      className="euiCheckbox__square"
-                                    />
-                                    <label
-                                      className="euiCheckbox__label"
-                                      htmlFor="_selection_column-checkbox_random_html_id"
-                                    >
-                                      Select all rows
-                                    </label>
-                                  </div>
-                                </EuiCheckbox>
-                              </EuiI18n>
-                            </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                            >
-                              <EuiTableSortMobile
-                                items={
-                                  Array [
-                                    Object {
-                                      "isSortAscending": true,
-                                      "isSorted": true,
-                                      "key": "_data_s_name_0",
-                                      "name": "Name",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_average_latency_1",
-                                      "name": "Average duration (ms)",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_error_rate_2",
-                                      "name": "Error rate",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_throughput_3",
-                                      "name": "Request rate",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_traces_4",
-                                      "name": "Traces",
-                                      "onSort": [Function],
-                                    },
-                                  ]
-                                }
-                              >
-                                <div
-                                  className="euiTableSortMobile"
-                                >
-                                  <EuiPopover
-                                    anchorPosition="downRight"
-                                    button={
-                                      <EuiButtonEmpty
-                                        flush="right"
-                                        iconSide="right"
-                                        iconType="arrowDown"
-                                        onClick={[Function]}
-                                        size="xs"
-                                      >
-                                        <EuiI18n
-                                          default="Sorting"
-                                          token="euiTableSortMobile.sorting"
-                                        />
-                                      </EuiButtonEmpty>
-                                    }
-                                    closePopover={[Function]}
-                                    display="inlineBlock"
-                                    hasArrow={true}
-                                    isOpen={false}
-                                    ownFocus={true}
-                                    panelPaddingSize="none"
-                                  >
-                                    <div
-                                      className="euiPopover euiPopover--anchorDownRight"
-                                    >
-                                      <div
-                                        className="euiPopover__anchor"
-                                      >
-                                        <EuiButtonEmpty
-                                          flush="right"
-                                          iconSide="right"
-                                          iconType="arrowDown"
-                                          onClick={[Function]}
-                                          size="xs"
-                                        >
-                                          <button
-                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiButtonContent
-                                              className="euiButtonEmpty__content"
-                                              iconSide="right"
-                                              iconSize="s"
-                                              iconType="arrowDown"
-                                              textProps={
-                                                Object {
-                                                  "className": "euiButtonEmpty__text",
-                                                }
-                                              }
-                                            >
-                                              <span
-                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                              >
-                                                <EuiIcon
-                                                  className="euiButtonContent__icon"
-                                                  color="inherit"
-                                                  size="s"
-                                                  type="arrowDown"
-                                                >
-                                                  <EuiIconArrowDown
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                    focusable="false"
-                                                    role="img"
-                                                    style={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                      focusable="false"
-                                                      height={16}
-                                                      role="img"
-                                                      style={null}
-                                                      viewBox="0 0 16 16"
-                                                      width={16}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                        fillRule="non-zero"
-                                                      />
-                                                    </svg>
-                                                  </EuiIconArrowDown>
-                                                </EuiIcon>
-                                                <span
-                                                  className="euiButtonEmpty__text"
-                                                >
-                                                  <EuiI18n
-                                                    default="Sorting"
-                                                    token="euiTableSortMobile.sorting"
-                                                  >
-                                                    Sorting
-                                                  </EuiI18n>
-                                                </span>
-                                              </span>
-                                            </EuiButtonContent>
-                                          </button>
-                                        </EuiButtonEmpty>
-                                      </div>
-                                    </div>
-                                  </EuiPopover>
-                                </div>
-                              </EuiTableSortMobile>
-                            </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
-                    </div>
-                  </EuiTableHeaderMobile>
-                  <EuiTable
-                    id="random_html_id"
-                    responsive={true}
-                    tableLayout="auto"
-                  >
-                    <table
-                      className="euiTable euiTable--responsive euiTable--auto"
-                      id="random_html_id"
-                      tabIndex={-1}
-                    >
-                      <EuiScreenReaderOnly>
-                        <caption
-                          className="euiScreenReaderOnly euiTableCaption"
-                        >
-                          <EuiDelayRender
-                            delay={500}
-                          />
-                        </caption>
-                      </EuiScreenReaderOnly>
-                      <EuiTableHeader>
-                        <thead>
-                          <tr>
-                            <EuiTableHeaderCellCheckbox
-                              key="_selection_column_h"
-                            >
-                              <th
-                                className="euiTableHeaderCellCheckbox"
-                                scope="col"
-                                style={
+                              <EuiButtonContent
+                                className="euiButtonEmpty__content"
+                                iconSide="left"
+                                iconSize="s"
+                                textProps={
                                   Object {
-                                    "width": undefined,
+                                    "className": "euiButtonEmpty__text",
                                   }
                                 }
                               >
-                                <div
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiI18n
-                                    default="Select all rows"
-                                    token="euiBasicTable.selectAllRows"
-                                  >
-                                    <EuiCheckbox
-                                      aria-label="Select all rows"
-                                      checked={false}
-                                      compressed={false}
-                                      data-test-subj="checkboxSelectAll"
-                                      disabled={false}
-                                      id="_selection_column-checkbox_random_html_id"
-                                      indeterminate={false}
-                                      label={null}
-                                      onChange={[Function]}
-                                      type="inList"
-                                    >
-                                      <div
-                                        className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                      >
-                                        <input
-                                          aria-label="Select all rows"
-                                          checked={false}
-                                          className="euiCheckbox__input"
-                                          data-test-subj="checkboxSelectAll"
-                                          disabled={false}
-                                          id="_selection_column-checkbox_random_html_id"
-                                          onChange={[Function]}
-                                          type="checkbox"
-                                        />
-                                        <div
-                                          className="euiCheckbox__square"
-                                        />
-                                      </div>
-                                    </EuiCheckbox>
-                                  </EuiI18n>
-                                </div>
-                              </th>
-                            </EuiTableHeaderCellCheckbox>
-                            <EuiTableHeaderCell
-                              align="left"
-                              data-test-subj="tableHeaderCell_name_0"
-                              isSortAscending={true}
-                              isSorted={true}
-                              key="_data_h_name_0"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="ascending"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_name_0"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent"
-                                    isSortAscending={true}
-                                    isSorted={true}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Name",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Name"
-                                          >
-                                            Name
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                      <EuiIcon
-                                        className="euiTableSortIcon"
-                                        size="m"
-                                        type="sortUp"
-                                      >
-                                        <EuiIconSortUp
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiTableSortIcon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiTableSortIcon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
-                                            />
-                                          </svg>
-                                        </EuiIconSortUp>
-                                      </EuiIcon>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_average_latency_1"
-                              isSorted={false}
-                              key="_data_h_average_latency_1"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_average_latency_1"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Average duration (ms)",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Average duration (ms)"
-                                          >
-                                            Average duration (ms)
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_error_rate_2"
-                              isSorted={false}
-                              key="_data_h_error_rate_2"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_error_rate_2"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Error rate",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Error rate"
-                                          >
-                                            Error rate
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_throughput_3"
-                              isSorted={false}
-                              key="_data_h_throughput_3"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_throughput_3"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Request rate",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Request rate"
-                                          >
-                                            Request rate
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_traces_4"
-                              isSorted={false}
-                              key="_data_h_traces_4"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_traces_4"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Traces",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Traces"
-                                          >
-                                            Traces
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="center"
-                              data-test-subj="tableHeaderCell_actions_5"
-                              key="_data_h_actions_5"
-                            >
-                              <th
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_actions_5"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignCenter"
-                                  showSortMsg={false}
+                                <span
+                                  className="euiButtonContent euiButtonEmpty__content"
                                 >
                                   <span
-                                    className="euiTableCellContent euiTableCellContent--alignCenter"
+                                    className="euiButtonEmpty__text"
                                   >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Actions",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Actions"
-                                        >
-                                          Actions
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
+                                    Filter services
                                   </span>
-                                </CellContents>
-                              </th>
-                            </EuiTableHeaderCell>
-                          </tr>
-                        </thead>
-                      </EuiTableHeader>
-                      <EuiTableBody
-                        bodyRef={[Function]}
-                      >
-                        <tbody>
-                          <EuiTableRow
-                            isSelectable={true}
-                            isSelected={false}
-                          >
-                            <tr
-                              className="euiTableRow euiTableRow-isSelectable"
-                            >
-                              <EuiTableRowCellCheckbox
-                                key="_selection_column_0"
-                              >
-                                <td
-                                  className="euiTableRowCellCheckbox"
-                                >
-                                  <div
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiI18n
-                                      default="Select this row"
-                                      token="euiBasicTable.selectThisRow"
-                                    >
-                                      <EuiCheckbox
-                                        aria-label="Select this row"
-                                        checked={false}
-                                        compressed={false}
-                                        data-test-subj="checkboxSelectRow-0"
-                                        disabled={false}
-                                        id="_selection_column_0-checkbox"
-                                        indeterminate={false}
-                                        onChange={[Function]}
-                                        title="Select this row"
-                                        type="inList"
-                                      >
-                                        <div
-                                          className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                        >
-                                          <input
-                                            aria-label="Select this row"
-                                            checked={false}
-                                            className="euiCheckbox__input"
-                                            data-test-subj="checkboxSelectRow-0"
-                                            disabled={false}
-                                            id="_selection_column_0-checkbox"
-                                            onChange={[Function]}
-                                            title="Select this row"
-                                            type="checkbox"
-                                          />
-                                          <div
-                                            className="euiCheckbox__square"
-                                          />
-                                        </div>
-                                      </EuiCheckbox>
-                                    </EuiI18n>
-                                  </div>
-                                </td>
-                              </EuiTableRowCellCheckbox>
-                              <EuiTableRowCell
-                                align="left"
-                                key="_data_column_name_0_0"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Name",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Name
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiLink
-                                      className=""
-                                      data-test-subj="service-link"
-                                      key=".0"
-                                      onClick={[Function]}
-                                    >
-                                      <button
-                                        className="euiLink euiLink--primary"
-                                        data-test-subj="service-link"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        database
-                                      </button>
-                                    </EuiLink>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_average_latency_0_1"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Average duration (ms)",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Average duration (ms)
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                  >
-                                    <ServiceTrendsPlots
-                                      className=""
-                                      fieldType="average_latency"
-                                      item={49.54}
-                                      key=".0"
-                                      row={
-                                        Object {
-                                          "average_latency": 49.54,
-                                          "error_rate": 3.77,
-                                          "name": "database",
-                                          "throughput": 53,
-                                          "traces": 31,
-                                        }
-                                      }
-                                    >
-                                      <EuiFlexGroup
-                                        gutterSize="s"
-                                        justifyContent="flexEnd"
-                                      >
-                                        <div
-                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                        >
-                                          <EuiFlexItem
-                                            grow={false}
-                                          >
-                                            <div
-                                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                                            >
-                                              <EuiText
-                                                color="default"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <div
-                                                  className="euiText euiText--medium"
-                                                  onMouseEnter={[Function]}
-                                                  onMouseLeave={[Function]}
-                                                >
-                                                  <EuiTextColor
-                                                    color="default"
-                                                    component="div"
-                                                  >
-                                                    <div
-                                                      className="euiTextColor euiTextColor--default"
-                                                    >
-                                                      49.54
-                                                    </div>
-                                                  </EuiTextColor>
-                                                </div>
-                                              </EuiText>
-                                            </div>
-                                          </EuiFlexItem>
-                                        </div>
-                                      </EuiFlexGroup>
-                                    </ServiceTrendsPlots>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_error_rate_0_2"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Error rate",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Error rate
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                  >
-                                    <ServiceTrendsPlots
-                                      className=""
-                                      fieldType="error_rate"
-                                      item={3.77}
-                                      key=".0"
-                                      row={
-                                        Object {
-                                          "average_latency": 49.54,
-                                          "error_rate": 3.77,
-                                          "name": "database",
-                                          "throughput": 53,
-                                          "traces": 31,
-                                        }
-                                      }
-                                    >
-                                      <EuiFlexGroup
-                                        gutterSize="s"
-                                        justifyContent="flexEnd"
-                                      >
-                                        <div
-                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                        >
-                                          <EuiFlexItem
-                                            grow={false}
-                                          >
-                                            <div
-                                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                                            >
-                                              <EuiText
-                                                color="default"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <div
-                                                  className="euiText euiText--medium"
-                                                  onMouseEnter={[Function]}
-                                                  onMouseLeave={[Function]}
-                                                >
-                                                  <EuiTextColor
-                                                    color="default"
-                                                    component="div"
-                                                  >
-                                                    <div
-                                                      className="euiTextColor euiTextColor--default"
-                                                    >
-                                                      <EuiText
-                                                        size="s"
-                                                      >
-                                                        <div
-                                                          className="euiText euiText--small"
-                                                        >
-                                                          3.77%
-                                                        </div>
-                                                      </EuiText>
-                                                    </div>
-                                                  </EuiTextColor>
-                                                </div>
-                                              </EuiText>
-                                            </div>
-                                          </EuiFlexItem>
-                                        </div>
-                                      </EuiFlexGroup>
-                                    </ServiceTrendsPlots>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_throughput_0_3"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Request rate",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Request rate
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    <ServiceTrendsPlots
-                                      className=""
-                                      fieldType="throughput"
-                                      item={53}
-                                      key=".0"
-                                      row={
-                                        Object {
-                                          "average_latency": 49.54,
-                                          "error_rate": 3.77,
-                                          "name": "database",
-                                          "throughput": 53,
-                                          "traces": 31,
-                                        }
-                                      }
-                                    >
-                                      <EuiFlexGroup
-                                        gutterSize="s"
-                                        justifyContent="flexEnd"
-                                      >
-                                        <div
-                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                        >
-                                          <EuiFlexItem
-                                            grow={false}
-                                          >
-                                            <div
-                                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                                            >
-                                              <EuiText
-                                                color="default"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <div
-                                                  className="euiText euiText--medium"
-                                                  onMouseEnter={[Function]}
-                                                  onMouseLeave={[Function]}
-                                                >
-                                                  <EuiTextColor
-                                                    color="default"
-                                                    component="div"
-                                                  >
-                                                    <div
-                                                      className="euiTextColor euiTextColor--default"
-                                                    >
-                                                      <EuiI18nNumber
-                                                        value={53}
-                                                      >
-                                                        53
-                                                      </EuiI18nNumber>
-                                                    </div>
-                                                  </EuiTextColor>
-                                                </div>
-                                              </EuiText>
-                                            </div>
-                                          </EuiFlexItem>
-                                        </div>
-                                      </EuiFlexGroup>
-                                    </ServiceTrendsPlots>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_traces_0_4"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Traces",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Traces
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiLink
-                                      onClick={[Function]}
-                                    >
-                                      <button
-                                        className="euiLink euiLink--primary"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiI18nNumber
-                                          value={31}
-                                        >
-                                          31
-                                        </EuiI18nNumber>
-                                      </button>
-                                    </EuiLink>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="center"
-                                key="_data_column_actions_0_5"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Actions",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Actions
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiFlexGroup
-                                      className=""
-                                      justifyContent="center"
-                                      key=".0"
-                                    >
-                                      <div
-                                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                      >
-                                        <EuiFlexItem
-                                          grow={false}
-                                          onClick={[Function]}
-                                        >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                                            onClick={[Function]}
-                                          >
-                                            <EuiLink
-                                              data-test-subj="service-flyout-action-btnundefined"
-                                            >
-                                              <button
-                                                className="euiLink euiLink--primary"
-                                                data-test-subj="service-flyout-action-btnundefined"
-                                                disabled={false}
-                                                type="button"
-                                              >
-                                                <EuiIcon
-                                                  color="primary"
-                                                  type="inspect"
-                                                >
-                                                  <EuiIconInspect
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium euiIcon--primary"
-                                                    focusable="false"
-                                                    role="img"
-                                                    style={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--primary"
-                                                      focusable="false"
-                                                      height={16}
-                                                      role="img"
-                                                      style={null}
-                                                      viewBox="0 0 16 16"
-                                                      width={16}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M15.363 14.658a.5.5 0 1 1-.713.7l-2.97-3.023a.5.5 0 0 1 .001-.7A3.9 3.9 0 1 0 8.9 12.8a.5.5 0 1 1 0 .999 4.9 4.9 0 1 1 3.821-1.833l2.642 2.691ZM3.094 13a.5.5 0 1 1 0 1H2.5A2.5 2.5 0 0 1 0 11.5v-9A2.5 2.5 0 0 1 2.5 0h9A2.5 2.5 0 0 1 14 2.5v.599a.5.5 0 1 1-1 0V2.5A1.5 1.5 0 0 0 11.5 1h-9A1.5 1.5 0 0 0 1 2.5v9A1.5 1.5 0 0 0 2.5 13h.594ZM2.5 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-4 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-2 1a.5.5 0 1 1 0 1 .5.5 0 0 1 0-1Zm0 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm6-6a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-8 8a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Z"
-                                                      />
-                                                    </svg>
-                                                  </EuiIconInspect>
-                                                </EuiIcon>
-                                              </button>
-                                            </EuiLink>
-                                          </div>
-                                        </EuiFlexItem>
-                                      </div>
-                                    </EuiFlexGroup>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                            </tr>
-                          </EuiTableRow>
-                        </tbody>
-                      </EuiTableBody>
-                    </table>
-                  </EuiTable>
+                                </span>
+                              </EuiButtonContent>
+                            </button>
+                          </EuiButtonEmpty>
+                        </span>
+                      </EuiToolTip>
+                    </div>
+                  </EuiFlexItem>
                 </div>
-                <PaginationBar
-                  aria-controls="random_html_id"
-                  onPageChange={[Function]}
-                  onPageSizeChange={[Function]}
-                  pagination={
-                    Object {
-                      "hidePerPageOptions": undefined,
-                      "pageIndex": 0,
-                      "pageSize": 10,
-                      "pageSizeOptions": Array [
-                        5,
-                        10,
-                        15,
-                      ],
-                      "totalItemCount": 1,
-                    }
-                  }
+              </EuiFlexGroup>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+      <EuiSpacer
+        size="m"
+      >
+        <div
+          className="euiSpacer euiSpacer--m"
+        />
+      </EuiSpacer>
+      <EuiHorizontalRule
+        margin="none"
+      >
+        <hr
+          className="euiHorizontalRule euiHorizontalRule--full"
+        />
+      </EuiHorizontalRule>
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "left",
+              "field": "name",
+              "name": "Name",
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "align": "right",
+              "field": "average_latency",
+              "name": "Average duration (ms)",
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "align": "right",
+              "field": "error_rate",
+              "name": "Error rate",
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "align": "right",
+              "field": "throughput",
+              "name": "Request rate",
+              "render": [Function],
+              "sortable": true,
+              "truncateText": true,
+            },
+            Object {
+              "align": "right",
+              "field": "traces",
+              "name": "Traces",
+              "render": [Function],
+              "sortable": true,
+              "truncateText": true,
+            },
+            Object {
+              "align": "center",
+              "field": "actions",
+              "name": "Actions",
+              "render": [Function],
+            },
+          ]
+        }
+        isSelectable={true}
+        itemId="itemId"
+        items={
+          Array [
+            Object {
+              "average_latency": 49.54,
+              "error_rate": 3.77,
+              "name": "database",
+              "throughput": 53,
+              "traces": 31,
+            },
+          ]
+        }
+        loading={false}
+        pagination={
+          Object {
+            "initialPageSize": 10,
+            "pageSizeOptions": Array [
+              5,
+              10,
+              15,
+            ],
+          }
+        }
+        responsive={true}
+        selection={
+          Object {
+            "onSelectionChange": [Function],
+          }
+        }
+        sorting={
+          Object {
+            "sort": Object {
+              "direction": "asc",
+              "field": "name",
+            },
+          }
+        }
+        tableLayout="auto"
+      >
+        <EuiBasicTable
+          columns={
+            Array [
+              Object {
+                "align": "left",
+                "field": "name",
+                "name": "Name",
+                "render": [Function],
+                "sortable": true,
+              },
+              Object {
+                "align": "right",
+                "field": "average_latency",
+                "name": "Average duration (ms)",
+                "render": [Function],
+                "sortable": true,
+              },
+              Object {
+                "align": "right",
+                "field": "error_rate",
+                "name": "Error rate",
+                "render": [Function],
+                "sortable": true,
+              },
+              Object {
+                "align": "right",
+                "field": "throughput",
+                "name": "Request rate",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": true,
+              },
+              Object {
+                "align": "right",
+                "field": "traces",
+                "name": "Traces",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": true,
+              },
+              Object {
+                "align": "center",
+                "field": "actions",
+                "name": "Actions",
+                "render": [Function],
+              },
+            ]
+          }
+          isSelectable={true}
+          itemId="itemId"
+          items={
+            Array [
+              Object {
+                "average_latency": 49.54,
+                "error_rate": 3.77,
+                "name": "database",
+                "throughput": 53,
+                "traces": 31,
+              },
+            ]
+          }
+          loading={false}
+          noItemsMessage="No items found"
+          onChange={[Function]}
+          pagination={
+            Object {
+              "hidePerPageOptions": undefined,
+              "pageIndex": 0,
+              "pageSize": 10,
+              "pageSizeOptions": Array [
+                5,
+                10,
+                15,
+              ],
+              "totalItemCount": 1,
+            }
+          }
+          responsive={true}
+          selection={
+            Object {
+              "onSelectionChange": [Function],
+            }
+          }
+          sorting={
+            Object {
+              "allowNeutralSort": true,
+              "sort": Object {
+                "direction": "asc",
+                "field": "Name",
+              },
+            }
+          }
+          tableLayout="auto"
+        >
+          <div
+            className="euiBasicTable"
+          >
+            <div>
+              <EuiTableHeaderMobile>
+                <div
+                  className="euiTableHeaderMobile"
                 >
-                  <div>
-                    <EuiSpacer
-                      size="m"
+                  <EuiFlexGroup
+                    alignItems="baseline"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiTablePagination
-                      activePage={0}
-                      aria-controls="random_html_id"
-                      itemsPerPage={10}
-                      itemsPerPageOptions={
-                        Array [
-                          5,
-                          10,
-                          15,
-                        ]
-                      }
-                      onChangeItemsPerPage={[Function]}
-                      onChangePage={[Function]}
-                      pageCount={1}
-                    >
-                      <EuiFlexGroup
-                        alignItems="center"
-                        justifyContent="spaceBetween"
-                        responsive={false}
+                      <EuiFlexItem
+                        grow={false}
                       >
                         <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
                         >
-                          <EuiFlexItem
-                            grow={false}
+                          <EuiI18n
+                            default="Select all rows"
+                            token="euiBasicTable.selectAllRows"
+                          >
+                            <EuiCheckbox
+                              aria-label="Select all rows"
+                              checked={false}
+                              compressed={false}
+                              disabled={false}
+                              id="_selection_column-checkbox_random_html_id"
+                              indeterminate={false}
+                              label="Select all rows"
+                              onChange={[Function]}
+                            >
+                              <div
+                                className="euiCheckbox"
+                              >
+                                <input
+                                  aria-label="Select all rows"
+                                  checked={false}
+                                  className="euiCheckbox__input"
+                                  disabled={false}
+                                  id="_selection_column-checkbox_random_html_id"
+                                  onChange={[Function]}
+                                  type="checkbox"
+                                />
+                                <div
+                                  className="euiCheckbox__square"
+                                />
+                                <label
+                                  className="euiCheckbox__label"
+                                  htmlFor="_selection_column-checkbox_random_html_id"
+                                >
+                                  Select all rows
+                                </label>
+                              </div>
+                            </EuiCheckbox>
+                          </EuiI18n>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiTableSortMobile
+                            items={
+                              Array [
+                                Object {
+                                  "isSortAscending": true,
+                                  "isSorted": true,
+                                  "key": "_data_s_name_0",
+                                  "name": "Name",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_average_latency_1",
+                                  "name": "Average duration (ms)",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_error_rate_2",
+                                  "name": "Error rate",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_throughput_3",
+                                  "name": "Request rate",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_traces_4",
+                                  "name": "Traces",
+                                  "onSort": [Function],
+                                },
+                              ]
+                            }
                           >
                             <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              className="euiTableSortMobile"
                             >
                               <EuiPopover
-                                anchorPosition="upRight"
+                                anchorPosition="downRight"
                                 button={
                                   <EuiButtonEmpty
-                                    color="text"
-                                    data-test-subj="tablePaginationPopoverButton"
+                                    flush="right"
                                     iconSide="right"
                                     iconType="arrowDown"
                                     onClick={[Function]}
                                     size="xs"
                                   >
                                     <EuiI18n
-                                      default="Rows per page"
-                                      token="euiTablePagination.rowsPerPage"
+                                      default="Sorting"
+                                      token="euiTableSortMobile.sorting"
                                     />
-                                    : 
-                                    10
                                   </EuiButtonEmpty>
                                 }
                                 closePopover={[Function]}
@@ -2098,22 +939,20 @@ exports[`Services table component renders jaeger services table 1`] = `
                                 panelPaddingSize="none"
                               >
                                 <div
-                                  className="euiPopover euiPopover--anchorUpRight"
+                                  className="euiPopover euiPopover--anchorDownRight"
                                 >
                                   <div
                                     className="euiPopover__anchor"
                                   >
                                     <EuiButtonEmpty
-                                      color="text"
-                                      data-test-subj="tablePaginationPopoverButton"
+                                      flush="right"
                                       iconSide="right"
                                       iconType="arrowDown"
                                       onClick={[Function]}
                                       size="xs"
                                     >
                                       <button
-                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
-                                        data-test-subj="tablePaginationPopoverButton"
+                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
                                         disabled={false}
                                         onClick={[Function]}
                                         type="button"
@@ -2167,13 +1006,11 @@ exports[`Services table component renders jaeger services table 1`] = `
                                               className="euiButtonEmpty__text"
                                             >
                                               <EuiI18n
-                                                default="Rows per page"
-                                                token="euiTablePagination.rowsPerPage"
+                                                default="Sorting"
+                                                token="euiTableSortMobile.sorting"
                                               >
-                                                Rows per page
+                                                Sorting
                                               </EuiI18n>
-                                              : 
-                                              10
                                             </span>
                                           </span>
                                         </EuiButtonContent>
@@ -2183,255 +1020,1394 @@ exports[`Services table component renders jaeger services table 1`] = `
                                 </div>
                               </EuiPopover>
                             </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
+                          </EuiTableSortMobile>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiTableHeaderMobile>
+              <EuiTable
+                id="random_html_id"
+                responsive={true}
+                tableLayout="auto"
+              >
+                <table
+                  className="euiTable euiTable--responsive euiTable--auto"
+                  id="random_html_id"
+                  tabIndex={-1}
+                >
+                  <EuiScreenReaderOnly>
+                    <caption
+                      className="euiScreenReaderOnly euiTableCaption"
+                    >
+                      <EuiDelayRender
+                        delay={500}
+                      />
+                    </caption>
+                  </EuiScreenReaderOnly>
+                  <EuiTableHeader>
+                    <thead>
+                      <tr>
+                        <EuiTableHeaderCellCheckbox
+                          key="_selection_column_h"
+                        >
+                          <th
+                            className="euiTableHeaderCellCheckbox"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
                           >
                             <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              className="euiTableCellContent"
                             >
-                              <EuiPagination
-                                activePage={0}
-                                aria-controls="random_html_id"
-                                onPageClick={[Function]}
-                                pageCount={1}
+                              <EuiI18n
+                                default="Select all rows"
+                                token="euiBasicTable.selectAllRows"
                               >
-                                <nav
-                                  className="euiPagination"
+                                <EuiCheckbox
+                                  aria-label="Select all rows"
+                                  checked={false}
+                                  compressed={false}
+                                  data-test-subj="checkboxSelectAll"
+                                  disabled={false}
+                                  id="_selection_column-checkbox_random_html_id"
+                                  indeterminate={false}
+                                  label={null}
+                                  onChange={[Function]}
+                                  type="inList"
                                 >
+                                  <div
+                                    className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                  >
+                                    <input
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      className="euiCheckbox__input"
+                                      data-test-subj="checkboxSelectAll"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      onChange={[Function]}
+                                      type="checkbox"
+                                    />
+                                    <div
+                                      className="euiCheckbox__square"
+                                    />
+                                  </div>
+                                </EuiCheckbox>
+                              </EuiI18n>
+                            </div>
+                          </th>
+                        </EuiTableHeaderCellCheckbox>
+                        <EuiTableHeaderCell
+                          align="left"
+                          data-test-subj="tableHeaderCell_name_0"
+                          isSortAscending={true}
+                          isSorted={true}
+                          key="_data_h_name_0"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="ascending"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_name_0"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent"
+                                isSortAscending={true}
+                                isSorted={true}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Name",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Name"
+                                      >
+                                        Name
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiIcon
+                                    className="euiTableSortIcon"
+                                    size="m"
+                                    type="sortUp"
+                                  >
+                                    <EuiIconSortUp
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiTableSortIcon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiTableSortIcon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
+                                        />
+                                      </svg>
+                                    </EuiIconSortUp>
+                                  </EuiIcon>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_average_latency_1"
+                          isSorted={false}
+                          key="_data_h_average_latency_1"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_average_latency_1"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Average duration (ms)",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Average duration (ms)"
+                                      >
+                                        Average duration (ms)
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_error_rate_2"
+                          isSorted={false}
+                          key="_data_h_error_rate_2"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_error_rate_2"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Error rate",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Error rate"
+                                      >
+                                        Error rate
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_throughput_3"
+                          isSorted={false}
+                          key="_data_h_throughput_3"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_throughput_3"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Request rate",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Request rate"
+                                      >
+                                        Request rate
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_traces_4"
+                          isSorted={false}
+                          key="_data_h_traces_4"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_traces_4"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Traces",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Traces"
+                                      >
+                                        Traces
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="center"
+                          data-test-subj="tableHeaderCell_actions_5"
+                          key="_data_h_actions_5"
+                        >
+                          <th
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_actions_5"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <CellContents
+                              className="euiTableCellContent euiTableCellContent--alignCenter"
+                              showSortMsg={false}
+                            >
+                              <span
+                                className="euiTableCellContent euiTableCellContent--alignCenter"
+                              >
+                                <EuiInnerText>
                                   <EuiI18n
-                                    default="Previous page, {page}"
-                                    token="euiPagination.previousPage"
+                                    default="{innerText}; {description}"
+                                    token="euiTableHeaderCell.titleTextWithDesc"
                                     values={
                                       Object {
-                                        "page": 0,
+                                        "description": undefined,
+                                        "innerText": "Actions",
                                       }
                                     }
                                   >
-                                    <EuiI18n
-                                      default="Previous page"
-                                      token="euiPagination.disabledPreviousPage"
+                                    <span
+                                      className="euiTableCellContent__text"
+                                      title="Actions"
                                     >
-                                      <EuiButtonIcon
-                                        aria-label="Previous page"
-                                        color="text"
-                                        data-test-subj="pagination-button-previous"
-                                        disabled={true}
-                                        iconType="arrowLeft"
+                                      Actions
+                                    </span>
+                                  </EuiI18n>
+                                </EuiInnerText>
+                              </span>
+                            </CellContents>
+                          </th>
+                        </EuiTableHeaderCell>
+                      </tr>
+                    </thead>
+                  </EuiTableHeader>
+                  <EuiTableBody
+                    bodyRef={[Function]}
+                  >
+                    <tbody>
+                      <EuiTableRow
+                        isSelectable={true}
+                        isSelected={false}
+                      >
+                        <tr
+                          className="euiTableRow euiTableRow-isSelectable"
+                        >
+                          <EuiTableRowCellCheckbox
+                            key="_selection_column_0"
+                          >
+                            <td
+                              className="euiTableRowCellCheckbox"
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiI18n
+                                  default="Select this row"
+                                  token="euiBasicTable.selectThisRow"
+                                >
+                                  <EuiCheckbox
+                                    aria-label="Select this row"
+                                    checked={false}
+                                    compressed={false}
+                                    data-test-subj="checkboxSelectRow-0"
+                                    disabled={false}
+                                    id="_selection_column_0-checkbox"
+                                    indeterminate={false}
+                                    onChange={[Function]}
+                                    title="Select this row"
+                                    type="inList"
+                                  >
+                                    <div
+                                      className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                    >
+                                      <input
+                                        aria-label="Select this row"
+                                        checked={false}
+                                        className="euiCheckbox__input"
+                                        data-test-subj="checkboxSelectRow-0"
+                                        disabled={false}
+                                        id="_selection_column_0-checkbox"
+                                        onChange={[Function]}
+                                        title="Select this row"
+                                        type="checkbox"
+                                      />
+                                      <div
+                                        className="euiCheckbox__square"
+                                      />
+                                    </div>
+                                  </EuiCheckbox>
+                                </EuiI18n>
+                              </div>
+                            </td>
+                          </EuiTableRowCellCheckbox>
+                          <EuiTableRowCell
+                            align="left"
+                            key="_data_column_name_0_0"
+                            mobileOptions={
+                              Object {
+                                "header": "Name",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Name
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--overflowingContent"
+                              >
+                                <EuiLink
+                                  className=""
+                                  data-test-subj="service-link"
+                                  key=".0"
+                                  onClick={[Function]}
+                                >
+                                  <button
+                                    className="euiLink euiLink--primary"
+                                    data-test-subj="service-link"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    database
+                                  </button>
+                                </EuiLink>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_average_latency_0_1"
+                            mobileOptions={
+                              Object {
+                                "header": "Average duration (ms)",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Average duration (ms)
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                              >
+                                <ServiceTrendsPlots
+                                  className=""
+                                  fieldType="average_latency"
+                                  item={49.54}
+                                  key=".0"
+                                  row={
+                                    Object {
+                                      "average_latency": 49.54,
+                                      "error_rate": 3.77,
+                                      "name": "database",
+                                      "throughput": 53,
+                                      "traces": 31,
+                                    }
+                                  }
+                                >
+                                  <EuiFlexGroup
+                                    gutterSize="s"
+                                    justifyContent="flexEnd"
+                                  >
+                                    <div
+                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <EuiFlexItem
+                                        grow={false}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        >
+                                          <EuiText
+                                            color="default"
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            <div
+                                              className="euiText euiText--medium"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <EuiTextColor
+                                                color="default"
+                                                component="div"
+                                              >
+                                                <div
+                                                  className="euiTextColor euiTextColor--default"
+                                                >
+                                                  49.54
+                                                </div>
+                                              </EuiTextColor>
+                                            </div>
+                                          </EuiText>
+                                        </div>
+                                      </EuiFlexItem>
+                                    </div>
+                                  </EuiFlexGroup>
+                                </ServiceTrendsPlots>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_error_rate_0_2"
+                            mobileOptions={
+                              Object {
+                                "header": "Error rate",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Error rate
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                              >
+                                <ServiceTrendsPlots
+                                  className=""
+                                  fieldType="error_rate"
+                                  item={3.77}
+                                  key=".0"
+                                  row={
+                                    Object {
+                                      "average_latency": 49.54,
+                                      "error_rate": 3.77,
+                                      "name": "database",
+                                      "throughput": 53,
+                                      "traces": 31,
+                                    }
+                                  }
+                                >
+                                  <EuiFlexGroup
+                                    gutterSize="s"
+                                    justifyContent="flexEnd"
+                                  >
+                                    <div
+                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <EuiFlexItem
+                                        grow={false}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        >
+                                          <EuiText
+                                            color="default"
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            <div
+                                              className="euiText euiText--medium"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <EuiTextColor
+                                                color="default"
+                                                component="div"
+                                              >
+                                                <div
+                                                  className="euiTextColor euiTextColor--default"
+                                                >
+                                                  <EuiText
+                                                    size="s"
+                                                  >
+                                                    <div
+                                                      className="euiText euiText--small"
+                                                    >
+                                                      3.77%
+                                                    </div>
+                                                  </EuiText>
+                                                </div>
+                                              </EuiTextColor>
+                                            </div>
+                                          </EuiText>
+                                        </div>
+                                      </EuiFlexItem>
+                                    </div>
+                                  </EuiFlexGroup>
+                                </ServiceTrendsPlots>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_throughput_0_3"
+                            mobileOptions={
+                              Object {
+                                "header": "Request rate",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                            truncateText={true}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Request rate
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                              >
+                                <ServiceTrendsPlots
+                                  className=""
+                                  fieldType="throughput"
+                                  item={53}
+                                  key=".0"
+                                  row={
+                                    Object {
+                                      "average_latency": 49.54,
+                                      "error_rate": 3.77,
+                                      "name": "database",
+                                      "throughput": 53,
+                                      "traces": 31,
+                                    }
+                                  }
+                                >
+                                  <EuiFlexGroup
+                                    gutterSize="s"
+                                    justifyContent="flexEnd"
+                                  >
+                                    <div
+                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <EuiFlexItem
+                                        grow={false}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        >
+                                          <EuiText
+                                            color="default"
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            <div
+                                              className="euiText euiText--medium"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <EuiTextColor
+                                                color="default"
+                                                component="div"
+                                              >
+                                                <div
+                                                  className="euiTextColor euiTextColor--default"
+                                                >
+                                                  <EuiI18nNumber
+                                                    value={53}
+                                                  >
+                                                    53
+                                                  </EuiI18nNumber>
+                                                </div>
+                                              </EuiTextColor>
+                                            </div>
+                                          </EuiText>
+                                        </div>
+                                      </EuiFlexItem>
+                                    </div>
+                                  </EuiFlexGroup>
+                                </ServiceTrendsPlots>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_traces_0_4"
+                            mobileOptions={
+                              Object {
+                                "header": "Traces",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                            truncateText={true}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Traces
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                              >
+                                <EuiLink
+                                  onClick={[Function]}
+                                >
+                                  <button
+                                    className="euiLink euiLink--primary"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <EuiI18nNumber
+                                      value={31}
+                                    >
+                                      31
+                                    </EuiI18nNumber>
+                                  </button>
+                                </EuiLink>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="center"
+                            key="_data_column_actions_0_5"
+                            mobileOptions={
+                              Object {
+                                "header": "Actions",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Actions
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
+                              >
+                                <EuiFlexGroup
+                                  className=""
+                                  justifyContent="center"
+                                  key=".0"
+                                >
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                  >
+                                    <EuiFlexItem
+                                      grow={false}
+                                      onClick={[Function]}
+                                    >
+                                      <div
+                                        className="euiFlexItem euiFlexItem--flexGrowZero"
                                         onClick={[Function]}
                                       >
-                                        <button
-                                          aria-label="Previous page"
-                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                          data-test-subj="pagination-button-previous"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          type="button"
+                                        <EuiLink
+                                          data-test-subj="service-flyout-action-btnundefined"
                                         >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="arrowLeft"
+                                          <button
+                                            className="euiLink euiLink--primary"
+                                            data-test-subj="service-flyout-action-btnundefined"
+                                            disabled={false}
+                                            type="button"
                                           >
-                                            <EuiIconArrowLeft
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
+                                            <EuiIcon
+                                              color="primary"
+                                              type="inspect"
                                             >
-                                              <svg
+                                              <EuiIconInspect
                                                 aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                className="euiIcon euiIcon--medium euiIcon--primary"
                                                 focusable="false"
-                                                height={16}
                                                 role="img"
                                                 style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
                                               >
-                                                <path
-                                                  d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
-                                                  fillRule="nonzero"
-                                                />
-                                              </svg>
-                                            </EuiIconArrowLeft>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiI18n>
-                                  </EuiI18n>
-                                  <ul
-                                    className="euiPagination__list"
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--medium euiIcon--primary"
+                                                  focusable="false"
+                                                  height={16}
+                                                  role="img"
+                                                  style={null}
+                                                  viewBox="0 0 16 16"
+                                                  width={16}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M15.363 14.658a.5.5 0 1 1-.713.7l-2.97-3.023a.5.5 0 0 1 .001-.7A3.9 3.9 0 1 0 8.9 12.8a.5.5 0 1 1 0 .999 4.9 4.9 0 1 1 3.821-1.833l2.642 2.691ZM3.094 13a.5.5 0 1 1 0 1H2.5A2.5 2.5 0 0 1 0 11.5v-9A2.5 2.5 0 0 1 2.5 0h9A2.5 2.5 0 0 1 14 2.5v.599a.5.5 0 1 1-1 0V2.5A1.5 1.5 0 0 0 11.5 1h-9A1.5 1.5 0 0 0 1 2.5v9A1.5 1.5 0 0 0 2.5 13h.594ZM2.5 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-4 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-2 1a.5.5 0 1 1 0 1 .5.5 0 0 1 0-1Zm0 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm6-6a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-8 8a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Z"
+                                                  />
+                                                </svg>
+                                              </EuiIconInspect>
+                                            </EuiIcon>
+                                          </button>
+                                        </EuiLink>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                        </tr>
+                      </EuiTableRow>
+                    </tbody>
+                  </EuiTableBody>
+                </table>
+              </EuiTable>
+            </div>
+            <PaginationBar
+              aria-controls="random_html_id"
+              onPageChange={[Function]}
+              onPageSizeChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+            >
+              <div>
+                <EuiSpacer
+                  size="m"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--m"
+                  />
+                </EuiSpacer>
+                <EuiTablePagination
+                  activePage={0}
+                  aria-controls="random_html_id"
+                  itemsPerPage={10}
+                  itemsPerPageOptions={
+                    Array [
+                      5,
+                      10,
+                      15,
+                    ]
+                  }
+                  onChangeItemsPerPage={[Function]}
+                  onChangePage={[Function]}
+                  pageCount={1}
+                >
+                  <EuiFlexGroup
+                    alignItems="center"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiPopover
+                            anchorPosition="upRight"
+                            button={
+                              <EuiButtonEmpty
+                                color="text"
+                                data-test-subj="tablePaginationPopoverButton"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="xs"
+                              >
+                                <EuiI18n
+                                  default="Rows per page"
+                                  token="euiTablePagination.rowsPerPage"
+                                />
+                                : 
+                                10
+                              </EuiButtonEmpty>
+                            }
+                            closePopover={[Function]}
+                            display="inlineBlock"
+                            hasArrow={true}
+                            isOpen={false}
+                            ownFocus={true}
+                            panelPaddingSize="none"
+                          >
+                            <div
+                              className="euiPopover euiPopover--anchorUpRight"
+                            >
+                              <div
+                                className="euiPopover__anchor"
+                              >
+                                <EuiButtonEmpty
+                                  color="text"
+                                  data-test-subj="tablePaginationPopoverButton"
+                                  iconSide="right"
+                                  iconType="arrowDown"
+                                  onClick={[Function]}
+                                  size="xs"
+                                >
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                    data-test-subj="tablePaginationPopoverButton"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
                                   >
-                                    <PaginationButton
-                                      key="0"
-                                      pageIndex={0}
+                                    <EuiButtonContent
+                                      className="euiButtonEmpty__content"
+                                      iconSide="right"
+                                      iconSize="s"
+                                      iconType="arrowDown"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButtonEmpty__text",
+                                        }
+                                      }
                                     >
-                                      <li
-                                        className="euiPagination__item"
+                                      <span
+                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                       >
-                                        <EuiPaginationButton
-                                          aria-controls="random_html_id"
-                                          hideOnMobile={true}
-                                          isActive={true}
-                                          onClick={[Function]}
-                                          pageIndex={0}
-                                          totalPages={1}
+                                        <EuiIcon
+                                          className="euiButtonContent__icon"
+                                          color="inherit"
+                                          size="s"
+                                          type="arrowDown"
+                                        >
+                                          <EuiIconArrowDown
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                fillRule="non-zero"
+                                              />
+                                            </svg>
+                                          </EuiIconArrowDown>
+                                        </EuiIcon>
+                                        <span
+                                          className="euiButtonEmpty__text"
                                         >
                                           <EuiI18n
-                                            default="Page {page} of {totalPages}"
-                                            token="euiPaginationButton.longPageString"
-                                            values={
-                                              Object {
-                                                "page": 1,
-                                                "totalPages": 1,
-                                              }
-                                            }
+                                            default="Rows per page"
+                                            token="euiTablePagination.rowsPerPage"
                                           >
-                                            <EuiI18n
-                                              default="Page {page}"
-                                              token="euiPaginationButton.shortPageString"
-                                              values={
-                                                Object {
-                                                  "page": 1,
-                                                }
-                                              }
-                                            >
-                                              <EuiButtonEmpty
-                                                aria-controls="random_html_id"
-                                                aria-current={true}
-                                                aria-label="Page 1 of 1"
-                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                                color="text"
-                                                data-test-subj="pagination-button-0"
-                                                href="#random_html_id"
-                                                isDisabled={true}
-                                                onClick={[Function]}
-                                                size="s"
-                                              >
-                                                <button
-                                                  aria-controls="random_html_id"
-                                                  aria-current={true}
-                                                  aria-label="Page 1 of 1"
-                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                                  data-test-subj="pagination-button-0"
-                                                  disabled={true}
-                                                  onClick={[Function]}
-                                                  type="button"
-                                                >
-                                                  <EuiButtonContent
-                                                    className="euiButtonEmpty__content"
-                                                    iconSide="left"
-                                                    iconSize="m"
-                                                    textProps={
-                                                      Object {
-                                                        "className": "euiButtonEmpty__text",
-                                                      }
-                                                    }
-                                                  >
-                                                    <span
-                                                      className="euiButtonContent euiButtonEmpty__content"
-                                                    >
-                                                      <span
-                                                        className="euiButtonEmpty__text"
-                                                      >
-                                                        1
-                                                      </span>
-                                                    </span>
-                                                  </EuiButtonContent>
-                                                </button>
-                                              </EuiButtonEmpty>
-                                            </EuiI18n>
+                                            Rows per page
                                           </EuiI18n>
-                                        </EuiPaginationButton>
-                                      </li>
-                                    </PaginationButton>
-                                  </ul>
-                                  <EuiI18n
-                                    default="Next page, {page}"
-                                    token="euiPagination.nextPage"
-                                    values={
-                                      Object {
-                                        "page": 2,
-                                      }
-                                    }
-                                  >
-                                    <EuiI18n
-                                      default="Next page"
-                                      token="euiPagination.disabledNextPage"
-                                    >
-                                      <EuiButtonIcon
-                                        aria-label="Next page"
-                                        color="text"
-                                        data-test-subj="pagination-button-next"
-                                        disabled={true}
-                                        iconType="arrowRight"
-                                        onClick={[Function]}
-                                      >
-                                        <button
-                                          aria-label="Next page"
-                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                          data-test-subj="pagination-button-next"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="arrowRight"
-                                          >
-                                            <EuiIconArrowRight
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                                                  fillRule="nonzero"
-                                                />
-                                              </svg>
-                                            </EuiIconArrowRight>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiI18n>
-                                  </EuiI18n>
-                                </nav>
-                              </EuiPagination>
+                                          : 
+                                          10
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonEmpty>
+                              </div>
                             </div>
-                          </EuiFlexItem>
+                          </EuiPopover>
                         </div>
-                      </EuiFlexGroup>
-                    </EuiTablePagination>
-                  </div>
-                </PaginationBar>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiPagination
+                            activePage={0}
+                            aria-controls="random_html_id"
+                            onPageClick={[Function]}
+                            pageCount={1}
+                          >
+                            <nav
+                              className="euiPagination"
+                            >
+                              <EuiI18n
+                                default="Previous page, {page}"
+                                token="euiPagination.previousPage"
+                                values={
+                                  Object {
+                                    "page": 0,
+                                  }
+                                }
+                              >
+                                <EuiI18n
+                                  default="Previous page"
+                                  token="euiPagination.disabledPreviousPage"
+                                >
+                                  <EuiButtonIcon
+                                    aria-label="Previous page"
+                                    color="text"
+                                    data-test-subj="pagination-button-previous"
+                                    disabled={true}
+                                    iconType="arrowLeft"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      aria-label="Previous page"
+                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      data-test-subj="pagination-button-previous"
+                                      disabled={true}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiButtonIcon__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowLeft"
+                                      >
+                                        <EuiIconArrowLeft
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
+                                              fillRule="nonzero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowLeft>
+                                      </EuiIcon>
+                                    </button>
+                                  </EuiButtonIcon>
+                                </EuiI18n>
+                              </EuiI18n>
+                              <ul
+                                className="euiPagination__list"
+                              >
+                                <PaginationButton
+                                  key="0"
+                                  pageIndex={0}
+                                >
+                                  <li
+                                    className="euiPagination__item"
+                                  >
+                                    <EuiPaginationButton
+                                      aria-controls="random_html_id"
+                                      hideOnMobile={true}
+                                      isActive={true}
+                                      onClick={[Function]}
+                                      pageIndex={0}
+                                      totalPages={1}
+                                    >
+                                      <EuiI18n
+                                        default="Page {page} of {totalPages}"
+                                        token="euiPaginationButton.longPageString"
+                                        values={
+                                          Object {
+                                            "page": 1,
+                                            "totalPages": 1,
+                                          }
+                                        }
+                                      >
+                                        <EuiI18n
+                                          default="Page {page}"
+                                          token="euiPaginationButton.shortPageString"
+                                          values={
+                                            Object {
+                                              "page": 1,
+                                            }
+                                          }
+                                        >
+                                          <EuiButtonEmpty
+                                            aria-controls="random_html_id"
+                                            aria-current={true}
+                                            aria-label="Page 1 of 1"
+                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                            color="text"
+                                            data-test-subj="pagination-button-0"
+                                            href="#random_html_id"
+                                            isDisabled={true}
+                                            onClick={[Function]}
+                                            size="s"
+                                          >
+                                            <button
+                                              aria-controls="random_html_id"
+                                              aria-current={true}
+                                              aria-label="Page 1 of 1"
+                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              data-test-subj="pagination-button-0"
+                                              disabled={true}
+                                              onClick={[Function]}
+                                              type="button"
+                                            >
+                                              <EuiButtonContent
+                                                className="euiButtonEmpty__content"
+                                                iconSide="left"
+                                                iconSize="m"
+                                                textProps={
+                                                  Object {
+                                                    "className": "euiButtonEmpty__text",
+                                                  }
+                                                }
+                                              >
+                                                <span
+                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                >
+                                                  <span
+                                                    className="euiButtonEmpty__text"
+                                                  >
+                                                    1
+                                                  </span>
+                                                </span>
+                                              </EuiButtonContent>
+                                            </button>
+                                          </EuiButtonEmpty>
+                                        </EuiI18n>
+                                      </EuiI18n>
+                                    </EuiPaginationButton>
+                                  </li>
+                                </PaginationButton>
+                              </ul>
+                              <EuiI18n
+                                default="Next page, {page}"
+                                token="euiPagination.nextPage"
+                                values={
+                                  Object {
+                                    "page": 2,
+                                  }
+                                }
+                              >
+                                <EuiI18n
+                                  default="Next page"
+                                  token="euiPagination.disabledNextPage"
+                                >
+                                  <EuiButtonIcon
+                                    aria-label="Next page"
+                                    color="text"
+                                    data-test-subj="pagination-button-next"
+                                    disabled={true}
+                                    iconType="arrowRight"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      aria-label="Next page"
+                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      data-test-subj="pagination-button-next"
+                                      disabled={true}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiButtonIcon__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowRight"
+                                      >
+                                        <EuiIconArrowRight
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                              fillRule="nonzero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowRight>
+                                      </EuiIcon>
+                                    </button>
+                                  </EuiButtonIcon>
+                                </EuiI18n>
+                              </EuiI18n>
+                            </nav>
+                          </EuiPagination>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </EuiTablePagination>
               </div>
-            </EuiBasicTable>
-          </EuiInMemoryTable>
-        </div>
-      </EuiPanel>
+            </PaginationBar>
+          </div>
+        </EuiBasicTable>
+      </EuiInMemoryTable>
     </div>
-  </EuiPage>
+  </EuiPanel>
 </ServicesTable>
 `;
 
@@ -2462,129 +2438,83 @@ exports[`Services table component renders services table 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPage
-    paddingSize="m"
-  >
+  <EuiPanel>
     <div
-      className="euiPage euiPage--paddingMedium euiPage--grow"
+      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     >
-      <EuiPanel>
+      <EuiFlexGroup
+        justifyContent="spaceBetween"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
+          <EuiFlexItem
+            grow={false}
           >
             <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <EuiFlexItem
-                grow={false}
+              <PanelTitle
+                title="Services"
+                totalItems={1}
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                <EuiText
+                  size="m"
                 >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={1}
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    <EuiText
-                      size="m"
+                    <span
+                      className="panel-title"
                     >
-                      <div
-                        className="euiText euiText--medium"
+                      Services
+                    </span>
+                    <span
+                      className="panel-title-count"
+                    >
+                       (1)
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <EuiFlexGroup>
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiToolTip
+                        content="Select services to filter"
+                        delay="regular"
+                        position="top"
                       >
                         <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (1)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                size="xs"
-                              >
-                                <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  type="button"
-                                >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="s"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
-                                    >
-                                      <span
-                                        className="euiButtonEmpty__text"
-                                      >
-                                        Filter services
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
+                          className="euiToolTipAnchor"
+                          onKeyUp={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
                         >
                           <EuiButtonEmpty
-                            onClick={[Function]}
+                            isDisabled={true}
+                            onBlur={[Function]}
+                            onFocus={[Function]}
                             size="xs"
                           >
                             <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                              disabled={false}
-                              onClick={[Function]}
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                              disabled={true}
+                              onBlur={[Function]}
+                              onFocus={[Function]}
                               type="button"
                             >
                               <EuiButtonContent
@@ -2603,1745 +2533,440 @@ exports[`Services table component renders services table 1`] = `
                                   <span
                                     className="euiButtonEmpty__text"
                                   >
-                                    Show 24 hour trends
+                                    Filter services
                                   </span>
                                 </span>
                               </EuiButtonContent>
                             </button>
                           </EuiButtonEmpty>
-                        </div>
-                      </EuiFlexItem>
+                        </span>
+                      </EuiToolTip>
                     </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <EuiInMemoryTable
-            columns={
-              Array [
-                Object {
-                  "align": "left",
-                  "field": "name",
-                  "name": "Name",
-                  "render": [Function],
-                  "sortable": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "average_latency",
-                  "name": "Average duration (ms)",
-                  "render": [Function],
-                  "sortable": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "error_rate",
-                  "name": "Error rate",
-                  "render": [Function],
-                  "sortable": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "throughput",
-                  "name": "Request rate",
-                  "render": [Function],
-                  "sortable": true,
-                  "truncateText": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "number_of_connected_services",
-                  "name": "No. of connected services",
-                  "render": [Function],
-                  "sortable": true,
-                  "truncateText": true,
-                  "width": "80px",
-                },
-                Object {
-                  "align": "left",
-                  "field": "connected_services",
-                  "name": "Connected services",
-                  "render": [Function],
-                  "sortable": true,
-                  "truncateText": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "traces",
-                  "name": "Traces",
-                  "render": [Function],
-                  "sortable": true,
-                  "truncateText": true,
-                },
-                Object {
-                  "align": "center",
-                  "field": "actions",
-                  "name": "Actions",
-                  "render": [Function],
-                },
-              ]
-            }
-            isSelectable={true}
-            itemId="itemId"
-            items={
-              Array [
-                Object {
-                  "average_latency": 49.54,
-                  "connected_services": Array [
-                    "order",
-                    "inventory",
-                  ],
-                  "error_rate": 3.77,
-                  "name": "database",
-                  "number_of_connected_services": 2,
-                  "throughput": 53,
-                  "traces": 31,
-                },
-              ]
-            }
-            loading={false}
-            pagination={
-              Object {
-                "initialPageSize": 10,
-                "pageSizeOptions": Array [
-                  5,
-                  10,
-                  15,
-                ],
-              }
-            }
-            responsive={true}
-            selection={
-              Object {
-                "onSelectionChange": [Function],
-              }
-            }
-            sorting={
-              Object {
-                "sort": Object {
-                  "direction": "asc",
-                  "field": "name",
-                },
-              }
-            }
-            tableLayout="auto"
-          >
-            <EuiBasicTable
-              columns={
-                Array [
-                  Object {
-                    "align": "left",
-                    "field": "name",
-                    "name": "Name",
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "average_latency",
-                    "name": "Average duration (ms)",
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "error_rate",
-                    "name": "Error rate",
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "throughput",
-                    "name": "Request rate",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "number_of_connected_services",
-                    "name": "No. of connected services",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                    "width": "80px",
-                  },
-                  Object {
-                    "align": "left",
-                    "field": "connected_services",
-                    "name": "Connected services",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "traces",
-                    "name": "Traces",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                  },
-                  Object {
-                    "align": "center",
-                    "field": "actions",
-                    "name": "Actions",
-                    "render": [Function],
-                  },
-                ]
-              }
-              isSelectable={true}
-              itemId="itemId"
-              items={
-                Array [
-                  Object {
-                    "average_latency": 49.54,
-                    "connected_services": Array [
-                      "order",
-                      "inventory",
-                    ],
-                    "error_rate": 3.77,
-                    "name": "database",
-                    "number_of_connected_services": 2,
-                    "throughput": 53,
-                    "traces": 31,
-                  },
-                ]
-              }
-              loading={false}
-              noItemsMessage="No items found"
-              onChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-              responsive={true}
-              selection={
-                Object {
-                  "onSelectionChange": [Function],
-                }
-              }
-              sorting={
-                Object {
-                  "allowNeutralSort": true,
-                  "sort": Object {
-                    "direction": "asc",
-                    "field": "Name",
-                  },
-                }
-              }
-              tableLayout="auto"
-            >
-              <div
-                className="euiBasicTable"
-              >
-                <div>
-                  <EuiTableHeaderMobile>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
                     <div
-                      className="euiTableHeaderMobile"
+                      className="euiFlexItem"
                     >
-                      <EuiFlexGroup
-                        alignItems="baseline"
-                        justifyContent="spaceBetween"
-                        responsive={false}
+                      <EuiButtonEmpty
+                        onClick={[Function]}
+                        size="xs"
+                      >
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
+                            >
+                              <span
+                                className="euiButtonEmpty__text"
+                              >
+                                Show 24 hour trends
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+      <EuiSpacer
+        size="m"
+      >
+        <div
+          className="euiSpacer euiSpacer--m"
+        />
+      </EuiSpacer>
+      <EuiHorizontalRule
+        margin="none"
+      >
+        <hr
+          className="euiHorizontalRule euiHorizontalRule--full"
+        />
+      </EuiHorizontalRule>
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "left",
+              "field": "name",
+              "name": "Name",
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "align": "right",
+              "field": "average_latency",
+              "name": "Average duration (ms)",
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "align": "right",
+              "field": "error_rate",
+              "name": "Error rate",
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "align": "right",
+              "field": "throughput",
+              "name": "Request rate",
+              "render": [Function],
+              "sortable": true,
+              "truncateText": true,
+            },
+            Object {
+              "align": "right",
+              "field": "number_of_connected_services",
+              "name": "No. of connected services",
+              "render": [Function],
+              "sortable": true,
+              "truncateText": true,
+              "width": "80px",
+            },
+            Object {
+              "align": "left",
+              "field": "connected_services",
+              "name": "Connected services",
+              "render": [Function],
+              "sortable": true,
+              "truncateText": true,
+            },
+            Object {
+              "align": "right",
+              "field": "traces",
+              "name": "Traces",
+              "render": [Function],
+              "sortable": true,
+              "truncateText": true,
+            },
+            Object {
+              "align": "center",
+              "field": "actions",
+              "name": "Actions",
+              "render": [Function],
+            },
+          ]
+        }
+        isSelectable={true}
+        itemId="itemId"
+        items={
+          Array [
+            Object {
+              "average_latency": 49.54,
+              "connected_services": Array [
+                "order",
+                "inventory",
+              ],
+              "error_rate": 3.77,
+              "name": "database",
+              "number_of_connected_services": 2,
+              "throughput": 53,
+              "traces": 31,
+            },
+          ]
+        }
+        loading={false}
+        pagination={
+          Object {
+            "initialPageSize": 10,
+            "pageSizeOptions": Array [
+              5,
+              10,
+              15,
+            ],
+          }
+        }
+        responsive={true}
+        selection={
+          Object {
+            "onSelectionChange": [Function],
+          }
+        }
+        sorting={
+          Object {
+            "sort": Object {
+              "direction": "asc",
+              "field": "name",
+            },
+          }
+        }
+        tableLayout="auto"
+      >
+        <EuiBasicTable
+          columns={
+            Array [
+              Object {
+                "align": "left",
+                "field": "name",
+                "name": "Name",
+                "render": [Function],
+                "sortable": true,
+              },
+              Object {
+                "align": "right",
+                "field": "average_latency",
+                "name": "Average duration (ms)",
+                "render": [Function],
+                "sortable": true,
+              },
+              Object {
+                "align": "right",
+                "field": "error_rate",
+                "name": "Error rate",
+                "render": [Function],
+                "sortable": true,
+              },
+              Object {
+                "align": "right",
+                "field": "throughput",
+                "name": "Request rate",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": true,
+              },
+              Object {
+                "align": "right",
+                "field": "number_of_connected_services",
+                "name": "No. of connected services",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": true,
+                "width": "80px",
+              },
+              Object {
+                "align": "left",
+                "field": "connected_services",
+                "name": "Connected services",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": true,
+              },
+              Object {
+                "align": "right",
+                "field": "traces",
+                "name": "Traces",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": true,
+              },
+              Object {
+                "align": "center",
+                "field": "actions",
+                "name": "Actions",
+                "render": [Function],
+              },
+            ]
+          }
+          isSelectable={true}
+          itemId="itemId"
+          items={
+            Array [
+              Object {
+                "average_latency": 49.54,
+                "connected_services": Array [
+                  "order",
+                  "inventory",
+                ],
+                "error_rate": 3.77,
+                "name": "database",
+                "number_of_connected_services": 2,
+                "throughput": 53,
+                "traces": 31,
+              },
+            ]
+          }
+          loading={false}
+          noItemsMessage="No items found"
+          onChange={[Function]}
+          pagination={
+            Object {
+              "hidePerPageOptions": undefined,
+              "pageIndex": 0,
+              "pageSize": 10,
+              "pageSizeOptions": Array [
+                5,
+                10,
+                15,
+              ],
+              "totalItemCount": 1,
+            }
+          }
+          responsive={true}
+          selection={
+            Object {
+              "onSelectionChange": [Function],
+            }
+          }
+          sorting={
+            Object {
+              "allowNeutralSort": true,
+              "sort": Object {
+                "direction": "asc",
+                "field": "Name",
+              },
+            }
+          }
+          tableLayout="auto"
+        >
+          <div
+            className="euiBasicTable"
+          >
+            <div>
+              <EuiTableHeaderMobile>
+                <div
+                  className="euiTableHeaderMobile"
+                >
+                  <EuiFlexGroup
+                    alignItems="baseline"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    >
+                      <EuiFlexItem
+                        grow={false}
                       >
                         <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
                         >
-                          <EuiFlexItem
-                            grow={false}
+                          <EuiI18n
+                            default="Select all rows"
+                            token="euiBasicTable.selectAllRows"
                           >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            <EuiCheckbox
+                              aria-label="Select all rows"
+                              checked={false}
+                              compressed={false}
+                              disabled={false}
+                              id="_selection_column-checkbox_random_html_id"
+                              indeterminate={false}
+                              label="Select all rows"
+                              onChange={[Function]}
                             >
-                              <EuiI18n
-                                default="Select all rows"
-                                token="euiBasicTable.selectAllRows"
+                              <div
+                                className="euiCheckbox"
                               >
-                                <EuiCheckbox
+                                <input
                                   aria-label="Select all rows"
                                   checked={false}
-                                  compressed={false}
+                                  className="euiCheckbox__input"
                                   disabled={false}
                                   id="_selection_column-checkbox_random_html_id"
-                                  indeterminate={false}
-                                  label="Select all rows"
                                   onChange={[Function]}
-                                >
-                                  <div
-                                    className="euiCheckbox"
-                                  >
-                                    <input
-                                      aria-label="Select all rows"
-                                      checked={false}
-                                      className="euiCheckbox__input"
-                                      disabled={false}
-                                      id="_selection_column-checkbox_random_html_id"
-                                      onChange={[Function]}
-                                      type="checkbox"
-                                    />
-                                    <div
-                                      className="euiCheckbox__square"
-                                    />
-                                    <label
-                                      className="euiCheckbox__label"
-                                      htmlFor="_selection_column-checkbox_random_html_id"
-                                    >
-                                      Select all rows
-                                    </label>
-                                  </div>
-                                </EuiCheckbox>
-                              </EuiI18n>
-                            </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                            >
-                              <EuiTableSortMobile
-                                items={
-                                  Array [
-                                    Object {
-                                      "isSortAscending": true,
-                                      "isSorted": true,
-                                      "key": "_data_s_name_0",
-                                      "name": "Name",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_average_latency_1",
-                                      "name": "Average duration (ms)",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_error_rate_2",
-                                      "name": "Error rate",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_throughput_3",
-                                      "name": "Request rate",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_number_of_connected_services_4",
-                                      "name": "No. of connected services",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_connected_services_5",
-                                      "name": "Connected services",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_traces_6",
-                                      "name": "Traces",
-                                      "onSort": [Function],
-                                    },
-                                  ]
-                                }
-                              >
+                                  type="checkbox"
+                                />
                                 <div
-                                  className="euiTableSortMobile"
+                                  className="euiCheckbox__square"
+                                />
+                                <label
+                                  className="euiCheckbox__label"
+                                  htmlFor="_selection_column-checkbox_random_html_id"
                                 >
-                                  <EuiPopover
-                                    anchorPosition="downRight"
-                                    button={
-                                      <EuiButtonEmpty
-                                        flush="right"
-                                        iconSide="right"
-                                        iconType="arrowDown"
-                                        onClick={[Function]}
-                                        size="xs"
-                                      >
-                                        <EuiI18n
-                                          default="Sorting"
-                                          token="euiTableSortMobile.sorting"
-                                        />
-                                      </EuiButtonEmpty>
-                                    }
-                                    closePopover={[Function]}
-                                    display="inlineBlock"
-                                    hasArrow={true}
-                                    isOpen={false}
-                                    ownFocus={true}
-                                    panelPaddingSize="none"
-                                  >
-                                    <div
-                                      className="euiPopover euiPopover--anchorDownRight"
-                                    >
-                                      <div
-                                        className="euiPopover__anchor"
-                                      >
-                                        <EuiButtonEmpty
-                                          flush="right"
-                                          iconSide="right"
-                                          iconType="arrowDown"
-                                          onClick={[Function]}
-                                          size="xs"
-                                        >
-                                          <button
-                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiButtonContent
-                                              className="euiButtonEmpty__content"
-                                              iconSide="right"
-                                              iconSize="s"
-                                              iconType="arrowDown"
-                                              textProps={
-                                                Object {
-                                                  "className": "euiButtonEmpty__text",
-                                                }
-                                              }
-                                            >
-                                              <span
-                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                              >
-                                                <EuiIcon
-                                                  className="euiButtonContent__icon"
-                                                  color="inherit"
-                                                  size="s"
-                                                  type="arrowDown"
-                                                >
-                                                  <EuiIconBeaker
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                    focusable="false"
-                                                    role="img"
-                                                    style={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                      focusable="false"
-                                                      height={16}
-                                                      role="img"
-                                                      style={null}
-                                                      viewBox="0 0 16 16"
-                                                      width={16}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                      />
-                                                    </svg>
-                                                  </EuiIconBeaker>
-                                                </EuiIcon>
-                                                <span
-                                                  className="euiButtonEmpty__text"
-                                                >
-                                                  <EuiI18n
-                                                    default="Sorting"
-                                                    token="euiTableSortMobile.sorting"
-                                                  >
-                                                    Sorting
-                                                  </EuiI18n>
-                                                </span>
-                                              </span>
-                                            </EuiButtonContent>
-                                          </button>
-                                        </EuiButtonEmpty>
-                                      </div>
-                                    </div>
-                                  </EuiPopover>
-                                </div>
-                              </EuiTableSortMobile>
-                            </div>
-                          </EuiFlexItem>
+                                  Select all rows
+                                </label>
+                              </div>
+                            </EuiCheckbox>
+                          </EuiI18n>
                         </div>
-                      </EuiFlexGroup>
-                    </div>
-                  </EuiTableHeaderMobile>
-                  <EuiTable
-                    id="random_html_id"
-                    responsive={true}
-                    tableLayout="auto"
-                  >
-                    <table
-                      className="euiTable euiTable--responsive euiTable--auto"
-                      id="random_html_id"
-                      tabIndex={-1}
-                    >
-                      <EuiScreenReaderOnly>
-                        <caption
-                          className="euiScreenReaderOnly euiTableCaption"
-                        >
-                          <EuiDelayRender
-                            delay={500}
-                          />
-                        </caption>
-                      </EuiScreenReaderOnly>
-                      <EuiTableHeader>
-                        <thead>
-                          <tr>
-                            <EuiTableHeaderCellCheckbox
-                              key="_selection_column_h"
-                            >
-                              <th
-                                className="euiTableHeaderCellCheckbox"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <div
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiI18n
-                                    default="Select all rows"
-                                    token="euiBasicTable.selectAllRows"
-                                  >
-                                    <EuiCheckbox
-                                      aria-label="Select all rows"
-                                      checked={false}
-                                      compressed={false}
-                                      data-test-subj="checkboxSelectAll"
-                                      disabled={false}
-                                      id="_selection_column-checkbox_random_html_id"
-                                      indeterminate={false}
-                                      label={null}
-                                      onChange={[Function]}
-                                      type="inList"
-                                    >
-                                      <div
-                                        className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                      >
-                                        <input
-                                          aria-label="Select all rows"
-                                          checked={false}
-                                          className="euiCheckbox__input"
-                                          data-test-subj="checkboxSelectAll"
-                                          disabled={false}
-                                          id="_selection_column-checkbox_random_html_id"
-                                          onChange={[Function]}
-                                          type="checkbox"
-                                        />
-                                        <div
-                                          className="euiCheckbox__square"
-                                        />
-                                      </div>
-                                    </EuiCheckbox>
-                                  </EuiI18n>
-                                </div>
-                              </th>
-                            </EuiTableHeaderCellCheckbox>
-                            <EuiTableHeaderCell
-                              align="left"
-                              data-test-subj="tableHeaderCell_name_0"
-                              isSortAscending={true}
-                              isSorted={true}
-                              key="_data_h_name_0"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="ascending"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_name_0"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent"
-                                    isSortAscending={true}
-                                    isSorted={true}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Name",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Name"
-                                          >
-                                            Name
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                      <EuiIcon
-                                        className="euiTableSortIcon"
-                                        size="m"
-                                        type="sortUp"
-                                      >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_average_latency_1"
-                              isSorted={false}
-                              key="_data_h_average_latency_1"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_average_latency_1"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Average duration (ms)",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Average duration (ms)"
-                                          >
-                                            Average duration (ms)
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_error_rate_2"
-                              isSorted={false}
-                              key="_data_h_error_rate_2"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_error_rate_2"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Error rate",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Error rate"
-                                          >
-                                            Error rate
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_throughput_3"
-                              isSorted={false}
-                              key="_data_h_throughput_3"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_throughput_3"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Request rate",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Request rate"
-                                          >
-                                            Request rate
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_number_of_connected_services_4"
-                              isSorted={false}
-                              key="_data_h_number_of_connected_services_4"
-                              onSort={[Function]}
-                              width="80px"
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_number_of_connected_services_4"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": "80px",
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "No. of connected services",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="No. of connected services"
-                                          >
-                                            No. of connected services
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="left"
-                              data-test-subj="tableHeaderCell_connected_services_5"
-                              isSorted={false}
-                              key="_data_h_connected_services_5"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_connected_services_5"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Connected services",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Connected services"
-                                          >
-                                            Connected services
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_traces_6"
-                              isSorted={false}
-                              key="_data_h_traces_6"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_traces_6"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Traces",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Traces"
-                                          >
-                                            Traces
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="center"
-                              data-test-subj="tableHeaderCell_actions_7"
-                              key="_data_h_actions_7"
-                            >
-                              <th
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_actions_7"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <CellContents
-                                  className="euiTableCellContent euiTableCellContent--alignCenter"
-                                  showSortMsg={false}
-                                >
-                                  <span
-                                    className="euiTableCellContent euiTableCellContent--alignCenter"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Actions",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Actions"
-                                        >
-                                          Actions
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </th>
-                            </EuiTableHeaderCell>
-                          </tr>
-                        </thead>
-                      </EuiTableHeader>
-                      <EuiTableBody
-                        bodyRef={[Function]}
-                      >
-                        <tbody>
-                          <EuiTableRow
-                            isSelectable={true}
-                            isSelected={false}
-                          >
-                            <tr
-                              className="euiTableRow euiTableRow-isSelectable"
-                            >
-                              <EuiTableRowCellCheckbox
-                                key="_selection_column_0"
-                              >
-                                <td
-                                  className="euiTableRowCellCheckbox"
-                                >
-                                  <div
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiI18n
-                                      default="Select this row"
-                                      token="euiBasicTable.selectThisRow"
-                                    >
-                                      <EuiCheckbox
-                                        aria-label="Select this row"
-                                        checked={false}
-                                        compressed={false}
-                                        data-test-subj="checkboxSelectRow-0"
-                                        disabled={false}
-                                        id="_selection_column_0-checkbox"
-                                        indeterminate={false}
-                                        onChange={[Function]}
-                                        title="Select this row"
-                                        type="inList"
-                                      >
-                                        <div
-                                          className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                        >
-                                          <input
-                                            aria-label="Select this row"
-                                            checked={false}
-                                            className="euiCheckbox__input"
-                                            data-test-subj="checkboxSelectRow-0"
-                                            disabled={false}
-                                            id="_selection_column_0-checkbox"
-                                            onChange={[Function]}
-                                            title="Select this row"
-                                            type="checkbox"
-                                          />
-                                          <div
-                                            className="euiCheckbox__square"
-                                          />
-                                        </div>
-                                      </EuiCheckbox>
-                                    </EuiI18n>
-                                  </div>
-                                </td>
-                              </EuiTableRowCellCheckbox>
-                              <EuiTableRowCell
-                                align="left"
-                                key="_data_column_name_0_0"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Name",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Name
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiLink
-                                      className=""
-                                      data-test-subj="service-link"
-                                      key=".0"
-                                      onClick={[Function]}
-                                    >
-                                      <button
-                                        className="euiLink euiLink--primary"
-                                        data-test-subj="service-link"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        database
-                                      </button>
-                                    </EuiLink>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_average_latency_0_1"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Average duration (ms)",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Average duration (ms)
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                  >
-                                    <ServiceTrendsPlots
-                                      className=""
-                                      fieldType="average_latency"
-                                      item={49.54}
-                                      key=".0"
-                                      row={
-                                        Object {
-                                          "average_latency": 49.54,
-                                          "connected_services": Array [
-                                            "order",
-                                            "inventory",
-                                          ],
-                                          "error_rate": 3.77,
-                                          "name": "database",
-                                          "number_of_connected_services": 2,
-                                          "throughput": 53,
-                                          "traces": 31,
-                                        }
-                                      }
-                                    >
-                                      <EuiFlexGroup
-                                        gutterSize="s"
-                                        justifyContent="flexEnd"
-                                      >
-                                        <div
-                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                        >
-                                          <EuiFlexItem
-                                            grow={false}
-                                          >
-                                            <div
-                                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                                            >
-                                              <EuiText
-                                                color="default"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <div
-                                                  className="euiText euiText--medium"
-                                                  onMouseEnter={[Function]}
-                                                  onMouseLeave={[Function]}
-                                                >
-                                                  <EuiTextColor
-                                                    color="default"
-                                                    component="div"
-                                                  >
-                                                    <div
-                                                      className="euiTextColor euiTextColor--default"
-                                                    >
-                                                      49.54
-                                                    </div>
-                                                  </EuiTextColor>
-                                                </div>
-                                              </EuiText>
-                                            </div>
-                                          </EuiFlexItem>
-                                        </div>
-                                      </EuiFlexGroup>
-                                    </ServiceTrendsPlots>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_error_rate_0_2"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Error rate",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Error rate
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                  >
-                                    <ServiceTrendsPlots
-                                      className=""
-                                      fieldType="error_rate"
-                                      item={3.77}
-                                      key=".0"
-                                      row={
-                                        Object {
-                                          "average_latency": 49.54,
-                                          "connected_services": Array [
-                                            "order",
-                                            "inventory",
-                                          ],
-                                          "error_rate": 3.77,
-                                          "name": "database",
-                                          "number_of_connected_services": 2,
-                                          "throughput": 53,
-                                          "traces": 31,
-                                        }
-                                      }
-                                    >
-                                      <EuiFlexGroup
-                                        gutterSize="s"
-                                        justifyContent="flexEnd"
-                                      >
-                                        <div
-                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                        >
-                                          <EuiFlexItem
-                                            grow={false}
-                                          >
-                                            <div
-                                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                                            >
-                                              <EuiText
-                                                color="default"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <div
-                                                  className="euiText euiText--medium"
-                                                  onMouseEnter={[Function]}
-                                                  onMouseLeave={[Function]}
-                                                >
-                                                  <EuiTextColor
-                                                    color="default"
-                                                    component="div"
-                                                  >
-                                                    <div
-                                                      className="euiTextColor euiTextColor--default"
-                                                    >
-                                                      <EuiText
-                                                        size="s"
-                                                      >
-                                                        <div
-                                                          className="euiText euiText--small"
-                                                        >
-                                                          3.77%
-                                                        </div>
-                                                      </EuiText>
-                                                    </div>
-                                                  </EuiTextColor>
-                                                </div>
-                                              </EuiText>
-                                            </div>
-                                          </EuiFlexItem>
-                                        </div>
-                                      </EuiFlexGroup>
-                                    </ServiceTrendsPlots>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_throughput_0_3"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Request rate",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Request rate
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    <ServiceTrendsPlots
-                                      className=""
-                                      fieldType="throughput"
-                                      item={53}
-                                      key=".0"
-                                      row={
-                                        Object {
-                                          "average_latency": 49.54,
-                                          "connected_services": Array [
-                                            "order",
-                                            "inventory",
-                                          ],
-                                          "error_rate": 3.77,
-                                          "name": "database",
-                                          "number_of_connected_services": 2,
-                                          "throughput": 53,
-                                          "traces": 31,
-                                        }
-                                      }
-                                    >
-                                      <EuiFlexGroup
-                                        gutterSize="s"
-                                        justifyContent="flexEnd"
-                                      >
-                                        <div
-                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                        >
-                                          <EuiFlexItem
-                                            grow={false}
-                                          >
-                                            <div
-                                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                                            >
-                                              <EuiText
-                                                color="default"
-                                                onMouseEnter={[Function]}
-                                                onMouseLeave={[Function]}
-                                              >
-                                                <div
-                                                  className="euiText euiText--medium"
-                                                  onMouseEnter={[Function]}
-                                                  onMouseLeave={[Function]}
-                                                >
-                                                  <EuiTextColor
-                                                    color="default"
-                                                    component="div"
-                                                  >
-                                                    <div
-                                                      className="euiTextColor euiTextColor--default"
-                                                    >
-                                                      <EuiI18nNumber
-                                                        value={53}
-                                                      >
-                                                        53
-                                                      </EuiI18nNumber>
-                                                    </div>
-                                                  </EuiTextColor>
-                                                </div>
-                                              </EuiText>
-                                            </div>
-                                          </EuiFlexItem>
-                                        </div>
-                                      </EuiFlexGroup>
-                                    </ServiceTrendsPlots>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_number_of_connected_services_0_4"
-                                mobileOptions={
-                                  Object {
-                                    "header": "No. of connected services",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                                width="80px"
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": "80px",
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    No. of connected services
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    2
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="left"
-                                key="_data_column_connected_services_0_5"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Connected services",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Connected services
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiText
-                                      className=""
-                                      key=".0"
-                                      size="s"
-                                    >
-                                      <div
-                                        className="euiText euiText--small"
-                                      >
-                                        order, inventory
-                                      </div>
-                                    </EuiText>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_traces_0_6"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Traces",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Traces
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiLink
-                                      onClick={[Function]}
-                                    >
-                                      <button
-                                        className="euiLink euiLink--primary"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiI18nNumber
-                                          value={31}
-                                        >
-                                          31
-                                        </EuiI18nNumber>
-                                      </button>
-                                    </EuiLink>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="center"
-                                key="_data_column_actions_0_7"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Actions",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Actions
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiFlexGroup
-                                      className=""
-                                      justifyContent="center"
-                                      key=".0"
-                                    >
-                                      <div
-                                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                      >
-                                        <EuiFlexItem
-                                          grow={false}
-                                          onClick={[Function]}
-                                        >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                                            onClick={[Function]}
-                                          >
-                                            <EuiLink
-                                              data-test-subj="service-flyout-action-btnundefined"
-                                            >
-                                              <button
-                                                className="euiLink euiLink--primary"
-                                                data-test-subj="service-flyout-action-btnundefined"
-                                                disabled={false}
-                                                type="button"
-                                              >
-                                                <EuiIcon
-                                                  color="primary"
-                                                  type="inspect"
-                                                >
-                                                  <EuiIconBeaker
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
-                                                    focusable="false"
-                                                    role="img"
-                                                    style={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
-                                                      focusable="false"
-                                                      height={16}
-                                                      role="img"
-                                                      style={null}
-                                                      viewBox="0 0 16 16"
-                                                      width={16}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                      />
-                                                    </svg>
-                                                  </EuiIconBeaker>
-                                                </EuiIcon>
-                                              </button>
-                                            </EuiLink>
-                                          </div>
-                                        </EuiFlexItem>
-                                      </div>
-                                    </EuiFlexGroup>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                            </tr>
-                          </EuiTableRow>
-                        </tbody>
-                      </EuiTableBody>
-                    </table>
-                  </EuiTable>
-                </div>
-                <PaginationBar
-                  aria-controls="random_html_id"
-                  onPageChange={[Function]}
-                  onPageSizeChange={[Function]}
-                  pagination={
-                    Object {
-                      "hidePerPageOptions": undefined,
-                      "pageIndex": 0,
-                      "pageSize": 10,
-                      "pageSizeOptions": Array [
-                        5,
-                        10,
-                        15,
-                      ],
-                      "totalItemCount": 1,
-                    }
-                  }
-                >
-                  <div>
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiTablePagination
-                      activePage={0}
-                      aria-controls="random_html_id"
-                      itemsPerPage={10}
-                      itemsPerPageOptions={
-                        Array [
-                          5,
-                          10,
-                          15,
-                        ]
-                      }
-                      onChangeItemsPerPage={[Function]}
-                      onChangePage={[Function]}
-                      pageCount={1}
-                    >
-                      <EuiFlexGroup
-                        alignItems="center"
-                        justifyContent="spaceBetween"
-                        responsive={false}
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
                       >
                         <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
                         >
-                          <EuiFlexItem
-                            grow={false}
+                          <EuiTableSortMobile
+                            items={
+                              Array [
+                                Object {
+                                  "isSortAscending": true,
+                                  "isSorted": true,
+                                  "key": "_data_s_name_0",
+                                  "name": "Name",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_average_latency_1",
+                                  "name": "Average duration (ms)",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_error_rate_2",
+                                  "name": "Error rate",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_throughput_3",
+                                  "name": "Request rate",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_number_of_connected_services_4",
+                                  "name": "No. of connected services",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_connected_services_5",
+                                  "name": "Connected services",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_traces_6",
+                                  "name": "Traces",
+                                  "onSort": [Function],
+                                },
+                              ]
+                            }
                           >
                             <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              className="euiTableSortMobile"
                             >
                               <EuiPopover
-                                anchorPosition="upRight"
+                                anchorPosition="downRight"
                                 button={
                                   <EuiButtonEmpty
-                                    color="text"
-                                    data-test-subj="tablePaginationPopoverButton"
+                                    flush="right"
                                     iconSide="right"
                                     iconType="arrowDown"
                                     onClick={[Function]}
                                     size="xs"
                                   >
                                     <EuiI18n
-                                      default="Rows per page"
-                                      token="euiTablePagination.rowsPerPage"
+                                      default="Sorting"
+                                      token="euiTableSortMobile.sorting"
                                     />
-                                    : 
-                                    10
                                   </EuiButtonEmpty>
                                 }
                                 closePopover={[Function]}
@@ -4352,22 +2977,20 @@ exports[`Services table component renders services table 1`] = `
                                 panelPaddingSize="none"
                               >
                                 <div
-                                  className="euiPopover euiPopover--anchorUpRight"
+                                  className="euiPopover euiPopover--anchorDownRight"
                                 >
                                   <div
                                     className="euiPopover__anchor"
                                   >
                                     <EuiButtonEmpty
-                                      color="text"
-                                      data-test-subj="tablePaginationPopoverButton"
+                                      flush="right"
                                       iconSide="right"
                                       iconType="arrowDown"
                                       onClick={[Function]}
                                       size="xs"
                                     >
                                       <button
-                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
-                                        data-test-subj="tablePaginationPopoverButton"
+                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
                                         disabled={false}
                                         onClick={[Function]}
                                         type="button"
@@ -4420,13 +3043,11 @@ exports[`Services table component renders services table 1`] = `
                                               className="euiButtonEmpty__text"
                                             >
                                               <EuiI18n
-                                                default="Rows per page"
-                                                token="euiTablePagination.rowsPerPage"
+                                                default="Sorting"
+                                                token="euiTableSortMobile.sorting"
                                               >
-                                                Rows per page
+                                                Sorting
                                               </EuiI18n>
-                                              : 
-                                              10
                                             </span>
                                           </span>
                                         </EuiButtonContent>
@@ -4436,252 +3057,1599 @@ exports[`Services table component renders services table 1`] = `
                                 </div>
                               </EuiPopover>
                             </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
+                          </EuiTableSortMobile>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiTableHeaderMobile>
+              <EuiTable
+                id="random_html_id"
+                responsive={true}
+                tableLayout="auto"
+              >
+                <table
+                  className="euiTable euiTable--responsive euiTable--auto"
+                  id="random_html_id"
+                  tabIndex={-1}
+                >
+                  <EuiScreenReaderOnly>
+                    <caption
+                      className="euiScreenReaderOnly euiTableCaption"
+                    >
+                      <EuiDelayRender
+                        delay={500}
+                      />
+                    </caption>
+                  </EuiScreenReaderOnly>
+                  <EuiTableHeader>
+                    <thead>
+                      <tr>
+                        <EuiTableHeaderCellCheckbox
+                          key="_selection_column_h"
+                        >
+                          <th
+                            className="euiTableHeaderCellCheckbox"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
                           >
                             <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              className="euiTableCellContent"
                             >
-                              <EuiPagination
-                                activePage={0}
-                                aria-controls="random_html_id"
-                                onPageClick={[Function]}
-                                pageCount={1}
+                              <EuiI18n
+                                default="Select all rows"
+                                token="euiBasicTable.selectAllRows"
                               >
-                                <nav
-                                  className="euiPagination"
+                                <EuiCheckbox
+                                  aria-label="Select all rows"
+                                  checked={false}
+                                  compressed={false}
+                                  data-test-subj="checkboxSelectAll"
+                                  disabled={false}
+                                  id="_selection_column-checkbox_random_html_id"
+                                  indeterminate={false}
+                                  label={null}
+                                  onChange={[Function]}
+                                  type="inList"
                                 >
+                                  <div
+                                    className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                  >
+                                    <input
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      className="euiCheckbox__input"
+                                      data-test-subj="checkboxSelectAll"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      onChange={[Function]}
+                                      type="checkbox"
+                                    />
+                                    <div
+                                      className="euiCheckbox__square"
+                                    />
+                                  </div>
+                                </EuiCheckbox>
+                              </EuiI18n>
+                            </div>
+                          </th>
+                        </EuiTableHeaderCellCheckbox>
+                        <EuiTableHeaderCell
+                          align="left"
+                          data-test-subj="tableHeaderCell_name_0"
+                          isSortAscending={true}
+                          isSorted={true}
+                          key="_data_h_name_0"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="ascending"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_name_0"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent"
+                                isSortAscending={true}
+                                isSorted={true}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Name",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Name"
+                                      >
+                                        Name
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiIcon
+                                    className="euiTableSortIcon"
+                                    size="m"
+                                    type="sortUp"
+                                  >
+                                    <EuiIconBeaker
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                    </EuiIconBeaker>
+                                  </EuiIcon>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_average_latency_1"
+                          isSorted={false}
+                          key="_data_h_average_latency_1"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_average_latency_1"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Average duration (ms)",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Average duration (ms)"
+                                      >
+                                        Average duration (ms)
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_error_rate_2"
+                          isSorted={false}
+                          key="_data_h_error_rate_2"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_error_rate_2"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Error rate",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Error rate"
+                                      >
+                                        Error rate
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_throughput_3"
+                          isSorted={false}
+                          key="_data_h_throughput_3"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_throughput_3"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Request rate",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Request rate"
+                                      >
+                                        Request rate
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_number_of_connected_services_4"
+                          isSorted={false}
+                          key="_data_h_number_of_connected_services_4"
+                          onSort={[Function]}
+                          width="80px"
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_number_of_connected_services_4"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": "80px",
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "No. of connected services",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="No. of connected services"
+                                      >
+                                        No. of connected services
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="left"
+                          data-test-subj="tableHeaderCell_connected_services_5"
+                          isSorted={false}
+                          key="_data_h_connected_services_5"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_connected_services_5"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Connected services",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Connected services"
+                                      >
+                                        Connected services
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_traces_6"
+                          isSorted={false}
+                          key="_data_h_traces_6"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_traces_6"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Traces",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Traces"
+                                      >
+                                        Traces
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="center"
+                          data-test-subj="tableHeaderCell_actions_7"
+                          key="_data_h_actions_7"
+                        >
+                          <th
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_actions_7"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <CellContents
+                              className="euiTableCellContent euiTableCellContent--alignCenter"
+                              showSortMsg={false}
+                            >
+                              <span
+                                className="euiTableCellContent euiTableCellContent--alignCenter"
+                              >
+                                <EuiInnerText>
                                   <EuiI18n
-                                    default="Previous page, {page}"
-                                    token="euiPagination.previousPage"
+                                    default="{innerText}; {description}"
+                                    token="euiTableHeaderCell.titleTextWithDesc"
                                     values={
                                       Object {
-                                        "page": 0,
+                                        "description": undefined,
+                                        "innerText": "Actions",
                                       }
                                     }
                                   >
-                                    <EuiI18n
-                                      default="Previous page"
-                                      token="euiPagination.disabledPreviousPage"
+                                    <span
+                                      className="euiTableCellContent__text"
+                                      title="Actions"
                                     >
-                                      <EuiButtonIcon
-                                        aria-label="Previous page"
-                                        color="text"
-                                        data-test-subj="pagination-button-previous"
-                                        disabled={true}
-                                        iconType="arrowLeft"
+                                      Actions
+                                    </span>
+                                  </EuiI18n>
+                                </EuiInnerText>
+                              </span>
+                            </CellContents>
+                          </th>
+                        </EuiTableHeaderCell>
+                      </tr>
+                    </thead>
+                  </EuiTableHeader>
+                  <EuiTableBody
+                    bodyRef={[Function]}
+                  >
+                    <tbody>
+                      <EuiTableRow
+                        isSelectable={true}
+                        isSelected={false}
+                      >
+                        <tr
+                          className="euiTableRow euiTableRow-isSelectable"
+                        >
+                          <EuiTableRowCellCheckbox
+                            key="_selection_column_0"
+                          >
+                            <td
+                              className="euiTableRowCellCheckbox"
+                            >
+                              <div
+                                className="euiTableCellContent"
+                              >
+                                <EuiI18n
+                                  default="Select this row"
+                                  token="euiBasicTable.selectThisRow"
+                                >
+                                  <EuiCheckbox
+                                    aria-label="Select this row"
+                                    checked={false}
+                                    compressed={false}
+                                    data-test-subj="checkboxSelectRow-0"
+                                    disabled={false}
+                                    id="_selection_column_0-checkbox"
+                                    indeterminate={false}
+                                    onChange={[Function]}
+                                    title="Select this row"
+                                    type="inList"
+                                  >
+                                    <div
+                                      className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                    >
+                                      <input
+                                        aria-label="Select this row"
+                                        checked={false}
+                                        className="euiCheckbox__input"
+                                        data-test-subj="checkboxSelectRow-0"
+                                        disabled={false}
+                                        id="_selection_column_0-checkbox"
+                                        onChange={[Function]}
+                                        title="Select this row"
+                                        type="checkbox"
+                                      />
+                                      <div
+                                        className="euiCheckbox__square"
+                                      />
+                                    </div>
+                                  </EuiCheckbox>
+                                </EuiI18n>
+                              </div>
+                            </td>
+                          </EuiTableRowCellCheckbox>
+                          <EuiTableRowCell
+                            align="left"
+                            key="_data_column_name_0_0"
+                            mobileOptions={
+                              Object {
+                                "header": "Name",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Name
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--overflowingContent"
+                              >
+                                <EuiLink
+                                  className=""
+                                  data-test-subj="service-link"
+                                  key=".0"
+                                  onClick={[Function]}
+                                >
+                                  <button
+                                    className="euiLink euiLink--primary"
+                                    data-test-subj="service-link"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    database
+                                  </button>
+                                </EuiLink>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_average_latency_0_1"
+                            mobileOptions={
+                              Object {
+                                "header": "Average duration (ms)",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Average duration (ms)
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                              >
+                                <ServiceTrendsPlots
+                                  className=""
+                                  fieldType="average_latency"
+                                  item={49.54}
+                                  key=".0"
+                                  row={
+                                    Object {
+                                      "average_latency": 49.54,
+                                      "connected_services": Array [
+                                        "order",
+                                        "inventory",
+                                      ],
+                                      "error_rate": 3.77,
+                                      "name": "database",
+                                      "number_of_connected_services": 2,
+                                      "throughput": 53,
+                                      "traces": 31,
+                                    }
+                                  }
+                                >
+                                  <EuiFlexGroup
+                                    gutterSize="s"
+                                    justifyContent="flexEnd"
+                                  >
+                                    <div
+                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <EuiFlexItem
+                                        grow={false}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        >
+                                          <EuiText
+                                            color="default"
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            <div
+                                              className="euiText euiText--medium"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <EuiTextColor
+                                                color="default"
+                                                component="div"
+                                              >
+                                                <div
+                                                  className="euiTextColor euiTextColor--default"
+                                                >
+                                                  49.54
+                                                </div>
+                                              </EuiTextColor>
+                                            </div>
+                                          </EuiText>
+                                        </div>
+                                      </EuiFlexItem>
+                                    </div>
+                                  </EuiFlexGroup>
+                                </ServiceTrendsPlots>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_error_rate_0_2"
+                            mobileOptions={
+                              Object {
+                                "header": "Error rate",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Error rate
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                              >
+                                <ServiceTrendsPlots
+                                  className=""
+                                  fieldType="error_rate"
+                                  item={3.77}
+                                  key=".0"
+                                  row={
+                                    Object {
+                                      "average_latency": 49.54,
+                                      "connected_services": Array [
+                                        "order",
+                                        "inventory",
+                                      ],
+                                      "error_rate": 3.77,
+                                      "name": "database",
+                                      "number_of_connected_services": 2,
+                                      "throughput": 53,
+                                      "traces": 31,
+                                    }
+                                  }
+                                >
+                                  <EuiFlexGroup
+                                    gutterSize="s"
+                                    justifyContent="flexEnd"
+                                  >
+                                    <div
+                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <EuiFlexItem
+                                        grow={false}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        >
+                                          <EuiText
+                                            color="default"
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            <div
+                                              className="euiText euiText--medium"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <EuiTextColor
+                                                color="default"
+                                                component="div"
+                                              >
+                                                <div
+                                                  className="euiTextColor euiTextColor--default"
+                                                >
+                                                  <EuiText
+                                                    size="s"
+                                                  >
+                                                    <div
+                                                      className="euiText euiText--small"
+                                                    >
+                                                      3.77%
+                                                    </div>
+                                                  </EuiText>
+                                                </div>
+                                              </EuiTextColor>
+                                            </div>
+                                          </EuiText>
+                                        </div>
+                                      </EuiFlexItem>
+                                    </div>
+                                  </EuiFlexGroup>
+                                </ServiceTrendsPlots>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_throughput_0_3"
+                            mobileOptions={
+                              Object {
+                                "header": "Request rate",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                            truncateText={true}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Request rate
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                              >
+                                <ServiceTrendsPlots
+                                  className=""
+                                  fieldType="throughput"
+                                  item={53}
+                                  key=".0"
+                                  row={
+                                    Object {
+                                      "average_latency": 49.54,
+                                      "connected_services": Array [
+                                        "order",
+                                        "inventory",
+                                      ],
+                                      "error_rate": 3.77,
+                                      "name": "database",
+                                      "number_of_connected_services": 2,
+                                      "throughput": 53,
+                                      "traces": 31,
+                                    }
+                                  }
+                                >
+                                  <EuiFlexGroup
+                                    gutterSize="s"
+                                    justifyContent="flexEnd"
+                                  >
+                                    <div
+                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                    >
+                                      <EuiFlexItem
+                                        grow={false}
+                                      >
+                                        <div
+                                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                                        >
+                                          <EuiText
+                                            color="default"
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            <div
+                                              className="euiText euiText--medium"
+                                              onMouseEnter={[Function]}
+                                              onMouseLeave={[Function]}
+                                            >
+                                              <EuiTextColor
+                                                color="default"
+                                                component="div"
+                                              >
+                                                <div
+                                                  className="euiTextColor euiTextColor--default"
+                                                >
+                                                  <EuiI18nNumber
+                                                    value={53}
+                                                  >
+                                                    53
+                                                  </EuiI18nNumber>
+                                                </div>
+                                              </EuiTextColor>
+                                            </div>
+                                          </EuiText>
+                                        </div>
+                                      </EuiFlexItem>
+                                    </div>
+                                  </EuiFlexGroup>
+                                </ServiceTrendsPlots>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_number_of_connected_services_0_4"
+                            mobileOptions={
+                              Object {
+                                "header": "No. of connected services",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                            truncateText={true}
+                            width="80px"
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": "80px",
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                No. of connected services
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                              >
+                                2
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="left"
+                            key="_data_column_connected_services_0_5"
+                            mobileOptions={
+                              Object {
+                                "header": "Connected services",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                            truncateText={true}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Connected services
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                              >
+                                <EuiText
+                                  className=""
+                                  key=".0"
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    order, inventory
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_traces_0_6"
+                            mobileOptions={
+                              Object {
+                                "header": "Traces",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                            truncateText={true}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Traces
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                              >
+                                <EuiLink
+                                  onClick={[Function]}
+                                >
+                                  <button
+                                    className="euiLink euiLink--primary"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <EuiI18nNumber
+                                      value={31}
+                                    >
+                                      31
+                                    </EuiI18nNumber>
+                                  </button>
+                                </EuiLink>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="center"
+                            key="_data_column_actions_0_7"
+                            mobileOptions={
+                              Object {
+                                "header": "Actions",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Actions
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
+                              >
+                                <EuiFlexGroup
+                                  className=""
+                                  justifyContent="center"
+                                  key=".0"
+                                >
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                  >
+                                    <EuiFlexItem
+                                      grow={false}
+                                      onClick={[Function]}
+                                    >
+                                      <div
+                                        className="euiFlexItem euiFlexItem--flexGrowZero"
                                         onClick={[Function]}
                                       >
-                                        <button
-                                          aria-label="Previous page"
-                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                          data-test-subj="pagination-button-previous"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          type="button"
+                                        <EuiLink
+                                          data-test-subj="service-flyout-action-btnundefined"
                                         >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="arrowLeft"
+                                          <button
+                                            className="euiLink euiLink--primary"
+                                            data-test-subj="service-flyout-action-btnundefined"
+                                            disabled={false}
+                                            type="button"
                                           >
-                                            <EuiIconBeaker
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
+                                            <EuiIcon
+                                              color="primary"
+                                              type="inspect"
                                             >
-                                              <svg
+                                              <EuiIconBeaker
                                                 aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
                                                 focusable="false"
-                                                height={16}
                                                 role="img"
                                                 style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
                                               >
-                                                <path
-                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                />
-                                              </svg>
-                                            </EuiIconBeaker>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiI18n>
-                                  </EuiI18n>
-                                  <ul
-                                    className="euiPagination__list"
+                                                <svg
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
+                                                  focusable="false"
+                                                  height={16}
+                                                  role="img"
+                                                  style={null}
+                                                  viewBox="0 0 16 16"
+                                                  width={16}
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                  />
+                                                </svg>
+                                              </EuiIconBeaker>
+                                            </EuiIcon>
+                                          </button>
+                                        </EuiLink>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                        </tr>
+                      </EuiTableRow>
+                    </tbody>
+                  </EuiTableBody>
+                </table>
+              </EuiTable>
+            </div>
+            <PaginationBar
+              aria-controls="random_html_id"
+              onPageChange={[Function]}
+              onPageSizeChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+            >
+              <div>
+                <EuiSpacer
+                  size="m"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--m"
+                  />
+                </EuiSpacer>
+                <EuiTablePagination
+                  activePage={0}
+                  aria-controls="random_html_id"
+                  itemsPerPage={10}
+                  itemsPerPageOptions={
+                    Array [
+                      5,
+                      10,
+                      15,
+                    ]
+                  }
+                  onChangeItemsPerPage={[Function]}
+                  onChangePage={[Function]}
+                  pageCount={1}
+                >
+                  <EuiFlexGroup
+                    alignItems="center"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiPopover
+                            anchorPosition="upRight"
+                            button={
+                              <EuiButtonEmpty
+                                color="text"
+                                data-test-subj="tablePaginationPopoverButton"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="xs"
+                              >
+                                <EuiI18n
+                                  default="Rows per page"
+                                  token="euiTablePagination.rowsPerPage"
+                                />
+                                : 
+                                10
+                              </EuiButtonEmpty>
+                            }
+                            closePopover={[Function]}
+                            display="inlineBlock"
+                            hasArrow={true}
+                            isOpen={false}
+                            ownFocus={true}
+                            panelPaddingSize="none"
+                          >
+                            <div
+                              className="euiPopover euiPopover--anchorUpRight"
+                            >
+                              <div
+                                className="euiPopover__anchor"
+                              >
+                                <EuiButtonEmpty
+                                  color="text"
+                                  data-test-subj="tablePaginationPopoverButton"
+                                  iconSide="right"
+                                  iconType="arrowDown"
+                                  onClick={[Function]}
+                                  size="xs"
+                                >
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                    data-test-subj="tablePaginationPopoverButton"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
                                   >
-                                    <PaginationButton
-                                      key="0"
-                                      pageIndex={0}
+                                    <EuiButtonContent
+                                      className="euiButtonEmpty__content"
+                                      iconSide="right"
+                                      iconSize="s"
+                                      iconType="arrowDown"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButtonEmpty__text",
+                                        }
+                                      }
                                     >
-                                      <li
-                                        className="euiPagination__item"
+                                      <span
+                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                       >
-                                        <EuiPaginationButton
-                                          aria-controls="random_html_id"
-                                          hideOnMobile={true}
-                                          isActive={true}
-                                          onClick={[Function]}
-                                          pageIndex={0}
-                                          totalPages={1}
+                                        <EuiIcon
+                                          className="euiButtonContent__icon"
+                                          color="inherit"
+                                          size="s"
+                                          type="arrowDown"
+                                        >
+                                          <EuiIconBeaker
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
+                                          </EuiIconBeaker>
+                                        </EuiIcon>
+                                        <span
+                                          className="euiButtonEmpty__text"
                                         >
                                           <EuiI18n
-                                            default="Page {page} of {totalPages}"
-                                            token="euiPaginationButton.longPageString"
-                                            values={
-                                              Object {
-                                                "page": 1,
-                                                "totalPages": 1,
-                                              }
-                                            }
+                                            default="Rows per page"
+                                            token="euiTablePagination.rowsPerPage"
                                           >
-                                            <EuiI18n
-                                              default="Page {page}"
-                                              token="euiPaginationButton.shortPageString"
-                                              values={
-                                                Object {
-                                                  "page": 1,
-                                                }
-                                              }
-                                            >
-                                              <EuiButtonEmpty
-                                                aria-controls="random_html_id"
-                                                aria-current={true}
-                                                aria-label="Page 1 of 1"
-                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                                color="text"
-                                                data-test-subj="pagination-button-0"
-                                                href="#random_html_id"
-                                                isDisabled={true}
-                                                onClick={[Function]}
-                                                size="s"
-                                              >
-                                                <button
-                                                  aria-controls="random_html_id"
-                                                  aria-current={true}
-                                                  aria-label="Page 1 of 1"
-                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                                  data-test-subj="pagination-button-0"
-                                                  disabled={true}
-                                                  onClick={[Function]}
-                                                  type="button"
-                                                >
-                                                  <EuiButtonContent
-                                                    className="euiButtonEmpty__content"
-                                                    iconSide="left"
-                                                    iconSize="m"
-                                                    textProps={
-                                                      Object {
-                                                        "className": "euiButtonEmpty__text",
-                                                      }
-                                                    }
-                                                  >
-                                                    <span
-                                                      className="euiButtonContent euiButtonEmpty__content"
-                                                    >
-                                                      <span
-                                                        className="euiButtonEmpty__text"
-                                                      >
-                                                        1
-                                                      </span>
-                                                    </span>
-                                                  </EuiButtonContent>
-                                                </button>
-                                              </EuiButtonEmpty>
-                                            </EuiI18n>
+                                            Rows per page
                                           </EuiI18n>
-                                        </EuiPaginationButton>
-                                      </li>
-                                    </PaginationButton>
-                                  </ul>
-                                  <EuiI18n
-                                    default="Next page, {page}"
-                                    token="euiPagination.nextPage"
-                                    values={
-                                      Object {
-                                        "page": 2,
-                                      }
-                                    }
-                                  >
-                                    <EuiI18n
-                                      default="Next page"
-                                      token="euiPagination.disabledNextPage"
-                                    >
-                                      <EuiButtonIcon
-                                        aria-label="Next page"
-                                        color="text"
-                                        data-test-subj="pagination-button-next"
-                                        disabled={true}
-                                        iconType="arrowRight"
-                                        onClick={[Function]}
-                                      >
-                                        <button
-                                          aria-label="Next page"
-                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                          data-test-subj="pagination-button-next"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="arrowRight"
-                                          >
-                                            <EuiIconBeaker
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                />
-                                              </svg>
-                                            </EuiIconBeaker>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiI18n>
-                                  </EuiI18n>
-                                </nav>
-                              </EuiPagination>
+                                          : 
+                                          10
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonEmpty>
+                              </div>
                             </div>
-                          </EuiFlexItem>
+                          </EuiPopover>
                         </div>
-                      </EuiFlexGroup>
-                    </EuiTablePagination>
-                  </div>
-                </PaginationBar>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiPagination
+                            activePage={0}
+                            aria-controls="random_html_id"
+                            onPageClick={[Function]}
+                            pageCount={1}
+                          >
+                            <nav
+                              className="euiPagination"
+                            >
+                              <EuiI18n
+                                default="Previous page, {page}"
+                                token="euiPagination.previousPage"
+                                values={
+                                  Object {
+                                    "page": 0,
+                                  }
+                                }
+                              >
+                                <EuiI18n
+                                  default="Previous page"
+                                  token="euiPagination.disabledPreviousPage"
+                                >
+                                  <EuiButtonIcon
+                                    aria-label="Previous page"
+                                    color="text"
+                                    data-test-subj="pagination-button-previous"
+                                    disabled={true}
+                                    iconType="arrowLeft"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      aria-label="Previous page"
+                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      data-test-subj="pagination-button-previous"
+                                      disabled={true}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiButtonIcon__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowLeft"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </button>
+                                  </EuiButtonIcon>
+                                </EuiI18n>
+                              </EuiI18n>
+                              <ul
+                                className="euiPagination__list"
+                              >
+                                <PaginationButton
+                                  key="0"
+                                  pageIndex={0}
+                                >
+                                  <li
+                                    className="euiPagination__item"
+                                  >
+                                    <EuiPaginationButton
+                                      aria-controls="random_html_id"
+                                      hideOnMobile={true}
+                                      isActive={true}
+                                      onClick={[Function]}
+                                      pageIndex={0}
+                                      totalPages={1}
+                                    >
+                                      <EuiI18n
+                                        default="Page {page} of {totalPages}"
+                                        token="euiPaginationButton.longPageString"
+                                        values={
+                                          Object {
+                                            "page": 1,
+                                            "totalPages": 1,
+                                          }
+                                        }
+                                      >
+                                        <EuiI18n
+                                          default="Page {page}"
+                                          token="euiPaginationButton.shortPageString"
+                                          values={
+                                            Object {
+                                              "page": 1,
+                                            }
+                                          }
+                                        >
+                                          <EuiButtonEmpty
+                                            aria-controls="random_html_id"
+                                            aria-current={true}
+                                            aria-label="Page 1 of 1"
+                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                            color="text"
+                                            data-test-subj="pagination-button-0"
+                                            href="#random_html_id"
+                                            isDisabled={true}
+                                            onClick={[Function]}
+                                            size="s"
+                                          >
+                                            <button
+                                              aria-controls="random_html_id"
+                                              aria-current={true}
+                                              aria-label="Page 1 of 1"
+                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              data-test-subj="pagination-button-0"
+                                              disabled={true}
+                                              onClick={[Function]}
+                                              type="button"
+                                            >
+                                              <EuiButtonContent
+                                                className="euiButtonEmpty__content"
+                                                iconSide="left"
+                                                iconSize="m"
+                                                textProps={
+                                                  Object {
+                                                    "className": "euiButtonEmpty__text",
+                                                  }
+                                                }
+                                              >
+                                                <span
+                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                >
+                                                  <span
+                                                    className="euiButtonEmpty__text"
+                                                  >
+                                                    1
+                                                  </span>
+                                                </span>
+                                              </EuiButtonContent>
+                                            </button>
+                                          </EuiButtonEmpty>
+                                        </EuiI18n>
+                                      </EuiI18n>
+                                    </EuiPaginationButton>
+                                  </li>
+                                </PaginationButton>
+                              </ul>
+                              <EuiI18n
+                                default="Next page, {page}"
+                                token="euiPagination.nextPage"
+                                values={
+                                  Object {
+                                    "page": 2,
+                                  }
+                                }
+                              >
+                                <EuiI18n
+                                  default="Next page"
+                                  token="euiPagination.disabledNextPage"
+                                >
+                                  <EuiButtonIcon
+                                    aria-label="Next page"
+                                    color="text"
+                                    data-test-subj="pagination-button-next"
+                                    disabled={true}
+                                    iconType="arrowRight"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      aria-label="Next page"
+                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      data-test-subj="pagination-button-next"
+                                      disabled={true}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiButtonIcon__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowRight"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </button>
+                                  </EuiButtonIcon>
+                                </EuiI18n>
+                              </EuiI18n>
+                            </nav>
+                          </EuiPagination>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </EuiTablePagination>
               </div>
-            </EuiBasicTable>
-          </EuiInMemoryTable>
-        </div>
-      </EuiPanel>
+            </PaginationBar>
+          </div>
+        </EuiBasicTable>
+      </EuiInMemoryTable>
     </div>
-  </EuiPage>
+  </EuiPanel>
 </ServicesTable>
 `;

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`Services table component renders empty jaeger services table message 1`
                             >
                               <EuiButtonContent
                                 className="euiButtonEmpty__content"
+                                iconGap="m"
                                 iconSide="left"
                                 iconSize="s"
                                 textProps={
@@ -311,6 +312,7 @@ exports[`Services table component renders empty services table message 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButtonEmpty__content"
+                                iconGap="m"
                                 iconSide="left"
                                 iconSize="s"
                                 textProps={
@@ -351,6 +353,7 @@ exports[`Services table component renders empty services table message 1`] = `
                         >
                           <EuiButtonContent
                             className="euiButtonEmpty__content"
+                            iconGap="m"
                             iconSide="left"
                             iconSize="s"
                             textProps={
@@ -577,6 +580,7 @@ exports[`Services table component renders jaeger services table 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButtonEmpty__content"
+                                iconGap="m"
                                 iconSide="left"
                                 iconSize="s"
                                 textProps={
@@ -959,6 +963,7 @@ exports[`Services table component renders jaeger services table 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -2098,6 +2103,7 @@ exports[`Services table component renders jaeger services table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -2303,6 +2309,7 @@ exports[`Services table component renders jaeger services table 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={
@@ -2519,6 +2526,7 @@ exports[`Services table component renders services table 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButtonEmpty__content"
+                                iconGap="m"
                                 iconSide="left"
                                 iconSize="s"
                                 textProps={
@@ -2559,6 +2567,7 @@ exports[`Services table component renders services table 1`] = `
                         >
                           <EuiButtonContent
                             className="euiButtonEmpty__content"
+                            iconGap="m"
                             iconSide="left"
                             iconSize="s"
                             textProps={
@@ -2997,6 +3006,7 @@ exports[`Services table component renders services table 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -4344,6 +4354,7 @@ exports[`Services table component renders services table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -4547,6 +4558,7 @@ exports[`Services table component renders services table 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
@@ -12,209 +12,217 @@ exports[`Services table component renders empty jaeger services table message 1`
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPanel>
+  <EuiPage
+    paddingSize="m"
+  >
     <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      className="euiPage euiPage--paddingMedium euiPage--grow"
     >
-      <EuiFlexGroup
-        justifyContent="spaceBetween"
-      >
+      <EuiPanel>
         <div
-          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <EuiFlexItem
-            grow={false}
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
           >
             <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <PanelTitle
-                title="Services"
-                totalItems={0}
+              <EuiFlexItem
+                grow={false}
               >
-                <EuiText
-                  size="m"
-                >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Services
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (0)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiFlexGroup>
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
-                    >
-                      <EuiToolTip
-                        content="Select services to filter"
-                        delay="regular"
-                        position="top"
-                      >
-                        <span
-                          className="euiToolTipAnchor"
-                          onKeyUp={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
-                        >
-                          <EuiButtonEmpty
-                            isDisabled={true}
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            size="xs"
-                          >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                              disabled={true}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              type="button"
-                            >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
-                                }
-                              >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
-                                >
-                                  <span
-                                    className="euiButtonEmpty__text"
-                                  >
-                                    Filter services
-                                  </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </span>
-                      </EuiToolTip>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <NoMatchMessage
-        size="xl"
-      >
-        <EuiSpacer
-          size="xl"
-        >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-        <EuiEmptyPrompt
-          body={
-            <EuiText
-              size="s"
-            >
-              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-            </EuiText>
-          }
-          title={
-            <h2>
-              No matches
-            </h2>
-          }
-        >
-          <div
-            className="euiEmptyPrompt"
-          >
-            <EuiTitle
-              size="m"
-            >
-              <h2
-                className="euiTitle euiTitle--medium"
-              >
-                No matches
-              </h2>
-            </EuiTitle>
-            <EuiTextColor
-              color="subdued"
-            >
-              <span
-                className="euiTextColor euiTextColor--subdued"
-              >
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiText>
-                  <div
-                    className="euiText euiText--medium"
+                  <PanelTitle
+                    title="Services"
+                    totalItems={0}
                   >
                     <EuiText
-                      size="s"
+                      size="m"
                     >
                       <div
-                        className="euiText euiText--small"
+                        className="euiText euiText--medium"
                       >
-                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        <span
+                          className="panel-title"
+                        >
+                          Services
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (0)
+                        </span>
                       </div>
                     </EuiText>
-                  </div>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <EuiFlexGroup>
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiToolTip
+                            content="Select services to filter"
+                            delay="regular"
+                            position="top"
+                          >
+                            <span
+                              className="euiToolTipAnchor"
+                              onKeyUp={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <EuiButtonEmpty
+                                isDisabled={true}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                size="xs"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                  disabled={true}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
+                                    >
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Filter services
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </span>
+                          </EuiToolTip>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <NoMatchMessage
+            size="xl"
+          >
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+            <EuiEmptyPrompt
+              body={
+                <EuiText
+                  size="s"
+                >
+                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                 </EuiText>
-              </span>
-            </EuiTextColor>
-          </div>
-        </EuiEmptyPrompt>
-        <EuiSpacer
-          size="xl"
-        >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-      </NoMatchMessage>
+              }
+              title={
+                <h2>
+                  No matches
+                </h2>
+              }
+            >
+              <div
+                className="euiEmptyPrompt"
+              >
+                <EuiTitle
+                  size="m"
+                >
+                  <h2
+                    className="euiTitle euiTitle--medium"
+                  >
+                    No matches
+                  </h2>
+                </EuiTitle>
+                <EuiTextColor
+                  color="subdued"
+                >
+                  <span
+                    className="euiTextColor euiTextColor--subdued"
+                  >
+                    <EuiSpacer
+                      size="m"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiText>
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <EuiText
+                          size="s"
+                        >
+                          <div
+                            className="euiText euiText--small"
+                          >
+                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                          </div>
+                        </EuiText>
+                      </div>
+                    </EuiText>
+                  </span>
+                </EuiTextColor>
+              </div>
+            </EuiEmptyPrompt>
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+          </NoMatchMessage>
+        </div>
+      </EuiPanel>
     </div>
-  </EuiPanel>
+  </EuiPage>
 </ServicesTable>
 `;
 
@@ -230,83 +238,129 @@ exports[`Services table component renders empty services table message 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPanel>
+  <EuiPage
+    paddingSize="m"
+  >
     <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      className="euiPage euiPage--paddingMedium euiPage--grow"
     >
-      <EuiFlexGroup
-        justifyContent="spaceBetween"
-      >
+      <EuiPanel>
         <div
-          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <EuiFlexItem
-            grow={false}
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
           >
             <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <PanelTitle
-                title="Services"
-                totalItems={0}
+              <EuiFlexItem
+                grow={false}
               >
-                <EuiText
-                  size="m"
-                >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Services
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (0)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiFlexGroup>
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
+                  <PanelTitle
+                    title="Services"
+                    totalItems={0}
+                  >
+                    <EuiText
+                      size="m"
                     >
-                      <EuiToolTip
-                        content="Select services to filter"
-                        delay="regular"
-                        position="top"
+                      <div
+                        className="euiText euiText--medium"
                       >
                         <span
-                          className="euiToolTipAnchor"
-                          onKeyUp={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
+                          className="panel-title"
+                        >
+                          Services
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (0)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <EuiFlexGroup>
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiToolTip
+                            content="Select services to filter"
+                            delay="regular"
+                            position="top"
+                          >
+                            <span
+                              className="euiToolTipAnchor"
+                              onKeyUp={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <EuiButtonEmpty
+                                isDisabled={true}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                size="xs"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                  disabled={true}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
+                                    >
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Filter services
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </span>
+                          </EuiToolTip>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
                         >
                           <EuiButtonEmpty
-                            isDisabled={true}
-                            onBlur={[Function]}
-                            onFocus={[Function]}
+                            onClick={[Function]}
                             size="xs"
                           >
                             <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                              disabled={true}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                              disabled={false}
+                              onClick={[Function]}
                               type="button"
                             >
                               <EuiButtonContent
@@ -325,152 +379,114 @@ exports[`Services table component renders empty services table message 1`] = `
                                   <span
                                     className="euiButtonEmpty__text"
                                   >
-                                    Filter services
+                                    Show 24 hour trends
                                   </span>
                                 </span>
                               </EuiButtonContent>
                             </button>
                           </EuiButtonEmpty>
-                        </span>
-                      </EuiToolTip>
+                        </div>
+                      </EuiFlexItem>
                     </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
-                    >
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
-                            iconSide="left"
-                            iconSize="s"
-                            textProps={
-                              Object {
-                                "className": "euiButtonEmpty__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButtonEmpty__content"
-                            >
-                              <span
-                                className="euiButtonEmpty__text"
-                              >
-                                Show 24 hour trends
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </div>
-                  </EuiFlexItem>
+                  </EuiFlexGroup>
                 </div>
-              </EuiFlexGroup>
+              </EuiFlexItem>
             </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <NoMatchMessage
-        size="xl"
-      >
-        <EuiSpacer
-          size="xl"
-        >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-        <EuiEmptyPrompt
-          body={
-            <EuiText
-              size="s"
-            >
-              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-            </EuiText>
-          }
-          title={
-            <h2>
-              No matches
-            </h2>
-          }
-        >
-          <div
-            className="euiEmptyPrompt"
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
           >
-            <EuiTitle
-              size="m"
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <NoMatchMessage
+            size="xl"
+          >
+            <EuiSpacer
+              size="xl"
             >
-              <h2
-                className="euiTitle euiTitle--medium"
-              >
-                No matches
-              </h2>
-            </EuiTitle>
-            <EuiTextColor
-              color="subdued"
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+            <EuiEmptyPrompt
+              body={
+                <EuiText
+                  size="s"
+                >
+                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                </EuiText>
+              }
+              title={
+                <h2>
+                  No matches
+                </h2>
+              }
             >
-              <span
-                className="euiTextColor euiTextColor--subdued"
+              <div
+                className="euiEmptyPrompt"
               >
-                <EuiSpacer
+                <EuiTitle
                   size="m"
                 >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiText>
-                  <div
-                    className="euiText euiText--medium"
+                  <h2
+                    className="euiTitle euiTitle--medium"
                   >
-                    <EuiText
-                      size="s"
+                    No matches
+                  </h2>
+                </EuiTitle>
+                <EuiTextColor
+                  color="subdued"
+                >
+                  <span
+                    className="euiTextColor euiTextColor--subdued"
+                  >
+                    <EuiSpacer
+                      size="m"
                     >
                       <div
-                        className="euiText euiText--small"
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiText>
+                      <div
+                        className="euiText euiText--medium"
                       >
-                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        <EuiText
+                          size="s"
+                        >
+                          <div
+                            className="euiText euiText--small"
+                          >
+                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                          </div>
+                        </EuiText>
                       </div>
                     </EuiText>
-                  </div>
-                </EuiText>
-              </span>
-            </EuiTextColor>
-          </div>
-        </EuiEmptyPrompt>
-        <EuiSpacer
-          size="xl"
-        >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-      </NoMatchMessage>
+                  </span>
+                </EuiTextColor>
+              </div>
+            </EuiEmptyPrompt>
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+          </NoMatchMessage>
+        </div>
+      </EuiPanel>
     </div>
-  </EuiPanel>
+  </EuiPage>
 </ServicesTable>
 `;
 
@@ -496,439 +512,1582 @@ exports[`Services table component renders jaeger services table 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPanel>
+  <EuiPage
+    paddingSize="m"
+  >
     <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      className="euiPage euiPage--paddingMedium euiPage--grow"
     >
-      <EuiFlexGroup
-        justifyContent="spaceBetween"
-      >
+      <EuiPanel>
         <div
-          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <EuiFlexItem
-            grow={false}
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
           >
             <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <PanelTitle
-                title="Services"
-                totalItems={1}
+              <EuiFlexItem
+                grow={false}
               >
-                <EuiText
-                  size="m"
-                >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Services
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (1)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiFlexGroup>
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
+                  <PanelTitle
+                    title="Services"
+                    totalItems={1}
+                  >
+                    <EuiText
+                      size="m"
                     >
-                      <EuiToolTip
-                        content="Select services to filter"
-                        delay="regular"
-                        position="top"
+                      <div
+                        className="euiText euiText--medium"
                       >
                         <span
-                          className="euiToolTipAnchor"
-                          onKeyUp={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
+                          className="panel-title"
                         >
-                          <EuiButtonEmpty
-                            isDisabled={true}
-                            onBlur={[Function]}
-                            onFocus={[Function]}
-                            size="xs"
+                          Services
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (1)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <EuiFlexGroup>
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiToolTip
+                            content="Select services to filter"
+                            delay="regular"
+                            position="top"
                           >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                              disabled={true}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              type="button"
+                            <span
+                              className="euiToolTipAnchor"
+                              onKeyUp={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
                             >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
+                              <EuiButtonEmpty
+                                isDisabled={true}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                size="xs"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                  disabled={true}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
+                                    >
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Filter services
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </span>
+                          </EuiToolTip>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiInMemoryTable
+            columns={
+              Array [
+                Object {
+                  "align": "left",
+                  "field": "name",
+                  "name": "Name",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "average_latency",
+                  "name": "Average duration (ms)",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "error_rate",
+                  "name": "Error rate",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "throughput",
+                  "name": "Request rate",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "traces",
+                  "name": "Traces",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "center",
+                  "field": "actions",
+                  "name": "Actions",
+                  "render": [Function],
+                },
+              ]
+            }
+            isSelectable={true}
+            itemId="itemId"
+            items={
+              Array [
+                Object {
+                  "average_latency": 49.54,
+                  "error_rate": 3.77,
+                  "name": "database",
+                  "throughput": 53,
+                  "traces": 31,
+                },
+              ]
+            }
+            loading={false}
+            pagination={
+              Object {
+                "initialPageSize": 10,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  15,
+                ],
+              }
+            }
+            responsive={true}
+            selection={
+              Object {
+                "onSelectionChange": [Function],
+              }
+            }
+            sorting={
+              Object {
+                "sort": Object {
+                  "direction": "asc",
+                  "field": "name",
+                },
+              }
+            }
+            tableLayout="auto"
+          >
+            <EuiBasicTable
+              columns={
+                Array [
+                  Object {
+                    "align": "left",
+                    "field": "name",
+                    "name": "Name",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "average_latency",
+                    "name": "Average duration (ms)",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "error_rate",
+                    "name": "Error rate",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "throughput",
+                    "name": "Request rate",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "traces",
+                    "name": "Traces",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "center",
+                    "field": "actions",
+                    "name": "Actions",
+                    "render": [Function],
+                  },
+                ]
+              }
+              isSelectable={true}
+              itemId="itemId"
+              items={
+                Array [
+                  Object {
+                    "average_latency": 49.54,
+                    "error_rate": 3.77,
+                    "name": "database",
+                    "throughput": 53,
+                    "traces": 31,
+                  },
+                ]
+              }
+              loading={false}
+              noItemsMessage="No items found"
+              onChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+              responsive={true}
+              selection={
+                Object {
+                  "onSelectionChange": [Function],
+                }
+              }
+              sorting={
+                Object {
+                  "allowNeutralSort": true,
+                  "sort": Object {
+                    "direction": "asc",
+                    "field": "Name",
+                  },
+                }
+              }
+              tableLayout="auto"
+            >
+              <div
+                className="euiBasicTable"
+              >
+                <div>
+                  <EuiTableHeaderMobile>
+                    <div
+                      className="euiTableHeaderMobile"
+                    >
+                      <EuiFlexGroup
+                        alignItems="baseline"
+                        justifyContent="spaceBetween"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiI18n
+                                default="Select all rows"
+                                token="euiBasicTable.selectAllRows"
+                              >
+                                <EuiCheckbox
+                                  aria-label="Select all rows"
+                                  checked={false}
+                                  compressed={false}
+                                  disabled={false}
+                                  id="_selection_column-checkbox_random_html_id"
+                                  indeterminate={false}
+                                  label="Select all rows"
+                                  onChange={[Function]}
+                                >
+                                  <div
+                                    className="euiCheckbox"
+                                  >
+                                    <input
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      className="euiCheckbox__input"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      onChange={[Function]}
+                                      type="checkbox"
+                                    />
+                                    <div
+                                      className="euiCheckbox__square"
+                                    />
+                                    <label
+                                      className="euiCheckbox__label"
+                                      htmlFor="_selection_column-checkbox_random_html_id"
+                                    >
+                                      Select all rows
+                                    </label>
+                                  </div>
+                                </EuiCheckbox>
+                              </EuiI18n>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiTableSortMobile
+                                items={
+                                  Array [
+                                    Object {
+                                      "isSortAscending": true,
+                                      "isSorted": true,
+                                      "key": "_data_s_name_0",
+                                      "name": "Name",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_average_latency_1",
+                                      "name": "Average duration (ms)",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_error_rate_2",
+                                      "name": "Error rate",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_throughput_3",
+                                      "name": "Request rate",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_traces_4",
+                                      "name": "Traces",
+                                      "onSort": [Function],
+                                    },
+                                  ]
+                                }
+                              >
+                                <div
+                                  className="euiTableSortMobile"
+                                >
+                                  <EuiPopover
+                                    anchorPosition="downRight"
+                                    button={
+                                      <EuiButtonEmpty
+                                        flush="right"
+                                        iconSide="right"
+                                        iconType="arrowDown"
+                                        onClick={[Function]}
+                                        size="xs"
+                                      >
+                                        <EuiI18n
+                                          default="Sorting"
+                                          token="euiTableSortMobile.sorting"
+                                        />
+                                      </EuiButtonEmpty>
+                                    }
+                                    closePopover={[Function]}
+                                    display="inlineBlock"
+                                    hasArrow={true}
+                                    isOpen={false}
+                                    ownFocus={true}
+                                    panelPaddingSize="none"
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
+                                          onClick={[Function]}
+                                          size="xs"
+                                        >
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <EuiButtonContent
+                                              className="euiButtonEmpty__content"
+                                              iconSide="right"
+                                              iconSize="s"
+                                              iconType="arrowDown"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButtonEmpty__text",
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                              >
+                                                <EuiIcon
+                                                  className="euiButtonContent__icon"
+                                                  color="inherit"
+                                                  size="s"
+                                                  type="arrowDown"
+                                                >
+                                                  <EuiIconArrowDown
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                    focusable="false"
+                                                    role="img"
+                                                    style={null}
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                        fillRule="non-zero"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconArrowDown>
+                                                </EuiIcon>
+                                                <span
+                                                  className="euiButtonEmpty__text"
+                                                >
+                                                  <EuiI18n
+                                                    default="Sorting"
+                                                    token="euiTableSortMobile.sorting"
+                                                  >
+                                                    Sorting
+                                                  </EuiI18n>
+                                                </span>
+                                              </span>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
+                                    </div>
+                                  </EuiPopover>
+                                </div>
+                              </EuiTableSortMobile>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiTableHeaderMobile>
+                  <EuiTable
+                    id="random_html_id"
+                    responsive={true}
+                    tableLayout="auto"
+                  >
+                    <table
+                      className="euiTable euiTable--responsive euiTable--auto"
+                      id="random_html_id"
+                      tabIndex={-1}
+                    >
+                      <EuiScreenReaderOnly>
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
+                        >
+                          <EuiDelayRender
+                            delay={500}
+                          />
+                        </caption>
+                      </EuiScreenReaderOnly>
+                      <EuiTableHeader>
+                        <thead>
+                          <tr>
+                            <EuiTableHeaderCellCheckbox
+                              key="_selection_column_h"
+                            >
+                              <th
+                                className="euiTableHeaderCellCheckbox"
+                                scope="col"
+                                style={
                                   Object {
-                                    "className": "euiButtonEmpty__text",
+                                    "width": undefined,
                                   }
                                 }
                               >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
+                                <div
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiI18n
+                                    default="Select all rows"
+                                    token="euiBasicTable.selectAllRows"
+                                  >
+                                    <EuiCheckbox
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      compressed={false}
+                                      data-test-subj="checkboxSelectAll"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      indeterminate={false}
+                                      label={null}
+                                      onChange={[Function]}
+                                      type="inList"
+                                    >
+                                      <div
+                                        className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                      >
+                                        <input
+                                          aria-label="Select all rows"
+                                          checked={false}
+                                          className="euiCheckbox__input"
+                                          data-test-subj="checkboxSelectAll"
+                                          disabled={false}
+                                          id="_selection_column-checkbox_random_html_id"
+                                          onChange={[Function]}
+                                          type="checkbox"
+                                        />
+                                        <div
+                                          className="euiCheckbox__square"
+                                        />
+                                      </div>
+                                    </EuiCheckbox>
+                                  </EuiI18n>
+                                </div>
+                              </th>
+                            </EuiTableHeaderCellCheckbox>
+                            <EuiTableHeaderCell
+                              align="left"
+                              data-test-subj="tableHeaderCell_name_0"
+                              isSortAscending={true}
+                              isSorted={true}
+                              key="_data_h_name_0"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="ascending"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_name_0"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSortAscending={true}
+                                    isSorted={true}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Name",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Name"
+                                          >
+                                            Name
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                      <EuiIcon
+                                        className="euiTableSortIcon"
+                                        size="m"
+                                        type="sortUp"
+                                      >
+                                        <EuiIconSortUp
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiTableSortIcon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiTableSortIcon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSortUp>
+                                      </EuiIcon>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_average_latency_1"
+                              isSorted={false}
+                              key="_data_h_average_latency_1"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_average_latency_1"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Average duration (ms)",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Average duration (ms)"
+                                          >
+                                            Average duration (ms)
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_error_rate_2"
+                              isSorted={false}
+                              key="_data_h_error_rate_2"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_error_rate_2"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Error rate",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Error rate"
+                                          >
+                                            Error rate
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_throughput_3"
+                              isSorted={false}
+                              key="_data_h_throughput_3"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_throughput_3"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Request rate",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Request rate"
+                                          >
+                                            Request rate
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_traces_4"
+                              isSorted={false}
+                              key="_data_h_traces_4"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_traces_4"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Traces",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Traces"
+                                          >
+                                            Traces
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="center"
+                              data-test-subj="tableHeaderCell_actions_5"
+                              key="_data_h_actions_5"
+                            >
+                              <th
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_actions_5"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignCenter"
+                                  showSortMsg={false}
                                 >
                                   <span
-                                    className="euiButtonEmpty__text"
+                                    className="euiTableCellContent euiTableCellContent--alignCenter"
                                   >
-                                    Filter services
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Actions",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Actions"
+                                        >
+                                          Actions
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
                                   </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </span>
-                      </EuiToolTip>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <EuiInMemoryTable
-        columns={
-          Array [
-            Object {
-              "align": "left",
-              "field": "name",
-              "name": "Name",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "average_latency",
-              "name": "Average duration (ms)",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "error_rate",
-              "name": "Error rate",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "throughput",
-              "name": "Request rate",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "traces",
-              "name": "Traces",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "center",
-              "field": "actions",
-              "name": "Actions",
-              "render": [Function],
-            },
-          ]
-        }
-        isSelectable={true}
-        itemId="itemId"
-        items={
-          Array [
-            Object {
-              "average_latency": 49.54,
-              "error_rate": 3.77,
-              "name": "database",
-              "throughput": 53,
-              "traces": 31,
-            },
-          ]
-        }
-        loading={false}
-        pagination={
-          Object {
-            "initialPageSize": 10,
-            "pageSizeOptions": Array [
-              5,
-              10,
-              15,
-            ],
-          }
-        }
-        responsive={true}
-        selection={
-          Object {
-            "onSelectionChange": [Function],
-          }
-        }
-        sorting={
-          Object {
-            "sort": Object {
-              "direction": "asc",
-              "field": "name",
-            },
-          }
-        }
-        tableLayout="auto"
-      >
-        <EuiBasicTable
-          columns={
-            Array [
-              Object {
-                "align": "left",
-                "field": "name",
-                "name": "Name",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "average_latency",
-                "name": "Average duration (ms)",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "error_rate",
-                "name": "Error rate",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "throughput",
-                "name": "Request rate",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "traces",
-                "name": "Traces",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "center",
-                "field": "actions",
-                "name": "Actions",
-                "render": [Function],
-              },
-            ]
-          }
-          isSelectable={true}
-          itemId="itemId"
-          items={
-            Array [
-              Object {
-                "average_latency": 49.54,
-                "error_rate": 3.77,
-                "name": "database",
-                "throughput": 53,
-                "traces": 31,
-              },
-            ]
-          }
-          loading={false}
-          noItemsMessage="No items found"
-          onChange={[Function]}
-          pagination={
-            Object {
-              "hidePerPageOptions": undefined,
-              "pageIndex": 0,
-              "pageSize": 10,
-              "pageSizeOptions": Array [
-                5,
-                10,
-                15,
-              ],
-              "totalItemCount": 1,
-            }
-          }
-          responsive={true}
-          selection={
-            Object {
-              "onSelectionChange": [Function],
-            }
-          }
-          sorting={
-            Object {
-              "allowNeutralSort": true,
-              "sort": Object {
-                "direction": "asc",
-                "field": "Name",
-              },
-            }
-          }
-          tableLayout="auto"
-        >
-          <div
-            className="euiBasicTable"
-          >
-            <div>
-              <EuiTableHeaderMobile>
-                <div
-                  className="euiTableHeaderMobile"
-                >
-                  <EuiFlexGroup
-                    alignItems="baseline"
-                    justifyContent="spaceBetween"
-                    responsive={false}
-                  >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-                    >
-                      <EuiFlexItem
-                        grow={false}
+                                </CellContents>
+                              </th>
+                            </EuiTableHeaderCell>
+                          </tr>
+                        </thead>
+                      </EuiTableHeader>
+                      <EuiTableBody
+                        bodyRef={[Function]}
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiI18n
-                            default="Select all rows"
-                            token="euiBasicTable.selectAllRows"
+                        <tbody>
+                          <EuiTableRow
+                            isSelectable={true}
+                            isSelected={false}
                           >
-                            <EuiCheckbox
-                              aria-label="Select all rows"
-                              checked={false}
-                              compressed={false}
-                              disabled={false}
-                              id="_selection_column-checkbox_random_html_id"
-                              indeterminate={false}
-                              label="Select all rows"
-                              onChange={[Function]}
+                            <tr
+                              className="euiTableRow euiTableRow-isSelectable"
                             >
-                              <div
-                                className="euiCheckbox"
+                              <EuiTableRowCellCheckbox
+                                key="_selection_column_0"
                               >
-                                <input
-                                  aria-label="Select all rows"
-                                  checked={false}
-                                  className="euiCheckbox__input"
-                                  disabled={false}
-                                  id="_selection_column-checkbox_random_html_id"
-                                  onChange={[Function]}
-                                  type="checkbox"
-                                />
-                                <div
-                                  className="euiCheckbox__square"
-                                />
-                                <label
-                                  className="euiCheckbox__label"
-                                  htmlFor="_selection_column-checkbox_random_html_id"
+                                <td
+                                  className="euiTableRowCellCheckbox"
                                 >
-                                  Select all rows
-                                </label>
-                              </div>
-                            </EuiCheckbox>
-                          </EuiI18n>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
+                                  <div
+                                    className="euiTableCellContent"
+                                  >
+                                    <EuiI18n
+                                      default="Select this row"
+                                      token="euiBasicTable.selectThisRow"
+                                    >
+                                      <EuiCheckbox
+                                        aria-label="Select this row"
+                                        checked={false}
+                                        compressed={false}
+                                        data-test-subj="checkboxSelectRow-0"
+                                        disabled={false}
+                                        id="_selection_column_0-checkbox"
+                                        indeterminate={false}
+                                        onChange={[Function]}
+                                        title="Select this row"
+                                        type="inList"
+                                      >
+                                        <div
+                                          className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                        >
+                                          <input
+                                            aria-label="Select this row"
+                                            checked={false}
+                                            className="euiCheckbox__input"
+                                            data-test-subj="checkboxSelectRow-0"
+                                            disabled={false}
+                                            id="_selection_column_0-checkbox"
+                                            onChange={[Function]}
+                                            title="Select this row"
+                                            type="checkbox"
+                                          />
+                                          <div
+                                            className="euiCheckbox__square"
+                                          />
+                                        </div>
+                                      </EuiCheckbox>
+                                    </EuiI18n>
+                                  </div>
+                                </td>
+                              </EuiTableRowCellCheckbox>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_name_0_0"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Name",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Name
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiLink
+                                      className=""
+                                      data-test-subj="service-link"
+                                      key=".0"
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        className="euiLink euiLink--primary"
+                                        data-test-subj="service-link"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        database
+                                      </button>
+                                    </EuiLink>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_average_latency_0_1"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Average duration (ms)",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Average duration (ms)
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="average_latency"
+                                      item={49.54}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      49.54
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_error_rate_0_2"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Error rate",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Error rate
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="error_rate"
+                                      item={3.77}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      <EuiText
+                                                        size="s"
+                                                      >
+                                                        <div
+                                                          className="euiText euiText--small"
+                                                        >
+                                                          3.77%
+                                                        </div>
+                                                      </EuiText>
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_throughput_0_3"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Request rate",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Request rate
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="throughput"
+                                      item={53}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      <EuiI18nNumber
+                                                        value={53}
+                                                      >
+                                                        53
+                                                      </EuiI18nNumber>
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_traces_0_4"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Traces",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Traces
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiLink
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        className="euiLink euiLink--primary"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiI18nNumber
+                                          value={31}
+                                        >
+                                          31
+                                        </EuiI18nNumber>
+                                      </button>
+                                    </EuiLink>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="center"
+                                key="_data_column_actions_0_5"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Actions",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Actions
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiFlexGroup
+                                      className=""
+                                      justifyContent="center"
+                                      key=".0"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
+                                          onClick={[Function]}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            onClick={[Function]}
+                                          >
+                                            <EuiLink
+                                              data-test-subj="service-flyout-action-btnundefined"
+                                            >
+                                              <button
+                                                className="euiLink euiLink--primary"
+                                                data-test-subj="service-flyout-action-btnundefined"
+                                                disabled={false}
+                                                type="button"
+                                              >
+                                                <EuiIcon
+                                                  color="primary"
+                                                  type="inspect"
+                                                >
+                                                  <EuiIconInspect
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--medium euiIcon--primary"
+                                                    focusable="false"
+                                                    role="img"
+                                                    style={null}
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--primary"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M15.363 14.658a.5.5 0 1 1-.713.7l-2.97-3.023a.5.5 0 0 1 .001-.7A3.9 3.9 0 1 0 8.9 12.8a.5.5 0 1 1 0 .999 4.9 4.9 0 1 1 3.821-1.833l2.642 2.691ZM3.094 13a.5.5 0 1 1 0 1H2.5A2.5 2.5 0 0 1 0 11.5v-9A2.5 2.5 0 0 1 2.5 0h9A2.5 2.5 0 0 1 14 2.5v.599a.5.5 0 1 1-1 0V2.5A1.5 1.5 0 0 0 11.5 1h-9A1.5 1.5 0 0 0 1 2.5v9A1.5 1.5 0 0 0 2.5 13h.594ZM2.5 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-4 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-2 1a.5.5 0 1 1 0 1 .5.5 0 0 1 0-1Zm0 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm6-6a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-8 8a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconInspect>
+                                                </EuiIcon>
+                                              </button>
+                                            </EuiLink>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                            </tr>
+                          </EuiTableRow>
+                        </tbody>
+                      </EuiTableBody>
+                    </table>
+                  </EuiTable>
+                </div>
+                <PaginationBar
+                  aria-controls="random_html_id"
+                  onPageChange={[Function]}
+                  onPageSizeChange={[Function]}
+                  pagination={
+                    Object {
+                      "hidePerPageOptions": undefined,
+                      "pageIndex": 0,
+                      "pageSize": 10,
+                      "pageSizeOptions": Array [
+                        5,
+                        10,
+                        15,
+                      ],
+                      "totalItemCount": 1,
+                    }
+                  }
+                >
+                  <div>
+                    <EuiSpacer
+                      size="m"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiTablePagination
+                      activePage={0}
+                      aria-controls="random_html_id"
+                      itemsPerPage={10}
+                      itemsPerPageOptions={
+                        Array [
+                          5,
+                          10,
+                          15,
+                        ]
+                      }
+                      onChangeItemsPerPage={[Function]}
+                      onChangePage={[Function]}
+                      pageCount={1}
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        justifyContent="spaceBetween"
+                        responsive={false}
                       >
                         <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                         >
-                          <EuiTableSortMobile
-                            items={
-                              Array [
-                                Object {
-                                  "isSortAscending": true,
-                                  "isSorted": true,
-                                  "key": "_data_s_name_0",
-                                  "name": "Name",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_average_latency_1",
-                                  "name": "Average duration (ms)",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_error_rate_2",
-                                  "name": "Error rate",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_throughput_3",
-                                  "name": "Request rate",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_traces_4",
-                                  "name": "Traces",
-                                  "onSort": [Function],
-                                },
-                              ]
-                            }
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiTableSortMobile"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
                               <EuiPopover
-                                anchorPosition="downRight"
+                                anchorPosition="upRight"
                                 button={
                                   <EuiButtonEmpty
-                                    flush="right"
+                                    color="text"
+                                    data-test-subj="tablePaginationPopoverButton"
                                     iconSide="right"
                                     iconType="arrowDown"
                                     onClick={[Function]}
                                     size="xs"
                                   >
                                     <EuiI18n
-                                      default="Sorting"
-                                      token="euiTableSortMobile.sorting"
+                                      default="Rows per page"
+                                      token="euiTablePagination.rowsPerPage"
                                     />
+                                    : 
+                                    10
                                   </EuiButtonEmpty>
                                 }
                                 closePopover={[Function]}
@@ -939,20 +2098,22 @@ exports[`Services table component renders jaeger services table 1`] = `
                                 panelPaddingSize="none"
                               >
                                 <div
-                                  className="euiPopover euiPopover--anchorDownRight"
+                                  className="euiPopover euiPopover--anchorUpRight"
                                 >
                                   <div
                                     className="euiPopover__anchor"
                                   >
                                     <EuiButtonEmpty
-                                      flush="right"
+                                      color="text"
+                                      data-test-subj="tablePaginationPopoverButton"
                                       iconSide="right"
                                       iconType="arrowDown"
                                       onClick={[Function]}
                                       size="xs"
                                     >
                                       <button
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                        data-test-subj="tablePaginationPopoverButton"
                                         disabled={false}
                                         onClick={[Function]}
                                         type="button"
@@ -1006,11 +2167,13 @@ exports[`Services table component renders jaeger services table 1`] = `
                                               className="euiButtonEmpty__text"
                                             >
                                               <EuiI18n
-                                                default="Sorting"
-                                                token="euiTableSortMobile.sorting"
+                                                default="Rows per page"
+                                                token="euiTablePagination.rowsPerPage"
                                               >
-                                                Sorting
+                                                Rows per page
                                               </EuiI18n>
+                                              : 
+                                              10
                                             </span>
                                           </span>
                                         </EuiButtonContent>
@@ -1020,1394 +2183,255 @@ exports[`Services table component renders jaeger services table 1`] = `
                                 </div>
                               </EuiPopover>
                             </div>
-                          </EuiTableSortMobile>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiTableHeaderMobile>
-              <EuiTable
-                id="random_html_id"
-                responsive={true}
-                tableLayout="auto"
-              >
-                <table
-                  className="euiTable euiTable--responsive euiTable--auto"
-                  id="random_html_id"
-                  tabIndex={-1}
-                >
-                  <EuiScreenReaderOnly>
-                    <caption
-                      className="euiScreenReaderOnly euiTableCaption"
-                    >
-                      <EuiDelayRender
-                        delay={500}
-                      />
-                    </caption>
-                  </EuiScreenReaderOnly>
-                  <EuiTableHeader>
-                    <thead>
-                      <tr>
-                        <EuiTableHeaderCellCheckbox
-                          key="_selection_column_h"
-                        >
-                          <th
-                            className="euiTableHeaderCellCheckbox"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiTableCellContent"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <EuiI18n
-                                default="Select all rows"
-                                token="euiBasicTable.selectAllRows"
+                              <EuiPagination
+                                activePage={0}
+                                aria-controls="random_html_id"
+                                onPageClick={[Function]}
+                                pageCount={1}
                               >
-                                <EuiCheckbox
-                                  aria-label="Select all rows"
-                                  checked={false}
-                                  compressed={false}
-                                  data-test-subj="checkboxSelectAll"
-                                  disabled={false}
-                                  id="_selection_column-checkbox_random_html_id"
-                                  indeterminate={false}
-                                  label={null}
-                                  onChange={[Function]}
-                                  type="inList"
+                                <nav
+                                  className="euiPagination"
                                 >
-                                  <div
-                                    className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                  >
-                                    <input
-                                      aria-label="Select all rows"
-                                      checked={false}
-                                      className="euiCheckbox__input"
-                                      data-test-subj="checkboxSelectAll"
-                                      disabled={false}
-                                      id="_selection_column-checkbox_random_html_id"
-                                      onChange={[Function]}
-                                      type="checkbox"
-                                    />
-                                    <div
-                                      className="euiCheckbox__square"
-                                    />
-                                  </div>
-                                </EuiCheckbox>
-                              </EuiI18n>
-                            </div>
-                          </th>
-                        </EuiTableHeaderCellCheckbox>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_name_0"
-                          isSortAscending={true}
-                          isSorted={true}
-                          key="_data_h_name_0"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="ascending"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_name_0"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSortAscending={true}
-                                isSorted={true}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Name",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Name"
-                                      >
-                                        Name
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                  <EuiIcon
-                                    className="euiTableSortIcon"
-                                    size="m"
-                                    type="sortUp"
-                                  >
-                                    <EuiIconSortUp
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiTableSortIcon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiTableSortIcon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
-                                        />
-                                      </svg>
-                                    </EuiIconSortUp>
-                                  </EuiIcon>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_average_latency_1"
-                          isSorted={false}
-                          key="_data_h_average_latency_1"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_average_latency_1"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Average duration (ms)",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Average duration (ms)"
-                                      >
-                                        Average duration (ms)
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_error_rate_2"
-                          isSorted={false}
-                          key="_data_h_error_rate_2"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_error_rate_2"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Error rate",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Error rate"
-                                      >
-                                        Error rate
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_throughput_3"
-                          isSorted={false}
-                          key="_data_h_throughput_3"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_throughput_3"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Request rate",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Request rate"
-                                      >
-                                        Request rate
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_traces_4"
-                          isSorted={false}
-                          key="_data_h_traces_4"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_traces_4"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Traces",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Traces"
-                                      >
-                                        Traces
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="center"
-                          data-test-subj="tableHeaderCell_actions_5"
-                          key="_data_h_actions_5"
-                        >
-                          <th
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_actions_5"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <CellContents
-                              className="euiTableCellContent euiTableCellContent--alignCenter"
-                              showSortMsg={false}
-                            >
-                              <span
-                                className="euiTableCellContent euiTableCellContent--alignCenter"
-                              >
-                                <EuiInnerText>
                                   <EuiI18n
-                                    default="{innerText}; {description}"
-                                    token="euiTableHeaderCell.titleTextWithDesc"
+                                    default="Previous page, {page}"
+                                    token="euiPagination.previousPage"
                                     values={
                                       Object {
-                                        "description": undefined,
-                                        "innerText": "Actions",
+                                        "page": 0,
                                       }
                                     }
                                   >
-                                    <span
-                                      className="euiTableCellContent__text"
-                                      title="Actions"
+                                    <EuiI18n
+                                      default="Previous page"
+                                      token="euiPagination.disabledPreviousPage"
                                     >
-                                      Actions
-                                    </span>
-                                  </EuiI18n>
-                                </EuiInnerText>
-                              </span>
-                            </CellContents>
-                          </th>
-                        </EuiTableHeaderCell>
-                      </tr>
-                    </thead>
-                  </EuiTableHeader>
-                  <EuiTableBody
-                    bodyRef={[Function]}
-                  >
-                    <tbody>
-                      <EuiTableRow
-                        isSelectable={true}
-                        isSelected={false}
-                      >
-                        <tr
-                          className="euiTableRow euiTableRow-isSelectable"
-                        >
-                          <EuiTableRowCellCheckbox
-                            key="_selection_column_0"
-                          >
-                            <td
-                              className="euiTableRowCellCheckbox"
-                            >
-                              <div
-                                className="euiTableCellContent"
-                              >
-                                <EuiI18n
-                                  default="Select this row"
-                                  token="euiBasicTable.selectThisRow"
-                                >
-                                  <EuiCheckbox
-                                    aria-label="Select this row"
-                                    checked={false}
-                                    compressed={false}
-                                    data-test-subj="checkboxSelectRow-0"
-                                    disabled={false}
-                                    id="_selection_column_0-checkbox"
-                                    indeterminate={false}
-                                    onChange={[Function]}
-                                    title="Select this row"
-                                    type="inList"
-                                  >
-                                    <div
-                                      className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                    >
-                                      <input
-                                        aria-label="Select this row"
-                                        checked={false}
-                                        className="euiCheckbox__input"
-                                        data-test-subj="checkboxSelectRow-0"
-                                        disabled={false}
-                                        id="_selection_column_0-checkbox"
-                                        onChange={[Function]}
-                                        title="Select this row"
-                                        type="checkbox"
-                                      />
-                                      <div
-                                        className="euiCheckbox__square"
-                                      />
-                                    </div>
-                                  </EuiCheckbox>
-                                </EuiI18n>
-                              </div>
-                            </td>
-                          </EuiTableRowCellCheckbox>
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_name_0_0"
-                            mobileOptions={
-                              Object {
-                                "header": "Name",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Name
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--overflowingContent"
-                              >
-                                <EuiLink
-                                  className=""
-                                  data-test-subj="service-link"
-                                  key=".0"
-                                  onClick={[Function]}
-                                >
-                                  <button
-                                    className="euiLink euiLink--primary"
-                                    data-test-subj="service-link"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    database
-                                  </button>
-                                </EuiLink>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_average_latency_0_1"
-                            mobileOptions={
-                              Object {
-                                "header": "Average duration (ms)",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Average duration (ms)
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="average_latency"
-                                  item={49.54}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
-                                >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
-                                  >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                                        >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  49.54
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_error_rate_0_2"
-                            mobileOptions={
-                              Object {
-                                "header": "Error rate",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Error rate
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="error_rate"
-                                  item={3.77}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
-                                >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
-                                  >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                                        >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  <EuiText
-                                                    size="s"
-                                                  >
-                                                    <div
-                                                      className="euiText euiText--small"
-                                                    >
-                                                      3.77%
-                                                    </div>
-                                                  </EuiText>
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_throughput_0_3"
-                            mobileOptions={
-                              Object {
-                                "header": "Request rate",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Request rate
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="throughput"
-                                  item={53}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
-                                >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
-                                  >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                                        >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  <EuiI18nNumber
-                                                    value={53}
-                                                  >
-                                                    53
-                                                  </EuiI18nNumber>
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_traces_0_4"
-                            mobileOptions={
-                              Object {
-                                "header": "Traces",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Traces
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiLink
-                                  onClick={[Function]}
-                                >
-                                  <button
-                                    className="euiLink euiLink--primary"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    <EuiI18nNumber
-                                      value={31}
-                                    >
-                                      31
-                                    </EuiI18nNumber>
-                                  </button>
-                                </EuiLink>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="center"
-                            key="_data_column_actions_0_5"
-                            mobileOptions={
-                              Object {
-                                "header": "Actions",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Actions
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
-                              >
-                                <EuiFlexGroup
-                                  className=""
-                                  justifyContent="center"
-                                  key=".0"
-                                >
-                                  <div
-                                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                  >
-                                    <EuiFlexItem
-                                      grow={false}
-                                      onClick={[Function]}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrowZero"
+                                      <EuiButtonIcon
+                                        aria-label="Previous page"
+                                        color="text"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        iconType="arrowLeft"
                                         onClick={[Function]}
                                       >
-                                        <EuiLink
-                                          data-test-subj="service-flyout-action-btnundefined"
+                                        <button
+                                          aria-label="Previous page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-previous"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <button
-                                            className="euiLink euiLink--primary"
-                                            data-test-subj="service-flyout-action-btnundefined"
-                                            disabled={false}
-                                            type="button"
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowLeft"
                                           >
-                                            <EuiIcon
-                                              color="primary"
-                                              type="inspect"
-                                            >
-                                              <EuiIconInspect
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--primary"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon--primary"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M15.363 14.658a.5.5 0 1 1-.713.7l-2.97-3.023a.5.5 0 0 1 .001-.7A3.9 3.9 0 1 0 8.9 12.8a.5.5 0 1 1 0 .999 4.9 4.9 0 1 1 3.821-1.833l2.642 2.691ZM3.094 13a.5.5 0 1 1 0 1H2.5A2.5 2.5 0 0 1 0 11.5v-9A2.5 2.5 0 0 1 2.5 0h9A2.5 2.5 0 0 1 14 2.5v.599a.5.5 0 1 1-1 0V2.5A1.5 1.5 0 0 0 11.5 1h-9A1.5 1.5 0 0 0 1 2.5v9A1.5 1.5 0 0 0 2.5 13h.594ZM2.5 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-4 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-2 1a.5.5 0 1 1 0 1 .5.5 0 0 1 0-1Zm0 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm6-6a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Zm-8 8a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconInspect>
-                                            </EuiIcon>
-                                          </button>
-                                        </EuiLink>
-                                      </div>
-                                    </EuiFlexItem>
-                                  </div>
-                                </EuiFlexGroup>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                        </tr>
-                      </EuiTableRow>
-                    </tbody>
-                  </EuiTableBody>
-                </table>
-              </EuiTable>
-            </div>
-            <PaginationBar
-              aria-controls="random_html_id"
-              onPageChange={[Function]}
-              onPageSizeChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-            >
-              <div>
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiTablePagination
-                  activePage={0}
-                  aria-controls="random_html_id"
-                  itemsPerPage={10}
-                  itemsPerPageOptions={
-                    Array [
-                      5,
-                      10,
-                      15,
-                    ]
-                  }
-                  onChangeItemsPerPage={[Function]}
-                  onChangePage={[Function]}
-                  pageCount={1}
-                >
-                  <EuiFlexGroup
-                    alignItems="center"
-                    justifyContent="spaceBetween"
-                    responsive={false}
-                  >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-                    >
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPopover
-                            anchorPosition="upRight"
-                            button={
-                              <EuiButtonEmpty
-                                color="text"
-                                data-test-subj="tablePaginationPopoverButton"
-                                iconSide="right"
-                                iconType="arrowDown"
-                                onClick={[Function]}
-                                size="xs"
-                              >
-                                <EuiI18n
-                                  default="Rows per page"
-                                  token="euiTablePagination.rowsPerPage"
-                                />
-                                : 
-                                10
-                              </EuiButtonEmpty>
-                            }
-                            closePopover={[Function]}
-                            display="inlineBlock"
-                            hasArrow={true}
-                            isOpen={false}
-                            ownFocus={true}
-                            panelPaddingSize="none"
-                          >
-                            <div
-                              className="euiPopover euiPopover--anchorUpRight"
-                            >
-                              <div
-                                className="euiPopover__anchor"
-                              >
-                                <EuiButtonEmpty
-                                  color="text"
-                                  data-test-subj="tablePaginationPopoverButton"
-                                  iconSide="right"
-                                  iconType="arrowDown"
-                                  onClick={[Function]}
-                                  size="xs"
-                                >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
-                                    data-test-subj="tablePaginationPopoverButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="right"
-                                      iconSize="s"
-                                      iconType="arrowDown"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                      >
-                                        <EuiIcon
-                                          className="euiButtonContent__icon"
-                                          color="inherit"
-                                          size="s"
-                                          type="arrowDown"
-                                        >
-                                          <EuiIconArrowDown
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
-                                          >
-                                            <svg
+                                            <EuiIconArrowLeft
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                               focusable="false"
-                                              height={16}
                                               role="img"
                                               style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <path
-                                                d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                fillRule="non-zero"
-                                              />
-                                            </svg>
-                                          </EuiIconArrowDown>
-                                        </EuiIcon>
-                                        <span
-                                          className="euiButtonEmpty__text"
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
+                                                  fillRule="nonzero"
+                                                />
+                                              </svg>
+                                            </EuiIconArrowLeft>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
+                                  </EuiI18n>
+                                  <ul
+                                    className="euiPagination__list"
+                                  >
+                                    <PaginationButton
+                                      key="0"
+                                      pageIndex={0}
+                                    >
+                                      <li
+                                        className="euiPagination__item"
+                                      >
+                                        <EuiPaginationButton
+                                          aria-controls="random_html_id"
+                                          hideOnMobile={true}
+                                          isActive={true}
+                                          onClick={[Function]}
+                                          pageIndex={0}
+                                          totalPages={1}
                                         >
                                           <EuiI18n
-                                            default="Rows per page"
-                                            token="euiTablePagination.rowsPerPage"
-                                          >
-                                            Rows per page
-                                          </EuiI18n>
-                                          : 
-                                          10
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </div>
-                            </div>
-                          </EuiPopover>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPagination
-                            activePage={0}
-                            aria-controls="random_html_id"
-                            onPageClick={[Function]}
-                            pageCount={1}
-                          >
-                            <nav
-                              className="euiPagination"
-                            >
-                              <EuiI18n
-                                default="Previous page, {page}"
-                                token="euiPagination.previousPage"
-                                values={
-                                  Object {
-                                    "page": 0,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Previous page"
-                                  token="euiPagination.disabledPreviousPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Previous page"
-                                    color="text"
-                                    data-test-subj="pagination-button-previous"
-                                    disabled={true}
-                                    iconType="arrowLeft"
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      aria-label="Previous page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowLeft"
-                                      >
-                                        <EuiIconArrowLeft
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
-                                              fillRule="nonzero"
-                                            />
-                                          </svg>
-                                        </EuiIconArrowLeft>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
-                                </EuiI18n>
-                              </EuiI18n>
-                              <ul
-                                className="euiPagination__list"
-                              >
-                                <PaginationButton
-                                  key="0"
-                                  pageIndex={0}
-                                >
-                                  <li
-                                    className="euiPagination__item"
-                                  >
-                                    <EuiPaginationButton
-                                      aria-controls="random_html_id"
-                                      hideOnMobile={true}
-                                      isActive={true}
-                                      onClick={[Function]}
-                                      pageIndex={0}
-                                      totalPages={1}
-                                    >
-                                      <EuiI18n
-                                        default="Page {page} of {totalPages}"
-                                        token="euiPaginationButton.longPageString"
-                                        values={
-                                          Object {
-                                            "page": 1,
-                                            "totalPages": 1,
-                                          }
-                                        }
-                                      >
-                                        <EuiI18n
-                                          default="Page {page}"
-                                          token="euiPaginationButton.shortPageString"
-                                          values={
-                                            Object {
-                                              "page": 1,
+                                            default="Page {page} of {totalPages}"
+                                            token="euiPaginationButton.longPageString"
+                                            values={
+                                              Object {
+                                                "page": 1,
+                                                "totalPages": 1,
+                                              }
                                             }
-                                          }
-                                        >
-                                          <EuiButtonEmpty
-                                            aria-controls="random_html_id"
-                                            aria-current={true}
-                                            aria-label="Page 1 of 1"
-                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                            color="text"
-                                            data-test-subj="pagination-button-0"
-                                            href="#random_html_id"
-                                            isDisabled={true}
-                                            onClick={[Function]}
-                                            size="s"
                                           >
-                                            <button
-                                              aria-controls="random_html_id"
-                                              aria-current={true}
-                                              aria-label="Page 1 of 1"
-                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                              data-test-subj="pagination-button-0"
-                                              disabled={true}
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <EuiButtonContent
-                                                className="euiButtonEmpty__content"
-                                                iconSide="left"
-                                                iconSize="m"
-                                                textProps={
-                                                  Object {
-                                                    "className": "euiButtonEmpty__text",
-                                                  }
+                                            <EuiI18n
+                                              default="Page {page}"
+                                              token="euiPaginationButton.shortPageString"
+                                              values={
+                                                Object {
+                                                  "page": 1,
                                                 }
+                                              }
+                                            >
+                                              <EuiButtonEmpty
+                                                aria-controls="random_html_id"
+                                                aria-current={true}
+                                                aria-label="Page 1 of 1"
+                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                color="text"
+                                                data-test-subj="pagination-button-0"
+                                                href="#random_html_id"
+                                                isDisabled={true}
+                                                onClick={[Function]}
+                                                size="s"
                                               >
-                                                <span
-                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                <button
+                                                  aria-controls="random_html_id"
+                                                  aria-current={true}
+                                                  aria-label="Page 1 of 1"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                  data-test-subj="pagination-button-0"
+                                                  disabled={true}
+                                                  onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <span
-                                                    className="euiButtonEmpty__text"
+                                                  <EuiButtonContent
+                                                    className="euiButtonEmpty__content"
+                                                    iconSide="left"
+                                                    iconSize="m"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiButtonEmpty__text",
+                                                      }
+                                                    }
                                                   >
-                                                    1
-                                                  </span>
-                                                </span>
-                                              </EuiButtonContent>
-                                            </button>
-                                          </EuiButtonEmpty>
-                                        </EuiI18n>
-                                      </EuiI18n>
-                                    </EuiPaginationButton>
-                                  </li>
-                                </PaginationButton>
-                              </ul>
-                              <EuiI18n
-                                default="Next page, {page}"
-                                token="euiPagination.nextPage"
-                                values={
-                                  Object {
-                                    "page": 2,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Next page"
-                                  token="euiPagination.disabledNextPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Next page"
-                                    color="text"
-                                    data-test-subj="pagination-button-next"
-                                    disabled={true}
-                                    iconType="arrowRight"
-                                    onClick={[Function]}
+                                                    <span
+                                                      className="euiButtonContent euiButtonEmpty__content"
+                                                    >
+                                                      <span
+                                                        className="euiButtonEmpty__text"
+                                                      >
+                                                        1
+                                                      </span>
+                                                    </span>
+                                                  </EuiButtonContent>
+                                                </button>
+                                              </EuiButtonEmpty>
+                                            </EuiI18n>
+                                          </EuiI18n>
+                                        </EuiPaginationButton>
+                                      </li>
+                                    </PaginationButton>
+                                  </ul>
+                                  <EuiI18n
+                                    default="Next page, {page}"
+                                    token="euiPagination.nextPage"
+                                    values={
+                                      Object {
+                                        "page": 2,
+                                      }
+                                    }
                                   >
-                                    <button
-                                      aria-label="Next page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-next"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
+                                    <EuiI18n
+                                      default="Next page"
+                                      token="euiPagination.disabledNextPage"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowRight"
+                                      <EuiButtonIcon
+                                        aria-label="Next page"
+                                        color="text"
+                                        data-test-subj="pagination-button-next"
+                                        disabled={true}
+                                        iconType="arrowRight"
+                                        onClick={[Function]}
                                       >
-                                        <EuiIconArrowRight
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
+                                        <button
+                                          aria-label="Next page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-next"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowRight"
                                           >
-                                            <path
-                                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                                              fillRule="nonzero"
-                                            />
-                                          </svg>
-                                        </EuiIconArrowRight>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
-                                </EuiI18n>
-                              </EuiI18n>
-                            </nav>
-                          </EuiPagination>
+                                            <EuiIconArrowRight
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                                  fillRule="nonzero"
+                                                />
+                                              </svg>
+                                            </EuiIconArrowRight>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
+                                  </EuiI18n>
+                                </nav>
+                              </EuiPagination>
+                            </div>
+                          </EuiFlexItem>
                         </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </EuiTablePagination>
+                      </EuiFlexGroup>
+                    </EuiTablePagination>
+                  </div>
+                </PaginationBar>
               </div>
-            </PaginationBar>
-          </div>
-        </EuiBasicTable>
-      </EuiInMemoryTable>
+            </EuiBasicTable>
+          </EuiInMemoryTable>
+        </div>
+      </EuiPanel>
     </div>
-  </EuiPanel>
+  </EuiPage>
 </ServicesTable>
 `;
 
@@ -2438,83 +2462,129 @@ exports[`Services table component renders services table 1`] = `
   setRedirect={[MockFunction]}
   traceColumnAction={[Function]}
 >
-  <EuiPanel>
+  <EuiPage
+    paddingSize="m"
+  >
     <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      className="euiPage euiPage--paddingMedium euiPage--grow"
     >
-      <EuiFlexGroup
-        justifyContent="spaceBetween"
-      >
+      <EuiPanel>
         <div
-          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <EuiFlexItem
-            grow={false}
+          <EuiFlexGroup
+            justifyContent="spaceBetween"
           >
             <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <PanelTitle
-                title="Services"
-                totalItems={1}
+              <EuiFlexItem
+                grow={false}
               >
-                <EuiText
-                  size="m"
-                >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Services
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (1)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiFlexGroup>
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
                 >
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
+                  <PanelTitle
+                    title="Services"
+                    totalItems={1}
+                  >
+                    <EuiText
+                      size="m"
                     >
-                      <EuiToolTip
-                        content="Select services to filter"
-                        delay="regular"
-                        position="top"
+                      <div
+                        className="euiText euiText--medium"
                       >
                         <span
-                          className="euiToolTipAnchor"
-                          onKeyUp={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
+                          className="panel-title"
+                        >
+                          Services
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (1)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <EuiFlexGroup>
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiToolTip
+                            content="Select services to filter"
+                            delay="regular"
+                            position="top"
+                          >
+                            <span
+                              className="euiToolTipAnchor"
+                              onKeyUp={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <EuiButtonEmpty
+                                isDisabled={true}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                size="xs"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                  disabled={true}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
+                                    >
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Filter services
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </span>
+                          </EuiToolTip>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
                         >
                           <EuiButtonEmpty
-                            isDisabled={true}
-                            onBlur={[Function]}
-                            onFocus={[Function]}
+                            onClick={[Function]}
                             size="xs"
                           >
                             <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                              disabled={true}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
+                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                              disabled={false}
+                              onClick={[Function]}
                               type="button"
                             >
                               <EuiButtonContent
@@ -2533,440 +2603,1745 @@ exports[`Services table component renders services table 1`] = `
                                   <span
                                     className="euiButtonEmpty__text"
                                   >
-                                    Filter services
+                                    Show 24 hour trends
                                   </span>
                                 </span>
                               </EuiButtonContent>
                             </button>
                           </EuiButtonEmpty>
-                        </span>
-                      </EuiToolTip>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem>
-                    <div
-                      className="euiFlexItem"
-                    >
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
-                            iconSide="left"
-                            iconSize="s"
-                            textProps={
-                              Object {
-                                "className": "euiButtonEmpty__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButtonEmpty__content"
-                            >
-                              <span
-                                className="euiButtonEmpty__text"
-                              >
-                                Show 24 hour trends
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <EuiInMemoryTable
-        columns={
-          Array [
-            Object {
-              "align": "left",
-              "field": "name",
-              "name": "Name",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "average_latency",
-              "name": "Average duration (ms)",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "error_rate",
-              "name": "Error rate",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "throughput",
-              "name": "Request rate",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "number_of_connected_services",
-              "name": "No. of connected services",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-              "width": "80px",
-            },
-            Object {
-              "align": "left",
-              "field": "connected_services",
-              "name": "Connected services",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "traces",
-              "name": "Traces",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "center",
-              "field": "actions",
-              "name": "Actions",
-              "render": [Function],
-            },
-          ]
-        }
-        isSelectable={true}
-        itemId="itemId"
-        items={
-          Array [
-            Object {
-              "average_latency": 49.54,
-              "connected_services": Array [
-                "order",
-                "inventory",
-              ],
-              "error_rate": 3.77,
-              "name": "database",
-              "number_of_connected_services": 2,
-              "throughput": 53,
-              "traces": 31,
-            },
-          ]
-        }
-        loading={false}
-        pagination={
-          Object {
-            "initialPageSize": 10,
-            "pageSizeOptions": Array [
-              5,
-              10,
-              15,
-            ],
-          }
-        }
-        responsive={true}
-        selection={
-          Object {
-            "onSelectionChange": [Function],
-          }
-        }
-        sorting={
-          Object {
-            "sort": Object {
-              "direction": "asc",
-              "field": "name",
-            },
-          }
-        }
-        tableLayout="auto"
-      >
-        <EuiBasicTable
-          columns={
-            Array [
-              Object {
-                "align": "left",
-                "field": "name",
-                "name": "Name",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "average_latency",
-                "name": "Average duration (ms)",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "error_rate",
-                "name": "Error rate",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "throughput",
-                "name": "Request rate",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "number_of_connected_services",
-                "name": "No. of connected services",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-                "width": "80px",
-              },
-              Object {
-                "align": "left",
-                "field": "connected_services",
-                "name": "Connected services",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "traces",
-                "name": "Traces",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "center",
-                "field": "actions",
-                "name": "Actions",
-                "render": [Function],
-              },
-            ]
-          }
-          isSelectable={true}
-          itemId="itemId"
-          items={
-            Array [
-              Object {
-                "average_latency": 49.54,
-                "connected_services": Array [
-                  "order",
-                  "inventory",
-                ],
-                "error_rate": 3.77,
-                "name": "database",
-                "number_of_connected_services": 2,
-                "throughput": 53,
-                "traces": 31,
-              },
-            ]
-          }
-          loading={false}
-          noItemsMessage="No items found"
-          onChange={[Function]}
-          pagination={
-            Object {
-              "hidePerPageOptions": undefined,
-              "pageIndex": 0,
-              "pageSize": 10,
-              "pageSizeOptions": Array [
-                5,
-                10,
-                15,
-              ],
-              "totalItemCount": 1,
-            }
-          }
-          responsive={true}
-          selection={
-            Object {
-              "onSelectionChange": [Function],
-            }
-          }
-          sorting={
-            Object {
-              "allowNeutralSort": true,
-              "sort": Object {
-                "direction": "asc",
-                "field": "Name",
-              },
-            }
-          }
-          tableLayout="auto"
-        >
-          <div
-            className="euiBasicTable"
-          >
-            <div>
-              <EuiTableHeaderMobile>
-                <div
-                  className="euiTableHeaderMobile"
-                >
-                  <EuiFlexGroup
-                    alignItems="baseline"
-                    justifyContent="spaceBetween"
-                    responsive={false}
-                  >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-                    >
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiI18n
-                            default="Select all rows"
-                            token="euiBasicTable.selectAllRows"
-                          >
-                            <EuiCheckbox
-                              aria-label="Select all rows"
-                              checked={false}
-                              compressed={false}
-                              disabled={false}
-                              id="_selection_column-checkbox_random_html_id"
-                              indeterminate={false}
-                              label="Select all rows"
-                              onChange={[Function]}
-                            >
-                              <div
-                                className="euiCheckbox"
-                              >
-                                <input
-                                  aria-label="Select all rows"
-                                  checked={false}
-                                  className="euiCheckbox__input"
-                                  disabled={false}
-                                  id="_selection_column-checkbox_random_html_id"
-                                  onChange={[Function]}
-                                  type="checkbox"
-                                />
-                                <div
-                                  className="euiCheckbox__square"
-                                />
-                                <label
-                                  className="euiCheckbox__label"
-                                  htmlFor="_selection_column-checkbox_random_html_id"
-                                >
-                                  Select all rows
-                                </label>
-                              </div>
-                            </EuiCheckbox>
-                          </EuiI18n>
                         </div>
                       </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiInMemoryTable
+            columns={
+              Array [
+                Object {
+                  "align": "left",
+                  "field": "name",
+                  "name": "Name",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "average_latency",
+                  "name": "Average duration (ms)",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "error_rate",
+                  "name": "Error rate",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "throughput",
+                  "name": "Request rate",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "number_of_connected_services",
+                  "name": "No. of connected services",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                  "width": "80px",
+                },
+                Object {
+                  "align": "left",
+                  "field": "connected_services",
+                  "name": "Connected services",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "traces",
+                  "name": "Traces",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "center",
+                  "field": "actions",
+                  "name": "Actions",
+                  "render": [Function],
+                },
+              ]
+            }
+            isSelectable={true}
+            itemId="itemId"
+            items={
+              Array [
+                Object {
+                  "average_latency": 49.54,
+                  "connected_services": Array [
+                    "order",
+                    "inventory",
+                  ],
+                  "error_rate": 3.77,
+                  "name": "database",
+                  "number_of_connected_services": 2,
+                  "throughput": 53,
+                  "traces": 31,
+                },
+              ]
+            }
+            loading={false}
+            pagination={
+              Object {
+                "initialPageSize": 10,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  15,
+                ],
+              }
+            }
+            responsive={true}
+            selection={
+              Object {
+                "onSelectionChange": [Function],
+              }
+            }
+            sorting={
+              Object {
+                "sort": Object {
+                  "direction": "asc",
+                  "field": "name",
+                },
+              }
+            }
+            tableLayout="auto"
+          >
+            <EuiBasicTable
+              columns={
+                Array [
+                  Object {
+                    "align": "left",
+                    "field": "name",
+                    "name": "Name",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "average_latency",
+                    "name": "Average duration (ms)",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "error_rate",
+                    "name": "Error rate",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "throughput",
+                    "name": "Request rate",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "number_of_connected_services",
+                    "name": "No. of connected services",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                    "width": "80px",
+                  },
+                  Object {
+                    "align": "left",
+                    "field": "connected_services",
+                    "name": "Connected services",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "traces",
+                    "name": "Traces",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "center",
+                    "field": "actions",
+                    "name": "Actions",
+                    "render": [Function],
+                  },
+                ]
+              }
+              isSelectable={true}
+              itemId="itemId"
+              items={
+                Array [
+                  Object {
+                    "average_latency": 49.54,
+                    "connected_services": Array [
+                      "order",
+                      "inventory",
+                    ],
+                    "error_rate": 3.77,
+                    "name": "database",
+                    "number_of_connected_services": 2,
+                    "throughput": 53,
+                    "traces": 31,
+                  },
+                ]
+              }
+              loading={false}
+              noItemsMessage="No items found"
+              onChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+              responsive={true}
+              selection={
+                Object {
+                  "onSelectionChange": [Function],
+                }
+              }
+              sorting={
+                Object {
+                  "allowNeutralSort": true,
+                  "sort": Object {
+                    "direction": "asc",
+                    "field": "Name",
+                  },
+                }
+              }
+              tableLayout="auto"
+            >
+              <div
+                className="euiBasicTable"
+              >
+                <div>
+                  <EuiTableHeaderMobile>
+                    <div
+                      className="euiTableHeaderMobile"
+                    >
+                      <EuiFlexGroup
+                        alignItems="baseline"
+                        justifyContent="spaceBetween"
+                        responsive={false}
                       >
                         <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                         >
-                          <EuiTableSortMobile
-                            items={
-                              Array [
-                                Object {
-                                  "isSortAscending": true,
-                                  "isSorted": true,
-                                  "key": "_data_s_name_0",
-                                  "name": "Name",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_average_latency_1",
-                                  "name": "Average duration (ms)",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_error_rate_2",
-                                  "name": "Error rate",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_throughput_3",
-                                  "name": "Request rate",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_number_of_connected_services_4",
-                                  "name": "No. of connected services",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_connected_services_5",
-                                  "name": "Connected services",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_traces_6",
-                                  "name": "Traces",
-                                  "onSort": [Function],
-                                },
-                              ]
-                            }
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiTableSortMobile"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiI18n
+                                default="Select all rows"
+                                token="euiBasicTable.selectAllRows"
+                              >
+                                <EuiCheckbox
+                                  aria-label="Select all rows"
+                                  checked={false}
+                                  compressed={false}
+                                  disabled={false}
+                                  id="_selection_column-checkbox_random_html_id"
+                                  indeterminate={false}
+                                  label="Select all rows"
+                                  onChange={[Function]}
+                                >
+                                  <div
+                                    className="euiCheckbox"
+                                  >
+                                    <input
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      className="euiCheckbox__input"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      onChange={[Function]}
+                                      type="checkbox"
+                                    />
+                                    <div
+                                      className="euiCheckbox__square"
+                                    />
+                                    <label
+                                      className="euiCheckbox__label"
+                                      htmlFor="_selection_column-checkbox_random_html_id"
+                                    >
+                                      Select all rows
+                                    </label>
+                                  </div>
+                                </EuiCheckbox>
+                              </EuiI18n>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiTableSortMobile
+                                items={
+                                  Array [
+                                    Object {
+                                      "isSortAscending": true,
+                                      "isSorted": true,
+                                      "key": "_data_s_name_0",
+                                      "name": "Name",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_average_latency_1",
+                                      "name": "Average duration (ms)",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_error_rate_2",
+                                      "name": "Error rate",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_throughput_3",
+                                      "name": "Request rate",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_number_of_connected_services_4",
+                                      "name": "No. of connected services",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_connected_services_5",
+                                      "name": "Connected services",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_traces_6",
+                                      "name": "Traces",
+                                      "onSort": [Function],
+                                    },
+                                  ]
+                                }
+                              >
+                                <div
+                                  className="euiTableSortMobile"
+                                >
+                                  <EuiPopover
+                                    anchorPosition="downRight"
+                                    button={
+                                      <EuiButtonEmpty
+                                        flush="right"
+                                        iconSide="right"
+                                        iconType="arrowDown"
+                                        onClick={[Function]}
+                                        size="xs"
+                                      >
+                                        <EuiI18n
+                                          default="Sorting"
+                                          token="euiTableSortMobile.sorting"
+                                        />
+                                      </EuiButtonEmpty>
+                                    }
+                                    closePopover={[Function]}
+                                    display="inlineBlock"
+                                    hasArrow={true}
+                                    isOpen={false}
+                                    ownFocus={true}
+                                    panelPaddingSize="none"
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
+                                          onClick={[Function]}
+                                          size="xs"
+                                        >
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <EuiButtonContent
+                                              className="euiButtonEmpty__content"
+                                              iconSide="right"
+                                              iconSize="s"
+                                              iconType="arrowDown"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButtonEmpty__text",
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                              >
+                                                <EuiIcon
+                                                  className="euiButtonContent__icon"
+                                                  color="inherit"
+                                                  size="s"
+                                                  type="arrowDown"
+                                                >
+                                                  <EuiIconBeaker
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                    focusable="false"
+                                                    role="img"
+                                                    style={null}
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconBeaker>
+                                                </EuiIcon>
+                                                <span
+                                                  className="euiButtonEmpty__text"
+                                                >
+                                                  <EuiI18n
+                                                    default="Sorting"
+                                                    token="euiTableSortMobile.sorting"
+                                                  >
+                                                    Sorting
+                                                  </EuiI18n>
+                                                </span>
+                                              </span>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
+                                    </div>
+                                  </EuiPopover>
+                                </div>
+                              </EuiTableSortMobile>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiTableHeaderMobile>
+                  <EuiTable
+                    id="random_html_id"
+                    responsive={true}
+                    tableLayout="auto"
+                  >
+                    <table
+                      className="euiTable euiTable--responsive euiTable--auto"
+                      id="random_html_id"
+                      tabIndex={-1}
+                    >
+                      <EuiScreenReaderOnly>
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
+                        >
+                          <EuiDelayRender
+                            delay={500}
+                          />
+                        </caption>
+                      </EuiScreenReaderOnly>
+                      <EuiTableHeader>
+                        <thead>
+                          <tr>
+                            <EuiTableHeaderCellCheckbox
+                              key="_selection_column_h"
+                            >
+                              <th
+                                className="euiTableHeaderCellCheckbox"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiI18n
+                                    default="Select all rows"
+                                    token="euiBasicTable.selectAllRows"
+                                  >
+                                    <EuiCheckbox
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      compressed={false}
+                                      data-test-subj="checkboxSelectAll"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      indeterminate={false}
+                                      label={null}
+                                      onChange={[Function]}
+                                      type="inList"
+                                    >
+                                      <div
+                                        className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                      >
+                                        <input
+                                          aria-label="Select all rows"
+                                          checked={false}
+                                          className="euiCheckbox__input"
+                                          data-test-subj="checkboxSelectAll"
+                                          disabled={false}
+                                          id="_selection_column-checkbox_random_html_id"
+                                          onChange={[Function]}
+                                          type="checkbox"
+                                        />
+                                        <div
+                                          className="euiCheckbox__square"
+                                        />
+                                      </div>
+                                    </EuiCheckbox>
+                                  </EuiI18n>
+                                </div>
+                              </th>
+                            </EuiTableHeaderCellCheckbox>
+                            <EuiTableHeaderCell
+                              align="left"
+                              data-test-subj="tableHeaderCell_name_0"
+                              isSortAscending={true}
+                              isSorted={true}
+                              key="_data_h_name_0"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="ascending"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_name_0"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSortAscending={true}
+                                    isSorted={true}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Name",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Name"
+                                          >
+                                            Name
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                      <EuiIcon
+                                        className="euiTableSortIcon"
+                                        size="m"
+                                        type="sortUp"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_average_latency_1"
+                              isSorted={false}
+                              key="_data_h_average_latency_1"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_average_latency_1"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Average duration (ms)",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Average duration (ms)"
+                                          >
+                                            Average duration (ms)
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_error_rate_2"
+                              isSorted={false}
+                              key="_data_h_error_rate_2"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_error_rate_2"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Error rate",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Error rate"
+                                          >
+                                            Error rate
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_throughput_3"
+                              isSorted={false}
+                              key="_data_h_throughput_3"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_throughput_3"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Request rate",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Request rate"
+                                          >
+                                            Request rate
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_number_of_connected_services_4"
+                              isSorted={false}
+                              key="_data_h_number_of_connected_services_4"
+                              onSort={[Function]}
+                              width="80px"
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_number_of_connected_services_4"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": "80px",
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "No. of connected services",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="No. of connected services"
+                                          >
+                                            No. of connected services
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="left"
+                              data-test-subj="tableHeaderCell_connected_services_5"
+                              isSorted={false}
+                              key="_data_h_connected_services_5"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_connected_services_5"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Connected services",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Connected services"
+                                          >
+                                            Connected services
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_traces_6"
+                              isSorted={false}
+                              key="_data_h_traces_6"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_traces_6"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Traces",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Traces"
+                                          >
+                                            Traces
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="center"
+                              data-test-subj="tableHeaderCell_actions_7"
+                              key="_data_h_actions_7"
+                            >
+                              <th
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_actions_7"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <CellContents
+                                  className="euiTableCellContent euiTableCellContent--alignCenter"
+                                  showSortMsg={false}
+                                >
+                                  <span
+                                    className="euiTableCellContent euiTableCellContent--alignCenter"
+                                  >
+                                    <EuiInnerText>
+                                      <EuiI18n
+                                        default="{innerText}; {description}"
+                                        token="euiTableHeaderCell.titleTextWithDesc"
+                                        values={
+                                          Object {
+                                            "description": undefined,
+                                            "innerText": "Actions",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiTableCellContent__text"
+                                          title="Actions"
+                                        >
+                                          Actions
+                                        </span>
+                                      </EuiI18n>
+                                    </EuiInnerText>
+                                  </span>
+                                </CellContents>
+                              </th>
+                            </EuiTableHeaderCell>
+                          </tr>
+                        </thead>
+                      </EuiTableHeader>
+                      <EuiTableBody
+                        bodyRef={[Function]}
+                      >
+                        <tbody>
+                          <EuiTableRow
+                            isSelectable={true}
+                            isSelected={false}
+                          >
+                            <tr
+                              className="euiTableRow euiTableRow-isSelectable"
+                            >
+                              <EuiTableRowCellCheckbox
+                                key="_selection_column_0"
+                              >
+                                <td
+                                  className="euiTableRowCellCheckbox"
+                                >
+                                  <div
+                                    className="euiTableCellContent"
+                                  >
+                                    <EuiI18n
+                                      default="Select this row"
+                                      token="euiBasicTable.selectThisRow"
+                                    >
+                                      <EuiCheckbox
+                                        aria-label="Select this row"
+                                        checked={false}
+                                        compressed={false}
+                                        data-test-subj="checkboxSelectRow-0"
+                                        disabled={false}
+                                        id="_selection_column_0-checkbox"
+                                        indeterminate={false}
+                                        onChange={[Function]}
+                                        title="Select this row"
+                                        type="inList"
+                                      >
+                                        <div
+                                          className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                        >
+                                          <input
+                                            aria-label="Select this row"
+                                            checked={false}
+                                            className="euiCheckbox__input"
+                                            data-test-subj="checkboxSelectRow-0"
+                                            disabled={false}
+                                            id="_selection_column_0-checkbox"
+                                            onChange={[Function]}
+                                            title="Select this row"
+                                            type="checkbox"
+                                          />
+                                          <div
+                                            className="euiCheckbox__square"
+                                          />
+                                        </div>
+                                      </EuiCheckbox>
+                                    </EuiI18n>
+                                  </div>
+                                </td>
+                              </EuiTableRowCellCheckbox>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_name_0_0"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Name",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Name
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiLink
+                                      className=""
+                                      data-test-subj="service-link"
+                                      key=".0"
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        className="euiLink euiLink--primary"
+                                        data-test-subj="service-link"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        database
+                                      </button>
+                                    </EuiLink>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_average_latency_0_1"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Average duration (ms)",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Average duration (ms)
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="average_latency"
+                                      item={49.54}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "connected_services": Array [
+                                            "order",
+                                            "inventory",
+                                          ],
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "number_of_connected_services": 2,
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      49.54
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_error_rate_0_2"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Error rate",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Error rate
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="error_rate"
+                                      item={3.77}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "connected_services": Array [
+                                            "order",
+                                            "inventory",
+                                          ],
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "number_of_connected_services": 2,
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      <EuiText
+                                                        size="s"
+                                                      >
+                                                        <div
+                                                          className="euiText euiText--small"
+                                                        >
+                                                          3.77%
+                                                        </div>
+                                                      </EuiText>
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_throughput_0_3"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Request rate",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Request rate
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <ServiceTrendsPlots
+                                      className=""
+                                      fieldType="throughput"
+                                      item={53}
+                                      key=".0"
+                                      row={
+                                        Object {
+                                          "average_latency": 49.54,
+                                          "connected_services": Array [
+                                            "order",
+                                            "inventory",
+                                          ],
+                                          "error_rate": 3.77,
+                                          "name": "database",
+                                          "number_of_connected_services": 2,
+                                          "throughput": 53,
+                                          "traces": 31,
+                                        }
+                                      }
+                                    >
+                                      <EuiFlexGroup
+                                        gutterSize="s"
+                                        justifyContent="flexEnd"
+                                      >
+                                        <div
+                                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                        >
+                                          <EuiFlexItem
+                                            grow={false}
+                                          >
+                                            <div
+                                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            >
+                                              <EuiText
+                                                color="default"
+                                                onMouseEnter={[Function]}
+                                                onMouseLeave={[Function]}
+                                              >
+                                                <div
+                                                  className="euiText euiText--medium"
+                                                  onMouseEnter={[Function]}
+                                                  onMouseLeave={[Function]}
+                                                >
+                                                  <EuiTextColor
+                                                    color="default"
+                                                    component="div"
+                                                  >
+                                                    <div
+                                                      className="euiTextColor euiTextColor--default"
+                                                    >
+                                                      <EuiI18nNumber
+                                                        value={53}
+                                                      >
+                                                        53
+                                                      </EuiI18nNumber>
+                                                    </div>
+                                                  </EuiTextColor>
+                                                </div>
+                                              </EuiText>
+                                            </div>
+                                          </EuiFlexItem>
+                                        </div>
+                                      </EuiFlexGroup>
+                                    </ServiceTrendsPlots>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_number_of_connected_services_0_4"
+                                mobileOptions={
+                                  Object {
+                                    "header": "No. of connected services",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                                width="80px"
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": "80px",
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    No. of connected services
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    2
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_connected_services_0_5"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Connected services",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Connected services
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiText
+                                      className=""
+                                      key=".0"
+                                      size="s"
+                                    >
+                                      <div
+                                        className="euiText euiText--small"
+                                      >
+                                        order, inventory
+                                      </div>
+                                    </EuiText>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_traces_0_6"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Traces",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Traces
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiLink
+                                      onClick={[Function]}
+                                    >
+                                      <button
+                                        className="euiLink euiLink--primary"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                        type="button"
+                                      >
+                                        <EuiI18nNumber
+                                          value={31}
+                                        >
+                                          31
+                                        </EuiI18nNumber>
+                                      </button>
+                                    </EuiLink>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="center"
+                                key="_data_column_actions_0_7"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Actions",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Actions
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiFlexGroup
+                                      className=""
+                                      justifyContent="center"
+                                      key=".0"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={false}
+                                          onClick={[Function]}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                            onClick={[Function]}
+                                          >
+                                            <EuiLink
+                                              data-test-subj="service-flyout-action-btnundefined"
+                                            >
+                                              <button
+                                                className="euiLink euiLink--primary"
+                                                data-test-subj="service-flyout-action-btnundefined"
+                                                disabled={false}
+                                                type="button"
+                                              >
+                                                <EuiIcon
+                                                  color="primary"
+                                                  type="inspect"
+                                                >
+                                                  <EuiIconBeaker
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
+                                                    focusable="false"
+                                                    role="img"
+                                                    style={null}
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconBeaker>
+                                                </EuiIcon>
+                                              </button>
+                                            </EuiLink>
+                                          </div>
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                            </tr>
+                          </EuiTableRow>
+                        </tbody>
+                      </EuiTableBody>
+                    </table>
+                  </EuiTable>
+                </div>
+                <PaginationBar
+                  aria-controls="random_html_id"
+                  onPageChange={[Function]}
+                  onPageSizeChange={[Function]}
+                  pagination={
+                    Object {
+                      "hidePerPageOptions": undefined,
+                      "pageIndex": 0,
+                      "pageSize": 10,
+                      "pageSizeOptions": Array [
+                        5,
+                        10,
+                        15,
+                      ],
+                      "totalItemCount": 1,
+                    }
+                  }
+                >
+                  <div>
+                    <EuiSpacer
+                      size="m"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiTablePagination
+                      activePage={0}
+                      aria-controls="random_html_id"
+                      itemsPerPage={10}
+                      itemsPerPageOptions={
+                        Array [
+                          5,
+                          10,
+                          15,
+                        ]
+                      }
+                      onChangeItemsPerPage={[Function]}
+                      onChangePage={[Function]}
+                      pageCount={1}
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        justifyContent="spaceBetween"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
                               <EuiPopover
-                                anchorPosition="downRight"
+                                anchorPosition="upRight"
                                 button={
                                   <EuiButtonEmpty
-                                    flush="right"
+                                    color="text"
+                                    data-test-subj="tablePaginationPopoverButton"
                                     iconSide="right"
                                     iconType="arrowDown"
                                     onClick={[Function]}
                                     size="xs"
                                   >
                                     <EuiI18n
-                                      default="Sorting"
-                                      token="euiTableSortMobile.sorting"
+                                      default="Rows per page"
+                                      token="euiTablePagination.rowsPerPage"
                                     />
+                                    : 
+                                    10
                                   </EuiButtonEmpty>
                                 }
                                 closePopover={[Function]}
@@ -2977,20 +4352,22 @@ exports[`Services table component renders services table 1`] = `
                                 panelPaddingSize="none"
                               >
                                 <div
-                                  className="euiPopover euiPopover--anchorDownRight"
+                                  className="euiPopover euiPopover--anchorUpRight"
                                 >
                                   <div
                                     className="euiPopover__anchor"
                                   >
                                     <EuiButtonEmpty
-                                      flush="right"
+                                      color="text"
+                                      data-test-subj="tablePaginationPopoverButton"
                                       iconSide="right"
                                       iconType="arrowDown"
                                       onClick={[Function]}
                                       size="xs"
                                     >
                                       <button
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                        data-test-subj="tablePaginationPopoverButton"
                                         disabled={false}
                                         onClick={[Function]}
                                         type="button"
@@ -3043,11 +4420,13 @@ exports[`Services table component renders services table 1`] = `
                                               className="euiButtonEmpty__text"
                                             >
                                               <EuiI18n
-                                                default="Sorting"
-                                                token="euiTableSortMobile.sorting"
+                                                default="Rows per page"
+                                                token="euiTablePagination.rowsPerPage"
                                               >
-                                                Sorting
+                                                Rows per page
                                               </EuiI18n>
+                                              : 
+                                              10
                                             </span>
                                           </span>
                                         </EuiButtonContent>
@@ -3057,1599 +4436,252 @@ exports[`Services table component renders services table 1`] = `
                                 </div>
                               </EuiPopover>
                             </div>
-                          </EuiTableSortMobile>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiTableHeaderMobile>
-              <EuiTable
-                id="random_html_id"
-                responsive={true}
-                tableLayout="auto"
-              >
-                <table
-                  className="euiTable euiTable--responsive euiTable--auto"
-                  id="random_html_id"
-                  tabIndex={-1}
-                >
-                  <EuiScreenReaderOnly>
-                    <caption
-                      className="euiScreenReaderOnly euiTableCaption"
-                    >
-                      <EuiDelayRender
-                        delay={500}
-                      />
-                    </caption>
-                  </EuiScreenReaderOnly>
-                  <EuiTableHeader>
-                    <thead>
-                      <tr>
-                        <EuiTableHeaderCellCheckbox
-                          key="_selection_column_h"
-                        >
-                          <th
-                            className="euiTableHeaderCellCheckbox"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiTableCellContent"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <EuiI18n
-                                default="Select all rows"
-                                token="euiBasicTable.selectAllRows"
+                              <EuiPagination
+                                activePage={0}
+                                aria-controls="random_html_id"
+                                onPageClick={[Function]}
+                                pageCount={1}
                               >
-                                <EuiCheckbox
-                                  aria-label="Select all rows"
-                                  checked={false}
-                                  compressed={false}
-                                  data-test-subj="checkboxSelectAll"
-                                  disabled={false}
-                                  id="_selection_column-checkbox_random_html_id"
-                                  indeterminate={false}
-                                  label={null}
-                                  onChange={[Function]}
-                                  type="inList"
+                                <nav
+                                  className="euiPagination"
                                 >
-                                  <div
-                                    className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                  >
-                                    <input
-                                      aria-label="Select all rows"
-                                      checked={false}
-                                      className="euiCheckbox__input"
-                                      data-test-subj="checkboxSelectAll"
-                                      disabled={false}
-                                      id="_selection_column-checkbox_random_html_id"
-                                      onChange={[Function]}
-                                      type="checkbox"
-                                    />
-                                    <div
-                                      className="euiCheckbox__square"
-                                    />
-                                  </div>
-                                </EuiCheckbox>
-                              </EuiI18n>
-                            </div>
-                          </th>
-                        </EuiTableHeaderCellCheckbox>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_name_0"
-                          isSortAscending={true}
-                          isSorted={true}
-                          key="_data_h_name_0"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="ascending"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_name_0"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSortAscending={true}
-                                isSorted={true}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Name",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Name"
-                                      >
-                                        Name
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                  <EuiIcon
-                                    className="euiTableSortIcon"
-                                    size="m"
-                                    type="sortUp"
-                                  >
-                                    <EuiIconBeaker
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                        />
-                                      </svg>
-                                    </EuiIconBeaker>
-                                  </EuiIcon>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_average_latency_1"
-                          isSorted={false}
-                          key="_data_h_average_latency_1"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_average_latency_1"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Average duration (ms)",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Average duration (ms)"
-                                      >
-                                        Average duration (ms)
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_error_rate_2"
-                          isSorted={false}
-                          key="_data_h_error_rate_2"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_error_rate_2"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Error rate",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Error rate"
-                                      >
-                                        Error rate
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_throughput_3"
-                          isSorted={false}
-                          key="_data_h_throughput_3"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_throughput_3"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Request rate",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Request rate"
-                                      >
-                                        Request rate
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_number_of_connected_services_4"
-                          isSorted={false}
-                          key="_data_h_number_of_connected_services_4"
-                          onSort={[Function]}
-                          width="80px"
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_number_of_connected_services_4"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": "80px",
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "No. of connected services",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="No. of connected services"
-                                      >
-                                        No. of connected services
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_connected_services_5"
-                          isSorted={false}
-                          key="_data_h_connected_services_5"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_connected_services_5"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Connected services",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Connected services"
-                                      >
-                                        Connected services
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_traces_6"
-                          isSorted={false}
-                          key="_data_h_traces_6"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_traces_6"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Traces",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Traces"
-                                      >
-                                        Traces
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="center"
-                          data-test-subj="tableHeaderCell_actions_7"
-                          key="_data_h_actions_7"
-                        >
-                          <th
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_actions_7"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <CellContents
-                              className="euiTableCellContent euiTableCellContent--alignCenter"
-                              showSortMsg={false}
-                            >
-                              <span
-                                className="euiTableCellContent euiTableCellContent--alignCenter"
-                              >
-                                <EuiInnerText>
                                   <EuiI18n
-                                    default="{innerText}; {description}"
-                                    token="euiTableHeaderCell.titleTextWithDesc"
+                                    default="Previous page, {page}"
+                                    token="euiPagination.previousPage"
                                     values={
                                       Object {
-                                        "description": undefined,
-                                        "innerText": "Actions",
+                                        "page": 0,
                                       }
                                     }
                                   >
-                                    <span
-                                      className="euiTableCellContent__text"
-                                      title="Actions"
+                                    <EuiI18n
+                                      default="Previous page"
+                                      token="euiPagination.disabledPreviousPage"
                                     >
-                                      Actions
-                                    </span>
-                                  </EuiI18n>
-                                </EuiInnerText>
-                              </span>
-                            </CellContents>
-                          </th>
-                        </EuiTableHeaderCell>
-                      </tr>
-                    </thead>
-                  </EuiTableHeader>
-                  <EuiTableBody
-                    bodyRef={[Function]}
-                  >
-                    <tbody>
-                      <EuiTableRow
-                        isSelectable={true}
-                        isSelected={false}
-                      >
-                        <tr
-                          className="euiTableRow euiTableRow-isSelectable"
-                        >
-                          <EuiTableRowCellCheckbox
-                            key="_selection_column_0"
-                          >
-                            <td
-                              className="euiTableRowCellCheckbox"
-                            >
-                              <div
-                                className="euiTableCellContent"
-                              >
-                                <EuiI18n
-                                  default="Select this row"
-                                  token="euiBasicTable.selectThisRow"
-                                >
-                                  <EuiCheckbox
-                                    aria-label="Select this row"
-                                    checked={false}
-                                    compressed={false}
-                                    data-test-subj="checkboxSelectRow-0"
-                                    disabled={false}
-                                    id="_selection_column_0-checkbox"
-                                    indeterminate={false}
-                                    onChange={[Function]}
-                                    title="Select this row"
-                                    type="inList"
-                                  >
-                                    <div
-                                      className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                                    >
-                                      <input
-                                        aria-label="Select this row"
-                                        checked={false}
-                                        className="euiCheckbox__input"
-                                        data-test-subj="checkboxSelectRow-0"
-                                        disabled={false}
-                                        id="_selection_column_0-checkbox"
-                                        onChange={[Function]}
-                                        title="Select this row"
-                                        type="checkbox"
-                                      />
-                                      <div
-                                        className="euiCheckbox__square"
-                                      />
-                                    </div>
-                                  </EuiCheckbox>
-                                </EuiI18n>
-                              </div>
-                            </td>
-                          </EuiTableRowCellCheckbox>
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_name_0_0"
-                            mobileOptions={
-                              Object {
-                                "header": "Name",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Name
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--overflowingContent"
-                              >
-                                <EuiLink
-                                  className=""
-                                  data-test-subj="service-link"
-                                  key=".0"
-                                  onClick={[Function]}
-                                >
-                                  <button
-                                    className="euiLink euiLink--primary"
-                                    data-test-subj="service-link"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    database
-                                  </button>
-                                </EuiLink>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_average_latency_0_1"
-                            mobileOptions={
-                              Object {
-                                "header": "Average duration (ms)",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Average duration (ms)
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="average_latency"
-                                  item={49.54}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "connected_services": Array [
-                                        "order",
-                                        "inventory",
-                                      ],
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "number_of_connected_services": 2,
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
-                                >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
-                                  >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                                        >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  49.54
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_error_rate_0_2"
-                            mobileOptions={
-                              Object {
-                                "header": "Error rate",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Error rate
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="error_rate"
-                                  item={3.77}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "connected_services": Array [
-                                        "order",
-                                        "inventory",
-                                      ],
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "number_of_connected_services": 2,
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
-                                >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
-                                  >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                                        >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  <EuiText
-                                                    size="s"
-                                                  >
-                                                    <div
-                                                      className="euiText euiText--small"
-                                                    >
-                                                      3.77%
-                                                    </div>
-                                                  </EuiText>
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_throughput_0_3"
-                            mobileOptions={
-                              Object {
-                                "header": "Request rate",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Request rate
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <ServiceTrendsPlots
-                                  className=""
-                                  fieldType="throughput"
-                                  item={53}
-                                  key=".0"
-                                  row={
-                                    Object {
-                                      "average_latency": 49.54,
-                                      "connected_services": Array [
-                                        "order",
-                                        "inventory",
-                                      ],
-                                      "error_rate": 3.77,
-                                      "name": "database",
-                                      "number_of_connected_services": 2,
-                                      "throughput": 53,
-                                      "traces": 31,
-                                    }
-                                  }
-                                >
-                                  <EuiFlexGroup
-                                    gutterSize="s"
-                                    justifyContent="flexEnd"
-                                  >
-                                    <div
-                                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                    >
-                                      <EuiFlexItem
-                                        grow={false}
-                                      >
-                                        <div
-                                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                                        >
-                                          <EuiText
-                                            color="default"
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                          >
-                                            <div
-                                              className="euiText euiText--medium"
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                            >
-                                              <EuiTextColor
-                                                color="default"
-                                                component="div"
-                                              >
-                                                <div
-                                                  className="euiTextColor euiTextColor--default"
-                                                >
-                                                  <EuiI18nNumber
-                                                    value={53}
-                                                  >
-                                                    53
-                                                  </EuiI18nNumber>
-                                                </div>
-                                              </EuiTextColor>
-                                            </div>
-                                          </EuiText>
-                                        </div>
-                                      </EuiFlexItem>
-                                    </div>
-                                  </EuiFlexGroup>
-                                </ServiceTrendsPlots>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_number_of_connected_services_0_4"
-                            mobileOptions={
-                              Object {
-                                "header": "No. of connected services",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                            width="80px"
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": "80px",
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                No. of connected services
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                2
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_connected_services_0_5"
-                            mobileOptions={
-                              Object {
-                                "header": "Connected services",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Connected services
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiText
-                                  className=""
-                                  key=".0"
-                                  size="s"
-                                >
-                                  <div
-                                    className="euiText euiText--small"
-                                  >
-                                    order, inventory
-                                  </div>
-                                </EuiText>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_traces_0_6"
-                            mobileOptions={
-                              Object {
-                                "header": "Traces",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Traces
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiLink
-                                  onClick={[Function]}
-                                >
-                                  <button
-                                    className="euiLink euiLink--primary"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    <EuiI18nNumber
-                                      value={31}
-                                    >
-                                      31
-                                    </EuiI18nNumber>
-                                  </button>
-                                </EuiLink>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="center"
-                            key="_data_column_actions_0_7"
-                            mobileOptions={
-                              Object {
-                                "header": "Actions",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Actions
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignCenter euiTableCellContent--overflowingContent"
-                              >
-                                <EuiFlexGroup
-                                  className=""
-                                  justifyContent="center"
-                                  key=".0"
-                                >
-                                  <div
-                                    className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                  >
-                                    <EuiFlexItem
-                                      grow={false}
-                                      onClick={[Function]}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrowZero"
+                                      <EuiButtonIcon
+                                        aria-label="Previous page"
+                                        color="text"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        iconType="arrowLeft"
                                         onClick={[Function]}
                                       >
-                                        <EuiLink
-                                          data-test-subj="service-flyout-action-btnundefined"
+                                        <button
+                                          aria-label="Previous page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-previous"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <button
-                                            className="euiLink euiLink--primary"
-                                            data-test-subj="service-flyout-action-btnundefined"
-                                            disabled={false}
-                                            type="button"
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowLeft"
                                           >
-                                            <EuiIcon
-                                              color="primary"
-                                              type="inspect"
-                                            >
-                                              <EuiIconBeaker
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconBeaker>
-                                            </EuiIcon>
-                                          </button>
-                                        </EuiLink>
-                                      </div>
-                                    </EuiFlexItem>
-                                  </div>
-                                </EuiFlexGroup>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                        </tr>
-                      </EuiTableRow>
-                    </tbody>
-                  </EuiTableBody>
-                </table>
-              </EuiTable>
-            </div>
-            <PaginationBar
-              aria-controls="random_html_id"
-              onPageChange={[Function]}
-              onPageSizeChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-            >
-              <div>
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiTablePagination
-                  activePage={0}
-                  aria-controls="random_html_id"
-                  itemsPerPage={10}
-                  itemsPerPageOptions={
-                    Array [
-                      5,
-                      10,
-                      15,
-                    ]
-                  }
-                  onChangeItemsPerPage={[Function]}
-                  onChangePage={[Function]}
-                  pageCount={1}
-                >
-                  <EuiFlexGroup
-                    alignItems="center"
-                    justifyContent="spaceBetween"
-                    responsive={false}
-                  >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-                    >
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPopover
-                            anchorPosition="upRight"
-                            button={
-                              <EuiButtonEmpty
-                                color="text"
-                                data-test-subj="tablePaginationPopoverButton"
-                                iconSide="right"
-                                iconType="arrowDown"
-                                onClick={[Function]}
-                                size="xs"
-                              >
-                                <EuiI18n
-                                  default="Rows per page"
-                                  token="euiTablePagination.rowsPerPage"
-                                />
-                                : 
-                                10
-                              </EuiButtonEmpty>
-                            }
-                            closePopover={[Function]}
-                            display="inlineBlock"
-                            hasArrow={true}
-                            isOpen={false}
-                            ownFocus={true}
-                            panelPaddingSize="none"
-                          >
-                            <div
-                              className="euiPopover euiPopover--anchorUpRight"
-                            >
-                              <div
-                                className="euiPopover__anchor"
-                              >
-                                <EuiButtonEmpty
-                                  color="text"
-                                  data-test-subj="tablePaginationPopoverButton"
-                                  iconSide="right"
-                                  iconType="arrowDown"
-                                  onClick={[Function]}
-                                  size="xs"
-                                >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
-                                    data-test-subj="tablePaginationPopoverButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="right"
-                                      iconSize="s"
-                                      iconType="arrowDown"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                      >
-                                        <EuiIcon
-                                          className="euiButtonContent__icon"
-                                          color="inherit"
-                                          size="s"
-                                          type="arrowDown"
-                                        >
-                                          <EuiIconBeaker
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
-                                          >
-                                            <svg
+                                            <EuiIconBeaker
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                               focusable="false"
-                                              height={16}
                                               role="img"
                                               style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <path
-                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                              />
-                                            </svg>
-                                          </EuiIconBeaker>
-                                        </EuiIcon>
-                                        <span
-                                          className="euiButtonEmpty__text"
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
+                                  </EuiI18n>
+                                  <ul
+                                    className="euiPagination__list"
+                                  >
+                                    <PaginationButton
+                                      key="0"
+                                      pageIndex={0}
+                                    >
+                                      <li
+                                        className="euiPagination__item"
+                                      >
+                                        <EuiPaginationButton
+                                          aria-controls="random_html_id"
+                                          hideOnMobile={true}
+                                          isActive={true}
+                                          onClick={[Function]}
+                                          pageIndex={0}
+                                          totalPages={1}
                                         >
                                           <EuiI18n
-                                            default="Rows per page"
-                                            token="euiTablePagination.rowsPerPage"
-                                          >
-                                            Rows per page
-                                          </EuiI18n>
-                                          : 
-                                          10
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </div>
-                            </div>
-                          </EuiPopover>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPagination
-                            activePage={0}
-                            aria-controls="random_html_id"
-                            onPageClick={[Function]}
-                            pageCount={1}
-                          >
-                            <nav
-                              className="euiPagination"
-                            >
-                              <EuiI18n
-                                default="Previous page, {page}"
-                                token="euiPagination.previousPage"
-                                values={
-                                  Object {
-                                    "page": 0,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Previous page"
-                                  token="euiPagination.disabledPreviousPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Previous page"
-                                    color="text"
-                                    data-test-subj="pagination-button-previous"
-                                    disabled={true}
-                                    iconType="arrowLeft"
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      aria-label="Previous page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowLeft"
-                                      >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
-                                </EuiI18n>
-                              </EuiI18n>
-                              <ul
-                                className="euiPagination__list"
-                              >
-                                <PaginationButton
-                                  key="0"
-                                  pageIndex={0}
-                                >
-                                  <li
-                                    className="euiPagination__item"
-                                  >
-                                    <EuiPaginationButton
-                                      aria-controls="random_html_id"
-                                      hideOnMobile={true}
-                                      isActive={true}
-                                      onClick={[Function]}
-                                      pageIndex={0}
-                                      totalPages={1}
-                                    >
-                                      <EuiI18n
-                                        default="Page {page} of {totalPages}"
-                                        token="euiPaginationButton.longPageString"
-                                        values={
-                                          Object {
-                                            "page": 1,
-                                            "totalPages": 1,
-                                          }
-                                        }
-                                      >
-                                        <EuiI18n
-                                          default="Page {page}"
-                                          token="euiPaginationButton.shortPageString"
-                                          values={
-                                            Object {
-                                              "page": 1,
+                                            default="Page {page} of {totalPages}"
+                                            token="euiPaginationButton.longPageString"
+                                            values={
+                                              Object {
+                                                "page": 1,
+                                                "totalPages": 1,
+                                              }
                                             }
-                                          }
-                                        >
-                                          <EuiButtonEmpty
-                                            aria-controls="random_html_id"
-                                            aria-current={true}
-                                            aria-label="Page 1 of 1"
-                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                            color="text"
-                                            data-test-subj="pagination-button-0"
-                                            href="#random_html_id"
-                                            isDisabled={true}
-                                            onClick={[Function]}
-                                            size="s"
                                           >
-                                            <button
-                                              aria-controls="random_html_id"
-                                              aria-current={true}
-                                              aria-label="Page 1 of 1"
-                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                              data-test-subj="pagination-button-0"
-                                              disabled={true}
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <EuiButtonContent
-                                                className="euiButtonEmpty__content"
-                                                iconSide="left"
-                                                iconSize="m"
-                                                textProps={
-                                                  Object {
-                                                    "className": "euiButtonEmpty__text",
-                                                  }
+                                            <EuiI18n
+                                              default="Page {page}"
+                                              token="euiPaginationButton.shortPageString"
+                                              values={
+                                                Object {
+                                                  "page": 1,
                                                 }
+                                              }
+                                            >
+                                              <EuiButtonEmpty
+                                                aria-controls="random_html_id"
+                                                aria-current={true}
+                                                aria-label="Page 1 of 1"
+                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                color="text"
+                                                data-test-subj="pagination-button-0"
+                                                href="#random_html_id"
+                                                isDisabled={true}
+                                                onClick={[Function]}
+                                                size="s"
                                               >
-                                                <span
-                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                <button
+                                                  aria-controls="random_html_id"
+                                                  aria-current={true}
+                                                  aria-label="Page 1 of 1"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                  data-test-subj="pagination-button-0"
+                                                  disabled={true}
+                                                  onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <span
-                                                    className="euiButtonEmpty__text"
+                                                  <EuiButtonContent
+                                                    className="euiButtonEmpty__content"
+                                                    iconSide="left"
+                                                    iconSize="m"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiButtonEmpty__text",
+                                                      }
+                                                    }
                                                   >
-                                                    1
-                                                  </span>
-                                                </span>
-                                              </EuiButtonContent>
-                                            </button>
-                                          </EuiButtonEmpty>
-                                        </EuiI18n>
-                                      </EuiI18n>
-                                    </EuiPaginationButton>
-                                  </li>
-                                </PaginationButton>
-                              </ul>
-                              <EuiI18n
-                                default="Next page, {page}"
-                                token="euiPagination.nextPage"
-                                values={
-                                  Object {
-                                    "page": 2,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Next page"
-                                  token="euiPagination.disabledNextPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Next page"
-                                    color="text"
-                                    data-test-subj="pagination-button-next"
-                                    disabled={true}
-                                    iconType="arrowRight"
-                                    onClick={[Function]}
+                                                    <span
+                                                      className="euiButtonContent euiButtonEmpty__content"
+                                                    >
+                                                      <span
+                                                        className="euiButtonEmpty__text"
+                                                      >
+                                                        1
+                                                      </span>
+                                                    </span>
+                                                  </EuiButtonContent>
+                                                </button>
+                                              </EuiButtonEmpty>
+                                            </EuiI18n>
+                                          </EuiI18n>
+                                        </EuiPaginationButton>
+                                      </li>
+                                    </PaginationButton>
+                                  </ul>
+                                  <EuiI18n
+                                    default="Next page, {page}"
+                                    token="euiPagination.nextPage"
+                                    values={
+                                      Object {
+                                        "page": 2,
+                                      }
+                                    }
                                   >
-                                    <button
-                                      aria-label="Next page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-next"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
+                                    <EuiI18n
+                                      default="Next page"
+                                      token="euiPagination.disabledNextPage"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowRight"
+                                      <EuiButtonIcon
+                                        aria-label="Next page"
+                                        color="text"
+                                        data-test-subj="pagination-button-next"
+                                        disabled={true}
+                                        iconType="arrowRight"
+                                        onClick={[Function]}
                                       >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
+                                        <button
+                                          aria-label="Next page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-next"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowRight"
                                           >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
-                                </EuiI18n>
-                              </EuiI18n>
-                            </nav>
-                          </EuiPagination>
+                                            <EuiIconBeaker
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
+                                  </EuiI18n>
+                                </nav>
+                              </EuiPagination>
+                            </div>
+                          </EuiFlexItem>
                         </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </EuiTablePagination>
+                      </EuiFlexGroup>
+                    </EuiTablePagination>
+                  </div>
+                </PaginationBar>
               </div>
-            </PaginationBar>
-          </div>
-        </EuiBasicTable>
-      </EuiInMemoryTable>
+            </EuiBasicTable>
+          </EuiInMemoryTable>
+        </div>
+      </EuiPanel>
     </div>
-  </EuiPanel>
+  </EuiPage>
 </ServicesTable>
 `;

--- a/public/components/trace_analytics/components/services/services.tsx
+++ b/public/components/trace_analytics/components/services/services.tsx
@@ -8,7 +8,6 @@ import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import React from 'react';
 import { DataSourceOption } from '../../../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
 import { TraceAnalyticsComponentDeps } from '../../home';
-import { DataSourcePicker } from '../dashboard/mode_picker';
 import { ServicesContent } from './services_content';
 
 export interface ServicesProps extends TraceAnalyticsComponentDeps {
@@ -23,7 +22,6 @@ export interface ServicesProps extends TraceAnalyticsComponentDeps {
 export function Services(props: ServicesProps) {
   return (
     <>
-      <DataSourcePicker modes={props.modes} selectedMode={props.mode} setMode={props.setMode!} />
       <ServicesContent {...props} />
     </>
   );

--- a/public/components/trace_analytics/components/services/services_content.tsx
+++ b/public/components/trace_analytics/components/services/services_content.tsx
@@ -179,7 +179,7 @@ export function ServicesContent(props: ServicesProps) {
         gutterSize="s"
         alignItems="center"
         justifyContent="spaceBetween"
-        style={{ padding: '0 16px' }}
+        style={{ padding: '0 24px' }}
       >
         <EuiFlexItem grow={false}>
           <DataSourcePicker

--- a/public/components/trace_analytics/components/services/services_content.tsx
+++ b/public/components/trace_analytics/components/services/services_content.tsx
@@ -177,12 +177,7 @@ export function ServicesContent(props: ServicesProps) {
     <>
       <EuiPage paddingSize="m">
         <EuiPageBody>
-          <EuiFlexGroup
-            gutterSize="s"
-            alignItems="center"
-            justifyContent="spaceBetween"
-            // style={{ padding: '0 24px' }}
-          >
+          <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="spaceBetween">
             <EuiFlexItem grow={false}>
               <DataSourcePicker
                 modes={props.modes}

--- a/public/components/trace_analytics/components/services/services_content.tsx
+++ b/public/components/trace_analytics/components/services/services_content.tsx
@@ -4,7 +4,7 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPage, EuiPageBody, EuiSpacer } from '@elastic/eui';
 import cloneDeep from 'lodash/cloneDeep';
 import React, { useEffect, useRef, useState } from 'react';
 import { ServiceTrends } from '../../../../../common/types/trace_analytics';
@@ -175,77 +175,81 @@ export function ServicesContent(props: ServicesProps) {
 
   return (
     <>
-      <EuiFlexGroup
-        gutterSize="s"
-        alignItems="center"
-        justifyContent="spaceBetween"
-        style={{ padding: '0 24px' }}
-      >
-        <EuiFlexItem grow={false}>
-          <DataSourcePicker
-            modes={props.modes}
-            selectedMode={props.mode}
-            setMode={props.setMode!}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={true}>
-          <SearchBar
-            ref={searchBarRef}
+      <EuiPage paddingSize="m">
+        <EuiPageBody>
+          <EuiFlexGroup
+            gutterSize="s"
+            alignItems="center"
+            justifyContent="spaceBetween"
+            // style={{ padding: '0 24px' }}
+          >
+            <EuiFlexItem grow={false}>
+              <DataSourcePicker
+                modes={props.modes}
+                selectedMode={props.mode}
+                setMode={props.setMode!}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={true}>
+              <SearchBar
+                ref={searchBarRef}
+                filters={filters}
+                setFilters={setFilters}
+                query={query}
+                setQuery={setQuery}
+                startTime={startTime}
+                setStartTime={setStartTime}
+                endTime={endTime}
+                setEndTime={setEndTime}
+                refresh={refresh}
+                page={page}
+                mode={mode}
+                attributesFilterFields={attributesFilterFields}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <Filters
+            page={page}
             filters={filters}
             setFilters={setFilters}
-            query={query}
-            setQuery={setQuery}
-            startTime={startTime}
-            setStartTime={setStartTime}
-            endTime={endTime}
-            setEndTime={setEndTime}
-            refresh={refresh}
-            page={page}
+            appConfigs={appConfigs}
             mode={mode}
             attributesFilterFields={attributesFilterFields}
           />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <Filters
-        page={page}
-        filters={filters}
-        setFilters={setFilters}
-        appConfigs={appConfigs}
-        mode={mode}
-        attributesFilterFields={attributesFilterFields}
-      />
-      <EuiSpacer size="s" />
-      <ServicesTable
-        items={tableItems}
-        selectedItems={selectedItems}
-        setSelectedItems={setSelectedItems}
-        addServicesGroupFilter={addServicesGroupFilter}
-        addFilter={addFilter}
-        setRedirect={setRedirect}
-        mode={mode}
-        loading={loading}
-        traceColumnAction={traceColumnAction}
-        setCurrentSelectedService={setCurrentSelectedService}
-        jaegerIndicesExist={jaegerIndicesExist}
-        dataPrepperIndicesExist={dataPrepperIndicesExist}
-        isServiceTrendEnabled={isServiceTrendEnabled}
-        setIsServiceTrendEnabled={setIsServiceTrendEnabled}
-        serviceTrends={serviceTrends}
-      />
-      <EuiSpacer size="s" />
-      {mode === 'data_prepper' && dataPrepperIndicesExist ? (
-        <ServiceMap
-          addFilter={addFilter}
-          serviceMap={serviceMap}
-          idSelected={serviceMapIdSelected}
-          setIdSelected={setServiceMapIdSelected}
-          currService={filteredService}
-          page={page}
-          setCurrentSelectedService={setCurrentSelectedService}
-        />
-      ) : (
-        <div />
-      )}
+          <EuiSpacer size="s" />
+          <ServicesTable
+            items={tableItems}
+            selectedItems={selectedItems}
+            setSelectedItems={setSelectedItems}
+            addServicesGroupFilter={addServicesGroupFilter}
+            addFilter={addFilter}
+            setRedirect={setRedirect}
+            mode={mode}
+            loading={loading}
+            traceColumnAction={traceColumnAction}
+            setCurrentSelectedService={setCurrentSelectedService}
+            jaegerIndicesExist={jaegerIndicesExist}
+            dataPrepperIndicesExist={dataPrepperIndicesExist}
+            isServiceTrendEnabled={isServiceTrendEnabled}
+            setIsServiceTrendEnabled={setIsServiceTrendEnabled}
+            serviceTrends={serviceTrends}
+          />
+          <EuiSpacer size="s" />
+          {mode === 'data_prepper' && dataPrepperIndicesExist ? (
+            <ServiceMap
+              addFilter={addFilter}
+              serviceMap={serviceMap}
+              idSelected={serviceMapIdSelected}
+              setIdSelected={setServiceMapIdSelected}
+              currService={filteredService}
+              page={page}
+              setCurrentSelectedService={setCurrentSelectedService}
+            />
+          ) : (
+            <div />
+          )}
+        </EuiPageBody>
+      </EuiPage>
     </>
   );
 }

--- a/public/components/trace_analytics/components/services/services_content.tsx
+++ b/public/components/trace_analytics/components/services/services_content.tsx
@@ -4,7 +4,7 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import cloneDeep from 'lodash/cloneDeep';
 import React, { useEffect, useRef, useState } from 'react';
 import { ServiceTrends } from '../../../../../common/types/trace_analytics';
@@ -14,13 +14,14 @@ import {
   handleServiceTrendsRequest,
 } from '../../requests/services_request_handler';
 import { getValidFilterFields } from '../common/filters/filter_helpers';
-import { FilterType } from '../common/filters/filters';
+import { FilterType, Filters } from '../common/filters/filters';
 import { filtersToDsl, processTimeStamp } from '../common/helper_functions';
 import { ServiceMap, ServiceObject } from '../common/plots/service_map';
 import { SearchBar } from '../common/search_bar';
 import { ServicesProps } from './services';
 import { ServicesTable } from './services_table';
 import { coreRefs } from '../../../../framework/core_refs';
+import { DataSourcePicker } from '../dashboard/mode_picker';
 
 export function ServicesContent(props: ServicesProps) {
   const {
@@ -174,23 +175,46 @@ export function ServicesContent(props: ServicesProps) {
 
   return (
     <>
-      <SearchBar
-        ref={searchBarRef}
-        query={query}
-        filters={filters}
-        appConfigs={appConfigs}
-        setFilters={setFilters}
-        setQuery={setQuery}
-        startTime={startTime}
-        setStartTime={setStartTime}
-        endTime={endTime}
-        setEndTime={setEndTime}
-        refresh={refresh}
+      <EuiFlexGroup
+        gutterSize="s"
+        alignItems="center"
+        justifyContent="spaceBetween"
+        style={{ padding: '0 16px' }}
+      >
+        <EuiFlexItem grow={false}>
+          <DataSourcePicker
+            modes={props.modes}
+            selectedMode={props.mode}
+            setMode={props.setMode!}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={true}>
+          <SearchBar
+            ref={searchBarRef}
+            filters={filters}
+            setFilters={setFilters}
+            query={query}
+            setQuery={setQuery}
+            startTime={startTime}
+            setStartTime={setStartTime}
+            endTime={endTime}
+            setEndTime={setEndTime}
+            refresh={refresh}
+            page={page}
+            mode={mode}
+            attributesFilterFields={attributesFilterFields}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <Filters
         page={page}
+        filters={filters}
+        setFilters={setFilters}
+        appConfigs={appConfigs}
         mode={mode}
         attributesFilterFields={attributesFilterFields}
       />
-      <EuiSpacer size="m" />
+      <EuiSpacer size="s" />
       <ServicesTable
         items={tableItems}
         selectedItems={selectedItems}
@@ -208,7 +232,7 @@ export function ServicesContent(props: ServicesProps) {
         setIsServiceTrendEnabled={setIsServiceTrendEnabled}
         serviceTrends={serviceTrends}
       />
-      <EuiSpacer size="m" />
+      <EuiSpacer size="s" />
       {mode === 'data_prepper' && dataPrepperIndicesExist ? (
         <ServiceMap
           addFilter={addFilter}

--- a/public/components/trace_analytics/components/services/services_table.tsx
+++ b/public/components/trace_analytics/components/services/services_table.tsx
@@ -13,7 +13,6 @@ import {
   EuiIcon,
   EuiInMemoryTable,
   EuiLink,
-  EuiPage,
   EuiPanel,
   EuiSpacer,
   EuiTableFieldDataColumnType,
@@ -265,41 +264,39 @@ export function ServicesTable(props: ServicesTableProps) {
 
   return (
     <>
-      <EuiPage paddingSize="m">
-        <EuiPanel>
-          {titleBar}
-          <EuiSpacer size="m" />
-          <EuiHorizontalRule margin="none" />
-          {!(
-            (mode === 'data_prepper' && dataPrepperIndicesExist) ||
-            (mode === 'jaeger' && jaegerIndicesExist)
-          ) ? (
-            <MissingConfigurationMessage mode={mode} />
-          ) : items?.length > 0 ? (
-            <EuiInMemoryTable
-              tableLayout="auto"
-              items={items}
-              columns={columns}
-              pagination={{
-                initialPageSize: 10,
-                pageSizeOptions: [5, 10, 15],
-              }}
-              sorting={{
-                sort: {
-                  field: 'name',
-                  direction: 'asc',
-                },
-              }}
-              loading={loading}
-              selection={selectionValue}
-              isSelectable={true}
-              itemId="itemId"
-            />
-          ) : (
-            <NoMatchMessage size="xl" />
-          )}
-        </EuiPanel>
-      </EuiPage>
+      <EuiPanel>
+        {titleBar}
+        <EuiSpacer size="m" />
+        <EuiHorizontalRule margin="none" />
+        {!(
+          (mode === 'data_prepper' && dataPrepperIndicesExist) ||
+          (mode === 'jaeger' && jaegerIndicesExist)
+        ) ? (
+          <MissingConfigurationMessage mode={mode} />
+        ) : items?.length > 0 ? (
+          <EuiInMemoryTable
+            tableLayout="auto"
+            items={items}
+            columns={columns}
+            pagination={{
+              initialPageSize: 10,
+              pageSizeOptions: [5, 10, 15],
+            }}
+            sorting={{
+              sort: {
+                field: 'name',
+                direction: 'asc',
+              },
+            }}
+            loading={loading}
+            selection={selectionValue}
+            isSelectable={true}
+            itemId="itemId"
+          />
+        ) : (
+          <NoMatchMessage size="xl" />
+        )}
+      </EuiPanel>
     </>
   );
 }

--- a/public/components/trace_analytics/components/services/services_table.tsx
+++ b/public/components/trace_analytics/components/services/services_table.tsx
@@ -13,6 +13,7 @@ import {
   EuiIcon,
   EuiInMemoryTable,
   EuiLink,
+  EuiPage,
   EuiPanel,
   EuiSpacer,
   EuiTableFieldDataColumnType,
@@ -264,39 +265,41 @@ export function ServicesTable(props: ServicesTableProps) {
 
   return (
     <>
-      <EuiPanel>
-        {titleBar}
-        <EuiSpacer size="m" />
-        <EuiHorizontalRule margin="none" />
-        {!(
-          (mode === 'data_prepper' && dataPrepperIndicesExist) ||
-          (mode === 'jaeger' && jaegerIndicesExist)
-        ) ? (
-          <MissingConfigurationMessage mode={mode} />
-        ) : items?.length > 0 ? (
-          <EuiInMemoryTable
-            tableLayout="auto"
-            items={items}
-            columns={columns}
-            pagination={{
-              initialPageSize: 10,
-              pageSizeOptions: [5, 10, 15],
-            }}
-            sorting={{
-              sort: {
-                field: 'name',
-                direction: 'asc',
-              },
-            }}
-            loading={loading}
-            selection={selectionValue}
-            isSelectable={true}
-            itemId="itemId"
-          />
-        ) : (
-          <NoMatchMessage size="xl" />
-        )}
-      </EuiPanel>
+      <EuiPage paddingSize="m">
+        <EuiPanel>
+          {titleBar}
+          <EuiSpacer size="m" />
+          <EuiHorizontalRule margin="none" />
+          {!(
+            (mode === 'data_prepper' && dataPrepperIndicesExist) ||
+            (mode === 'jaeger' && jaegerIndicesExist)
+          ) ? (
+            <MissingConfigurationMessage mode={mode} />
+          ) : items?.length > 0 ? (
+            <EuiInMemoryTable
+              tableLayout="auto"
+              items={items}
+              columns={columns}
+              pagination={{
+                initialPageSize: 10,
+                pageSizeOptions: [5, 10, 15],
+              }}
+              sorting={{
+                sort: {
+                  field: 'name',
+                  direction: 'asc',
+                },
+              }}
+              loading={loading}
+              selection={selectionValue}
+              isSelectable={true}
+              itemId="itemId"
+            />
+          ) : (
+            <NoMatchMessage size="xl" />
+          )}
+        </EuiPanel>
+      </EuiPage>
     </>
   );
 }

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_flyout.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_flyout.test.tsx.snap
@@ -775,6 +775,7 @@ exports[`<SpanDetailFlyout /> spec renders the empty component 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="left"
                                           iconSize="s"
                                           textProps={

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_panel.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_panel.test.tsx.snap
@@ -185,6 +185,7 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             textProps={
                               Object {
@@ -265,6 +266,7 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             textProps={
                               Object {

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -1418,6 +1418,7 @@ exports[`Traces component renders empty traces page 1`] = `
                           anchorPosition="downLeft"
                           button={
                             <EuiButtonEmpty
+                              flush="left"
                               onClick={[Function]}
                               size="xs"
                             >
@@ -1440,11 +1441,12 @@ exports[`Traces component renders empty traces page 1`] = `
                               className="euiPopover__anchor"
                             >
                               <EuiButtonEmpty
+                                flush="left"
                                 onClick={[Function]}
                                 size="xs"
                               >
                                 <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                                   disabled={false}
                                   onClick={[Function]}
                                   type="button"
@@ -3170,6 +3172,7 @@ exports[`Traces component renders jaeger traces page 1`] = `
                           anchorPosition="downLeft"
                           button={
                             <EuiButtonEmpty
+                              flush="left"
                               onClick={[Function]}
                               size="xs"
                             >
@@ -3192,11 +3195,12 @@ exports[`Traces component renders jaeger traces page 1`] = `
                               className="euiPopover__anchor"
                             >
                               <EuiButtonEmpty
+                                flush="left"
                                 onClick={[Function]}
                                 size="xs"
                               >
                                 <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                                   disabled={false}
                                   onClick={[Function]}
                                   type="button"
@@ -4922,6 +4926,7 @@ exports[`Traces component renders traces page 1`] = `
                           anchorPosition="downLeft"
                           button={
                             <EuiButtonEmpty
+                              flush="left"
                               onClick={[Function]}
                               size="xs"
                             >
@@ -4944,11 +4949,12 @@ exports[`Traces component renders traces page 1`] = `
                               className="euiPopover__anchor"
                             >
                               <EuiButtonEmpty
+                                flush="left"
                                 onClick={[Function]}
                                 size="xs"
                               >
                                 <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                                   disabled={false}
                                   onClick={[Function]}
                                   type="button"

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -475,181 +475,914 @@ exports[`Traces component renders empty traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="s"
-      justifyContent="spaceBetween"
-      style={
-        Object {
-          "padding": "0 24px",
-        }
-      }
+    <EuiPage
+      paddingSize="m"
     >
       <div
-        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-        style={
-          Object {
-            "padding": "0 24px",
-          }
-        }
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <EuiFlexItem
-          grow={false}
-        >
+        <EuiPageBody>
           <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
+            className="euiPageBody euiPageBody--borderRadiusNone"
           >
-            <DataSourcePicker
-              modes={
-                Array [
-                  Object {
-                    "id": "jaeger",
-                    "title": "Jaeger",
-                  },
-                  Object {
-                    "id": "data_prepper",
-                    "title": "Data Prepper",
-                  },
-                ]
-              }
-              selectedMode="data_prepper"
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiPopover
-                anchorClassName="eui-textTruncate"
-                anchorPosition="downCenter"
-                button={
-                  <EuiSmallButtonEmpty
-                    className="dscIndexPattern__triggerButton"
-                    color="text"
-                    data-test-subj="indexPattern-switch-link"
-                    flush="left"
-                    iconSide="right"
-                    iconType="arrowDown"
-                    onClick={[Function]}
-                    title="data_prepper"
-                  >
-                    Data Prepper
-                  </EuiSmallButtonEmpty>
-                }
-                className="eui-textTruncate"
-                closePopover={[Function]}
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="s"
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <div
-                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiPopover__anchor eui-textTruncate"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <EuiSmallButtonEmpty
-                      className="dscIndexPattern__triggerButton"
-                      color="text"
-                      data-test-subj="indexPattern-switch-link"
-                      flush="left"
-                      iconSide="right"
-                      iconType="arrowDown"
-                      onClick={[Function]}
-                      title="data_prepper"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="data_prepper"
                     >
-                      <EuiButtonEmpty
-                        className="dscIndexPattern__triggerButton"
-                        color="text"
-                        data-test-subj="indexPattern-switch-link"
-                        flush="left"
-                        iconSide="right"
-                        iconType="arrowDown"
-                        onClick={[Function]}
-                        size="s"
-                        title="data_prepper"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                          data-test-subj="indexPattern-switch-link"
-                          disabled={false}
-                          onClick={[Function]}
-                          title="data_prepper"
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
                             iconSide="right"
-                            iconSize="m"
                             iconType="arrowDown"
-                            textProps={
+                            onClick={[Function]}
+                            title="data_prepper"
+                          >
+                            Data Prepper
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
+                      >
+                        <div
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                        >
+                          <div
+                            className="euiPopover__anchor eui-textTruncate"
+                          >
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="data_prepper"
+                            >
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="data_prepper"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="data_prepper"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="right"
+                                    iconSize="m"
+                                    iconType="arrowDown"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Data Prepper
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      appConfigs={Array []}
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="data_prepper"
+                      page="traces"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
+                                }
+                                value=""
+                              >
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                                  >
+                                    <GlobalFilterButton
+                                      className="euiFormControlLayout__prepend"
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    >
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor"
+                                          >
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
+                                            >
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
+                                              >
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
+                                                >
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconBeaker
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <span
+                                              className="euiFormControlLayoutCustomIcon"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
+                                              >
+                                                <EuiIconBeaker
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconBeaker>
+                                              </EuiIcon>
+                                            </span>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
                               Object {
-                                "className": "euiButtonEmpty__text",
+                                "maxWidth": "30vw",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
+                                Object {
+                                  "maxWidth": "30vw",
+                                }
+                              }
                             >
-                              <EuiIcon
-                                className="euiButtonContent__icon"
-                                color="inherit"
-                                size="m"
-                                type="arrowDown"
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
                                   >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                              <span
-                                className="euiButtonEmpty__text"
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
+                                      >
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconBeaker
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconBeaker>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconBeaker
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconBeaker>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
                               >
-                                Data Prepper
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </EuiSmallButtonEmpty>
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconBeaker
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                    </EuiIconBeaker>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
                   </div>
-                </div>
-              </EuiPopover>
-            </DataSourcePicker>
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem
-          grow={true}
-        >
-          <div
-            className="euiFlexItem"
-          >
-            <ForwardRef
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
               appConfigs={Array []}
               attributesFilterFields={Array []}
-              endTime="now"
               filters={Array []}
               mode="data_prepper"
               page="traces"
-              query=""
-              refresh={[Function]}
-              setEndTime={[MockFunction]}
               setFilters={
                 [MockFunction] {
                   "calls": Array [
@@ -665,693 +1398,145 @@ exports[`Traces component renders empty traces page 1`] = `
                   ],
                 }
               }
-              setQuery={[MockFunction]}
-              setStartTime={[MockFunction]}
-              startTime="now-5m"
             >
               <EuiFlexGroup
                 alignItems="center"
-                gutterSize="s"
+                gutterSize="xs"
+                responsive={false}
               >
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
                 >
-                  <EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
                     <div
-                      className="euiFlexItem"
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiCompressedFieldSearch
-                        compressed={true}
-                        data-test-subj="search-bar-input-box"
-                        fullWidth={true}
-                        incremental={false}
-                        isClearable={false}
-                        isLoading={false}
-                        onChange={[Function]}
-                        onSearch={[Function]}
-                        placeholder="Trace ID, trace group name, service name"
-                        prepend={
-                          <GlobalFilterButton
-                            filters={Array []}
-                            setFilters={
-                              [MockFunction] {
-                                "calls": Array [
-                                  Array [
-                                    Array [],
-                                  ],
-                                ],
-                                "results": Array [
-                                  Object {
-                                    "type": "return",
-                                    "value": undefined,
-                                  },
-                                ],
-                              }
-                            }
-                          />
-                        }
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          compressed={true}
-                          fullWidth={true}
-                          icon="search"
-                          isLoading={false}
-                          prepend={
-                            <GlobalFilterButton
-                              filters={Array []}
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            />
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
                           }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
                           >
-                            <GlobalFilterButton
-                              className="euiFormControlLayout__prepend"
-                              filters={Array []}
-                              key="0/.0"
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <EuiSmallButtonIcon
-                                    aria-label="Change all filters"
-                                    iconType="filter"
-                                    onClick={[Function]}
-                                    title="Change all filters"
-                                  />
-                                }
-                                closePopover={[Function]}
-                                data-test-subj="global-filter-button"
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="none"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp"
-                                  data-test-subj="global-filter-button"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
-                                    <EuiSmallButtonIcon
-                                      aria-label="Change all filters"
-                                      iconType="filter"
-                                      onClick={[Function]}
-                                      title="Change all filters"
-                                    >
-                                      <EuiButtonIcon
-                                        aria-label="Change all filters"
-                                        iconType="filter"
-                                        onClick={[Function]}
-                                        size="s"
-                                        title="Change all filters"
-                                      >
-                                        <button
-                                          aria-label="Change all filters"
-                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          title="Change all filters"
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="filter"
-                                          >
-                                            <EuiIconBeaker
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                />
-                                              </svg>
-                                            </EuiIconBeaker>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiSmallButtonIcon>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </GlobalFilterButton>
                             <div
-                              className="euiFormControlLayout__childrenWrapper"
+                              className="euiPopover__anchor"
                             >
-                              <EuiValidatableControl>
-                                <input
-                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
-                                  data-test-subj="search-bar-input-box"
-                                  onChange={[Function]}
-                                  onKeyUp={[Function]}
-                                  placeholder="Trace ID, trace group name, service name"
-                                  type="search"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons
-                                compressed={true}
-                                icon="search"
-                                isLoading={false}
+                              <EuiButtonEmpty
+                                onClick={[Function]}
+                                size="xs"
                               >
-                                <div
-                                  className="euiFormControlLayoutIcons"
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <EuiFormControlLayoutCustomIcon
-                                    size="s"
-                                    type="search"
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiFormControlLayoutCustomIcon"
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiFormControlLayoutCustomIcon__icon"
-                                        size="s"
-                                        type="search"
+                                      <span
+                                        className="euiButtonEmpty__text"
                                       >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
+                                        + Add filter
+                                      </span>
                                     </span>
-                                  </EuiFormControlLayoutCustomIcon>
-                                </div>
-                              </EuiFormControlLayoutIcons>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
                             </div>
                           </div>
-                        </EuiFormControlLayout>
-                      </EuiCompressedFieldSearch>
+                        </EuiPopover>
+                      </AddFilterButton>
                     </div>
                   </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                    style={
-                      Object {
-                        "maxWidth": "30vw",
-                      }
-                    }
+                </div>
+              </EuiFlexGroup>
+            </Filters>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <EuiPanel>
+              <div
+                className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+              >
+                <EuiAccordion
+                  arrowDisplay="left"
+                  buttonContent="Trace Groups"
+                  data-test-subj="trace-groups-service-operation-accordian"
+                  forceState="closed"
+                  id="accordion1"
+                  initialIsOpen={false}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion"
+                    data-test-subj="trace-groups-service-operation-accordian"
+                    onToggle={[Function]}
                   >
                     <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                      style={
-                        Object {
-                          "maxWidth": "30vw",
-                        }
-                      }
+                      className="euiAccordion__triggerWrapper"
                     >
-                      <EuiSuperDatePicker
-                        commonlyUsedRanges={
-                          Array [
-                            Object {
-                              "end": "now/d",
-                              "label": "Today",
-                              "start": "now/d",
-                            },
-                            Object {
-                              "end": "now/w",
-                              "label": "This week",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now/M",
-                              "label": "This month",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now/y",
-                              "label": "This year",
-                              "start": "now/y",
-                            },
-                            Object {
-                              "end": "now-1d/d",
-                              "label": "Yesterday",
-                              "start": "now-1d/d",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Week to date",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Month to date",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Year to date",
-                              "start": "now/y",
-                            },
-                          ]
-                        }
-                        compressed={true}
-                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                        end="now"
-                        isAutoRefreshOnly={false}
-                        isDisabled={false}
-                        isPaused={true}
-                        onTimeChange={[Function]}
-                        recentlyUsedRanges={Array []}
-                        refreshInterval={0}
-                        showUpdateButton={false}
-                        start="now-5m"
-                        timeFormat="HH:mm"
-                      >
-                        <EuiFlexGroup
-                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          gutterSize="s"
-                          responsive={false}
-                        >
-                          <div
-                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          >
-                            <EuiFlexItem>
-                              <div
-                                className="euiFlexItem"
-                              >
-                                <EuiFormControlLayout
-                                  className="euiSuperDatePicker"
-                                  compressed={true}
-                                  isDisabled={false}
-                                  prepend={
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    />
-                                  }
-                                >
-                                  <div
-                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
-                                  >
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      className="euiFormControlLayout__prepend"
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      key="0/.0"
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    >
-                                      <EuiPopover
-                                        anchorClassName="euiQuickSelectPopover__anchor"
-                                        anchorPosition="downLeft"
-                                        button={
-                                          <EuiButtonEmpty
-                                            aria-label="Date quick select"
-                                            className="euiFormControlLayout__prepend"
-                                            data-test-subj="superDatePickerToggleQuickMenuButton"
-                                            iconSide="right"
-                                            iconType="arrowDown"
-                                            isDisabled={false}
-                                            onClick={[Function]}
-                                            size="xs"
-                                            textProps={
-                                              Object {
-                                                "className": "euiQuickSelectPopover__buttonText",
-                                              }
-                                            }
-                                          >
-                                            <EuiIcon
-                                              type="calendar"
-                                            />
-                                          </EuiButtonEmpty>
-                                        }
-                                        closePopover={[Function]}
-                                        display="inlineBlock"
-                                        hasArrow={true}
-                                        isOpen={false}
-                                        ownFocus={true}
-                                        panelPaddingSize="s"
-                                      >
-                                        <div
-                                          className="euiPopover euiPopover--anchorDownLeft"
-                                        >
-                                          <div
-                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                          >
-                                            <EuiButtonEmpty
-                                              aria-label="Date quick select"
-                                              className="euiFormControlLayout__prepend"
-                                              data-test-subj="superDatePickerToggleQuickMenuButton"
-                                              iconSide="right"
-                                              iconType="arrowDown"
-                                              isDisabled={false}
-                                              onClick={[Function]}
-                                              size="xs"
-                                              textProps={
-                                                Object {
-                                                  "className": "euiQuickSelectPopover__buttonText",
-                                                }
-                                              }
-                                            >
-                                              <button
-                                                aria-label="Date quick select"
-                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                                data-test-subj="superDatePickerToggleQuickMenuButton"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <EuiButtonContent
-                                                  className="euiButtonEmpty__content"
-                                                  iconSide="right"
-                                                  iconSize="s"
-                                                  iconType="arrowDown"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                                    }
-                                                  }
-                                                >
-                                                  <span
-                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                                  >
-                                                    <EuiIcon
-                                                      className="euiButtonContent__icon"
-                                                      color="inherit"
-                                                      size="s"
-                                                      type="arrowDown"
-                                                    >
-                                                      <EuiIconBeaker
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                        focusable="false"
-                                                        role="img"
-                                                        style={null}
-                                                      >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                          focusable="false"
-                                                          height={16}
-                                                          role="img"
-                                                          style={null}
-                                                          viewBox="0 0 16 16"
-                                                          width={16}
-                                                          xmlns="http://www.w3.org/2000/svg"
-                                                        >
-                                                          <path
-                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                          />
-                                                        </svg>
-                                                      </EuiIconBeaker>
-                                                    </EuiIcon>
-                                                    <span
-                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                                    >
-                                                      <EuiIcon
-                                                        type="calendar"
-                                                      >
-                                                        <EuiIconBeaker
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                          focusable="false"
-                                                          role="img"
-                                                          style={null}
-                                                        >
-                                                          <svg
-                                                            aria-hidden={true}
-                                                            className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                            focusable="false"
-                                                            height={16}
-                                                            role="img"
-                                                            style={null}
-                                                            viewBox="0 0 16 16"
-                                                            width={16}
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                          >
-                                                            <path
-                                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                            />
-                                                          </svg>
-                                                        </EuiIconBeaker>
-                                                      </EuiIcon>
-                                                    </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonEmpty>
-                                          </div>
-                                        </div>
-                                      </EuiPopover>
-                                    </EuiQuickSelectPopover>
-                                    <div
-                                      className="euiFormControlLayout__childrenWrapper"
-                                    >
-                                      <EuiDatePickerRange
-                                        className="euiDatePickerRange--inGroup"
-                                        endDateControl={<div />}
-                                        iconType={false}
-                                        isCustom={true}
-                                        startDateControl={<div />}
-                                      >
-                                        <div
-                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                        >
-                                          <button
-                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
-                                            data-test-subj="superDatePickerShowDatesButton"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                          >
-                                            Last 5 minutes
-                                            <span
-                                              className="euiSuperDatePicker__prettyFormatLink"
-                                            >
-                                              <EuiI18n
-                                                default="Show dates"
-                                                token="euiSuperDatePicker.showDatesButtonLabel"
-                                              >
-                                                Show dates
-                                              </EuiI18n>
-                                            </span>
-                                          </button>
-                                        </div>
-                                      </EuiDatePickerRange>
-                                      <EuiFormControlLayoutIcons
-                                        compressed={true}
-                                      />
-                                    </div>
-                                  </div>
-                                </EuiFormControlLayout>
-                              </div>
-                            </EuiFlexItem>
-                          </div>
-                        </EuiFlexGroup>
-                      </EuiSuperDatePicker>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiButtonIcon
-                        aria-label="Refresh"
-                        data-click-metric-element="trace_analytics.refresh_button"
-                        data-test-subj="superDatePickerApplyTimeButton"
-                        display="base"
-                        iconType="refresh"
+                      <button
+                        aria-controls="accordion1"
+                        aria-expanded={false}
+                        className="euiAccordion__button"
+                        id="random_html_id"
                         onClick={[Function]}
-                        size="s"
+                        type="button"
                       >
-                        <button
-                          aria-label="Refresh"
-                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
-                          data-click-metric-element="trace_analytics.refresh_button"
-                          data-test-subj="superDatePickerApplyTimeButton"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
+                        <span
+                          className="euiAccordion__iconWrapper"
                         >
                           <EuiIcon
-                            aria-hidden="true"
-                            className="euiButtonIcon__icon"
-                            color="inherit"
+                            className="euiAccordion__icon"
                             size="m"
-                            type="refresh"
+                            type="arrowRight"
                           >
                             <EuiIconBeaker
                               aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                              className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
                               focusable="false"
                               role="img"
                               style={null}
                             >
                               <svg
                                 aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
                                 focusable="false"
                                 height={16}
                                 role="img"
@@ -1366,401 +1551,199 @@ exports[`Traces component renders empty traces page 1`] = `
                               </svg>
                             </EuiIconBeaker>
                           </EuiIcon>
-                        </button>
-                      </EuiButtonIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          Trace Groups
+                        </span>
+                      </button>
                     </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </ForwardRef>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
-    <Filters
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      filters={Array []}
-      mode="data_prepper"
-      page="traces"
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-    >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="xs"
-        responsive={false}
-        style={
-          Object {
-            "minHeight": 32,
-            "padding": "0 16px",
-          }
-        }
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-          style={
-            Object {
-              "minHeight": 32,
-              "padding": "0 16px",
-            }
-          }
-        >
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <AddFilterButton>
-                <EuiPopover
-                  anchorPosition="downLeft"
-                  button={
-                    <EuiButtonEmpty
-                      onClick={[Function]}
-                      size="xs"
-                    >
-                      + Add filter
-                    </EuiButtonEmpty>
-                  }
-                  closePopover={[Function]}
-                  data-test-subj="addfilter"
-                  display="inlineBlock"
-                  hasArrow={true}
-                  isOpen={false}
-                  ownFocus={true}
-                  panelPaddingSize="m"
-                >
-                  <div
-                    className="euiPopover euiPopover--anchorDownLeft"
-                    data-test-subj="addfilter"
-                  >
                     <div
-                      className="euiPopover__anchor"
+                      aria-labelledby="random_html_id"
+                      className="euiAccordion__childWrapper"
+                      id="accordion1"
+                      role="region"
+                      tabIndex={-1}
                     >
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
+                      <EuiResizeObserver
+                        onResize={[Function]}
                       >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
-                            iconSide="left"
-                            iconSize="s"
-                            textProps={
-                              Object {
-                                "className": "euiButtonEmpty__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButtonEmpty__content"
-                            >
-                              <span
-                                className="euiButtonEmpty__text"
-                              >
-                                + Add filter
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </div>
-                  </div>
-                </EuiPopover>
-              </AddFilterButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-    </Filters>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <EuiPage
-      paddingSize="m"
-    >
-      <div
-        className="euiPage euiPage--paddingMedium euiPage--grow"
-      >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <EuiAccordion
-              arrowDisplay="left"
-              buttonContent="Trace Groups"
-              data-test-subj="trace-groups-service-operation-accordian"
-              forceState="closed"
-              id="accordion1"
-              initialIsOpen={false}
-              isLoading={false}
-              isLoadingMessage={false}
-              onToggle={[Function]}
-              paddingSize="none"
-            >
-              <div
-                className="euiAccordion"
-                data-test-subj="trace-groups-service-operation-accordian"
-                onToggle={[Function]}
-              >
-                <div
-                  className="euiAccordion__triggerWrapper"
-                >
-                  <button
-                    aria-controls="accordion1"
-                    aria-expanded={false}
-                    className="euiAccordion__button"
-                    id="random_html_id"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="euiAccordion__iconWrapper"
-                    >
-                      <EuiIcon
-                        className="euiAccordion__icon"
-                        size="m"
-                        type="arrowRight"
-                      >
-                        <EuiIconBeaker
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                          focusable="false"
-                          role="img"
-                          style={null}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                            focusable="false"
-                            height={16}
-                            role="img"
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                            />
-                          </svg>
-                        </EuiIconBeaker>
-                      </EuiIcon>
-                    </span>
-                    <span
-                      className="euiIEFlexWrapFix"
-                    >
-                      Trace Groups
-                    </span>
-                  </button>
-                </div>
-                <div
-                  aria-labelledby="random_html_id"
-                  className="euiAccordion__childWrapper"
-                  id="accordion1"
-                  role="region"
-                  tabIndex={-1}
-                >
-                  <EuiResizeObserver
-                    onResize={[Function]}
-                  >
-                    <div>
-                      <div
-                        className=""
-                      >
-                        <EuiSpacer
-                          size="m"
-                        >
+                        <div>
                           <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                      </div>
-                    </div>
-                  </EuiResizeObserver>
-                </div>
-              </div>
-            </EuiAccordion>
-          </div>
-        </EuiPanel>
-      </div>
-    </EuiPage>
-    <TracesTable
-      dataPrepperIndicesExist={true}
-      items={Array []}
-      loading={true}
-      mode="data_prepper"
-      refresh={[Function]}
-      traceIdColumnAction={[Function]}
-    >
-      <EuiPage
-        paddingSize="m"
-      >
-        <div
-          className="euiPage euiPage--paddingMedium euiPage--grow"
-        >
-          <EuiPanel>
-            <div
-              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-            >
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-              >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem
-                    grow={10}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrow10"
-                    >
-                      <PanelTitle
-                        title="Traces"
-                        totalItems={0}
-                      >
-                        <EuiText
-                          size="m"
-                        >
-                          <div
-                            className="euiText euiText--medium"
+                            className=""
                           >
-                            <span
-                              className="panel-title"
-                            >
-                              Traces
-                            </span>
-                            <span
-                              className="panel-title-count"
-                            >
-                               (0)
-                            </span>
-                          </div>
-                        </EuiText>
-                      </PanelTitle>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-              <EuiSpacer
-                size="m"
-              >
-                <div
-                  className="euiSpacer euiSpacer--m"
-                />
-              </EuiSpacer>
-              <EuiHorizontalRule
-                margin="none"
-              >
-                <hr
-                  className="euiHorizontalRule euiHorizontalRule--full"
-                />
-              </EuiHorizontalRule>
-              <NoMatchMessage
-                size="xl"
-              >
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-                <EuiEmptyPrompt
-                  body={
-                    <EuiText
-                      size="s"
-                    >
-                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                    </EuiText>
-                  }
-                  title={
-                    <h2>
-                      No matches
-                    </h2>
-                  }
-                >
-                  <div
-                    className="euiEmptyPrompt"
-                  >
-                    <EuiTitle
-                      size="m"
-                    >
-                      <h2
-                        className="euiTitle euiTitle--medium"
-                      >
-                        No matches
-                      </h2>
-                    </EuiTitle>
-                    <EuiTextColor
-                      color="subdued"
-                    >
-                      <span
-                        className="euiTextColor euiTextColor--subdued"
-                      >
-                        <EuiSpacer
-                          size="m"
-                        >
-                          <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            <EuiText
-                              size="s"
+                            <EuiSpacer
+                              size="m"
                             >
                               <div
-                                className="euiText euiText--small"
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </div>
+            </EuiPanel>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <TracesTable
+              dataPrepperIndicesExist={true}
+              items={Array []}
+              loading={true}
+              mode="data_prepper"
+              refresh={[Function]}
+              traceIdColumnAction={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={10}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrow10"
+                        >
+                          <PanelTitle
+                            title="Traces"
+                            totalItems={0}
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
                               >
-                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                <span
+                                  className="panel-title"
+                                >
+                                  Traces
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
                               </div>
                             </EuiText>
-                          </div>
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
+                  >
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                    <EuiEmptyPrompt
+                      body={
+                        <EuiText
+                          size="s"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                         </EuiText>
-                      </span>
-                    </EuiTextColor>
-                  </div>
-                </EuiEmptyPrompt>
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-              </NoMatchMessage>
-            </div>
-          </EuiPanel>
-        </div>
-      </EuiPage>
-    </TracesTable>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
+                      </div>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </TracesTable>
+          </div>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </TracesContent>
 </Traces>
 `;
@@ -2240,182 +2223,918 @@ exports[`Traces component renders jaeger traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="s"
-      justifyContent="spaceBetween"
-      style={
-        Object {
-          "padding": "0 24px",
-        }
-      }
+    <EuiPage
+      paddingSize="m"
     >
       <div
-        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-        style={
-          Object {
-            "padding": "0 24px",
-          }
-        }
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <EuiFlexItem
-          grow={false}
-        >
+        <EuiPageBody>
           <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
+            className="euiPageBody euiPageBody--borderRadiusNone"
           >
-            <DataSourcePicker
-              modes={
-                Array [
-                  Object {
-                    "id": "jaeger",
-                    "title": "Jaeger",
-                  },
-                  Object {
-                    "id": "data_prepper",
-                    "title": "Data Prepper",
-                  },
-                ]
-              }
-              selectedMode="jaeger"
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiPopover
-                anchorClassName="eui-textTruncate"
-                anchorPosition="downCenter"
-                button={
-                  <EuiSmallButtonEmpty
-                    className="dscIndexPattern__triggerButton"
-                    color="text"
-                    data-test-subj="indexPattern-switch-link"
-                    flush="left"
-                    iconSide="right"
-                    iconType="arrowDown"
-                    onClick={[Function]}
-                    title="jaeger"
-                  >
-                    Jaeger
-                  </EuiSmallButtonEmpty>
-                }
-                className="eui-textTruncate"
-                closePopover={[Function]}
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="s"
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <div
-                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiPopover__anchor eui-textTruncate"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <EuiSmallButtonEmpty
-                      className="dscIndexPattern__triggerButton"
-                      color="text"
-                      data-test-subj="indexPattern-switch-link"
-                      flush="left"
-                      iconSide="right"
-                      iconType="arrowDown"
-                      onClick={[Function]}
-                      title="jaeger"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="jaeger"
                     >
-                      <EuiButtonEmpty
-                        className="dscIndexPattern__triggerButton"
-                        color="text"
-                        data-test-subj="indexPattern-switch-link"
-                        flush="left"
-                        iconSide="right"
-                        iconType="arrowDown"
-                        onClick={[Function]}
-                        size="s"
-                        title="jaeger"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                          data-test-subj="indexPattern-switch-link"
-                          disabled={false}
-                          onClick={[Function]}
-                          title="jaeger"
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
                             iconSide="right"
-                            iconSize="m"
                             iconType="arrowDown"
-                            textProps={
+                            onClick={[Function]}
+                            title="jaeger"
+                          >
+                            Jaeger
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
+                      >
+                        <div
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                        >
+                          <div
+                            className="euiPopover__anchor eui-textTruncate"
+                          >
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="jaeger"
+                            >
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="jaeger"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="jaeger"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="right"
+                                    iconSize="m"
+                                    iconType="arrowDown"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconArrowDown
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                              fillRule="non-zero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowDown>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Jaeger
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      appConfigs={Array []}
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="jaeger"
+                      page="traces"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
+                                }
+                                value=""
+                              >
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                                  >
+                                    <GlobalFilterButton
+                                      className="euiFormControlLayout__prepend"
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    >
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor"
+                                          >
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
+                                            >
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
+                                              >
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
+                                                >
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconFilter
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                          fillRule="evenodd"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconFilter>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <span
+                                              className="euiFormControlLayoutCustomIcon"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
+                                              >
+                                                <EuiIconSearch
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconSearch>
+                                              </EuiIcon>
+                                            </span>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
                               Object {
-                                "className": "euiButtonEmpty__text",
+                                "maxWidth": "30vw",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
+                                Object {
+                                  "maxWidth": "30vw",
+                                }
+                              }
                             >
-                              <EuiIcon
-                                className="euiButtonContent__icon"
-                                color="inherit"
-                                size="m"
-                                type="arrowDown"
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <EuiIconArrowDown
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
                                   >
-                                    <path
-                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                      fillRule="non-zero"
-                                    />
-                                  </svg>
-                                </EuiIconArrowDown>
-                              </EuiIcon>
-                              <span
-                                className="euiButtonEmpty__text"
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
+                                      >
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconArrowDown
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                                    fillRule="non-zero"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconArrowDown>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconCalendar
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                                      fillRule="evenodd"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconCalendar>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
                               >
-                                Jaeger
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </EuiSmallButtonEmpty>
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconRefresh
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                        />
+                                      </svg>
+                                    </EuiIconRefresh>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
                   </div>
-                </div>
-              </EuiPopover>
-            </DataSourcePicker>
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem
-          grow={true}
-        >
-          <div
-            className="euiFlexItem"
-          >
-            <ForwardRef
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
               appConfigs={Array []}
               attributesFilterFields={Array []}
-              endTime="now"
               filters={Array []}
               mode="jaeger"
               page="traces"
-              query=""
-              refresh={[Function]}
-              setEndTime={[MockFunction]}
               setFilters={
                 [MockFunction] {
                   "calls": Array [
@@ -2431,696 +3150,145 @@ exports[`Traces component renders jaeger traces page 1`] = `
                   ],
                 }
               }
-              setQuery={[MockFunction]}
-              setStartTime={[MockFunction]}
-              startTime="now-5m"
             >
               <EuiFlexGroup
                 alignItems="center"
-                gutterSize="s"
+                gutterSize="xs"
+                responsive={false}
               >
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
                 >
-                  <EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
                     <div
-                      className="euiFlexItem"
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiCompressedFieldSearch
-                        compressed={true}
-                        data-test-subj="search-bar-input-box"
-                        fullWidth={true}
-                        incremental={false}
-                        isClearable={false}
-                        isLoading={false}
-                        onChange={[Function]}
-                        onSearch={[Function]}
-                        placeholder="Trace ID, trace group name, service name"
-                        prepend={
-                          <GlobalFilterButton
-                            filters={Array []}
-                            setFilters={
-                              [MockFunction] {
-                                "calls": Array [
-                                  Array [
-                                    Array [],
-                                  ],
-                                ],
-                                "results": Array [
-                                  Object {
-                                    "type": "return",
-                                    "value": undefined,
-                                  },
-                                ],
-                              }
-                            }
-                          />
-                        }
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          compressed={true}
-                          fullWidth={true}
-                          icon="search"
-                          isLoading={false}
-                          prepend={
-                            <GlobalFilterButton
-                              filters={Array []}
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            />
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
                           }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
                           >
-                            <GlobalFilterButton
-                              className="euiFormControlLayout__prepend"
-                              filters={Array []}
-                              key="0/.0"
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <EuiSmallButtonIcon
-                                    aria-label="Change all filters"
-                                    iconType="filter"
-                                    onClick={[Function]}
-                                    title="Change all filters"
-                                  />
-                                }
-                                closePopover={[Function]}
-                                data-test-subj="global-filter-button"
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="none"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp"
-                                  data-test-subj="global-filter-button"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
-                                    <EuiSmallButtonIcon
-                                      aria-label="Change all filters"
-                                      iconType="filter"
-                                      onClick={[Function]}
-                                      title="Change all filters"
-                                    >
-                                      <EuiButtonIcon
-                                        aria-label="Change all filters"
-                                        iconType="filter"
-                                        onClick={[Function]}
-                                        size="s"
-                                        title="Change all filters"
-                                      >
-                                        <button
-                                          aria-label="Change all filters"
-                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          title="Change all filters"
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="filter"
-                                          >
-                                            <EuiIconFilter
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                                  fillRule="evenodd"
-                                                />
-                                              </svg>
-                                            </EuiIconFilter>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiSmallButtonIcon>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </GlobalFilterButton>
                             <div
-                              className="euiFormControlLayout__childrenWrapper"
+                              className="euiPopover__anchor"
                             >
-                              <EuiValidatableControl>
-                                <input
-                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
-                                  data-test-subj="search-bar-input-box"
-                                  onChange={[Function]}
-                                  onKeyUp={[Function]}
-                                  placeholder="Trace ID, trace group name, service name"
-                                  type="search"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons
-                                compressed={true}
-                                icon="search"
-                                isLoading={false}
+                              <EuiButtonEmpty
+                                onClick={[Function]}
+                                size="xs"
                               >
-                                <div
-                                  className="euiFormControlLayoutIcons"
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <EuiFormControlLayoutCustomIcon
-                                    size="s"
-                                    type="search"
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiFormControlLayoutCustomIcon"
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiFormControlLayoutCustomIcon__icon"
-                                        size="s"
-                                        type="search"
+                                      <span
+                                        className="euiButtonEmpty__text"
                                       >
-                                        <EuiIconSearch
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                            />
-                                          </svg>
-                                        </EuiIconSearch>
-                                      </EuiIcon>
+                                        + Add filter
+                                      </span>
                                     </span>
-                                  </EuiFormControlLayoutCustomIcon>
-                                </div>
-                              </EuiFormControlLayoutIcons>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
                             </div>
                           </div>
-                        </EuiFormControlLayout>
-                      </EuiCompressedFieldSearch>
+                        </EuiPopover>
+                      </AddFilterButton>
                     </div>
                   </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                    style={
-                      Object {
-                        "maxWidth": "30vw",
-                      }
-                    }
+                </div>
+              </EuiFlexGroup>
+            </Filters>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <EuiPanel>
+              <div
+                className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+              >
+                <EuiAccordion
+                  arrowDisplay="left"
+                  buttonContent="Service and Operations"
+                  data-test-subj="trace-groups-service-operation-accordian"
+                  forceState="closed"
+                  id="accordion1"
+                  initialIsOpen={false}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion"
+                    data-test-subj="trace-groups-service-operation-accordian"
+                    onToggle={[Function]}
                   >
                     <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                      style={
-                        Object {
-                          "maxWidth": "30vw",
-                        }
-                      }
+                      className="euiAccordion__triggerWrapper"
                     >
-                      <EuiSuperDatePicker
-                        commonlyUsedRanges={
-                          Array [
-                            Object {
-                              "end": "now/d",
-                              "label": "Today",
-                              "start": "now/d",
-                            },
-                            Object {
-                              "end": "now/w",
-                              "label": "This week",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now/M",
-                              "label": "This month",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now/y",
-                              "label": "This year",
-                              "start": "now/y",
-                            },
-                            Object {
-                              "end": "now-1d/d",
-                              "label": "Yesterday",
-                              "start": "now-1d/d",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Week to date",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Month to date",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Year to date",
-                              "start": "now/y",
-                            },
-                          ]
-                        }
-                        compressed={true}
-                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                        end="now"
-                        isAutoRefreshOnly={false}
-                        isDisabled={false}
-                        isPaused={true}
-                        onTimeChange={[Function]}
-                        recentlyUsedRanges={Array []}
-                        refreshInterval={0}
-                        showUpdateButton={false}
-                        start="now-5m"
-                        timeFormat="HH:mm"
-                      >
-                        <EuiFlexGroup
-                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          gutterSize="s"
-                          responsive={false}
-                        >
-                          <div
-                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          >
-                            <EuiFlexItem>
-                              <div
-                                className="euiFlexItem"
-                              >
-                                <EuiFormControlLayout
-                                  className="euiSuperDatePicker"
-                                  compressed={true}
-                                  isDisabled={false}
-                                  prepend={
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    />
-                                  }
-                                >
-                                  <div
-                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
-                                  >
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      className="euiFormControlLayout__prepend"
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      key="0/.0"
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    >
-                                      <EuiPopover
-                                        anchorClassName="euiQuickSelectPopover__anchor"
-                                        anchorPosition="downLeft"
-                                        button={
-                                          <EuiButtonEmpty
-                                            aria-label="Date quick select"
-                                            className="euiFormControlLayout__prepend"
-                                            data-test-subj="superDatePickerToggleQuickMenuButton"
-                                            iconSide="right"
-                                            iconType="arrowDown"
-                                            isDisabled={false}
-                                            onClick={[Function]}
-                                            size="xs"
-                                            textProps={
-                                              Object {
-                                                "className": "euiQuickSelectPopover__buttonText",
-                                              }
-                                            }
-                                          >
-                                            <EuiIcon
-                                              type="calendar"
-                                            />
-                                          </EuiButtonEmpty>
-                                        }
-                                        closePopover={[Function]}
-                                        display="inlineBlock"
-                                        hasArrow={true}
-                                        isOpen={false}
-                                        ownFocus={true}
-                                        panelPaddingSize="s"
-                                      >
-                                        <div
-                                          className="euiPopover euiPopover--anchorDownLeft"
-                                        >
-                                          <div
-                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                          >
-                                            <EuiButtonEmpty
-                                              aria-label="Date quick select"
-                                              className="euiFormControlLayout__prepend"
-                                              data-test-subj="superDatePickerToggleQuickMenuButton"
-                                              iconSide="right"
-                                              iconType="arrowDown"
-                                              isDisabled={false}
-                                              onClick={[Function]}
-                                              size="xs"
-                                              textProps={
-                                                Object {
-                                                  "className": "euiQuickSelectPopover__buttonText",
-                                                }
-                                              }
-                                            >
-                                              <button
-                                                aria-label="Date quick select"
-                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                                data-test-subj="superDatePickerToggleQuickMenuButton"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <EuiButtonContent
-                                                  className="euiButtonEmpty__content"
-                                                  iconSide="right"
-                                                  iconSize="s"
-                                                  iconType="arrowDown"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                                    }
-                                                  }
-                                                >
-                                                  <span
-                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                                  >
-                                                    <EuiIcon
-                                                      className="euiButtonContent__icon"
-                                                      color="inherit"
-                                                      size="s"
-                                                      type="arrowDown"
-                                                    >
-                                                      <EuiIconArrowDown
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                        focusable="false"
-                                                        role="img"
-                                                        style={null}
-                                                      >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                          focusable="false"
-                                                          height={16}
-                                                          role="img"
-                                                          style={null}
-                                                          viewBox="0 0 16 16"
-                                                          width={16}
-                                                          xmlns="http://www.w3.org/2000/svg"
-                                                        >
-                                                          <path
-                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                            fillRule="non-zero"
-                                                          />
-                                                        </svg>
-                                                      </EuiIconArrowDown>
-                                                    </EuiIcon>
-                                                    <span
-                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                                    >
-                                                      <EuiIcon
-                                                        type="calendar"
-                                                      >
-                                                        <EuiIconCalendar
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--medium"
-                                                          focusable="false"
-                                                          role="img"
-                                                          style={null}
-                                                        >
-                                                          <svg
-                                                            aria-hidden={true}
-                                                            className="euiIcon euiIcon--medium"
-                                                            focusable="false"
-                                                            height={16}
-                                                            role="img"
-                                                            style={null}
-                                                            viewBox="0 0 16 16"
-                                                            width={16}
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                          >
-                                                            <path
-                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                              fillRule="evenodd"
-                                                            />
-                                                          </svg>
-                                                        </EuiIconCalendar>
-                                                      </EuiIcon>
-                                                    </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonEmpty>
-                                          </div>
-                                        </div>
-                                      </EuiPopover>
-                                    </EuiQuickSelectPopover>
-                                    <div
-                                      className="euiFormControlLayout__childrenWrapper"
-                                    >
-                                      <EuiDatePickerRange
-                                        className="euiDatePickerRange--inGroup"
-                                        endDateControl={<div />}
-                                        iconType={false}
-                                        isCustom={true}
-                                        startDateControl={<div />}
-                                      >
-                                        <div
-                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                        >
-                                          <button
-                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
-                                            data-test-subj="superDatePickerShowDatesButton"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                          >
-                                            Last 5 minutes
-                                            <span
-                                              className="euiSuperDatePicker__prettyFormatLink"
-                                            >
-                                              <EuiI18n
-                                                default="Show dates"
-                                                token="euiSuperDatePicker.showDatesButtonLabel"
-                                              >
-                                                Show dates
-                                              </EuiI18n>
-                                            </span>
-                                          </button>
-                                        </div>
-                                      </EuiDatePickerRange>
-                                      <EuiFormControlLayoutIcons
-                                        compressed={true}
-                                      />
-                                    </div>
-                                  </div>
-                                </EuiFormControlLayout>
-                              </div>
-                            </EuiFlexItem>
-                          </div>
-                        </EuiFlexGroup>
-                      </EuiSuperDatePicker>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiButtonIcon
-                        aria-label="Refresh"
-                        data-click-metric-element="trace_analytics.refresh_button"
-                        data-test-subj="superDatePickerApplyTimeButton"
-                        display="base"
-                        iconType="refresh"
+                      <button
+                        aria-controls="accordion1"
+                        aria-expanded={false}
+                        className="euiAccordion__button"
+                        id="random_html_id"
                         onClick={[Function]}
-                        size="s"
+                        type="button"
                       >
-                        <button
-                          aria-label="Refresh"
-                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
-                          data-click-metric-element="trace_analytics.refresh_button"
-                          data-test-subj="superDatePickerApplyTimeButton"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
+                        <span
+                          className="euiAccordion__iconWrapper"
                         >
                           <EuiIcon
-                            aria-hidden="true"
-                            className="euiButtonIcon__icon"
-                            color="inherit"
+                            className="euiAccordion__icon"
                             size="m"
-                            type="refresh"
+                            type="arrowRight"
                           >
-                            <EuiIconRefresh
+                            <EuiIconArrowRight
                               aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                              className="euiIcon euiIcon--medium euiAccordion__icon"
                               focusable="false"
                               role="img"
                               style={null}
                             >
                               <svg
                                 aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                className="euiIcon euiIcon--medium euiAccordion__icon"
                                 focusable="false"
                                 height={16}
                                 role="img"
@@ -3130,408 +3298,206 @@ exports[`Traces component renders jaeger traces page 1`] = `
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                  fillRule="nonzero"
                                 />
                               </svg>
-                            </EuiIconRefresh>
+                            </EuiIconArrowRight>
                           </EuiIcon>
-                        </button>
-                      </EuiButtonIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          Service and Operations
+                        </span>
+                      </button>
                     </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </ForwardRef>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
-    <Filters
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      filters={Array []}
-      mode="jaeger"
-      page="traces"
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-    >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="xs"
-        responsive={false}
-        style={
-          Object {
-            "minHeight": 32,
-            "padding": "0 16px",
-          }
-        }
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-          style={
-            Object {
-              "minHeight": 32,
-              "padding": "0 16px",
-            }
-          }
-        >
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <AddFilterButton>
-                <EuiPopover
-                  anchorPosition="downLeft"
-                  button={
-                    <EuiButtonEmpty
-                      onClick={[Function]}
-                      size="xs"
-                    >
-                      + Add filter
-                    </EuiButtonEmpty>
-                  }
-                  closePopover={[Function]}
-                  data-test-subj="addfilter"
-                  display="inlineBlock"
-                  hasArrow={true}
-                  isOpen={false}
-                  ownFocus={true}
-                  panelPaddingSize="m"
-                >
-                  <div
-                    className="euiPopover euiPopover--anchorDownLeft"
-                    data-test-subj="addfilter"
-                  >
                     <div
-                      className="euiPopover__anchor"
+                      aria-labelledby="random_html_id"
+                      className="euiAccordion__childWrapper"
+                      id="accordion1"
+                      role="region"
+                      tabIndex={-1}
                     >
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
+                      <EuiResizeObserver
+                        onResize={[Function]}
                       >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
-                            iconSide="left"
-                            iconSize="s"
-                            textProps={
-                              Object {
-                                "className": "euiButtonEmpty__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButtonEmpty__content"
-                            >
-                              <span
-                                className="euiButtonEmpty__text"
-                              >
-                                + Add filter
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </div>
-                  </div>
-                </EuiPopover>
-              </AddFilterButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-    </Filters>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <EuiPage
-      paddingSize="m"
-    >
-      <div
-        className="euiPage euiPage--paddingMedium euiPage--grow"
-      >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <EuiAccordion
-              arrowDisplay="left"
-              buttonContent="Service and Operations"
-              data-test-subj="trace-groups-service-operation-accordian"
-              forceState="closed"
-              id="accordion1"
-              initialIsOpen={false}
-              isLoading={false}
-              isLoadingMessage={false}
-              onToggle={[Function]}
-              paddingSize="none"
-            >
-              <div
-                className="euiAccordion"
-                data-test-subj="trace-groups-service-operation-accordian"
-                onToggle={[Function]}
-              >
-                <div
-                  className="euiAccordion__triggerWrapper"
-                >
-                  <button
-                    aria-controls="accordion1"
-                    aria-expanded={false}
-                    className="euiAccordion__button"
-                    id="random_html_id"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="euiAccordion__iconWrapper"
-                    >
-                      <EuiIcon
-                        className="euiAccordion__icon"
-                        size="m"
-                        type="arrowRight"
-                      >
-                        <EuiIconArrowRight
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiAccordion__icon"
-                          focusable="false"
-                          role="img"
-                          style={null}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiAccordion__icon"
-                            focusable="false"
-                            height={16}
-                            role="img"
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                              fillRule="nonzero"
-                            />
-                          </svg>
-                        </EuiIconArrowRight>
-                      </EuiIcon>
-                    </span>
-                    <span
-                      className="euiIEFlexWrapFix"
-                    >
-                      Service and Operations
-                    </span>
-                  </button>
-                </div>
-                <div
-                  aria-labelledby="random_html_id"
-                  className="euiAccordion__childWrapper"
-                  id="accordion1"
-                  role="region"
-                  tabIndex={-1}
-                >
-                  <EuiResizeObserver
-                    onResize={[Function]}
-                  >
-                    <div>
-                      <div
-                        className=""
-                      >
-                        <EuiSpacer
-                          size="m"
-                        >
+                        <div>
                           <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                      </div>
-                    </div>
-                  </EuiResizeObserver>
-                </div>
-              </div>
-            </EuiAccordion>
-          </div>
-        </EuiPanel>
-      </div>
-    </EuiPage>
-    <TracesTable
-      dataPrepperIndicesExist={false}
-      items={Array []}
-      jaegerIndicesExist={true}
-      loading={true}
-      mode="jaeger"
-      refresh={[Function]}
-      traceIdColumnAction={[Function]}
-    >
-      <EuiPage
-        paddingSize="m"
-      >
-        <div
-          className="euiPage euiPage--paddingMedium euiPage--grow"
-        >
-          <EuiPanel>
-            <div
-              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-            >
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-              >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem
-                    grow={10}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrow10"
-                    >
-                      <PanelTitle
-                        title="Traces"
-                        totalItems={0}
-                      >
-                        <EuiText
-                          size="m"
-                        >
-                          <div
-                            className="euiText euiText--medium"
+                            className=""
                           >
-                            <span
-                              className="panel-title"
-                            >
-                              Traces
-                            </span>
-                            <span
-                              className="panel-title-count"
-                            >
-                               (0)
-                            </span>
-                          </div>
-                        </EuiText>
-                      </PanelTitle>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-              <EuiSpacer
-                size="m"
-              >
-                <div
-                  className="euiSpacer euiSpacer--m"
-                />
-              </EuiSpacer>
-              <EuiHorizontalRule
-                margin="none"
-              >
-                <hr
-                  className="euiHorizontalRule euiHorizontalRule--full"
-                />
-              </EuiHorizontalRule>
-              <NoMatchMessage
-                size="xl"
-              >
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-                <EuiEmptyPrompt
-                  body={
-                    <EuiText
-                      size="s"
-                    >
-                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                    </EuiText>
-                  }
-                  title={
-                    <h2>
-                      No matches
-                    </h2>
-                  }
-                >
-                  <div
-                    className="euiEmptyPrompt"
-                  >
-                    <EuiTitle
-                      size="m"
-                    >
-                      <h2
-                        className="euiTitle euiTitle--medium"
-                      >
-                        No matches
-                      </h2>
-                    </EuiTitle>
-                    <EuiTextColor
-                      color="subdued"
-                    >
-                      <span
-                        className="euiTextColor euiTextColor--subdued"
-                      >
-                        <EuiSpacer
-                          size="m"
-                        >
-                          <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            <EuiText
-                              size="s"
+                            <EuiSpacer
+                              size="m"
                             >
                               <div
-                                className="euiText euiText--small"
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </div>
+            </EuiPanel>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <TracesTable
+              dataPrepperIndicesExist={false}
+              items={Array []}
+              jaegerIndicesExist={true}
+              loading={true}
+              mode="jaeger"
+              refresh={[Function]}
+              traceIdColumnAction={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={10}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrow10"
+                        >
+                          <PanelTitle
+                            title="Traces"
+                            totalItems={0}
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
                               >
-                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                <span
+                                  className="panel-title"
+                                >
+                                  Traces
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
                               </div>
                             </EuiText>
-                          </div>
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
+                  >
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                    <EuiEmptyPrompt
+                      body={
+                        <EuiText
+                          size="s"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                         </EuiText>
-                      </span>
-                    </EuiTextColor>
-                  </div>
-                </EuiEmptyPrompt>
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-              </NoMatchMessage>
-            </div>
-          </EuiPanel>
-        </div>
-      </EuiPage>
-    </TracesTable>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
+                      </div>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </TracesTable>
+          </div>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </TracesContent>
 </Traces>
 `;
@@ -4009,182 +3975,918 @@ exports[`Traces component renders traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="s"
-      justifyContent="spaceBetween"
-      style={
-        Object {
-          "padding": "0 24px",
-        }
-      }
+    <EuiPage
+      paddingSize="m"
     >
       <div
-        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-        style={
-          Object {
-            "padding": "0 24px",
-          }
-        }
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <EuiFlexItem
-          grow={false}
-        >
+        <EuiPageBody>
           <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
+            className="euiPageBody euiPageBody--borderRadiusNone"
           >
-            <DataSourcePicker
-              modes={
-                Array [
-                  Object {
-                    "id": "jaeger",
-                    "title": "Jaeger",
-                  },
-                  Object {
-                    "id": "data_prepper",
-                    "title": "Data Prepper",
-                  },
-                ]
-              }
-              selectedMode="data_prepper"
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiPopover
-                anchorClassName="eui-textTruncate"
-                anchorPosition="downCenter"
-                button={
-                  <EuiSmallButtonEmpty
-                    className="dscIndexPattern__triggerButton"
-                    color="text"
-                    data-test-subj="indexPattern-switch-link"
-                    flush="left"
-                    iconSide="right"
-                    iconType="arrowDown"
-                    onClick={[Function]}
-                    title="data_prepper"
-                  >
-                    Data Prepper
-                  </EuiSmallButtonEmpty>
-                }
-                className="eui-textTruncate"
-                closePopover={[Function]}
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="s"
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <div
-                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiPopover__anchor eui-textTruncate"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <EuiSmallButtonEmpty
-                      className="dscIndexPattern__triggerButton"
-                      color="text"
-                      data-test-subj="indexPattern-switch-link"
-                      flush="left"
-                      iconSide="right"
-                      iconType="arrowDown"
-                      onClick={[Function]}
-                      title="data_prepper"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="data_prepper"
                     >
-                      <EuiButtonEmpty
-                        className="dscIndexPattern__triggerButton"
-                        color="text"
-                        data-test-subj="indexPattern-switch-link"
-                        flush="left"
-                        iconSide="right"
-                        iconType="arrowDown"
-                        onClick={[Function]}
-                        size="s"
-                        title="data_prepper"
-                      >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                          data-test-subj="indexPattern-switch-link"
-                          disabled={false}
-                          onClick={[Function]}
-                          title="data_prepper"
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
                             iconSide="right"
-                            iconSize="m"
                             iconType="arrowDown"
-                            textProps={
+                            onClick={[Function]}
+                            title="data_prepper"
+                          >
+                            Data Prepper
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
+                      >
+                        <div
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                        >
+                          <div
+                            className="euiPopover__anchor eui-textTruncate"
+                          >
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="data_prepper"
+                            >
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="data_prepper"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="data_prepper"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="right"
+                                    iconSize="m"
+                                    iconType="arrowDown"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconArrowDown
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                              fillRule="non-zero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowDown>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Data Prepper
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      appConfigs={Array []}
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="data_prepper"
+                      page="traces"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
+                                }
+                                value=""
+                              >
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                                  >
+                                    <GlobalFilterButton
+                                      className="euiFormControlLayout__prepend"
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    >
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor"
+                                          >
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
+                                            >
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
+                                              >
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
+                                                >
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconFilter
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                          fillRule="evenodd"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconFilter>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <span
+                                              className="euiFormControlLayoutCustomIcon"
+                                            >
+                                              <EuiIcon
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
+                                              >
+                                                <EuiIconSearch
+                                                  aria-hidden={true}
+                                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                  focusable="false"
+                                                  role="img"
+                                                  style={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                    focusable="false"
+                                                    height={16}
+                                                    role="img"
+                                                    style={null}
+                                                    viewBox="0 0 16 16"
+                                                    width={16}
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <path
+                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                    />
+                                                  </svg>
+                                                </EuiIconSearch>
+                                              </EuiIcon>
+                                            </span>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
                               Object {
-                                "className": "euiButtonEmpty__text",
+                                "maxWidth": "30vw",
                               }
                             }
                           >
-                            <span
-                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
+                                Object {
+                                  "maxWidth": "30vw",
+                                }
+                              }
                             >
-                              <EuiIcon
-                                className="euiButtonContent__icon"
-                                color="inherit"
-                                size="m"
-                                type="arrowDown"
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <EuiIconArrowDown
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
                                   >
-                                    <path
-                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                      fillRule="non-zero"
-                                    />
-                                  </svg>
-                                </EuiIconArrowDown>
-                              </EuiIcon>
-                              <span
-                                className="euiButtonEmpty__text"
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
+                                      >
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconArrowDown
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                                    fillRule="non-zero"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconArrowDown>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconCalendar
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                                      fillRule="evenodd"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconCalendar>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
                               >
-                                Data Prepper
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </EuiSmallButtonEmpty>
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconRefresh
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                        />
+                                      </svg>
+                                    </EuiIconRefresh>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
                   </div>
-                </div>
-              </EuiPopover>
-            </DataSourcePicker>
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem
-          grow={true}
-        >
-          <div
-            className="euiFlexItem"
-          >
-            <ForwardRef
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
               appConfigs={Array []}
               attributesFilterFields={Array []}
-              endTime="now"
               filters={Array []}
               mode="data_prepper"
               page="traces"
-              query=""
-              refresh={[Function]}
-              setEndTime={[MockFunction]}
               setFilters={
                 [MockFunction] {
                   "calls": Array [
@@ -4200,696 +4902,145 @@ exports[`Traces component renders traces page 1`] = `
                   ],
                 }
               }
-              setQuery={[MockFunction]}
-              setStartTime={[MockFunction]}
-              startTime="now-5m"
             >
               <EuiFlexGroup
                 alignItems="center"
-                gutterSize="s"
+                gutterSize="xs"
+                responsive={false}
               >
                 <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
                 >
-                  <EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
                     <div
-                      className="euiFlexItem"
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      <EuiCompressedFieldSearch
-                        compressed={true}
-                        data-test-subj="search-bar-input-box"
-                        fullWidth={true}
-                        incremental={false}
-                        isClearable={false}
-                        isLoading={false}
-                        onChange={[Function]}
-                        onSearch={[Function]}
-                        placeholder="Trace ID, trace group name, service name"
-                        prepend={
-                          <GlobalFilterButton
-                            filters={Array []}
-                            setFilters={
-                              [MockFunction] {
-                                "calls": Array [
-                                  Array [
-                                    Array [],
-                                  ],
-                                ],
-                                "results": Array [
-                                  Object {
-                                    "type": "return",
-                                    "value": undefined,
-                                  },
-                                ],
-                              }
-                            }
-                          />
-                        }
-                        value=""
-                      >
-                        <EuiFormControlLayout
-                          compressed={true}
-                          fullWidth={true}
-                          icon="search"
-                          isLoading={false}
-                          prepend={
-                            <GlobalFilterButton
-                              filters={Array []}
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            />
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
                           }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
                           >
-                            <GlobalFilterButton
-                              className="euiFormControlLayout__prepend"
-                              filters={Array []}
-                              key="0/.0"
-                              setFilters={
-                                [MockFunction] {
-                                  "calls": Array [
-                                    Array [
-                                      Array [],
-                                    ],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": undefined,
-                                    },
-                                  ],
-                                }
-                              }
-                            >
-                              <EuiPopover
-                                anchorPosition="rightUp"
-                                button={
-                                  <EuiSmallButtonIcon
-                                    aria-label="Change all filters"
-                                    iconType="filter"
-                                    onClick={[Function]}
-                                    title="Change all filters"
-                                  />
-                                }
-                                closePopover={[Function]}
-                                data-test-subj="global-filter-button"
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="none"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorRightUp"
-                                  data-test-subj="global-filter-button"
-                                >
-                                  <div
-                                    className="euiPopover__anchor"
-                                  >
-                                    <EuiSmallButtonIcon
-                                      aria-label="Change all filters"
-                                      iconType="filter"
-                                      onClick={[Function]}
-                                      title="Change all filters"
-                                    >
-                                      <EuiButtonIcon
-                                        aria-label="Change all filters"
-                                        iconType="filter"
-                                        onClick={[Function]}
-                                        size="s"
-                                        title="Change all filters"
-                                      >
-                                        <button
-                                          aria-label="Change all filters"
-                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          title="Change all filters"
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="filter"
-                                          >
-                                            <EuiIconFilter
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                                  fillRule="evenodd"
-                                                />
-                                              </svg>
-                                            </EuiIconFilter>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiSmallButtonIcon>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </GlobalFilterButton>
                             <div
-                              className="euiFormControlLayout__childrenWrapper"
+                              className="euiPopover__anchor"
                             >
-                              <EuiValidatableControl>
-                                <input
-                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
-                                  data-test-subj="search-bar-input-box"
-                                  onChange={[Function]}
-                                  onKeyUp={[Function]}
-                                  placeholder="Trace ID, trace group name, service name"
-                                  type="search"
-                                  value=""
-                                />
-                              </EuiValidatableControl>
-                              <EuiFormControlLayoutIcons
-                                compressed={true}
-                                icon="search"
-                                isLoading={false}
+                              <EuiButtonEmpty
+                                onClick={[Function]}
+                                size="xs"
                               >
-                                <div
-                                  className="euiFormControlLayoutIcons"
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
                                 >
-                                  <EuiFormControlLayoutCustomIcon
-                                    size="s"
-                                    type="search"
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
                                   >
                                     <span
-                                      className="euiFormControlLayoutCustomIcon"
+                                      className="euiButtonContent euiButtonEmpty__content"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiFormControlLayoutCustomIcon__icon"
-                                        size="s"
-                                        type="search"
+                                      <span
+                                        className="euiButtonEmpty__text"
                                       >
-                                        <EuiIconSearch
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                            />
-                                          </svg>
-                                        </EuiIconSearch>
-                                      </EuiIcon>
+                                        + Add filter
+                                      </span>
                                     </span>
-                                  </EuiFormControlLayoutCustomIcon>
-                                </div>
-                              </EuiFormControlLayoutIcons>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
                             </div>
                           </div>
-                        </EuiFormControlLayout>
-                      </EuiCompressedFieldSearch>
+                        </EuiPopover>
+                      </AddFilterButton>
                     </div>
                   </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                    style={
-                      Object {
-                        "maxWidth": "30vw",
-                      }
-                    }
+                </div>
+              </EuiFlexGroup>
+            </Filters>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <EuiPanel>
+              <div
+                className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+              >
+                <EuiAccordion
+                  arrowDisplay="left"
+                  buttonContent="Trace Groups"
+                  data-test-subj="trace-groups-service-operation-accordian"
+                  forceState="closed"
+                  id="accordion1"
+                  initialIsOpen={false}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
+                >
+                  <div
+                    className="euiAccordion"
+                    data-test-subj="trace-groups-service-operation-accordian"
+                    onToggle={[Function]}
                   >
                     <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                      style={
-                        Object {
-                          "maxWidth": "30vw",
-                        }
-                      }
+                      className="euiAccordion__triggerWrapper"
                     >
-                      <EuiSuperDatePicker
-                        commonlyUsedRanges={
-                          Array [
-                            Object {
-                              "end": "now/d",
-                              "label": "Today",
-                              "start": "now/d",
-                            },
-                            Object {
-                              "end": "now/w",
-                              "label": "This week",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now/M",
-                              "label": "This month",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now/y",
-                              "label": "This year",
-                              "start": "now/y",
-                            },
-                            Object {
-                              "end": "now-1d/d",
-                              "label": "Yesterday",
-                              "start": "now-1d/d",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Week to date",
-                              "start": "now/w",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Month to date",
-                              "start": "now/M",
-                            },
-                            Object {
-                              "end": "now",
-                              "label": "Year to date",
-                              "start": "now/y",
-                            },
-                          ]
-                        }
-                        compressed={true}
-                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                        end="now"
-                        isAutoRefreshOnly={false}
-                        isDisabled={false}
-                        isPaused={true}
-                        onTimeChange={[Function]}
-                        recentlyUsedRanges={Array []}
-                        refreshInterval={0}
-                        showUpdateButton={false}
-                        start="now-5m"
-                        timeFormat="HH:mm"
-                      >
-                        <EuiFlexGroup
-                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          gutterSize="s"
-                          responsive={false}
-                        >
-                          <div
-                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                          >
-                            <EuiFlexItem>
-                              <div
-                                className="euiFlexItem"
-                              >
-                                <EuiFormControlLayout
-                                  className="euiSuperDatePicker"
-                                  compressed={true}
-                                  isDisabled={false}
-                                  prepend={
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    />
-                                  }
-                                >
-                                  <div
-                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
-                                  >
-                                    <EuiQuickSelectPopover
-                                      applyTime={[Function]}
-                                      className="euiFormControlLayout__prepend"
-                                      commonlyUsedRanges={
-                                        Array [
-                                          Object {
-                                            "end": "now/d",
-                                            "label": "Today",
-                                            "start": "now/d",
-                                          },
-                                          Object {
-                                            "end": "now/w",
-                                            "label": "This week",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now/M",
-                                            "label": "This month",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now/y",
-                                            "label": "This year",
-                                            "start": "now/y",
-                                          },
-                                          Object {
-                                            "end": "now-1d/d",
-                                            "label": "Yesterday",
-                                            "start": "now-1d/d",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Week to date",
-                                            "start": "now/w",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Month to date",
-                                            "start": "now/M",
-                                          },
-                                          Object {
-                                            "end": "now",
-                                            "label": "Year to date",
-                                            "start": "now/y",
-                                          },
-                                        ]
-                                      }
-                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
-                                      end="now"
-                                      isAutoRefreshOnly={false}
-                                      isDisabled={false}
-                                      isPaused={true}
-                                      key="0/.0"
-                                      recentlyUsedRanges={Array []}
-                                      refreshInterval={0}
-                                      start="now-5m"
-                                    >
-                                      <EuiPopover
-                                        anchorClassName="euiQuickSelectPopover__anchor"
-                                        anchorPosition="downLeft"
-                                        button={
-                                          <EuiButtonEmpty
-                                            aria-label="Date quick select"
-                                            className="euiFormControlLayout__prepend"
-                                            data-test-subj="superDatePickerToggleQuickMenuButton"
-                                            iconSide="right"
-                                            iconType="arrowDown"
-                                            isDisabled={false}
-                                            onClick={[Function]}
-                                            size="xs"
-                                            textProps={
-                                              Object {
-                                                "className": "euiQuickSelectPopover__buttonText",
-                                              }
-                                            }
-                                          >
-                                            <EuiIcon
-                                              type="calendar"
-                                            />
-                                          </EuiButtonEmpty>
-                                        }
-                                        closePopover={[Function]}
-                                        display="inlineBlock"
-                                        hasArrow={true}
-                                        isOpen={false}
-                                        ownFocus={true}
-                                        panelPaddingSize="s"
-                                      >
-                                        <div
-                                          className="euiPopover euiPopover--anchorDownLeft"
-                                        >
-                                          <div
-                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                          >
-                                            <EuiButtonEmpty
-                                              aria-label="Date quick select"
-                                              className="euiFormControlLayout__prepend"
-                                              data-test-subj="superDatePickerToggleQuickMenuButton"
-                                              iconSide="right"
-                                              iconType="arrowDown"
-                                              isDisabled={false}
-                                              onClick={[Function]}
-                                              size="xs"
-                                              textProps={
-                                                Object {
-                                                  "className": "euiQuickSelectPopover__buttonText",
-                                                }
-                                              }
-                                            >
-                                              <button
-                                                aria-label="Date quick select"
-                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                                data-test-subj="superDatePickerToggleQuickMenuButton"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <EuiButtonContent
-                                                  className="euiButtonEmpty__content"
-                                                  iconSide="right"
-                                                  iconSize="s"
-                                                  iconType="arrowDown"
-                                                  textProps={
-                                                    Object {
-                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                                    }
-                                                  }
-                                                >
-                                                  <span
-                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                                  >
-                                                    <EuiIcon
-                                                      className="euiButtonContent__icon"
-                                                      color="inherit"
-                                                      size="s"
-                                                      type="arrowDown"
-                                                    >
-                                                      <EuiIconArrowDown
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                        focusable="false"
-                                                        role="img"
-                                                        style={null}
-                                                      >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                          focusable="false"
-                                                          height={16}
-                                                          role="img"
-                                                          style={null}
-                                                          viewBox="0 0 16 16"
-                                                          width={16}
-                                                          xmlns="http://www.w3.org/2000/svg"
-                                                        >
-                                                          <path
-                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                            fillRule="non-zero"
-                                                          />
-                                                        </svg>
-                                                      </EuiIconArrowDown>
-                                                    </EuiIcon>
-                                                    <span
-                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                                    >
-                                                      <EuiIcon
-                                                        type="calendar"
-                                                      >
-                                                        <EuiIconCalendar
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--medium"
-                                                          focusable="false"
-                                                          role="img"
-                                                          style={null}
-                                                        >
-                                                          <svg
-                                                            aria-hidden={true}
-                                                            className="euiIcon euiIcon--medium"
-                                                            focusable="false"
-                                                            height={16}
-                                                            role="img"
-                                                            style={null}
-                                                            viewBox="0 0 16 16"
-                                                            width={16}
-                                                            xmlns="http://www.w3.org/2000/svg"
-                                                          >
-                                                            <path
-                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                              fillRule="evenodd"
-                                                            />
-                                                          </svg>
-                                                        </EuiIconCalendar>
-                                                      </EuiIcon>
-                                                    </span>
-                                                  </span>
-                                                </EuiButtonContent>
-                                              </button>
-                                            </EuiButtonEmpty>
-                                          </div>
-                                        </div>
-                                      </EuiPopover>
-                                    </EuiQuickSelectPopover>
-                                    <div
-                                      className="euiFormControlLayout__childrenWrapper"
-                                    >
-                                      <EuiDatePickerRange
-                                        className="euiDatePickerRange--inGroup"
-                                        endDateControl={<div />}
-                                        iconType={false}
-                                        isCustom={true}
-                                        startDateControl={<div />}
-                                      >
-                                        <div
-                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                        >
-                                          <button
-                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
-                                            data-test-subj="superDatePickerShowDatesButton"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                          >
-                                            Last 5 minutes
-                                            <span
-                                              className="euiSuperDatePicker__prettyFormatLink"
-                                            >
-                                              <EuiI18n
-                                                default="Show dates"
-                                                token="euiSuperDatePicker.showDatesButtonLabel"
-                                              >
-                                                Show dates
-                                              </EuiI18n>
-                                            </span>
-                                          </button>
-                                        </div>
-                                      </EuiDatePickerRange>
-                                      <EuiFormControlLayoutIcons
-                                        compressed={true}
-                                      />
-                                    </div>
-                                  </div>
-                                </EuiFormControlLayout>
-                              </div>
-                            </EuiFlexItem>
-                          </div>
-                        </EuiFlexGroup>
-                      </EuiSuperDatePicker>
-                    </div>
-                  </EuiFlexItem>
-                  <EuiFlexItem
-                    grow={false}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrowZero"
-                    >
-                      <EuiButtonIcon
-                        aria-label="Refresh"
-                        data-click-metric-element="trace_analytics.refresh_button"
-                        data-test-subj="superDatePickerApplyTimeButton"
-                        display="base"
-                        iconType="refresh"
+                      <button
+                        aria-controls="accordion1"
+                        aria-expanded={false}
+                        className="euiAccordion__button"
+                        id="random_html_id"
                         onClick={[Function]}
-                        size="s"
+                        type="button"
                       >
-                        <button
-                          aria-label="Refresh"
-                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
-                          data-click-metric-element="trace_analytics.refresh_button"
-                          data-test-subj="superDatePickerApplyTimeButton"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
+                        <span
+                          className="euiAccordion__iconWrapper"
                         >
                           <EuiIcon
-                            aria-hidden="true"
-                            className="euiButtonIcon__icon"
-                            color="inherit"
+                            className="euiAccordion__icon"
                             size="m"
-                            type="refresh"
+                            type="arrowRight"
                           >
-                            <EuiIconRefresh
+                            <EuiIconArrowRight
                               aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                              className="euiIcon euiIcon--medium euiAccordion__icon"
                               focusable="false"
                               role="img"
                               style={null}
                             >
                               <svg
                                 aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                className="euiIcon euiIcon--medium euiAccordion__icon"
                                 focusable="false"
                                 height={16}
                                 role="img"
@@ -4899,407 +5050,205 @@ exports[`Traces component renders traces page 1`] = `
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                  fillRule="nonzero"
                                 />
                               </svg>
-                            </EuiIconRefresh>
+                            </EuiIconArrowRight>
                           </EuiIcon>
-                        </button>
-                      </EuiButtonIcon>
+                        </span>
+                        <span
+                          className="euiIEFlexWrapFix"
+                        >
+                          Trace Groups
+                        </span>
+                      </button>
                     </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-            </ForwardRef>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
-    <Filters
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      filters={Array []}
-      mode="data_prepper"
-      page="traces"
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-    >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="xs"
-        responsive={false}
-        style={
-          Object {
-            "minHeight": 32,
-            "padding": "0 16px",
-          }
-        }
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-          style={
-            Object {
-              "minHeight": 32,
-              "padding": "0 16px",
-            }
-          }
-        >
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <AddFilterButton>
-                <EuiPopover
-                  anchorPosition="downLeft"
-                  button={
-                    <EuiButtonEmpty
-                      onClick={[Function]}
-                      size="xs"
-                    >
-                      + Add filter
-                    </EuiButtonEmpty>
-                  }
-                  closePopover={[Function]}
-                  data-test-subj="addfilter"
-                  display="inlineBlock"
-                  hasArrow={true}
-                  isOpen={false}
-                  ownFocus={true}
-                  panelPaddingSize="m"
-                >
-                  <div
-                    className="euiPopover euiPopover--anchorDownLeft"
-                    data-test-subj="addfilter"
-                  >
                     <div
-                      className="euiPopover__anchor"
+                      aria-labelledby="random_html_id"
+                      className="euiAccordion__childWrapper"
+                      id="accordion1"
+                      role="region"
+                      tabIndex={-1}
                     >
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
+                      <EuiResizeObserver
+                        onResize={[Function]}
                       >
-                        <button
-                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButtonEmpty__content"
-                            iconSide="left"
-                            iconSize="s"
-                            textProps={
-                              Object {
-                                "className": "euiButtonEmpty__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButtonEmpty__content"
-                            >
-                              <span
-                                className="euiButtonEmpty__text"
-                              >
-                                + Add filter
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonEmpty>
-                    </div>
-                  </div>
-                </EuiPopover>
-              </AddFilterButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-    </Filters>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <EuiPage
-      paddingSize="m"
-    >
-      <div
-        className="euiPage euiPage--paddingMedium euiPage--grow"
-      >
-        <EuiPanel>
-          <div
-            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          >
-            <EuiAccordion
-              arrowDisplay="left"
-              buttonContent="Trace Groups"
-              data-test-subj="trace-groups-service-operation-accordian"
-              forceState="closed"
-              id="accordion1"
-              initialIsOpen={false}
-              isLoading={false}
-              isLoadingMessage={false}
-              onToggle={[Function]}
-              paddingSize="none"
-            >
-              <div
-                className="euiAccordion"
-                data-test-subj="trace-groups-service-operation-accordian"
-                onToggle={[Function]}
-              >
-                <div
-                  className="euiAccordion__triggerWrapper"
-                >
-                  <button
-                    aria-controls="accordion1"
-                    aria-expanded={false}
-                    className="euiAccordion__button"
-                    id="random_html_id"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="euiAccordion__iconWrapper"
-                    >
-                      <EuiIcon
-                        className="euiAccordion__icon"
-                        size="m"
-                        type="arrowRight"
-                      >
-                        <EuiIconArrowRight
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiAccordion__icon"
-                          focusable="false"
-                          role="img"
-                          style={null}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiAccordion__icon"
-                            focusable="false"
-                            height={16}
-                            role="img"
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                              fillRule="nonzero"
-                            />
-                          </svg>
-                        </EuiIconArrowRight>
-                      </EuiIcon>
-                    </span>
-                    <span
-                      className="euiIEFlexWrapFix"
-                    >
-                      Trace Groups
-                    </span>
-                  </button>
-                </div>
-                <div
-                  aria-labelledby="random_html_id"
-                  className="euiAccordion__childWrapper"
-                  id="accordion1"
-                  role="region"
-                  tabIndex={-1}
-                >
-                  <EuiResizeObserver
-                    onResize={[Function]}
-                  >
-                    <div>
-                      <div
-                        className=""
-                      >
-                        <EuiSpacer
-                          size="m"
-                        >
+                        <div>
                           <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                      </div>
-                    </div>
-                  </EuiResizeObserver>
-                </div>
-              </div>
-            </EuiAccordion>
-          </div>
-        </EuiPanel>
-      </div>
-    </EuiPage>
-    <TracesTable
-      dataPrepperIndicesExist={true}
-      items={Array []}
-      loading={true}
-      mode="data_prepper"
-      refresh={[Function]}
-      traceIdColumnAction={[Function]}
-    >
-      <EuiPage
-        paddingSize="m"
-      >
-        <div
-          className="euiPage euiPage--paddingMedium euiPage--grow"
-        >
-          <EuiPanel>
-            <div
-              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-            >
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-              >
-                <div
-                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                >
-                  <EuiFlexItem
-                    grow={10}
-                  >
-                    <div
-                      className="euiFlexItem euiFlexItem--flexGrow10"
-                    >
-                      <PanelTitle
-                        title="Traces"
-                        totalItems={0}
-                      >
-                        <EuiText
-                          size="m"
-                        >
-                          <div
-                            className="euiText euiText--medium"
+                            className=""
                           >
-                            <span
-                              className="panel-title"
-                            >
-                              Traces
-                            </span>
-                            <span
-                              className="panel-title-count"
-                            >
-                               (0)
-                            </span>
-                          </div>
-                        </EuiText>
-                      </PanelTitle>
-                    </div>
-                  </EuiFlexItem>
-                </div>
-              </EuiFlexGroup>
-              <EuiSpacer
-                size="m"
-              >
-                <div
-                  className="euiSpacer euiSpacer--m"
-                />
-              </EuiSpacer>
-              <EuiHorizontalRule
-                margin="none"
-              >
-                <hr
-                  className="euiHorizontalRule euiHorizontalRule--full"
-                />
-              </EuiHorizontalRule>
-              <NoMatchMessage
-                size="xl"
-              >
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-                <EuiEmptyPrompt
-                  body={
-                    <EuiText
-                      size="s"
-                    >
-                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                    </EuiText>
-                  }
-                  title={
-                    <h2>
-                      No matches
-                    </h2>
-                  }
-                >
-                  <div
-                    className="euiEmptyPrompt"
-                  >
-                    <EuiTitle
-                      size="m"
-                    >
-                      <h2
-                        className="euiTitle euiTitle--medium"
-                      >
-                        No matches
-                      </h2>
-                    </EuiTitle>
-                    <EuiTextColor
-                      color="subdued"
-                    >
-                      <span
-                        className="euiTextColor euiTextColor--subdued"
-                      >
-                        <EuiSpacer
-                          size="m"
-                        >
-                          <div
-                            className="euiSpacer euiSpacer--m"
-                          />
-                        </EuiSpacer>
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            <EuiText
-                              size="s"
+                            <EuiSpacer
+                              size="m"
                             >
                               <div
-                                className="euiText euiText--small"
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
+                    </div>
+                  </div>
+                </EuiAccordion>
+              </div>
+            </EuiPanel>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <TracesTable
+              dataPrepperIndicesExist={true}
+              items={Array []}
+              loading={true}
+              mode="data_prepper"
+              refresh={[Function]}
+              traceIdColumnAction={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={10}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrow10"
+                        >
+                          <PanelTitle
+                            title="Traces"
+                            totalItems={0}
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
                               >
-                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                <span
+                                  className="panel-title"
+                                >
+                                  Traces
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
                               </div>
                             </EuiText>
-                          </div>
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
+                  >
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                    <EuiEmptyPrompt
+                      body={
+                        <EuiText
+                          size="s"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                         </EuiText>
-                      </span>
-                    </EuiTextColor>
-                  </div>
-                </EuiEmptyPrompt>
-                <EuiSpacer
-                  size="xl"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--xl"
-                  />
-                </EuiSpacer>
-              </NoMatchMessage>
-            </div>
-          </EuiPanel>
-        </div>
-      </EuiPage>
-    </TracesTable>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
+                      </div>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </TracesTable>
+          </div>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </TracesContent>
 </Traces>
 `;

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -238,139 +238,6 @@ exports[`Traces component renders empty traces page 1`] = `
   startTime="now-5m"
   traceIdColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="data_prepper"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="data_prepper"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconBeaker
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                          />
-                        </svg>
-                      </EuiIconBeaker>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Data Prepper
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <TracesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -608,16 +475,914 @@ exports[`Traces component renders empty traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 24px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 24px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="data_prepper"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiSmallButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="data_prepper"
+                  >
+                    Data Prepper
+                  </EuiSmallButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiSmallButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="data_prepper"
+                    >
+                      <EuiButtonEmpty
+                        className="dscIndexPattern__triggerButton"
+                        color="text"
+                        data-test-subj="indexPattern-switch-link"
+                        flush="left"
+                        iconSide="right"
+                        iconType="arrowDown"
+                        onClick={[Function]}
+                        size="s"
+                        title="data_prepper"
+                      >
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                          data-test-subj="indexPattern-switch-link"
+                          disabled={false}
+                          onClick={[Function]}
+                          title="data_prepper"
+                          type="button"
+                        >
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="right"
+                            iconSize="m"
+                            iconType="arrowDown"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            >
+                              <EuiIcon
+                                className="euiButtonContent__icon"
+                                color="inherit"
+                                size="m"
+                                type="arrowDown"
+                              >
+                                <EuiIconBeaker
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                  focusable="false"
+                                  role="img"
+                                  style={null}
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
+                                </EuiIconBeaker>
+                              </EuiIcon>
+                              <span
+                                className="euiButtonEmpty__text"
+                              >
+                                Data Prepper
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </EuiSmallButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="data_prepper"
+              page="traces"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiCompressedFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiSmallButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiSmallButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <EuiButtonIcon
+                                        aria-label="Change all filters"
+                                        iconType="filter"
+                                        onClick={[Function]}
+                                        size="s"
+                                        title="Change all filters"
+                                      >
+                                        <button
+                                          aria-label="Change all filters"
+                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          title="Change all filters"
+                                          type="button"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="filter"
+                                          >
+                                            <EuiIconBeaker
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiSmallButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiCompressedFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconBeaker
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconBeaker>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconBeaker
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconBeaker>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconBeaker
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </EuiIconBeaker>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="data_prepper"
       page="traces"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -633,942 +1398,216 @@ exports[`Traces component renders empty traces page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconBeaker
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconBeaker>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconBeaker
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                    />
-                                                  </svg>
-                                                </EuiIconBeaker>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
-                  >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
-                          >
-                            <EuiIconBeaker
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                />
-                              </svg>
-                            </EuiIconBeaker>
-                          </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="traces"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </div>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
+    <EuiSpacer
+      size="m"
+    >
+      <div
+        className="euiSpacer euiSpacer--m"
+      />
+    </EuiSpacer>
+    <EuiPage
+      paddingSize="m"
+    >
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          >
+            <EuiAccordion
+              arrowDisplay="left"
+              buttonContent="Trace Groups"
+              data-test-subj="trace-groups-service-operation-accordian"
+              forceState="closed"
+              id="accordion1"
+              initialIsOpen={false}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion"
+                data-test-subj="trace-groups-service-operation-accordian"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="accordion1"
+                    aria-expanded={false}
+                    className="euiAccordion__button"
+                    id="random_html_id"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <EuiIconBeaker
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                          focusable="false"
+                          role="img"
+                          style={null}
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
+                            focusable="false"
+                            height={16}
+                            role="img"
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                            />
+                          </svg>
+                        </EuiIconBeaker>
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      Trace Groups
+                    </span>
+                  </button>
+                </div>
+                <div
+                  aria-labelledby="random_html_id"
+                  className="euiAccordion__childWrapper"
+                  id="accordion1"
+                  role="region"
+                  tabIndex={-1}
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
                       </div>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiAccordion
-          arrowDisplay="left"
-          buttonContent="Trace Groups"
-          data-test-subj="trace-groups-service-operation-accordian"
-          forceState="closed"
-          id="accordion1"
-          initialIsOpen={false}
-          isLoading={false}
-          isLoadingMessage={false}
-          onToggle={[Function]}
-          paddingSize="none"
-        >
-          <div
-            className="euiAccordion"
-            data-test-subj="trace-groups-service-operation-accordian"
-            onToggle={[Function]}
-          >
-            <div
-              className="euiAccordion__triggerWrapper"
-            >
-              <button
-                aria-controls="accordion1"
-                aria-expanded={false}
-                className="euiAccordion__button"
-                id="random_html_id"
-                onClick={[Function]}
-                type="button"
-              >
-                <span
-                  className="euiAccordion__iconWrapper"
-                >
-                  <EuiIcon
-                    className="euiAccordion__icon"
-                    size="m"
-                    type="arrowRight"
-                  >
-                    <EuiIconBeaker
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                        />
-                      </svg>
-                    </EuiIconBeaker>
-                  </EuiIcon>
-                </span>
-                <span
-                  className="euiIEFlexWrapFix"
-                >
-                  Trace Groups
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="random_html_id"
-              className="euiAccordion__childWrapper"
-              id="accordion1"
-              role="region"
-              tabIndex={-1}
-            >
-              <EuiResizeObserver
-                onResize={[Function]}
-              >
-                <div>
-                  <div
-                    className=""
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                  </div>
+                  </EuiResizeObserver>
                 </div>
-              </EuiResizeObserver>
-            </div>
+              </div>
+            </EuiAccordion>
           </div>
-        </EuiAccordion>
+        </EuiPanel>
       </div>
-    </EuiPanel>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
+    </EuiPage>
     <TracesTable
       dataPrepperIndicesExist={true}
       items={Array []}
@@ -1577,142 +1616,150 @@ exports[`Traces component renders empty traces page 1`] = `
       refresh={[Function]}
       traceIdColumnAction={[Function]}
     >
-      <EuiPanel>
+      <EuiPage
+        paddingSize="m"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiPage euiPage--paddingMedium euiPage--grow"
         >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
+          <EuiPanel>
             <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <EuiFlexItem
-                grow={10}
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
               >
                 <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
+                  <EuiFlexItem
+                    grow={10}
                   >
-                    <EuiText
-                      size="m"
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrow10"
                     >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                      <PanelTitle
+                        title="Traces"
+                        totalItems={0}
                       >
                         <EuiText
-                          size="s"
+                          size="m"
                         >
                           <div
-                            className="euiText euiText--small"
+                            className="euiText euiText--medium"
                           >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                            <span
+                              className="panel-title"
+                            >
+                              Traces
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
                           </div>
                         </EuiText>
-                      </div>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
+              <NoMatchMessage
+                size="xl"
+              >
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText
+                      size="s"
+                    >
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                     </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
+                  }
+                  title={
+                    <h2>
+                      No matches
+                    </h2>
+                  }
+                >
+                  <div
+                    className="euiEmptyPrompt"
+                  >
+                    <EuiTitle
+                      size="m"
+                    >
+                      <h2
+                        className="euiTitle euiTitle--medium"
+                      >
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <EuiText
+                              size="s"
+                            >
+                              <div
+                                className="euiText euiText--small"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiText>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </EuiPanel>
         </div>
-      </EuiPanel>
+      </EuiPage>
     </TracesTable>
   </TracesContent>
 </Traces>
@@ -1956,140 +2003,6 @@ exports[`Traces component renders jaeger traces page 1`] = `
   startTime="now-5m"
   traceIdColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="jaeger"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="jaeger"
-        >
-          Jaeger
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="jaeger"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="jaeger"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="jaeger"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconArrowDown
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                            fillRule="non-zero"
-                          />
-                        </svg>
-                      </EuiIconArrowDown>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Jaeger
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <TracesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -2327,16 +2240,918 @@ exports[`Traces component renders jaeger traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 24px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 24px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="jaeger"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiSmallButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="jaeger"
+                  >
+                    Jaeger
+                  </EuiSmallButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiSmallButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="jaeger"
+                    >
+                      <EuiButtonEmpty
+                        className="dscIndexPattern__triggerButton"
+                        color="text"
+                        data-test-subj="indexPattern-switch-link"
+                        flush="left"
+                        iconSide="right"
+                        iconType="arrowDown"
+                        onClick={[Function]}
+                        size="s"
+                        title="jaeger"
+                      >
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                          data-test-subj="indexPattern-switch-link"
+                          disabled={false}
+                          onClick={[Function]}
+                          title="jaeger"
+                          type="button"
+                        >
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="right"
+                            iconSize="m"
+                            iconType="arrowDown"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            >
+                              <EuiIcon
+                                className="euiButtonContent__icon"
+                                color="inherit"
+                                size="m"
+                                type="arrowDown"
+                              >
+                                <EuiIconArrowDown
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                  focusable="false"
+                                  role="img"
+                                  style={null}
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                      fillRule="non-zero"
+                                    />
+                                  </svg>
+                                </EuiIconArrowDown>
+                              </EuiIcon>
+                              <span
+                                className="euiButtonEmpty__text"
+                              >
+                                Jaeger
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </EuiSmallButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="jaeger"
+              page="traces"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiCompressedFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiSmallButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiSmallButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <EuiButtonIcon
+                                        aria-label="Change all filters"
+                                        iconType="filter"
+                                        onClick={[Function]}
+                                        size="s"
+                                        title="Change all filters"
+                                      >
+                                        <button
+                                          aria-label="Change all filters"
+                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          title="Change all filters"
+                                          type="button"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="filter"
+                                          >
+                                            <EuiIconFilter
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                  fillRule="evenodd"
+                                                />
+                                              </svg>
+                                            </EuiIconFilter>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiSmallButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconSearch
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSearch>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiCompressedFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconArrowDown
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                            fillRule="non-zero"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconArrowDown>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconCalendar
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                              fillRule="evenodd"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconCalendar>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconRefresh
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                />
+                              </svg>
+                            </EuiIconRefresh>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="jaeger"
       page="traces"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -2352,946 +3167,217 @@ exports[`Traces component renders jaeger traces page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconCalendar
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
-                                                    />
-                                                  </svg>
-                                                </EuiIconCalendar>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
-                  >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
-                          >
-                            <EuiIconRefresh
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                                />
-                              </svg>
-                            </EuiIconRefresh>
-                          </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="jaeger"
-        page="traces"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconFilter
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                      fillRule="evenodd"
-                                    />
-                                  </svg>
-                                </EuiIconFilter>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </div>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
+    <EuiSpacer
+      size="m"
+    >
+      <div
+        className="euiSpacer euiSpacer--m"
+      />
+    </EuiSpacer>
+    <EuiPage
+      paddingSize="m"
+    >
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          >
+            <EuiAccordion
+              arrowDisplay="left"
+              buttonContent="Service and Operations"
+              data-test-subj="trace-groups-service-operation-accordian"
+              forceState="closed"
+              id="accordion1"
+              initialIsOpen={false}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion"
+                data-test-subj="trace-groups-service-operation-accordian"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="accordion1"
+                    aria-expanded={false}
+                    className="euiAccordion__button"
+                    id="random_html_id"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <EuiIconArrowRight
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiAccordion__icon"
+                          focusable="false"
+                          role="img"
+                          style={null}
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiAccordion__icon"
+                            focusable="false"
+                            height={16}
+                            role="img"
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                              fillRule="nonzero"
+                            />
+                          </svg>
+                        </EuiIconArrowRight>
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      Service and Operations
+                    </span>
+                  </button>
+                </div>
+                <div
+                  aria-labelledby="random_html_id"
+                  className="euiAccordion__childWrapper"
+                  id="accordion1"
+                  role="region"
+                  tabIndex={-1}
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
                       </div>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiAccordion
-          arrowDisplay="left"
-          buttonContent="Service and Operations"
-          data-test-subj="trace-groups-service-operation-accordian"
-          forceState="closed"
-          id="accordion1"
-          initialIsOpen={false}
-          isLoading={false}
-          isLoadingMessage={false}
-          onToggle={[Function]}
-          paddingSize="none"
-        >
-          <div
-            className="euiAccordion"
-            data-test-subj="trace-groups-service-operation-accordian"
-            onToggle={[Function]}
-          >
-            <div
-              className="euiAccordion__triggerWrapper"
-            >
-              <button
-                aria-controls="accordion1"
-                aria-expanded={false}
-                className="euiAccordion__button"
-                id="random_html_id"
-                onClick={[Function]}
-                type="button"
-              >
-                <span
-                  className="euiAccordion__iconWrapper"
-                >
-                  <EuiIcon
-                    className="euiAccordion__icon"
-                    size="m"
-                    type="arrowRight"
-                  >
-                    <EuiIconArrowRight
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiAccordion__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiAccordion__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                          fillRule="nonzero"
-                        />
-                      </svg>
-                    </EuiIconArrowRight>
-                  </EuiIcon>
-                </span>
-                <span
-                  className="euiIEFlexWrapFix"
-                >
-                  Service and Operations
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="random_html_id"
-              className="euiAccordion__childWrapper"
-              id="accordion1"
-              role="region"
-              tabIndex={-1}
-            >
-              <EuiResizeObserver
-                onResize={[Function]}
-              >
-                <div>
-                  <div
-                    className=""
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                  </div>
+                  </EuiResizeObserver>
                 </div>
-              </EuiResizeObserver>
-            </div>
+              </div>
+            </EuiAccordion>
           </div>
-        </EuiAccordion>
+        </EuiPanel>
       </div>
-    </EuiPanel>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
+    </EuiPage>
     <TracesTable
       dataPrepperIndicesExist={false}
       items={Array []}
@@ -3301,142 +3387,150 @@ exports[`Traces component renders jaeger traces page 1`] = `
       refresh={[Function]}
       traceIdColumnAction={[Function]}
     >
-      <EuiPanel>
+      <EuiPage
+        paddingSize="m"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiPage euiPage--paddingMedium euiPage--grow"
         >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
+          <EuiPanel>
             <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <EuiFlexItem
-                grow={10}
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
               >
                 <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
+                  <EuiFlexItem
+                    grow={10}
                   >
-                    <EuiText
-                      size="m"
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrow10"
                     >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                      <PanelTitle
+                        title="Traces"
+                        totalItems={0}
                       >
                         <EuiText
-                          size="s"
+                          size="m"
                         >
                           <div
-                            className="euiText euiText--small"
+                            className="euiText euiText--medium"
                           >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                            <span
+                              className="panel-title"
+                            >
+                              Traces
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
                           </div>
                         </EuiText>
-                      </div>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
+              <NoMatchMessage
+                size="xl"
+              >
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText
+                      size="s"
+                    >
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                     </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
+                  }
+                  title={
+                    <h2>
+                      No matches
+                    </h2>
+                  }
+                >
+                  <div
+                    className="euiEmptyPrompt"
+                  >
+                    <EuiTitle
+                      size="m"
+                    >
+                      <h2
+                        className="euiTitle euiTitle--medium"
+                      >
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <EuiText
+                              size="s"
+                            >
+                              <div
+                                className="euiText euiText--small"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiText>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </EuiPanel>
         </div>
-      </EuiPanel>
+      </EuiPage>
     </TracesTable>
   </TracesContent>
 </Traces>
@@ -3679,140 +3773,6 @@ exports[`Traces component renders traces page 1`] = `
   startTime="now-5m"
   traceIdColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="data_prepper"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="data_prepper"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconArrowDown
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                            fillRule="non-zero"
-                          />
-                        </svg>
-                      </EuiIconArrowDown>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Data Prepper
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <TracesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -4049,16 +4009,918 @@ exports[`Traces component renders traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <ForwardRef
+    <EuiFlexGroup
+      alignItems="center"
+      gutterSize="s"
+      justifyContent="spaceBetween"
+      style={
+        Object {
+          "padding": "0 24px",
+        }
+      }
+    >
+      <div
+        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style={
+          Object {
+            "padding": "0 24px",
+          }
+        }
+      >
+        <EuiFlexItem
+          grow={false}
+        >
+          <div
+            className="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <DataSourcePicker
+              modes={
+                Array [
+                  Object {
+                    "id": "jaeger",
+                    "title": "Jaeger",
+                  },
+                  Object {
+                    "id": "data_prepper",
+                    "title": "Data Prepper",
+                  },
+                ]
+              }
+              selectedMode="data_prepper"
+            >
+              <EuiPopover
+                anchorClassName="eui-textTruncate"
+                anchorPosition="downCenter"
+                button={
+                  <EuiSmallButtonEmpty
+                    className="dscIndexPattern__triggerButton"
+                    color="text"
+                    data-test-subj="indexPattern-switch-link"
+                    flush="left"
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                    title="data_prepper"
+                  >
+                    Data Prepper
+                  </EuiSmallButtonEmpty>
+                }
+                className="eui-textTruncate"
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                isOpen={false}
+                ownFocus={true}
+                panelPaddingSize="s"
+              >
+                <div
+                  className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
+                >
+                  <div
+                    className="euiPopover__anchor eui-textTruncate"
+                  >
+                    <EuiSmallButtonEmpty
+                      className="dscIndexPattern__triggerButton"
+                      color="text"
+                      data-test-subj="indexPattern-switch-link"
+                      flush="left"
+                      iconSide="right"
+                      iconType="arrowDown"
+                      onClick={[Function]}
+                      title="data_prepper"
+                    >
+                      <EuiButtonEmpty
+                        className="dscIndexPattern__triggerButton"
+                        color="text"
+                        data-test-subj="indexPattern-switch-link"
+                        flush="left"
+                        iconSide="right"
+                        iconType="arrowDown"
+                        onClick={[Function]}
+                        size="s"
+                        title="data_prepper"
+                      >
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                          data-test-subj="indexPattern-switch-link"
+                          disabled={false}
+                          onClick={[Function]}
+                          title="data_prepper"
+                          type="button"
+                        >
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="right"
+                            iconSize="m"
+                            iconType="arrowDown"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
+                              }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                            >
+                              <EuiIcon
+                                className="euiButtonContent__icon"
+                                color="inherit"
+                                size="m"
+                                type="arrowDown"
+                              >
+                                <EuiIconArrowDown
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                  focusable="false"
+                                  role="img"
+                                  style={null}
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                      fillRule="non-zero"
+                                    />
+                                  </svg>
+                                </EuiIconArrowDown>
+                              </EuiIcon>
+                              <span
+                                className="euiButtonEmpty__text"
+                              >
+                                Data Prepper
+                              </span>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </EuiSmallButtonEmpty>
+                  </div>
+                </div>
+              </EuiPopover>
+            </DataSourcePicker>
+          </div>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={true}
+        >
+          <div
+            className="euiFlexItem"
+          >
+            <ForwardRef
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              endTime="now"
+              filters={Array []}
+              mode="data_prepper"
+              page="traces"
+              query=""
+              refresh={[Function]}
+              setEndTime={[MockFunction]}
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+              setQuery={[MockFunction]}
+              setStartTime={[MockFunction]}
+              startTime="now-5m"
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <EuiFlexItem>
+                    <div
+                      className="euiFlexItem"
+                    >
+                      <EuiCompressedFieldSearch
+                        compressed={true}
+                        data-test-subj="search-bar-input-box"
+                        fullWidth={true}
+                        incremental={false}
+                        isClearable={false}
+                        isLoading={false}
+                        onChange={[Function]}
+                        onSearch={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        prepend={
+                          <GlobalFilterButton
+                            filters={Array []}
+                            setFilters={
+                              [MockFunction] {
+                                "calls": Array [
+                                  Array [
+                                    Array [],
+                                  ],
+                                ],
+                                "results": Array [
+                                  Object {
+                                    "type": "return",
+                                    "value": undefined,
+                                  },
+                                ],
+                              }
+                            }
+                          />
+                        }
+                        value=""
+                      >
+                        <EuiFormControlLayout
+                          compressed={true}
+                          fullWidth={true}
+                          icon="search"
+                          isLoading={false}
+                          prepend={
+                            <GlobalFilterButton
+                              filters={Array []}
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            />
+                          }
+                        >
+                          <div
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
+                          >
+                            <GlobalFilterButton
+                              className="euiFormControlLayout__prepend"
+                              filters={Array []}
+                              key="0/.0"
+                              setFilters={
+                                [MockFunction] {
+                                  "calls": Array [
+                                    Array [
+                                      Array [],
+                                    ],
+                                  ],
+                                  "results": Array [
+                                    Object {
+                                      "type": "return",
+                                      "value": undefined,
+                                    },
+                                  ],
+                                }
+                              }
+                            >
+                              <EuiPopover
+                                anchorPosition="rightUp"
+                                button={
+                                  <EuiSmallButtonIcon
+                                    aria-label="Change all filters"
+                                    iconType="filter"
+                                    onClick={[Function]}
+                                    title="Change all filters"
+                                  />
+                                }
+                                closePopover={[Function]}
+                                data-test-subj="global-filter-button"
+                                display="inlineBlock"
+                                hasArrow={true}
+                                isOpen={false}
+                                ownFocus={true}
+                                panelPaddingSize="none"
+                              >
+                                <div
+                                  className="euiPopover euiPopover--anchorRightUp"
+                                  data-test-subj="global-filter-button"
+                                >
+                                  <div
+                                    className="euiPopover__anchor"
+                                  >
+                                    <EuiSmallButtonIcon
+                                      aria-label="Change all filters"
+                                      iconType="filter"
+                                      onClick={[Function]}
+                                      title="Change all filters"
+                                    >
+                                      <EuiButtonIcon
+                                        aria-label="Change all filters"
+                                        iconType="filter"
+                                        onClick={[Function]}
+                                        size="s"
+                                        title="Change all filters"
+                                      >
+                                        <button
+                                          aria-label="Change all filters"
+                                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                          disabled={false}
+                                          onClick={[Function]}
+                                          title="Change all filters"
+                                          type="button"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="filter"
+                                          >
+                                            <EuiIconFilter
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                  fillRule="evenodd"
+                                                />
+                                              </svg>
+                                            </EuiIconFilter>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiSmallButtonIcon>
+                                  </div>
+                                </div>
+                              </EuiPopover>
+                            </GlobalFilterButton>
+                            <div
+                              className="euiFormControlLayout__childrenWrapper"
+                            >
+                              <EuiValidatableControl>
+                                <input
+                                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                  data-test-subj="search-bar-input-box"
+                                  onChange={[Function]}
+                                  onKeyUp={[Function]}
+                                  placeholder="Trace ID, trace group name, service name"
+                                  type="search"
+                                  value=""
+                                />
+                              </EuiValidatableControl>
+                              <EuiFormControlLayoutIcons
+                                compressed={true}
+                                icon="search"
+                                isLoading={false}
+                              >
+                                <div
+                                  className="euiFormControlLayoutIcons"
+                                >
+                                  <EuiFormControlLayoutCustomIcon
+                                    size="s"
+                                    type="search"
+                                  >
+                                    <span
+                                      className="euiFormControlLayoutCustomIcon"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiFormControlLayoutCustomIcon__icon"
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <EuiIconSearch
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSearch>
+                                      </EuiIcon>
+                                    </span>
+                                  </EuiFormControlLayoutCustomIcon>
+                                </div>
+                              </EuiFormControlLayoutIcons>
+                            </div>
+                          </div>
+                        </EuiFormControlLayout>
+                      </EuiCompressedFieldSearch>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                    style={
+                      Object {
+                        "maxWidth": "30vw",
+                      }
+                    }
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                      style={
+                        Object {
+                          "maxWidth": "30vw",
+                        }
+                      }
+                    >
+                      <EuiSuperDatePicker
+                        commonlyUsedRanges={
+                          Array [
+                            Object {
+                              "end": "now/d",
+                              "label": "Today",
+                              "start": "now/d",
+                            },
+                            Object {
+                              "end": "now/w",
+                              "label": "This week",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now/M",
+                              "label": "This month",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now/y",
+                              "label": "This year",
+                              "start": "now/y",
+                            },
+                            Object {
+                              "end": "now-1d/d",
+                              "label": "Yesterday",
+                              "start": "now-1d/d",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Week to date",
+                              "start": "now/w",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Month to date",
+                              "start": "now/M",
+                            },
+                            Object {
+                              "end": "now",
+                              "label": "Year to date",
+                              "start": "now/y",
+                            },
+                          ]
+                        }
+                        compressed={true}
+                        dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                        end="now"
+                        isAutoRefreshOnly={false}
+                        isDisabled={false}
+                        isPaused={true}
+                        onTimeChange={[Function]}
+                        recentlyUsedRanges={Array []}
+                        refreshInterval={0}
+                        showUpdateButton={false}
+                        start="now-5m"
+                        timeFormat="HH:mm"
+                      >
+                        <EuiFlexGroup
+                          className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          gutterSize="s"
+                          responsive={false}
+                        >
+                          <div
+                            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                          >
+                            <EuiFlexItem>
+                              <div
+                                className="euiFlexItem"
+                              >
+                                <EuiFormControlLayout
+                                  className="euiSuperDatePicker"
+                                  compressed={true}
+                                  isDisabled={false}
+                                  prepend={
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    />
+                                  }
+                                >
+                                  <div
+                                    className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                  >
+                                    <EuiQuickSelectPopover
+                                      applyTime={[Function]}
+                                      className="euiFormControlLayout__prepend"
+                                      commonlyUsedRanges={
+                                        Array [
+                                          Object {
+                                            "end": "now/d",
+                                            "label": "Today",
+                                            "start": "now/d",
+                                          },
+                                          Object {
+                                            "end": "now/w",
+                                            "label": "This week",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now/M",
+                                            "label": "This month",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now/y",
+                                            "label": "This year",
+                                            "start": "now/y",
+                                          },
+                                          Object {
+                                            "end": "now-1d/d",
+                                            "label": "Yesterday",
+                                            "start": "now-1d/d",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Week to date",
+                                            "start": "now/w",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Month to date",
+                                            "start": "now/M",
+                                          },
+                                          Object {
+                                            "end": "now",
+                                            "label": "Year to date",
+                                            "start": "now/y",
+                                          },
+                                        ]
+                                      }
+                                      dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                      end="now"
+                                      isAutoRefreshOnly={false}
+                                      isDisabled={false}
+                                      isPaused={true}
+                                      key="0/.0"
+                                      recentlyUsedRanges={Array []}
+                                      refreshInterval={0}
+                                      start="now-5m"
+                                    >
+                                      <EuiPopover
+                                        anchorClassName="euiQuickSelectPopover__anchor"
+                                        anchorPosition="downLeft"
+                                        button={
+                                          <EuiButtonEmpty
+                                            aria-label="Date quick select"
+                                            className="euiFormControlLayout__prepend"
+                                            data-test-subj="superDatePickerToggleQuickMenuButton"
+                                            iconSide="right"
+                                            iconType="arrowDown"
+                                            isDisabled={false}
+                                            onClick={[Function]}
+                                            size="xs"
+                                            textProps={
+                                              Object {
+                                                "className": "euiQuickSelectPopover__buttonText",
+                                              }
+                                            }
+                                          >
+                                            <EuiIcon
+                                              type="calendar"
+                                            />
+                                          </EuiButtonEmpty>
+                                        }
+                                        closePopover={[Function]}
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="s"
+                                      >
+                                        <div
+                                          className="euiPopover euiPopover--anchorDownLeft"
+                                        >
+                                          <div
+                                            className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                          >
+                                            <EuiButtonEmpty
+                                              aria-label="Date quick select"
+                                              className="euiFormControlLayout__prepend"
+                                              data-test-subj="superDatePickerToggleQuickMenuButton"
+                                              iconSide="right"
+                                              iconType="arrowDown"
+                                              isDisabled={false}
+                                              onClick={[Function]}
+                                              size="xs"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiQuickSelectPopover__buttonText",
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-label="Date quick select"
+                                                className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <EuiButtonContent
+                                                  className="euiButtonEmpty__content"
+                                                  iconSide="right"
+                                                  iconSize="s"
+                                                  iconType="arrowDown"
+                                                  textProps={
+                                                    Object {
+                                                      "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                    }
+                                                  }
+                                                >
+                                                  <span
+                                                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                  >
+                                                    <EuiIcon
+                                                      className="euiButtonContent__icon"
+                                                      color="inherit"
+                                                      size="s"
+                                                      type="arrowDown"
+                                                    >
+                                                      <EuiIconArrowDown
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                            fillRule="non-zero"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconArrowDown>
+                                                    </EuiIcon>
+                                                    <span
+                                                      className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                    >
+                                                      <EuiIcon
+                                                        type="calendar"
+                                                      >
+                                                        <EuiIconCalendar
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium"
+                                                          focusable="false"
+                                                          role="img"
+                                                          style={null}
+                                                        >
+                                                          <svg
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium"
+                                                            focusable="false"
+                                                            height={16}
+                                                            role="img"
+                                                            style={null}
+                                                            viewBox="0 0 16 16"
+                                                            width={16}
+                                                            xmlns="http://www.w3.org/2000/svg"
+                                                          >
+                                                            <path
+                                                              d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                              fillRule="evenodd"
+                                                            />
+                                                          </svg>
+                                                        </EuiIconCalendar>
+                                                      </EuiIcon>
+                                                    </span>
+                                                  </span>
+                                                </EuiButtonContent>
+                                              </button>
+                                            </EuiButtonEmpty>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </EuiQuickSelectPopover>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiDatePickerRange
+                                        className="euiDatePickerRange--inGroup"
+                                        endDateControl={<div />}
+                                        iconType={false}
+                                        isCustom={true}
+                                        startDateControl={<div />}
+                                      >
+                                        <div
+                                          className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                        >
+                                          <button
+                                            className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                            data-test-subj="superDatePickerShowDatesButton"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                          >
+                                            Last 5 minutes
+                                            <span
+                                              className="euiSuperDatePicker__prettyFormatLink"
+                                            >
+                                              <EuiI18n
+                                                default="Show dates"
+                                                token="euiSuperDatePicker.showDatesButtonLabel"
+                                              >
+                                                Show dates
+                                              </EuiI18n>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </EuiDatePickerRange>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                      />
+                                    </div>
+                                  </div>
+                                </EuiFormControlLayout>
+                              </div>
+                            </EuiFlexItem>
+                          </div>
+                        </EuiFlexGroup>
+                      </EuiSuperDatePicker>
+                    </div>
+                  </EuiFlexItem>
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <EuiButtonIcon
+                        aria-label="Refresh"
+                        data-click-metric-element="trace_analytics.refresh_button"
+                        data-test-subj="superDatePickerApplyTimeButton"
+                        display="base"
+                        iconType="refresh"
+                        onClick={[Function]}
+                        size="s"
+                      >
+                        <button
+                          aria-label="Refresh"
+                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                          data-click-metric-element="trace_analytics.refresh_button"
+                          data-test-subj="superDatePickerApplyTimeButton"
+                          disabled={false}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <EuiIcon
+                            aria-hidden="true"
+                            className="euiButtonIcon__icon"
+                            color="inherit"
+                            size="m"
+                            type="refresh"
+                          >
+                            <EuiIconRefresh
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                />
+                              </svg>
+                            </EuiIconRefresh>
+                          </EuiIcon>
+                        </button>
+                      </EuiButtonIcon>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </ForwardRef>
+          </div>
+        </EuiFlexItem>
+      </div>
+    </EuiFlexGroup>
+    <Filters
       appConfigs={Array []}
       attributesFilterFields={Array []}
-      endTime="now"
       filters={Array []}
       mode="data_prepper"
       page="traces"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
       setFilters={
         [MockFunction] {
           "calls": Array [
@@ -4074,946 +4936,217 @@ exports[`Traces component renders traces page 1`] = `
           ],
         }
       }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
     >
       <EuiFlexGroup
-        gutterSize="s"
-      >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
-            >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
-              >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
-                  >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
-                    >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
-                      >
-                        <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
-                        >
-                          <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
-                          >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
-                                    iconSide="right"
-                                    iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
-                                    textProps={
-                                      Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
-                                      }
-                                    }
-                                  >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
-                                }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
-                              >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
-                                >
-                                  <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
-                                  >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
-                                      className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
-                                        }
-                                      }
-                                    >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                          >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
-                                            >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
-                                              >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
-                                                >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
-                                            <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
-                                            >
-                                              <EuiIcon
-                                                type="calendar"
-                                              >
-                                                <EuiIconCalendar
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
-                                                  focusable="false"
-                                                  role="img"
-                                                  style={null}
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
-                                                    focusable="false"
-                                                    height={16}
-                                                    role="img"
-                                                    style={null}
-                                                    viewBox="0 0 16 16"
-                                                    width={16}
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                  >
-                                                    <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
-                                                    />
-                                                  </svg>
-                                                </EuiIconCalendar>
-                                              </EuiIcon>
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
-                                  </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
-                            </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
-                  >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
-                          >
-                            <EuiIconRefresh
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                                />
-                              </svg>
-                            </EuiIconRefresh>
-                          </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="traces"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+            "padding": "0 16px",
           }
         }
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
           style={
             Object {
               "minHeight": 32,
+              "padding": "0 16px",
             }
           }
         >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
+          <EuiFlexItem
+            grow={false}
           >
-            <EuiFlexItem
-              grow={false}
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
             >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  data-test-subj="addfilter"
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={true}
+                  panelPaddingSize="m"
+                >
+                  <div
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    data-test-subj="addfilter"
                   >
                     <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
+                      className="euiPopover__anchor"
                     >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconFilter
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                      fillRule="evenodd"
-                                    />
-                                  </svg>
-                                </EuiIconFilter>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
                       <EuiButtonEmpty
                         onClick={[Function]}
                         size="xs"
                       >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
+                        <button
+                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                          disabled={false}
                           onClick={[Function]}
-                          size="xs"
+                          type="button"
                         >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
+                          <EuiButtonContent
+                            className="euiButtonEmpty__content"
+                            iconSide="left"
+                            iconSize="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonEmpty__text",
                               }
+                            }
+                          >
+                            <span
+                              className="euiButtonContent euiButtonEmpty__content"
                             >
                               <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                                className="euiButtonEmpty__text"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
+                                + Add filter
                               </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
+                            </span>
+                          </EuiButtonContent>
+                        </button>
+                      </EuiButtonEmpty>
+                    </div>
+                  </div>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
+    <EuiSpacer
+      size="m"
+    >
+      <div
+        className="euiSpacer euiSpacer--m"
+      />
+    </EuiSpacer>
+    <EuiPage
+      paddingSize="m"
+    >
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
+      >
+        <EuiPanel>
+          <div
+            className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          >
+            <EuiAccordion
+              arrowDisplay="left"
+              buttonContent="Trace Groups"
+              data-test-subj="trace-groups-service-operation-accordian"
+              forceState="closed"
+              id="accordion1"
+              initialIsOpen={false}
+              isLoading={false}
+              isLoadingMessage={false}
+              onToggle={[Function]}
+              paddingSize="none"
+            >
+              <div
+                className="euiAccordion"
+                data-test-subj="trace-groups-service-operation-accordian"
+                onToggle={[Function]}
+              >
+                <div
+                  className="euiAccordion__triggerWrapper"
+                >
+                  <button
+                    aria-controls="accordion1"
+                    aria-expanded={false}
+                    className="euiAccordion__button"
+                    id="random_html_id"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <span
+                      className="euiAccordion__iconWrapper"
+                    >
+                      <EuiIcon
+                        className="euiAccordion__icon"
+                        size="m"
+                        type="arrowRight"
+                      >
+                        <EuiIconArrowRight
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiAccordion__icon"
+                          focusable="false"
+                          role="img"
+                          style={null}
+                        >
+                          <svg
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiAccordion__icon"
+                            focusable="false"
+                            height={16}
+                            role="img"
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                              fillRule="nonzero"
+                            />
+                          </svg>
+                        </EuiIconArrowRight>
+                      </EuiIcon>
+                    </span>
+                    <span
+                      className="euiIEFlexWrapFix"
+                    >
+                      Trace Groups
+                    </span>
+                  </button>
+                </div>
+                <div
+                  aria-labelledby="random_html_id"
+                  className="euiAccordion__childWrapper"
+                  id="accordion1"
+                  role="region"
+                  tabIndex={-1}
+                >
+                  <EuiResizeObserver
+                    onResize={[Function]}
+                  >
+                    <div>
+                      <div
+                        className=""
+                      >
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
                       </div>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiAccordion
-          arrowDisplay="left"
-          buttonContent="Trace Groups"
-          data-test-subj="trace-groups-service-operation-accordian"
-          forceState="closed"
-          id="accordion1"
-          initialIsOpen={false}
-          isLoading={false}
-          isLoadingMessage={false}
-          onToggle={[Function]}
-          paddingSize="none"
-        >
-          <div
-            className="euiAccordion"
-            data-test-subj="trace-groups-service-operation-accordian"
-            onToggle={[Function]}
-          >
-            <div
-              className="euiAccordion__triggerWrapper"
-            >
-              <button
-                aria-controls="accordion1"
-                aria-expanded={false}
-                className="euiAccordion__button"
-                id="random_html_id"
-                onClick={[Function]}
-                type="button"
-              >
-                <span
-                  className="euiAccordion__iconWrapper"
-                >
-                  <EuiIcon
-                    className="euiAccordion__icon"
-                    size="m"
-                    type="arrowRight"
-                  >
-                    <EuiIconArrowRight
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiAccordion__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiAccordion__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                          fillRule="nonzero"
-                        />
-                      </svg>
-                    </EuiIconArrowRight>
-                  </EuiIcon>
-                </span>
-                <span
-                  className="euiIEFlexWrapFix"
-                >
-                  Trace Groups
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="random_html_id"
-              className="euiAccordion__childWrapper"
-              id="accordion1"
-              role="region"
-              tabIndex={-1}
-            >
-              <EuiResizeObserver
-                onResize={[Function]}
-              >
-                <div>
-                  <div
-                    className=""
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                  </div>
+                  </EuiResizeObserver>
                 </div>
-              </EuiResizeObserver>
-            </div>
+              </div>
+            </EuiAccordion>
           </div>
-        </EuiAccordion>
+        </EuiPanel>
       </div>
-    </EuiPanel>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
+    </EuiPage>
     <TracesTable
       dataPrepperIndicesExist={true}
       items={Array []}
@@ -5022,142 +5155,150 @@ exports[`Traces component renders traces page 1`] = `
       refresh={[Function]}
       traceIdColumnAction={[Function]}
     >
-      <EuiPanel>
+      <EuiPage
+        paddingSize="m"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiPage euiPage--paddingMedium euiPage--grow"
         >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
+          <EuiPanel>
             <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <EuiFlexItem
-                grow={10}
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
               >
                 <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
+                  className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
+                  <EuiFlexItem
+                    grow={10}
                   >
-                    <EuiText
-                      size="m"
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrow10"
                     >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                      <PanelTitle
+                        title="Traces"
+                        totalItems={0}
                       >
                         <EuiText
-                          size="s"
+                          size="m"
                         >
                           <div
-                            className="euiText euiText--small"
+                            className="euiText euiText--medium"
                           >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                            <span
+                              className="panel-title"
+                            >
+                              Traces
+                            </span>
+                            <span
+                              className="panel-title-count"
+                            >
+                               (0)
+                            </span>
                           </div>
                         </EuiText>
-                      </div>
+                      </PanelTitle>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+              <EuiSpacer
+                size="m"
+              >
+                <div
+                  className="euiSpacer euiSpacer--m"
+                />
+              </EuiSpacer>
+              <EuiHorizontalRule
+                margin="none"
+              >
+                <hr
+                  className="euiHorizontalRule euiHorizontalRule--full"
+                />
+              </EuiHorizontalRule>
+              <NoMatchMessage
+                size="xl"
+              >
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+                <EuiEmptyPrompt
+                  body={
+                    <EuiText
+                      size="s"
+                    >
+                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                     </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
+                  }
+                  title={
+                    <h2>
+                      No matches
+                    </h2>
+                  }
+                >
+                  <div
+                    className="euiEmptyPrompt"
+                  >
+                    <EuiTitle
+                      size="m"
+                    >
+                      <h2
+                        className="euiTitle euiTitle--medium"
+                      >
+                        No matches
+                      </h2>
+                    </EuiTitle>
+                    <EuiTextColor
+                      color="subdued"
+                    >
+                      <span
+                        className="euiTextColor euiTextColor--subdued"
+                      >
+                        <EuiSpacer
+                          size="m"
+                        >
+                          <div
+                            className="euiSpacer euiSpacer--m"
+                          />
+                        </EuiSpacer>
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            <EuiText
+                              size="s"
+                            >
+                              <div
+                                className="euiText euiText--small"
+                              >
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </div>
+                            </EuiText>
+                          </div>
+                        </EuiText>
+                      </span>
+                    </EuiTextColor>
+                  </div>
+                </EuiEmptyPrompt>
+                <EuiSpacer
+                  size="xl"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--xl"
+                  />
+                </EuiSpacer>
+              </NoMatchMessage>
+            </div>
+          </EuiPanel>
         </div>
-      </EuiPanel>
+      </EuiPage>
     </TracesTable>
   </TracesContent>
 </Traces>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -576,6 +576,7 @@ exports[`Traces component renders empty traces page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
                                     iconSize="m"
                                     iconType="arrowDown"
@@ -1184,6 +1185,7 @@ exports[`Traces component renders empty traces page 1`] = `
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButtonEmpty__content"
+                                                          iconGap="m"
                                                           iconSide="right"
                                                           iconSize="s"
                                                           iconType="arrowDown"
@@ -1453,6 +1455,7 @@ exports[`Traces component renders empty traces page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     iconSize="s"
                                     textProps={
@@ -2326,6 +2329,7 @@ exports[`Traces component renders jaeger traces page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
                                     iconSize="m"
                                     iconType="arrowDown"
@@ -2936,6 +2940,7 @@ exports[`Traces component renders jaeger traces page 1`] = `
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButtonEmpty__content"
+                                                          iconGap="m"
                                                           iconSide="right"
                                                           iconSize="s"
                                                           iconType="arrowDown"
@@ -3207,6 +3212,7 @@ exports[`Traces component renders jaeger traces page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     iconSize="s"
                                     textProps={
@@ -4080,6 +4086,7 @@ exports[`Traces component renders traces page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
                                     iconSize="m"
                                     iconType="arrowDown"
@@ -4690,6 +4697,7 @@ exports[`Traces component renders traces page 1`] = `
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButtonEmpty__content"
+                                                          iconGap="m"
                                                           iconSide="right"
                                                           iconSize="s"
                                                           iconType="arrowDown"
@@ -4961,6 +4969,7 @@ exports[`Traces component renders traces page 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     iconSize="s"
                                     textProps={

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -10,218 +10,226 @@ exports[`Traces table component renders empty traces table message 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPanel>
+  <EuiPage
+    paddingSize="m"
+  >
     <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      className="euiPage euiPage--paddingMedium euiPage--grow"
     >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="s"
-      >
+      <EuiPanel>
         <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <EuiFlexItem
-            grow={10}
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
           >
             <div
-              className="euiFlexItem euiFlexItem--flexGrow10"
+              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <PanelTitle
-                title="Traces"
-                totalItems={0}
+              <EuiFlexItem
+                grow={10}
               >
-                <EuiText
-                  size="m"
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrow10"
                 >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Traces
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (0)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <MissingConfigurationMessage
-        mode="data_prepper"
-      >
-        <EuiEmptyPrompt
-          actions={
-            <EuiSmallButtonEmpty
-              color="primary"
-              iconSide="right"
-              iconType="popout"
-              onClick={[Function]}
-            >
-              Learn more
-            </EuiSmallButtonEmpty>
-          }
-          body={
-            <EuiText
-              size="s"
-            >
-              The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
-            </EuiText>
-          }
-          title={
-            <h2>
-              Trace Analytics not set up
-            </h2>
-          }
-        >
-          <div
-            className="euiEmptyPrompt"
-          >
-            <EuiTitle
-              size="m"
-            >
-              <h2
-                className="euiTitle euiTitle--medium"
-              >
-                Trace Analytics not set up
-              </h2>
-            </EuiTitle>
-            <EuiTextColor
-              color="subdued"
-            >
-              <span
-                className="euiTextColor euiTextColor--subdued"
-              >
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiText>
-                  <div
-                    className="euiText euiText--medium"
+                  <PanelTitle
+                    title="Traces"
+                    totalItems={0}
                   >
                     <EuiText
-                      size="s"
+                      size="m"
                     >
                       <div
-                        className="euiText euiText--small"
+                        className="euiText euiText--medium"
                       >
-                        The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
+                        <span
+                          className="panel-title"
+                        >
+                          Traces
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (0)
+                        </span>
                       </div>
                     </EuiText>
-                  </div>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <MissingConfigurationMessage
+            mode="data_prepper"
+          >
+            <EuiEmptyPrompt
+              actions={
+                <EuiSmallButtonEmpty
+                  color="primary"
+                  iconSide="right"
+                  iconType="popout"
+                  onClick={[Function]}
+                >
+                  Learn more
+                </EuiSmallButtonEmpty>
+              }
+              body={
+                <EuiText
+                  size="s"
+                >
+                  The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
                 </EuiText>
-              </span>
-            </EuiTextColor>
-            <EuiSpacer
-              size="l"
+              }
+              title={
+                <h2>
+                  Trace Analytics not set up
+                </h2>
+              }
             >
               <div
-                className="euiSpacer euiSpacer--l"
-              />
-            </EuiSpacer>
-            <EuiSmallButtonEmpty
-              color="primary"
-              iconSide="right"
-              iconType="popout"
-              onClick={[Function]}
-            >
-              <EuiButtonEmpty
-                color="primary"
-                iconSide="right"
-                iconType="popout"
-                onClick={[Function]}
-                size="s"
+                className="euiEmptyPrompt"
               >
-                <button
-                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
+                <EuiTitle
+                  size="m"
                 >
-                  <EuiButtonContent
-                    className="euiButtonEmpty__content"
-                    iconSide="right"
-                    iconSize="m"
-                    iconType="popout"
-                    textProps={
-                      Object {
-                        "className": "euiButtonEmpty__text",
-                      }
-                    }
+                  <h2
+                    className="euiTitle euiTitle--medium"
                   >
-                    <span
-                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                    Trace Analytics not set up
+                  </h2>
+                </EuiTitle>
+                <EuiTextColor
+                  color="subdued"
+                >
+                  <span
+                    className="euiTextColor euiTextColor--subdued"
+                  >
+                    <EuiSpacer
+                      size="m"
                     >
-                      <EuiIcon
-                        className="euiButtonContent__icon"
-                        color="inherit"
-                        size="m"
-                        type="popout"
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiText>
+                      <div
+                        className="euiText euiText--medium"
                       >
-                        <EuiIconBeaker
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                          focusable="false"
-                          role="img"
-                          style={null}
+                        <EuiText
+                          size="s"
                         >
-                          <svg
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                            focusable="false"
-                            height={16}
-                            role="img"
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            className="euiText euiText--small"
                           >
-                            <path
-                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                            />
-                          </svg>
-                        </EuiIconBeaker>
-                      </EuiIcon>
-                      <span
-                        className="euiButtonEmpty__text"
+                            The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
+                          </div>
+                        </EuiText>
+                      </div>
+                    </EuiText>
+                  </span>
+                </EuiTextColor>
+                <EuiSpacer
+                  size="l"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                </EuiSpacer>
+                <EuiSmallButtonEmpty
+                  color="primary"
+                  iconSide="right"
+                  iconType="popout"
+                  onClick={[Function]}
+                >
+                  <EuiButtonEmpty
+                    color="primary"
+                    iconSide="right"
+                    iconType="popout"
+                    onClick={[Function]}
+                    size="s"
+                  >
+                    <button
+                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
+                      disabled={false}
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <EuiButtonContent
+                        className="euiButtonEmpty__content"
+                        iconSide="right"
+                        iconSize="m"
+                        iconType="popout"
+                        textProps={
+                          Object {
+                            "className": "euiButtonEmpty__text",
+                          }
+                        }
                       >
-                        Learn more
-                      </span>
-                    </span>
-                  </EuiButtonContent>
-                </button>
-              </EuiButtonEmpty>
-            </EuiSmallButtonEmpty>
-          </div>
-        </EuiEmptyPrompt>
-      </MissingConfigurationMessage>
+                        <span
+                          className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        >
+                          <EuiIcon
+                            className="euiButtonContent__icon"
+                            color="inherit"
+                            size="m"
+                            type="popout"
+                          >
+                            <EuiIconBeaker
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                              focusable="false"
+                              role="img"
+                              style={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                focusable="false"
+                                height={16}
+                                role="img"
+                                style={null}
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </EuiIconBeaker>
+                          </EuiIcon>
+                          <span
+                            className="euiButtonEmpty__text"
+                          >
+                            Learn more
+                          </span>
+                        </span>
+                      </EuiButtonContent>
+                    </button>
+                  </EuiButtonEmpty>
+                </EuiSmallButtonEmpty>
+              </div>
+            </EuiEmptyPrompt>
+          </MissingConfigurationMessage>
+        </div>
+      </EuiPanel>
     </div>
-  </EuiPanel>
+  </EuiPage>
 </TracesTable>
 `;
 
@@ -235,142 +243,150 @@ exports[`Traces table component renders empty traces table message 2`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPanel>
+  <EuiPage
+    paddingSize="m"
+  >
     <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      className="euiPage euiPage--paddingMedium euiPage--grow"
     >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="s"
-      >
+      <EuiPanel>
         <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <EuiFlexItem
-            grow={10}
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
           >
             <div
-              className="euiFlexItem euiFlexItem--flexGrow10"
+              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <PanelTitle
-                title="Traces"
-                totalItems={0}
+              <EuiFlexItem
+                grow={10}
               >
-                <EuiText
-                  size="m"
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrow10"
                 >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Traces
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (0)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <NoMatchMessage
-        size="xl"
-      >
-        <EuiSpacer
-          size="xl"
-        >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-        <EuiEmptyPrompt
-          body={
-            <EuiText
-              size="s"
-            >
-              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-            </EuiText>
-          }
-          title={
-            <h2>
-              No matches
-            </h2>
-          }
-        >
-          <div
-            className="euiEmptyPrompt"
-          >
-            <EuiTitle
-              size="m"
-            >
-              <h2
-                className="euiTitle euiTitle--medium"
-              >
-                No matches
-              </h2>
-            </EuiTitle>
-            <EuiTextColor
-              color="subdued"
-            >
-              <span
-                className="euiTextColor euiTextColor--subdued"
-              >
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiText>
-                  <div
-                    className="euiText euiText--medium"
+                  <PanelTitle
+                    title="Traces"
+                    totalItems={0}
                   >
                     <EuiText
-                      size="s"
+                      size="m"
                     >
                       <div
-                        className="euiText euiText--small"
+                        className="euiText euiText--medium"
                       >
-                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        <span
+                          className="panel-title"
+                        >
+                          Traces
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (0)
+                        </span>
                       </div>
                     </EuiText>
-                  </div>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <NoMatchMessage
+            size="xl"
+          >
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+            <EuiEmptyPrompt
+              body={
+                <EuiText
+                  size="s"
+                >
+                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                 </EuiText>
-              </span>
-            </EuiTextColor>
-          </div>
-        </EuiEmptyPrompt>
-        <EuiSpacer
-          size="xl"
-        >
-          <div
-            className="euiSpacer euiSpacer--xl"
-          />
-        </EuiSpacer>
-      </NoMatchMessage>
+              }
+              title={
+                <h2>
+                  No matches
+                </h2>
+              }
+            >
+              <div
+                className="euiEmptyPrompt"
+              >
+                <EuiTitle
+                  size="m"
+                >
+                  <h2
+                    className="euiTitle euiTitle--medium"
+                  >
+                    No matches
+                  </h2>
+                </EuiTitle>
+                <EuiTextColor
+                  color="subdued"
+                >
+                  <span
+                    className="euiTextColor euiTextColor--subdued"
+                  >
+                    <EuiSpacer
+                      size="m"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiText>
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <EuiText
+                          size="s"
+                        >
+                          <div
+                            className="euiText euiText--small"
+                          >
+                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                          </div>
+                        </EuiText>
+                      </div>
+                    </EuiText>
+                  </span>
+                </EuiTextColor>
+              </div>
+            </EuiEmptyPrompt>
+            <EuiSpacer
+              size="xl"
+            >
+              <div
+                className="euiSpacer euiSpacer--xl"
+              />
+            </EuiSpacer>
+          </NoMatchMessage>
+        </div>
+      </EuiPanel>
     </div>
-  </EuiPanel>
+  </EuiPage>
 </TracesTable>
 `;
 
@@ -395,287 +411,1030 @@ exports[`Traces table component renders jaeger traces table 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPanel>
+  <EuiPage
+    paddingSize="m"
+  >
     <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      className="euiPage euiPage--paddingMedium euiPage--grow"
     >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="s"
-      >
+      <EuiPanel>
         <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <EuiFlexItem
-            grow={10}
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
           >
             <div
-              className="euiFlexItem euiFlexItem--flexGrow10"
+              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <PanelTitle
-                title="Traces"
-                totalItems={1}
+              <EuiFlexItem
+                grow={10}
               >
-                <EuiText
-                  size="m"
-                >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Traces
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (1)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <EuiInMemoryTable
-        columns={
-          Array [
-            Object {
-              "align": "left",
-              "field": "trace_id",
-              "name": "Trace ID",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "latency",
-              "name": "Latency (ms)",
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "error_count",
-              "name": "Errors",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "left",
-              "field": "last_updated",
-              "name": "Last updated",
-              "render": [Function],
-              "sortable": true,
-            },
-          ]
-        }
-        items={
-          Array [
-            Object {
-              "actions": "#",
-              "error_count": "Yes",
-              "last_updated": "11/10/2020 09:55:45",
-              "latency": 19.91,
-              "trace_group": "HTTP GET",
-              "trace_id": "00079a615e31e61766fcb20b557051c1",
-            },
-          ]
-        }
-        loading={false}
-        onTableChange={[Function]}
-        pagination={
-          Object {
-            "initialPageSize": 10,
-            "pageSizeOptions": Array [
-              5,
-              10,
-              15,
-            ],
-          }
-        }
-        responsive={true}
-        sorting={
-          Object {
-            "sort": Object {
-              "direction": "asc",
-              "field": "trace_id",
-            },
-          }
-        }
-        tableLayout="auto"
-      >
-        <EuiBasicTable
-          columns={
-            Array [
-              Object {
-                "align": "left",
-                "field": "trace_id",
-                "name": "Trace ID",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "latency",
-                "name": "Latency (ms)",
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "error_count",
-                "name": "Errors",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "left",
-                "field": "last_updated",
-                "name": "Last updated",
-                "render": [Function],
-                "sortable": true,
-              },
-            ]
-          }
-          items={
-            Array [
-              Object {
-                "actions": "#",
-                "error_count": "Yes",
-                "last_updated": "11/10/2020 09:55:45",
-                "latency": 19.91,
-                "trace_group": "HTTP GET",
-                "trace_id": "00079a615e31e61766fcb20b557051c1",
-              },
-            ]
-          }
-          loading={false}
-          noItemsMessage="No items found"
-          onChange={[Function]}
-          pagination={
-            Object {
-              "hidePerPageOptions": undefined,
-              "pageIndex": 0,
-              "pageSize": 10,
-              "pageSizeOptions": Array [
-                5,
-                10,
-                15,
-              ],
-              "totalItemCount": 1,
-            }
-          }
-          responsive={true}
-          sorting={
-            Object {
-              "allowNeutralSort": true,
-              "sort": Object {
-                "direction": "asc",
-                "field": "Trace ID",
-              },
-            }
-          }
-          tableLayout="auto"
-        >
-          <div
-            className="euiBasicTable"
-          >
-            <div>
-              <EuiTableHeaderMobile>
                 <div
-                  className="euiTableHeaderMobile"
+                  className="euiFlexItem euiFlexItem--flexGrow10"
                 >
-                  <EuiFlexGroup
-                    alignItems="baseline"
-                    justifyContent="spaceBetween"
-                    responsive={false}
+                  <PanelTitle
+                    title="Traces"
+                    totalItems={1}
                   >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    <EuiText
+                      size="m"
                     >
-                      <EuiFlexItem
-                        grow={false}
+                      <div
+                        className="euiText euiText--medium"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        />
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <span
+                          className="panel-title"
                         >
-                          <EuiTableSortMobile
-                            items={
-                              Array [
-                                Object {
-                                  "isSortAscending": true,
-                                  "isSorted": true,
-                                  "key": "_data_s_trace_id_0",
-                                  "name": "Trace ID",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_latency_1",
-                                  "name": "Latency (ms)",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_error_count_2",
-                                  "name": "Errors",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_last_updated_3",
-                                  "name": "Last updated",
-                                  "onSort": [Function],
-                                },
-                              ]
-                            }
+                          Traces
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (1)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiInMemoryTable
+            columns={
+              Array [
+                Object {
+                  "align": "left",
+                  "field": "trace_id",
+                  "name": "Trace ID",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "latency",
+                  "name": "Latency (ms)",
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "error_count",
+                  "name": "Errors",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "left",
+                  "field": "last_updated",
+                  "name": "Last updated",
+                  "render": [Function],
+                  "sortable": true,
+                },
+              ]
+            }
+            items={
+              Array [
+                Object {
+                  "actions": "#",
+                  "error_count": "Yes",
+                  "last_updated": "11/10/2020 09:55:45",
+                  "latency": 19.91,
+                  "trace_group": "HTTP GET",
+                  "trace_id": "00079a615e31e61766fcb20b557051c1",
+                },
+              ]
+            }
+            loading={false}
+            onTableChange={[Function]}
+            pagination={
+              Object {
+                "initialPageSize": 10,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  15,
+                ],
+              }
+            }
+            responsive={true}
+            sorting={
+              Object {
+                "sort": Object {
+                  "direction": "asc",
+                  "field": "trace_id",
+                },
+              }
+            }
+            tableLayout="auto"
+          >
+            <EuiBasicTable
+              columns={
+                Array [
+                  Object {
+                    "align": "left",
+                    "field": "trace_id",
+                    "name": "Trace ID",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "latency",
+                    "name": "Latency (ms)",
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "error_count",
+                    "name": "Errors",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "left",
+                    "field": "last_updated",
+                    "name": "Last updated",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                ]
+              }
+              items={
+                Array [
+                  Object {
+                    "actions": "#",
+                    "error_count": "Yes",
+                    "last_updated": "11/10/2020 09:55:45",
+                    "latency": 19.91,
+                    "trace_group": "HTTP GET",
+                    "trace_id": "00079a615e31e61766fcb20b557051c1",
+                  },
+                ]
+              }
+              loading={false}
+              noItemsMessage="No items found"
+              onChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+              responsive={true}
+              sorting={
+                Object {
+                  "allowNeutralSort": true,
+                  "sort": Object {
+                    "direction": "asc",
+                    "field": "Trace ID",
+                  },
+                }
+              }
+              tableLayout="auto"
+            >
+              <div
+                className="euiBasicTable"
+              >
+                <div>
+                  <EuiTableHeaderMobile>
+                    <div
+                      className="euiTableHeaderMobile"
+                    >
+                      <EuiFlexGroup
+                        alignItems="baseline"
+                        justifyContent="spaceBetween"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiTableSortMobile"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            />
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiTableSortMobile
+                                items={
+                                  Array [
+                                    Object {
+                                      "isSortAscending": true,
+                                      "isSorted": true,
+                                      "key": "_data_s_trace_id_0",
+                                      "name": "Trace ID",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_latency_1",
+                                      "name": "Latency (ms)",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_error_count_2",
+                                      "name": "Errors",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_last_updated_3",
+                                      "name": "Last updated",
+                                      "onSort": [Function],
+                                    },
+                                  ]
+                                }
+                              >
+                                <div
+                                  className="euiTableSortMobile"
+                                >
+                                  <EuiPopover
+                                    anchorPosition="downRight"
+                                    button={
+                                      <EuiButtonEmpty
+                                        flush="right"
+                                        iconSide="right"
+                                        iconType="arrowDown"
+                                        onClick={[Function]}
+                                        size="xs"
+                                      >
+                                        <EuiI18n
+                                          default="Sorting"
+                                          token="euiTableSortMobile.sorting"
+                                        />
+                                      </EuiButtonEmpty>
+                                    }
+                                    closePopover={[Function]}
+                                    display="inlineBlock"
+                                    hasArrow={true}
+                                    isOpen={false}
+                                    ownFocus={true}
+                                    panelPaddingSize="none"
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
+                                          onClick={[Function]}
+                                          size="xs"
+                                        >
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <EuiButtonContent
+                                              className="euiButtonEmpty__content"
+                                              iconSide="right"
+                                              iconSize="s"
+                                              iconType="arrowDown"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButtonEmpty__text",
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                              >
+                                                <EuiIcon
+                                                  className="euiButtonContent__icon"
+                                                  color="inherit"
+                                                  size="s"
+                                                  type="arrowDown"
+                                                >
+                                                  <EuiIconArrowDown
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                    focusable="false"
+                                                    role="img"
+                                                    style={null}
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                        fillRule="non-zero"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconArrowDown>
+                                                </EuiIcon>
+                                                <span
+                                                  className="euiButtonEmpty__text"
+                                                >
+                                                  <EuiI18n
+                                                    default="Sorting"
+                                                    token="euiTableSortMobile.sorting"
+                                                  >
+                                                    Sorting
+                                                  </EuiI18n>
+                                                </span>
+                                              </span>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
+                                    </div>
+                                  </EuiPopover>
+                                </div>
+                              </EuiTableSortMobile>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiTableHeaderMobile>
+                  <EuiTable
+                    id="random_html_id"
+                    responsive={true}
+                    tableLayout="auto"
+                  >
+                    <table
+                      className="euiTable euiTable--responsive euiTable--auto"
+                      id="random_html_id"
+                      tabIndex={-1}
+                    >
+                      <EuiScreenReaderOnly>
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
+                        >
+                          <EuiDelayRender
+                            delay={500}
+                          />
+                        </caption>
+                      </EuiScreenReaderOnly>
+                      <EuiTableHeader>
+                        <thead>
+                          <tr>
+                            <EuiTableHeaderCell
+                              align="left"
+                              data-test-subj="tableHeaderCell_trace_id_0"
+                              isSortAscending={true}
+                              isSorted={true}
+                              key="_data_h_trace_id_0"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="ascending"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_trace_id_0"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSortAscending={true}
+                                    isSorted={true}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Trace ID",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Trace ID"
+                                          >
+                                            Trace ID
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                      <EuiIcon
+                                        className="euiTableSortIcon"
+                                        size="m"
+                                        type="sortUp"
+                                      >
+                                        <EuiIconSortUp
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiTableSortIcon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiTableSortIcon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
+                                            />
+                                          </svg>
+                                        </EuiIconSortUp>
+                                      </EuiIcon>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_latency_1"
+                              isSorted={false}
+                              key="_data_h_latency_1"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_latency_1"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Latency (ms)",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Latency (ms)"
+                                          >
+                                            Latency (ms)
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_error_count_2"
+                              isSorted={false}
+                              key="_data_h_error_count_2"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_error_count_2"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Errors",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Errors"
+                                          >
+                                            Errors
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="left"
+                              data-test-subj="tableHeaderCell_last_updated_3"
+                              isSorted={false}
+                              key="_data_h_last_updated_3"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_last_updated_3"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Last updated",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Last updated"
+                                          >
+                                            Last updated
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                          </tr>
+                        </thead>
+                      </EuiTableHeader>
+                      <EuiTableBody
+                        bodyRef={[Function]}
+                      >
+                        <tbody>
+                          <EuiTableRow
+                            isSelected={false}
+                          >
+                            <tr
+                              className="euiTableRow"
+                            >
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_trace_id_0_0"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Trace ID",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Trace ID
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiFlexGroup
+                                      alignItems="center"
+                                      className=""
+                                      gutterSize="s"
+                                      key=".0"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={10}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrow10"
+                                          >
+                                            <EuiLink
+                                              onClick={[Function]}
+                                            >
+                                              <button
+                                                className="euiLink euiLink--primary"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <div
+                                                  title="00079a615e31e61766fcb20b557051c1"
+                                                >
+                                                  00079a615e31e61766fcb...
+                                                </div>
+                                              </button>
+                                            </EuiLink>
+                                          </div>
+                                        </EuiFlexItem>
+                                        <EuiFlexItem
+                                          grow={false}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          >
+                                            <EuiCopy
+                                              afterMessage="Copied"
+                                              textToCopy="00079a615e31e61766fcb20b557051c1"
+                                            >
+                                              <EuiToolTip
+                                                delay="regular"
+                                                onMouseOut={[Function]}
+                                                position="top"
+                                              >
+                                                <span
+                                                  className="euiToolTipAnchor"
+                                                  onKeyUp={[Function]}
+                                                  onMouseOut={[Function]}
+                                                  onMouseOver={[Function]}
+                                                >
+                                                  <EuiSmallButtonIcon
+                                                    aria-label="Copy trace id"
+                                                    iconType="copyClipboard"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onFocus={[Function]}
+                                                  >
+                                                    <EuiButtonIcon
+                                                      aria-label="Copy trace id"
+                                                      iconType="copyClipboard"
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onFocus={[Function]}
+                                                      size="s"
+                                                    >
+                                                      <button
+                                                        aria-label="Copy trace id"
+                                                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                        disabled={false}
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onFocus={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiIcon
+                                                          aria-hidden="true"
+                                                          className="euiButtonIcon__icon"
+                                                          color="inherit"
+                                                          size="m"
+                                                          type="copyClipboard"
+                                                        >
+                                                          <EuiIconCopyClipboard
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                            focusable="false"
+                                                            role="img"
+                                                            style={null}
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                              focusable="false"
+                                                              height={16}
+                                                              role="img"
+                                                              style={null}
+                                                              viewBox="0 0 16 16"
+                                                              width={16}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <path
+                                                                d="M0 2.729V2a1 1 0 0 1 1-1h2v1H1v12h4v1H1a1 1 0 0 1-1-1V2.729zM12 5V2a1 1 0 0 0-1-1H9v1h2v3h1zm-1 1h2v9H6V6h5V5H6a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2v1z"
+                                                              />
+                                                              <path
+                                                                d="M7 10h5V9H7zM7 8h5V7H7zM7 12h5v-1H7zM7 14h5v-1H7zM9 2V1a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v1h1V1h4v1h1ZM3 3h6V2H3z"
+                                                              />
+                                                            </svg>
+                                                          </EuiIconCopyClipboard>
+                                                        </EuiIcon>
+                                                      </button>
+                                                    </EuiButtonIcon>
+                                                  </EuiSmallButtonIcon>
+                                                </span>
+                                              </EuiToolTip>
+                                            </EuiCopy>
+                                          </div>
+                                        </EuiFlexItem>
+                                        <EuiFlexItem
+                                          grow={3}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrow3"
+                                          />
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_latency_0_1"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Latency (ms)",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={true}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Latency (ms)
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
+                                  >
+                                    <span
+                                      className="euiTableCellContent__text"
+                                    >
+                                      19.91
+                                    </span>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_error_count_0_2"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Errors",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Errors
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    No
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_last_updated_0_3"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Last updated",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Last updated
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                  >
+                                    11/10/2020 09:55:45
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                            </tr>
+                          </EuiTableRow>
+                        </tbody>
+                      </EuiTableBody>
+                    </table>
+                  </EuiTable>
+                </div>
+                <PaginationBar
+                  aria-controls="random_html_id"
+                  onPageChange={[Function]}
+                  onPageSizeChange={[Function]}
+                  pagination={
+                    Object {
+                      "hidePerPageOptions": undefined,
+                      "pageIndex": 0,
+                      "pageSize": 10,
+                      "pageSizeOptions": Array [
+                        5,
+                        10,
+                        15,
+                      ],
+                      "totalItemCount": 1,
+                    }
+                  }
+                >
+                  <div>
+                    <EuiSpacer
+                      size="m"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiTablePagination
+                      activePage={0}
+                      aria-controls="random_html_id"
+                      itemsPerPage={10}
+                      itemsPerPageOptions={
+                        Array [
+                          5,
+                          10,
+                          15,
+                        ]
+                      }
+                      onChangeItemsPerPage={[Function]}
+                      onChangePage={[Function]}
+                      pageCount={1}
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        justifyContent="spaceBetween"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
                               <EuiPopover
-                                anchorPosition="downRight"
+                                anchorPosition="upRight"
                                 button={
                                   <EuiButtonEmpty
-                                    flush="right"
+                                    color="text"
+                                    data-test-subj="tablePaginationPopoverButton"
                                     iconSide="right"
                                     iconType="arrowDown"
                                     onClick={[Function]}
                                     size="xs"
                                   >
                                     <EuiI18n
-                                      default="Sorting"
-                                      token="euiTableSortMobile.sorting"
+                                      default="Rows per page"
+                                      token="euiTablePagination.rowsPerPage"
                                     />
+                                    : 
+                                    10
                                   </EuiButtonEmpty>
                                 }
                                 closePopover={[Function]}
@@ -686,20 +1445,22 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                 panelPaddingSize="none"
                               >
                                 <div
-                                  className="euiPopover euiPopover--anchorDownRight"
+                                  className="euiPopover euiPopover--anchorUpRight"
                                 >
                                   <div
                                     className="euiPopover__anchor"
                                   >
                                     <EuiButtonEmpty
-                                      flush="right"
+                                      color="text"
+                                      data-test-subj="tablePaginationPopoverButton"
                                       iconSide="right"
                                       iconType="arrowDown"
                                       onClick={[Function]}
                                       size="xs"
                                     >
                                       <button
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                        data-test-subj="tablePaginationPopoverButton"
                                         disabled={false}
                                         onClick={[Function]}
                                         type="button"
@@ -753,11 +1514,13 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                               className="euiButtonEmpty__text"
                                             >
                                               <EuiI18n
-                                                default="Sorting"
-                                                token="euiTableSortMobile.sorting"
+                                                default="Rows per page"
+                                                token="euiTablePagination.rowsPerPage"
                                               >
-                                                Sorting
+                                                Rows per page
                                               </EuiI18n>
+                                              : 
+                                              10
                                             </span>
                                           </span>
                                         </EuiButtonContent>
@@ -767,994 +1530,255 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                 </div>
                               </EuiPopover>
                             </div>
-                          </EuiTableSortMobile>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiTableHeaderMobile>
-              <EuiTable
-                id="random_html_id"
-                responsive={true}
-                tableLayout="auto"
-              >
-                <table
-                  className="euiTable euiTable--responsive euiTable--auto"
-                  id="random_html_id"
-                  tabIndex={-1}
-                >
-                  <EuiScreenReaderOnly>
-                    <caption
-                      className="euiScreenReaderOnly euiTableCaption"
-                    >
-                      <EuiDelayRender
-                        delay={500}
-                      />
-                    </caption>
-                  </EuiScreenReaderOnly>
-                  <EuiTableHeader>
-                    <thead>
-                      <tr>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_trace_id_0"
-                          isSortAscending={true}
-                          isSorted={true}
-                          key="_data_h_trace_id_0"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="ascending"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_trace_id_0"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSortAscending={true}
-                                isSorted={true}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Trace ID",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Trace ID"
-                                      >
-                                        Trace ID
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                  <EuiIcon
-                                    className="euiTableSortIcon"
-                                    size="m"
-                                    type="sortUp"
-                                  >
-                                    <EuiIconSortUp
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiTableSortIcon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiTableSortIcon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
-                                        />
-                                      </svg>
-                                    </EuiIconSortUp>
-                                  </EuiIcon>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_latency_1"
-                          isSorted={false}
-                          key="_data_h_latency_1"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_latency_1"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Latency (ms)",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Latency (ms)"
-                                      >
-                                        Latency (ms)
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_error_count_2"
-                          isSorted={false}
-                          key="_data_h_error_count_2"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_error_count_2"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Errors",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Errors"
-                                      >
-                                        Errors
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_last_updated_3"
-                          isSorted={false}
-                          key="_data_h_last_updated_3"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_last_updated_3"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Last updated",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Last updated"
-                                      >
-                                        Last updated
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                      </tr>
-                    </thead>
-                  </EuiTableHeader>
-                  <EuiTableBody
-                    bodyRef={[Function]}
-                  >
-                    <tbody>
-                      <EuiTableRow
-                        isSelected={false}
-                      >
-                        <tr
-                          className="euiTableRow"
-                        >
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_trace_id_0_0"
-                            mobileOptions={
-                              Object {
-                                "header": "Trace ID",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Trace ID
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiFlexGroup
-                                  alignItems="center"
-                                  className=""
-                                  gutterSize="s"
-                                  key=".0"
-                                >
-                                  <div
-                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                  >
-                                    <EuiFlexItem
-                                      grow={10}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrow10"
-                                      >
-                                        <EuiLink
-                                          onClick={[Function]}
-                                        >
-                                          <button
-                                            className="euiLink euiLink--primary"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <div
-                                              title="00079a615e31e61766fcb20b557051c1"
-                                            >
-                                              00079a615e31e61766fcb...
-                                            </div>
-                                          </button>
-                                        </EuiLink>
-                                      </div>
-                                    </EuiFlexItem>
-                                    <EuiFlexItem
-                                      grow={false}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrowZero"
-                                      >
-                                        <EuiCopy
-                                          afterMessage="Copied"
-                                          textToCopy="00079a615e31e61766fcb20b557051c1"
-                                        >
-                                          <EuiToolTip
-                                            delay="regular"
-                                            onMouseOut={[Function]}
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            >
-                                              <EuiSmallButtonIcon
-                                                aria-label="Copy trace id"
-                                                iconType="copyClipboard"
-                                                onBlur={[Function]}
-                                                onClick={[Function]}
-                                                onFocus={[Function]}
-                                              >
-                                                <EuiButtonIcon
-                                                  aria-label="Copy trace id"
-                                                  iconType="copyClipboard"
-                                                  onBlur={[Function]}
-                                                  onClick={[Function]}
-                                                  onFocus={[Function]}
-                                                  size="s"
-                                                >
-                                                  <button
-                                                    aria-label="Copy trace id"
-                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                                                    disabled={false}
-                                                    onBlur={[Function]}
-                                                    onClick={[Function]}
-                                                    onFocus={[Function]}
-                                                    type="button"
-                                                  >
-                                                    <EuiIcon
-                                                      aria-hidden="true"
-                                                      className="euiButtonIcon__icon"
-                                                      color="inherit"
-                                                      size="m"
-                                                      type="copyClipboard"
-                                                    >
-                                                      <EuiIconCopyClipboard
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                        focusable="false"
-                                                        role="img"
-                                                        style={null}
-                                                      >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                          focusable="false"
-                                                          height={16}
-                                                          role="img"
-                                                          style={null}
-                                                          viewBox="0 0 16 16"
-                                                          width={16}
-                                                          xmlns="http://www.w3.org/2000/svg"
-                                                        >
-                                                          <path
-                                                            d="M0 2.729V2a1 1 0 0 1 1-1h2v1H1v12h4v1H1a1 1 0 0 1-1-1V2.729zM12 5V2a1 1 0 0 0-1-1H9v1h2v3h1zm-1 1h2v9H6V6h5V5H6a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2v1z"
-                                                          />
-                                                          <path
-                                                            d="M7 10h5V9H7zM7 8h5V7H7zM7 12h5v-1H7zM7 14h5v-1H7zM9 2V1a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v1h1V1h4v1h1ZM3 3h6V2H3z"
-                                                          />
-                                                        </svg>
-                                                      </EuiIconCopyClipboard>
-                                                    </EuiIcon>
-                                                  </button>
-                                                </EuiButtonIcon>
-                                              </EuiSmallButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                        </EuiCopy>
-                                      </div>
-                                    </EuiFlexItem>
-                                    <EuiFlexItem
-                                      grow={3}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrow3"
-                                      />
-                                    </EuiFlexItem>
-                                  </div>
-                                </EuiFlexGroup>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_latency_0_1"
-                            mobileOptions={
-                              Object {
-                                "header": "Latency (ms)",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={true}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Latency (ms)
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
-                              >
-                                <span
-                                  className="euiTableCellContent__text"
-                                >
-                                  19.91
-                                </span>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_error_count_0_2"
-                            mobileOptions={
-                              Object {
-                                "header": "Errors",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Errors
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                No
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_last_updated_0_3"
-                            mobileOptions={
-                              Object {
-                                "header": "Last updated",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Last updated
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--overflowingContent"
-                              >
-                                11/10/2020 09:55:45
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                        </tr>
-                      </EuiTableRow>
-                    </tbody>
-                  </EuiTableBody>
-                </table>
-              </EuiTable>
-            </div>
-            <PaginationBar
-              aria-controls="random_html_id"
-              onPageChange={[Function]}
-              onPageSizeChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-            >
-              <div>
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiTablePagination
-                  activePage={0}
-                  aria-controls="random_html_id"
-                  itemsPerPage={10}
-                  itemsPerPageOptions={
-                    Array [
-                      5,
-                      10,
-                      15,
-                    ]
-                  }
-                  onChangeItemsPerPage={[Function]}
-                  onChangePage={[Function]}
-                  pageCount={1}
-                >
-                  <EuiFlexGroup
-                    alignItems="center"
-                    justifyContent="spaceBetween"
-                    responsive={false}
-                  >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-                    >
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPopover
-                            anchorPosition="upRight"
-                            button={
-                              <EuiButtonEmpty
-                                color="text"
-                                data-test-subj="tablePaginationPopoverButton"
-                                iconSide="right"
-                                iconType="arrowDown"
-                                onClick={[Function]}
-                                size="xs"
-                              >
-                                <EuiI18n
-                                  default="Rows per page"
-                                  token="euiTablePagination.rowsPerPage"
-                                />
-                                : 
-                                10
-                              </EuiButtonEmpty>
-                            }
-                            closePopover={[Function]}
-                            display="inlineBlock"
-                            hasArrow={true}
-                            isOpen={false}
-                            ownFocus={true}
-                            panelPaddingSize="none"
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiPopover euiPopover--anchorUpRight"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <div
-                                className="euiPopover__anchor"
+                              <EuiPagination
+                                activePage={0}
+                                aria-controls="random_html_id"
+                                onPageClick={[Function]}
+                                pageCount={1}
                               >
-                                <EuiButtonEmpty
-                                  color="text"
-                                  data-test-subj="tablePaginationPopoverButton"
-                                  iconSide="right"
-                                  iconType="arrowDown"
-                                  onClick={[Function]}
-                                  size="xs"
+                                <nav
+                                  className="euiPagination"
                                 >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
-                                    data-test-subj="tablePaginationPopoverButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="right"
-                                      iconSize="s"
-                                      iconType="arrowDown"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
+                                  <EuiI18n
+                                    default="Previous page, {page}"
+                                    token="euiPagination.previousPage"
+                                    values={
+                                      Object {
+                                        "page": 0,
                                       }
+                                    }
+                                  >
+                                    <EuiI18n
+                                      default="Previous page"
+                                      token="euiPagination.disabledPreviousPage"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                      <EuiButtonIcon
+                                        aria-label="Previous page"
+                                        color="text"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        iconType="arrowLeft"
+                                        onClick={[Function]}
                                       >
-                                        <EuiIcon
-                                          className="euiButtonContent__icon"
-                                          color="inherit"
-                                          size="s"
-                                          type="arrowDown"
+                                        <button
+                                          aria-label="Previous page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-previous"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <EuiIconArrowDown
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowLeft"
                                           >
-                                            <svg
+                                            <EuiIconArrowLeft
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
                                               focusable="false"
-                                              height={16}
                                               role="img"
                                               style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <path
-                                                d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                fillRule="non-zero"
-                                              />
-                                            </svg>
-                                          </EuiIconArrowDown>
-                                        </EuiIcon>
-                                        <span
-                                          className="euiButtonEmpty__text"
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
+                                                  fillRule="nonzero"
+                                                />
+                                              </svg>
+                                            </EuiIconArrowLeft>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
+                                  </EuiI18n>
+                                  <ul
+                                    className="euiPagination__list"
+                                  >
+                                    <PaginationButton
+                                      key="0"
+                                      pageIndex={0}
+                                    >
+                                      <li
+                                        className="euiPagination__item"
+                                      >
+                                        <EuiPaginationButton
+                                          aria-controls="random_html_id"
+                                          hideOnMobile={true}
+                                          isActive={true}
+                                          onClick={[Function]}
+                                          pageIndex={0}
+                                          totalPages={1}
                                         >
                                           <EuiI18n
-                                            default="Rows per page"
-                                            token="euiTablePagination.rowsPerPage"
-                                          >
-                                            Rows per page
-                                          </EuiI18n>
-                                          : 
-                                          10
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </div>
-                            </div>
-                          </EuiPopover>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPagination
-                            activePage={0}
-                            aria-controls="random_html_id"
-                            onPageClick={[Function]}
-                            pageCount={1}
-                          >
-                            <nav
-                              className="euiPagination"
-                            >
-                              <EuiI18n
-                                default="Previous page, {page}"
-                                token="euiPagination.previousPage"
-                                values={
-                                  Object {
-                                    "page": 0,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Previous page"
-                                  token="euiPagination.disabledPreviousPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Previous page"
-                                    color="text"
-                                    data-test-subj="pagination-button-previous"
-                                    disabled={true}
-                                    iconType="arrowLeft"
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      aria-label="Previous page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowLeft"
-                                      >
-                                        <EuiIconArrowLeft
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
-                                              fillRule="nonzero"
-                                            />
-                                          </svg>
-                                        </EuiIconArrowLeft>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
-                                </EuiI18n>
-                              </EuiI18n>
-                              <ul
-                                className="euiPagination__list"
-                              >
-                                <PaginationButton
-                                  key="0"
-                                  pageIndex={0}
-                                >
-                                  <li
-                                    className="euiPagination__item"
-                                  >
-                                    <EuiPaginationButton
-                                      aria-controls="random_html_id"
-                                      hideOnMobile={true}
-                                      isActive={true}
-                                      onClick={[Function]}
-                                      pageIndex={0}
-                                      totalPages={1}
-                                    >
-                                      <EuiI18n
-                                        default="Page {page} of {totalPages}"
-                                        token="euiPaginationButton.longPageString"
-                                        values={
-                                          Object {
-                                            "page": 1,
-                                            "totalPages": 1,
-                                          }
-                                        }
-                                      >
-                                        <EuiI18n
-                                          default="Page {page}"
-                                          token="euiPaginationButton.shortPageString"
-                                          values={
-                                            Object {
-                                              "page": 1,
+                                            default="Page {page} of {totalPages}"
+                                            token="euiPaginationButton.longPageString"
+                                            values={
+                                              Object {
+                                                "page": 1,
+                                                "totalPages": 1,
+                                              }
                                             }
-                                          }
-                                        >
-                                          <EuiButtonEmpty
-                                            aria-controls="random_html_id"
-                                            aria-current={true}
-                                            aria-label="Page 1 of 1"
-                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                            color="text"
-                                            data-test-subj="pagination-button-0"
-                                            href="#random_html_id"
-                                            isDisabled={true}
-                                            onClick={[Function]}
-                                            size="s"
                                           >
-                                            <button
-                                              aria-controls="random_html_id"
-                                              aria-current={true}
-                                              aria-label="Page 1 of 1"
-                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                              data-test-subj="pagination-button-0"
-                                              disabled={true}
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <EuiButtonContent
-                                                className="euiButtonEmpty__content"
-                                                iconSide="left"
-                                                iconSize="m"
-                                                textProps={
-                                                  Object {
-                                                    "className": "euiButtonEmpty__text",
-                                                  }
+                                            <EuiI18n
+                                              default="Page {page}"
+                                              token="euiPaginationButton.shortPageString"
+                                              values={
+                                                Object {
+                                                  "page": 1,
                                                 }
+                                              }
+                                            >
+                                              <EuiButtonEmpty
+                                                aria-controls="random_html_id"
+                                                aria-current={true}
+                                                aria-label="Page 1 of 1"
+                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                color="text"
+                                                data-test-subj="pagination-button-0"
+                                                href="#random_html_id"
+                                                isDisabled={true}
+                                                onClick={[Function]}
+                                                size="s"
                                               >
-                                                <span
-                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                <button
+                                                  aria-controls="random_html_id"
+                                                  aria-current={true}
+                                                  aria-label="Page 1 of 1"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                  data-test-subj="pagination-button-0"
+                                                  disabled={true}
+                                                  onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <span
-                                                    className="euiButtonEmpty__text"
+                                                  <EuiButtonContent
+                                                    className="euiButtonEmpty__content"
+                                                    iconSide="left"
+                                                    iconSize="m"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiButtonEmpty__text",
+                                                      }
+                                                    }
                                                   >
-                                                    1
-                                                  </span>
-                                                </span>
-                                              </EuiButtonContent>
-                                            </button>
-                                          </EuiButtonEmpty>
-                                        </EuiI18n>
-                                      </EuiI18n>
-                                    </EuiPaginationButton>
-                                  </li>
-                                </PaginationButton>
-                              </ul>
-                              <EuiI18n
-                                default="Next page, {page}"
-                                token="euiPagination.nextPage"
-                                values={
-                                  Object {
-                                    "page": 2,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Next page"
-                                  token="euiPagination.disabledNextPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Next page"
-                                    color="text"
-                                    data-test-subj="pagination-button-next"
-                                    disabled={true}
-                                    iconType="arrowRight"
-                                    onClick={[Function]}
+                                                    <span
+                                                      className="euiButtonContent euiButtonEmpty__content"
+                                                    >
+                                                      <span
+                                                        className="euiButtonEmpty__text"
+                                                      >
+                                                        1
+                                                      </span>
+                                                    </span>
+                                                  </EuiButtonContent>
+                                                </button>
+                                              </EuiButtonEmpty>
+                                            </EuiI18n>
+                                          </EuiI18n>
+                                        </EuiPaginationButton>
+                                      </li>
+                                    </PaginationButton>
+                                  </ul>
+                                  <EuiI18n
+                                    default="Next page, {page}"
+                                    token="euiPagination.nextPage"
+                                    values={
+                                      Object {
+                                        "page": 2,
+                                      }
+                                    }
                                   >
-                                    <button
-                                      aria-label="Next page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-next"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
+                                    <EuiI18n
+                                      default="Next page"
+                                      token="euiPagination.disabledNextPage"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowRight"
+                                      <EuiButtonIcon
+                                        aria-label="Next page"
+                                        color="text"
+                                        data-test-subj="pagination-button-next"
+                                        disabled={true}
+                                        iconType="arrowRight"
+                                        onClick={[Function]}
                                       >
-                                        <EuiIconArrowRight
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
+                                        <button
+                                          aria-label="Next page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-next"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowRight"
                                           >
-                                            <path
-                                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                                              fillRule="nonzero"
-                                            />
-                                          </svg>
-                                        </EuiIconArrowRight>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
-                                </EuiI18n>
-                              </EuiI18n>
-                            </nav>
-                          </EuiPagination>
+                                            <EuiIconArrowRight
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                                  fillRule="nonzero"
+                                                />
+                                              </svg>
+                                            </EuiIconArrowRight>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
+                                  </EuiI18n>
+                                </nav>
+                              </EuiPagination>
+                            </div>
+                          </EuiFlexItem>
                         </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </EuiTablePagination>
+                      </EuiFlexGroup>
+                    </EuiTablePagination>
+                  </div>
+                </PaginationBar>
               </div>
-            </PaginationBar>
-          </div>
-        </EuiBasicTable>
-      </EuiInMemoryTable>
+            </EuiBasicTable>
+          </EuiInMemoryTable>
+        </div>
+      </EuiPanel>
     </div>
-  </EuiPanel>
+  </EuiPage>
 </TracesTable>
 `;
 
@@ -1780,345 +1804,1295 @@ exports[`Traces table component renders traces table 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPanel>
+  <EuiPage
+    paddingSize="m"
+  >
     <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      className="euiPage euiPage--paddingMedium euiPage--grow"
     >
-      <EuiFlexGroup
-        alignItems="center"
-        gutterSize="s"
-      >
+      <EuiPanel>
         <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
         >
-          <EuiFlexItem
-            grow={10}
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
           >
             <div
-              className="euiFlexItem euiFlexItem--flexGrow10"
+              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
-              <PanelTitle
-                title="Traces"
-                totalItems={1}
+              <EuiFlexItem
+                grow={10}
               >
-                <EuiText
-                  size="m"
-                >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Traces
-                    </span>
-                    <span
-                      className="panel-title-count"
-                    >
-                       (1)
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="m"
-      >
-        <div
-          className="euiSpacer euiSpacer--m"
-        />
-      </EuiSpacer>
-      <EuiHorizontalRule
-        margin="none"
-      >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full"
-        />
-      </EuiHorizontalRule>
-      <EuiInMemoryTable
-        columns={
-          Array [
-            Object {
-              "align": "left",
-              "field": "trace_id",
-              "name": "Trace ID",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "left",
-              "field": "trace_group",
-              "name": "Trace group",
-              "render": [Function],
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "latency",
-              "name": "Duration (ms)",
-              "sortable": true,
-              "truncateText": true,
-            },
-            Object {
-              "align": "right",
-              "field": "percentile_in_trace_group",
-              "name": <React.Fragment>
-                <div>
-                  Percentile in trace group
-                </div>
-              </React.Fragment>,
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "right",
-              "field": "error_count",
-              "name": "Errors",
-              "render": [Function],
-              "sortable": true,
-            },
-            Object {
-              "align": "left",
-              "field": "last_updated",
-              "name": "Last updated",
-              "render": [Function],
-              "sortable": true,
-            },
-          ]
-        }
-        items={
-          Array [
-            Object {
-              "actions": "#",
-              "error_count": "Yes",
-              "last_updated": "11/10/2020 09:55:45",
-              "latency": 19.91,
-              "percentile_in_trace_group": 30,
-              "trace_group": "HTTP GET",
-              "trace_id": "00079a615e31e61766fcb20b557051c1",
-            },
-          ]
-        }
-        loading={false}
-        onTableChange={[Function]}
-        pagination={
-          Object {
-            "initialPageSize": 10,
-            "pageSizeOptions": Array [
-              5,
-              10,
-              15,
-            ],
-          }
-        }
-        responsive={true}
-        sorting={
-          Object {
-            "sort": Object {
-              "direction": "asc",
-              "field": "trace_id",
-            },
-          }
-        }
-        tableLayout="auto"
-      >
-        <EuiBasicTable
-          columns={
-            Array [
-              Object {
-                "align": "left",
-                "field": "trace_id",
-                "name": "Trace ID",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "left",
-                "field": "trace_group",
-                "name": "Trace group",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "latency",
-                "name": "Duration (ms)",
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "align": "right",
-                "field": "percentile_in_trace_group",
-                "name": <React.Fragment>
-                  <div>
-                    Percentile in trace group
-                  </div>
-                </React.Fragment>,
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "right",
-                "field": "error_count",
-                "name": "Errors",
-                "render": [Function],
-                "sortable": true,
-              },
-              Object {
-                "align": "left",
-                "field": "last_updated",
-                "name": "Last updated",
-                "render": [Function],
-                "sortable": true,
-              },
-            ]
-          }
-          items={
-            Array [
-              Object {
-                "actions": "#",
-                "error_count": "Yes",
-                "last_updated": "11/10/2020 09:55:45",
-                "latency": 19.91,
-                "percentile_in_trace_group": 30,
-                "trace_group": "HTTP GET",
-                "trace_id": "00079a615e31e61766fcb20b557051c1",
-              },
-            ]
-          }
-          loading={false}
-          noItemsMessage="No items found"
-          onChange={[Function]}
-          pagination={
-            Object {
-              "hidePerPageOptions": undefined,
-              "pageIndex": 0,
-              "pageSize": 10,
-              "pageSizeOptions": Array [
-                5,
-                10,
-                15,
-              ],
-              "totalItemCount": 1,
-            }
-          }
-          responsive={true}
-          sorting={
-            Object {
-              "allowNeutralSort": true,
-              "sort": Object {
-                "direction": "asc",
-                "field": "Trace ID",
-              },
-            }
-          }
-          tableLayout="auto"
-        >
-          <div
-            className="euiBasicTable"
-          >
-            <div>
-              <EuiTableHeaderMobile>
                 <div
-                  className="euiTableHeaderMobile"
+                  className="euiFlexItem euiFlexItem--flexGrow10"
                 >
-                  <EuiFlexGroup
-                    alignItems="baseline"
-                    justifyContent="spaceBetween"
-                    responsive={false}
+                  <PanelTitle
+                    title="Traces"
+                    totalItems={1}
                   >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    <EuiText
+                      size="m"
                     >
-                      <EuiFlexItem
-                        grow={false}
+                      <div
+                        className="euiText euiText--medium"
                       >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        />
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        <span
+                          className="panel-title"
                         >
-                          <EuiTableSortMobile
-                            items={
-                              Array [
-                                Object {
-                                  "isSortAscending": true,
-                                  "isSorted": true,
-                                  "key": "_data_s_trace_id_0",
-                                  "name": "Trace ID",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_trace_group_1",
-                                  "name": "Trace group",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_latency_2",
-                                  "name": "Duration (ms)",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_percentile_in_trace_group_3",
-                                  "name": <React.Fragment>
+                          Traces
+                        </span>
+                        <span
+                          className="panel-title-count"
+                        >
+                           (1)
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
+          <EuiSpacer
+            size="m"
+          >
+            <div
+              className="euiSpacer euiSpacer--m"
+            />
+          </EuiSpacer>
+          <EuiHorizontalRule
+            margin="none"
+          >
+            <hr
+              className="euiHorizontalRule euiHorizontalRule--full"
+            />
+          </EuiHorizontalRule>
+          <EuiInMemoryTable
+            columns={
+              Array [
+                Object {
+                  "align": "left",
+                  "field": "trace_id",
+                  "name": "Trace ID",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "left",
+                  "field": "trace_group",
+                  "name": "Trace group",
+                  "render": [Function],
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "latency",
+                  "name": "Duration (ms)",
+                  "sortable": true,
+                  "truncateText": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "percentile_in_trace_group",
+                  "name": <React.Fragment>
+                    <div>
+                      Percentile in trace group
+                    </div>
+                  </React.Fragment>,
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "right",
+                  "field": "error_count",
+                  "name": "Errors",
+                  "render": [Function],
+                  "sortable": true,
+                },
+                Object {
+                  "align": "left",
+                  "field": "last_updated",
+                  "name": "Last updated",
+                  "render": [Function],
+                  "sortable": true,
+                },
+              ]
+            }
+            items={
+              Array [
+                Object {
+                  "actions": "#",
+                  "error_count": "Yes",
+                  "last_updated": "11/10/2020 09:55:45",
+                  "latency": 19.91,
+                  "percentile_in_trace_group": 30,
+                  "trace_group": "HTTP GET",
+                  "trace_id": "00079a615e31e61766fcb20b557051c1",
+                },
+              ]
+            }
+            loading={false}
+            onTableChange={[Function]}
+            pagination={
+              Object {
+                "initialPageSize": 10,
+                "pageSizeOptions": Array [
+                  5,
+                  10,
+                  15,
+                ],
+              }
+            }
+            responsive={true}
+            sorting={
+              Object {
+                "sort": Object {
+                  "direction": "asc",
+                  "field": "trace_id",
+                },
+              }
+            }
+            tableLayout="auto"
+          >
+            <EuiBasicTable
+              columns={
+                Array [
+                  Object {
+                    "align": "left",
+                    "field": "trace_id",
+                    "name": "Trace ID",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "left",
+                    "field": "trace_group",
+                    "name": "Trace group",
+                    "render": [Function],
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "latency",
+                    "name": "Duration (ms)",
+                    "sortable": true,
+                    "truncateText": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "percentile_in_trace_group",
+                    "name": <React.Fragment>
+                      <div>
+                        Percentile in trace group
+                      </div>
+                    </React.Fragment>,
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "right",
+                    "field": "error_count",
+                    "name": "Errors",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                  Object {
+                    "align": "left",
+                    "field": "last_updated",
+                    "name": "Last updated",
+                    "render": [Function],
+                    "sortable": true,
+                  },
+                ]
+              }
+              items={
+                Array [
+                  Object {
+                    "actions": "#",
+                    "error_count": "Yes",
+                    "last_updated": "11/10/2020 09:55:45",
+                    "latency": 19.91,
+                    "percentile_in_trace_group": 30,
+                    "trace_group": "HTTP GET",
+                    "trace_id": "00079a615e31e61766fcb20b557051c1",
+                  },
+                ]
+              }
+              loading={false}
+              noItemsMessage="No items found"
+              onChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+              responsive={true}
+              sorting={
+                Object {
+                  "allowNeutralSort": true,
+                  "sort": Object {
+                    "direction": "asc",
+                    "field": "Trace ID",
+                  },
+                }
+              }
+              tableLayout="auto"
+            >
+              <div
+                className="euiBasicTable"
+              >
+                <div>
+                  <EuiTableHeaderMobile>
+                    <div
+                      className="euiTableHeaderMobile"
+                    >
+                      <EuiFlexGroup
+                        alignItems="baseline"
+                        justifyContent="spaceBetween"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            />
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiTableSortMobile
+                                items={
+                                  Array [
+                                    Object {
+                                      "isSortAscending": true,
+                                      "isSorted": true,
+                                      "key": "_data_s_trace_id_0",
+                                      "name": "Trace ID",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_trace_group_1",
+                                      "name": "Trace group",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_latency_2",
+                                      "name": "Duration (ms)",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_percentile_in_trace_group_3",
+                                      "name": <React.Fragment>
+                                        <div>
+                                          Percentile in trace group
+                                        </div>
+                                      </React.Fragment>,
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_error_count_4",
+                                      "name": "Errors",
+                                      "onSort": [Function],
+                                    },
+                                    Object {
+                                      "isSortAscending": undefined,
+                                      "isSorted": false,
+                                      "key": "_data_s_last_updated_5",
+                                      "name": "Last updated",
+                                      "onSort": [Function],
+                                    },
+                                  ]
+                                }
+                              >
+                                <div
+                                  className="euiTableSortMobile"
+                                >
+                                  <EuiPopover
+                                    anchorPosition="downRight"
+                                    button={
+                                      <EuiButtonEmpty
+                                        flush="right"
+                                        iconSide="right"
+                                        iconType="arrowDown"
+                                        onClick={[Function]}
+                                        size="xs"
+                                      >
+                                        <EuiI18n
+                                          default="Sorting"
+                                          token="euiTableSortMobile.sorting"
+                                        />
+                                      </EuiButtonEmpty>
+                                    }
+                                    closePopover={[Function]}
+                                    display="inlineBlock"
+                                    hasArrow={true}
+                                    isOpen={false}
+                                    ownFocus={true}
+                                    panelPaddingSize="none"
+                                  >
+                                    <div
+                                      className="euiPopover euiPopover--anchorDownRight"
+                                    >
+                                      <div
+                                        className="euiPopover__anchor"
+                                      >
+                                        <EuiButtonEmpty
+                                          flush="right"
+                                          iconSide="right"
+                                          iconType="arrowDown"
+                                          onClick={[Function]}
+                                          size="xs"
+                                        >
+                                          <button
+                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <EuiButtonContent
+                                              className="euiButtonEmpty__content"
+                                              iconSide="right"
+                                              iconSize="s"
+                                              iconType="arrowDown"
+                                              textProps={
+                                                Object {
+                                                  "className": "euiButtonEmpty__text",
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                              >
+                                                <EuiIcon
+                                                  className="euiButtonContent__icon"
+                                                  color="inherit"
+                                                  size="s"
+                                                  type="arrowDown"
+                                                >
+                                                  <EuiIconBeaker
+                                                    aria-hidden={true}
+                                                    className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                    focusable="false"
+                                                    role="img"
+                                                    style={null}
+                                                  >
+                                                    <svg
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                      focusable="false"
+                                                      height={16}
+                                                      role="img"
+                                                      style={null}
+                                                      viewBox="0 0 16 16"
+                                                      width={16}
+                                                      xmlns="http://www.w3.org/2000/svg"
+                                                    >
+                                                      <path
+                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconBeaker>
+                                                </EuiIcon>
+                                                <span
+                                                  className="euiButtonEmpty__text"
+                                                >
+                                                  <EuiI18n
+                                                    default="Sorting"
+                                                    token="euiTableSortMobile.sorting"
+                                                  >
+                                                    Sorting
+                                                  </EuiI18n>
+                                                </span>
+                                              </span>
+                                            </EuiButtonContent>
+                                          </button>
+                                        </EuiButtonEmpty>
+                                      </div>
+                                    </div>
+                                  </EuiPopover>
+                                </div>
+                              </EuiTableSortMobile>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </div>
+                  </EuiTableHeaderMobile>
+                  <EuiTable
+                    id="random_html_id"
+                    responsive={true}
+                    tableLayout="auto"
+                  >
+                    <table
+                      className="euiTable euiTable--responsive euiTable--auto"
+                      id="random_html_id"
+                      tabIndex={-1}
+                    >
+                      <EuiScreenReaderOnly>
+                        <caption
+                          className="euiScreenReaderOnly euiTableCaption"
+                        >
+                          <EuiDelayRender
+                            delay={500}
+                          />
+                        </caption>
+                      </EuiScreenReaderOnly>
+                      <EuiTableHeader>
+                        <thead>
+                          <tr>
+                            <EuiTableHeaderCell
+                              align="left"
+                              data-test-subj="tableHeaderCell_trace_id_0"
+                              isSortAscending={true}
+                              isSorted={true}
+                              key="_data_h_trace_id_0"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="ascending"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_trace_id_0"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSortAscending={true}
+                                    isSorted={true}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Trace ID",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Trace ID"
+                                          >
+                                            Trace ID
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                      <EuiIcon
+                                        className="euiTableSortIcon"
+                                        size="m"
+                                        type="sortUp"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="left"
+                              data-test-subj="tableHeaderCell_trace_group_1"
+                              isSorted={false}
+                              key="_data_h_trace_group_1"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_trace_group_1"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Trace group",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Trace group"
+                                          >
+                                            Trace group
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_latency_2"
+                              isSorted={false}
+                              key="_data_h_latency_2"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_latency_2"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Duration (ms)",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Duration (ms)"
+                                          >
+                                            Duration (ms)
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
+                              isSorted={false}
+                              key="_data_h_percentile_in_trace_group_3"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Percentile in trace group",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Percentile in trace group"
+                                          >
+                                            <div>
+                                              Percentile in trace group
+                                            </div>
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="right"
+                              data-test-subj="tableHeaderCell_error_count_4"
+                              isSorted={false}
+                              key="_data_h_error_count_4"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_error_count_4"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent euiTableCellContent--alignRight"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent euiTableCellContent--alignRight"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Errors",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Errors"
+                                          >
+                                            Errors
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                            <EuiTableHeaderCell
+                              align="left"
+                              data-test-subj="tableHeaderCell_last_updated_5"
+                              isSorted={false}
+                              key="_data_h_last_updated_5"
+                              onSort={[Function]}
+                            >
+                              <th
+                                aria-live="polite"
+                                aria-sort="none"
+                                className="euiTableHeaderCell"
+                                data-test-subj="tableHeaderCell_last_updated_5"
+                                role="columnheader"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <button
+                                  className="euiTableHeaderButton"
+                                  data-test-subj="tableHeaderSortButton"
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <CellContents
+                                    className="euiTableCellContent"
+                                    isSorted={false}
+                                    showSortMsg={true}
+                                  >
+                                    <span
+                                      className="euiTableCellContent"
+                                    >
+                                      <EuiInnerText>
+                                        <EuiI18n
+                                          default="{innerText}; {description}"
+                                          token="euiTableHeaderCell.titleTextWithDesc"
+                                          values={
+                                            Object {
+                                              "description": undefined,
+                                              "innerText": "Last updated",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="euiTableCellContent__text"
+                                            title="Last updated"
+                                          >
+                                            Last updated
+                                          </span>
+                                        </EuiI18n>
+                                      </EuiInnerText>
+                                    </span>
+                                  </CellContents>
+                                </button>
+                              </th>
+                            </EuiTableHeaderCell>
+                          </tr>
+                        </thead>
+                      </EuiTableHeader>
+                      <EuiTableBody
+                        bodyRef={[Function]}
+                      >
+                        <tbody>
+                          <EuiTableRow
+                            isSelected={false}
+                          >
+                            <tr
+                              className="euiTableRow"
+                            >
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_trace_id_0_0"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Trace ID",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Trace ID
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiFlexGroup
+                                      alignItems="center"
+                                      className=""
+                                      gutterSize="s"
+                                      key=".0"
+                                    >
+                                      <div
+                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                      >
+                                        <EuiFlexItem
+                                          grow={10}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrow10"
+                                          >
+                                            <EuiLink
+                                              data-test-subj="trace-link"
+                                              onClick={[Function]}
+                                            >
+                                              <button
+                                                className="euiLink euiLink--primary"
+                                                data-test-subj="trace-link"
+                                                disabled={false}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <div
+                                                  title="00079a615e31e61766fcb20b557051c1"
+                                                >
+                                                  00079a615e31e61766fcb...
+                                                </div>
+                                              </button>
+                                            </EuiLink>
+                                          </div>
+                                        </EuiFlexItem>
+                                        <EuiFlexItem
+                                          grow={false}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrowZero"
+                                          >
+                                            <EuiCopy
+                                              afterMessage="Copied"
+                                              textToCopy="00079a615e31e61766fcb20b557051c1"
+                                            >
+                                              <EuiToolTip
+                                                delay="regular"
+                                                onMouseOut={[Function]}
+                                                position="top"
+                                              >
+                                                <span
+                                                  className="euiToolTipAnchor"
+                                                  onKeyUp={[Function]}
+                                                  onMouseOut={[Function]}
+                                                  onMouseOver={[Function]}
+                                                >
+                                                  <EuiSmallButtonIcon
+                                                    aria-label="Copy trace id"
+                                                    iconType="copyClipboard"
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onFocus={[Function]}
+                                                  >
+                                                    <EuiButtonIcon
+                                                      aria-label="Copy trace id"
+                                                      iconType="copyClipboard"
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onFocus={[Function]}
+                                                      size="s"
+                                                    >
+                                                      <button
+                                                        aria-label="Copy trace id"
+                                                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                        disabled={false}
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onFocus={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiIcon
+                                                          aria-hidden="true"
+                                                          className="euiButtonIcon__icon"
+                                                          color="inherit"
+                                                          size="m"
+                                                          type="copyClipboard"
+                                                        >
+                                                          <EuiIconBeaker
+                                                            aria-hidden={true}
+                                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                            focusable="false"
+                                                            role="img"
+                                                            style={null}
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                              focusable="false"
+                                                              height={16}
+                                                              role="img"
+                                                              style={null}
+                                                              viewBox="0 0 16 16"
+                                                              width={16}
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                            >
+                                                              <path
+                                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                              />
+                                                            </svg>
+                                                          </EuiIconBeaker>
+                                                        </EuiIcon>
+                                                      </button>
+                                                    </EuiButtonIcon>
+                                                  </EuiSmallButtonIcon>
+                                                </span>
+                                              </EuiToolTip>
+                                            </EuiCopy>
+                                          </div>
+                                        </EuiFlexItem>
+                                        <EuiFlexItem
+                                          grow={3}
+                                        >
+                                          <div
+                                            className="euiFlexItem euiFlexItem--flexGrow3"
+                                          />
+                                        </EuiFlexItem>
+                                      </div>
+                                    </EuiFlexGroup>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_trace_group_0_1"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Trace group",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Trace group
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiText
+                                      className=""
+                                      key=".0"
+                                      size="s"
+                                    >
+                                      <div
+                                        className="euiText euiText--small"
+                                      >
+                                        HTTP GET
+                                      </div>
+                                    </EuiText>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_latency_0_2"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Duration (ms)",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={true}
+                                truncateText={true}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Duration (ms)
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
+                                  >
+                                    <span
+                                      className="euiTableCellContent__text"
+                                    >
+                                      19.91
+                                    </span>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_percentile_in_trace_group_0_3"
+                                mobileOptions={
+                                  Object {
+                                    "header": <React.Fragment>
+                                      <div>
+                                        Percentile in trace group
+                                      </div>
+                                    </React.Fragment>,
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
                                     <div>
                                       Percentile in trace group
                                     </div>
-                                  </React.Fragment>,
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_error_count_4",
-                                  "name": "Errors",
-                                  "onSort": [Function],
-                                },
-                                Object {
-                                  "isSortAscending": undefined,
-                                  "isSorted": false,
-                                  "key": "_data_s_last_updated_5",
-                                  "name": "Last updated",
-                                  "onSort": [Function],
-                                },
-                              ]
-                            }
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    <EuiText
+                                      className=""
+                                      key=".0"
+                                      size="s"
+                                    >
+                                      <div
+                                        className="euiText euiText--small"
+                                      >
+                                        30th
+                                      </div>
+                                    </EuiText>
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="right"
+                                key="_data_column_error_count_0_4"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Errors",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Errors
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                                  >
+                                    No
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                              <EuiTableRowCell
+                                align="left"
+                                key="_data_column_last_updated_0_5"
+                                mobileOptions={
+                                  Object {
+                                    "header": "Last updated",
+                                    "render": undefined,
+                                  }
+                                }
+                                setScopeRow={false}
+                                textOnly={false}
+                              >
+                                <td
+                                  className="euiTableRowCell"
+                                  style={
+                                    Object {
+                                      "width": undefined,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                                  >
+                                    Last updated
+                                  </div>
+                                  <div
+                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
+                                  >
+                                    11/10/2020 09:55:45
+                                  </div>
+                                </td>
+                              </EuiTableRowCell>
+                            </tr>
+                          </EuiTableRow>
+                        </tbody>
+                      </EuiTableBody>
+                    </table>
+                  </EuiTable>
+                </div>
+                <PaginationBar
+                  aria-controls="random_html_id"
+                  onPageChange={[Function]}
+                  onPageSizeChange={[Function]}
+                  pagination={
+                    Object {
+                      "hidePerPageOptions": undefined,
+                      "pageIndex": 0,
+                      "pageSize": 10,
+                      "pageSizeOptions": Array [
+                        5,
+                        10,
+                        15,
+                      ],
+                      "totalItemCount": 1,
+                    }
+                  }
+                >
+                  <div>
+                    <EuiSpacer
+                      size="m"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--m"
+                      />
+                    </EuiSpacer>
+                    <EuiTablePagination
+                      activePage={0}
+                      aria-controls="random_html_id"
+                      itemsPerPage={10}
+                      itemsPerPageOptions={
+                        Array [
+                          5,
+                          10,
+                          15,
+                        ]
+                      }
+                      onChangeItemsPerPage={[Function]}
+                      onChangePage={[Function]}
+                      pageCount={1}
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        justifyContent="spaceBetween"
+                        responsive={false}
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        >
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiTableSortMobile"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
                               <EuiPopover
-                                anchorPosition="downRight"
+                                anchorPosition="upRight"
                                 button={
                                   <EuiButtonEmpty
-                                    flush="right"
+                                    color="text"
+                                    data-test-subj="tablePaginationPopoverButton"
                                     iconSide="right"
                                     iconType="arrowDown"
                                     onClick={[Function]}
                                     size="xs"
                                   >
                                     <EuiI18n
-                                      default="Sorting"
-                                      token="euiTableSortMobile.sorting"
+                                      default="Rows per page"
+                                      token="euiTablePagination.rowsPerPage"
                                     />
+                                    : 
+                                    10
                                   </EuiButtonEmpty>
                                 }
                                 closePopover={[Function]}
@@ -2129,20 +3103,22 @@ exports[`Traces table component renders traces table 1`] = `
                                 panelPaddingSize="none"
                               >
                                 <div
-                                  className="euiPopover euiPopover--anchorDownRight"
+                                  className="euiPopover euiPopover--anchorUpRight"
                                 >
                                   <div
                                     className="euiPopover__anchor"
                                   >
                                     <EuiButtonEmpty
-                                      flush="right"
+                                      color="text"
+                                      data-test-subj="tablePaginationPopoverButton"
                                       iconSide="right"
                                       iconType="arrowDown"
                                       onClick={[Function]}
                                       size="xs"
                                     >
                                       <button
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                        data-test-subj="tablePaginationPopoverButton"
                                         disabled={false}
                                         onClick={[Function]}
                                         type="button"
@@ -2195,11 +3171,13 @@ exports[`Traces table component renders traces table 1`] = `
                                               className="euiButtonEmpty__text"
                                             >
                                               <EuiI18n
-                                                default="Sorting"
-                                                token="euiTableSortMobile.sorting"
+                                                default="Rows per page"
+                                                token="euiTablePagination.rowsPerPage"
                                               >
-                                                Sorting
+                                                Rows per page
                                               </EuiI18n>
+                                              : 
+                                              10
                                             </span>
                                           </span>
                                         </EuiButtonContent>
@@ -2209,1198 +3187,252 @@ exports[`Traces table component renders traces table 1`] = `
                                 </div>
                               </EuiPopover>
                             </div>
-                          </EuiTableSortMobile>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiTableHeaderMobile>
-              <EuiTable
-                id="random_html_id"
-                responsive={true}
-                tableLayout="auto"
-              >
-                <table
-                  className="euiTable euiTable--responsive euiTable--auto"
-                  id="random_html_id"
-                  tabIndex={-1}
-                >
-                  <EuiScreenReaderOnly>
-                    <caption
-                      className="euiScreenReaderOnly euiTableCaption"
-                    >
-                      <EuiDelayRender
-                        delay={500}
-                      />
-                    </caption>
-                  </EuiScreenReaderOnly>
-                  <EuiTableHeader>
-                    <thead>
-                      <tr>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_trace_id_0"
-                          isSortAscending={true}
-                          isSorted={true}
-                          key="_data_h_trace_id_0"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="ascending"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_trace_id_0"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSortAscending={true}
-                                isSorted={true}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Trace ID",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Trace ID"
-                                      >
-                                        Trace ID
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                  <EuiIcon
-                                    className="euiTableSortIcon"
-                                    size="m"
-                                    type="sortUp"
-                                  >
-                                    <EuiIconBeaker
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                        />
-                                      </svg>
-                                    </EuiIconBeaker>
-                                  </EuiIcon>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_trace_group_1"
-                          isSorted={false}
-                          key="_data_h_trace_group_1"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_trace_group_1"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Trace group",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Trace group"
-                                      >
-                                        Trace group
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_latency_2"
-                          isSorted={false}
-                          key="_data_h_latency_2"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_latency_2"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Duration (ms)",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Duration (ms)"
-                                      >
-                                        Duration (ms)
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
-                          isSorted={false}
-                          key="_data_h_percentile_in_trace_group_3"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Percentile in trace group",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Percentile in trace group"
-                                      >
-                                        <div>
-                                          Percentile in trace group
-                                        </div>
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="right"
-                          data-test-subj="tableHeaderCell_error_count_4"
-                          isSorted={false}
-                          key="_data_h_error_count_4"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_error_count_4"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent euiTableCellContent--alignRight"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent euiTableCellContent--alignRight"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Errors",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Errors"
-                                      >
-                                        Errors
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                        <EuiTableHeaderCell
-                          align="left"
-                          data-test-subj="tableHeaderCell_last_updated_5"
-                          isSorted={false}
-                          key="_data_h_last_updated_5"
-                          onSort={[Function]}
-                        >
-                          <th
-                            aria-live="polite"
-                            aria-sort="none"
-                            className="euiTableHeaderCell"
-                            data-test-subj="tableHeaderCell_last_updated_5"
-                            role="columnheader"
-                            scope="col"
-                            style={
-                              Object {
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <button
-                              className="euiTableHeaderButton"
-                              data-test-subj="tableHeaderSortButton"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <CellContents
-                                className="euiTableCellContent"
-                                isSorted={false}
-                                showSortMsg={true}
-                              >
-                                <span
-                                  className="euiTableCellContent"
-                                >
-                                  <EuiInnerText>
-                                    <EuiI18n
-                                      default="{innerText}; {description}"
-                                      token="euiTableHeaderCell.titleTextWithDesc"
-                                      values={
-                                        Object {
-                                          "description": undefined,
-                                          "innerText": "Last updated",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="euiTableCellContent__text"
-                                        title="Last updated"
-                                      >
-                                        Last updated
-                                      </span>
-                                    </EuiI18n>
-                                  </EuiInnerText>
-                                </span>
-                              </CellContents>
-                            </button>
-                          </th>
-                        </EuiTableHeaderCell>
-                      </tr>
-                    </thead>
-                  </EuiTableHeader>
-                  <EuiTableBody
-                    bodyRef={[Function]}
-                  >
-                    <tbody>
-                      <EuiTableRow
-                        isSelected={false}
-                      >
-                        <tr
-                          className="euiTableRow"
-                        >
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_trace_id_0_0"
-                            mobileOptions={
-                              Object {
-                                "header": "Trace ID",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Trace ID
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiFlexGroup
-                                  alignItems="center"
-                                  className=""
-                                  gutterSize="s"
-                                  key=".0"
-                                >
-                                  <div
-                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                  >
-                                    <EuiFlexItem
-                                      grow={10}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrow10"
-                                      >
-                                        <EuiLink
-                                          data-test-subj="trace-link"
-                                          onClick={[Function]}
-                                        >
-                                          <button
-                                            className="euiLink euiLink--primary"
-                                            data-test-subj="trace-link"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <div
-                                              title="00079a615e31e61766fcb20b557051c1"
-                                            >
-                                              00079a615e31e61766fcb...
-                                            </div>
-                                          </button>
-                                        </EuiLink>
-                                      </div>
-                                    </EuiFlexItem>
-                                    <EuiFlexItem
-                                      grow={false}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrowZero"
-                                      >
-                                        <EuiCopy
-                                          afterMessage="Copied"
-                                          textToCopy="00079a615e31e61766fcb20b557051c1"
-                                        >
-                                          <EuiToolTip
-                                            delay="regular"
-                                            onMouseOut={[Function]}
-                                            position="top"
-                                          >
-                                            <span
-                                              className="euiToolTipAnchor"
-                                              onKeyUp={[Function]}
-                                              onMouseOut={[Function]}
-                                              onMouseOver={[Function]}
-                                            >
-                                              <EuiSmallButtonIcon
-                                                aria-label="Copy trace id"
-                                                iconType="copyClipboard"
-                                                onBlur={[Function]}
-                                                onClick={[Function]}
-                                                onFocus={[Function]}
-                                              >
-                                                <EuiButtonIcon
-                                                  aria-label="Copy trace id"
-                                                  iconType="copyClipboard"
-                                                  onBlur={[Function]}
-                                                  onClick={[Function]}
-                                                  onFocus={[Function]}
-                                                  size="s"
-                                                >
-                                                  <button
-                                                    aria-label="Copy trace id"
-                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                                                    disabled={false}
-                                                    onBlur={[Function]}
-                                                    onClick={[Function]}
-                                                    onFocus={[Function]}
-                                                    type="button"
-                                                  >
-                                                    <EuiIcon
-                                                      aria-hidden="true"
-                                                      className="euiButtonIcon__icon"
-                                                      color="inherit"
-                                                      size="m"
-                                                      type="copyClipboard"
-                                                    >
-                                                      <EuiIconBeaker
-                                                        aria-hidden={true}
-                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                        focusable="false"
-                                                        role="img"
-                                                        style={null}
-                                                      >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                          focusable="false"
-                                                          height={16}
-                                                          role="img"
-                                                          style={null}
-                                                          viewBox="0 0 16 16"
-                                                          width={16}
-                                                          xmlns="http://www.w3.org/2000/svg"
-                                                        >
-                                                          <path
-                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                          />
-                                                        </svg>
-                                                      </EuiIconBeaker>
-                                                    </EuiIcon>
-                                                  </button>
-                                                </EuiButtonIcon>
-                                              </EuiSmallButtonIcon>
-                                            </span>
-                                          </EuiToolTip>
-                                        </EuiCopy>
-                                      </div>
-                                    </EuiFlexItem>
-                                    <EuiFlexItem
-                                      grow={3}
-                                    >
-                                      <div
-                                        className="euiFlexItem euiFlexItem--flexGrow3"
-                                      />
-                                    </EuiFlexItem>
-                                  </div>
-                                </EuiFlexGroup>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_trace_group_0_1"
-                            mobileOptions={
-                              Object {
-                                "header": "Trace group",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Trace group
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                              >
-                                <EuiText
-                                  className=""
-                                  key=".0"
-                                  size="s"
-                                >
-                                  <div
-                                    className="euiText euiText--small"
-                                  >
-                                    HTTP GET
-                                  </div>
-                                </EuiText>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_latency_0_2"
-                            mobileOptions={
-                              Object {
-                                "header": "Duration (ms)",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={true}
-                            truncateText={true}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Duration (ms)
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
-                              >
-                                <span
-                                  className="euiTableCellContent__text"
-                                >
-                                  19.91
-                                </span>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_percentile_in_trace_group_0_3"
-                            mobileOptions={
-                              Object {
-                                "header": <React.Fragment>
-                                  <div>
-                                    Percentile in trace group
-                                  </div>
-                                </React.Fragment>,
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                <div>
-                                  Percentile in trace group
-                                </div>
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                <EuiText
-                                  className=""
-                                  key=".0"
-                                  size="s"
-                                >
-                                  <div
-                                    className="euiText euiText--small"
-                                  >
-                                    30th
-                                  </div>
-                                </EuiText>
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="right"
-                            key="_data_column_error_count_0_4"
-                            mobileOptions={
-                              Object {
-                                "header": "Errors",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Errors
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                              >
-                                No
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                          <EuiTableRowCell
-                            align="left"
-                            key="_data_column_last_updated_0_5"
-                            mobileOptions={
-                              Object {
-                                "header": "Last updated",
-                                "render": undefined,
-                              }
-                            }
-                            setScopeRow={false}
-                            textOnly={false}
-                          >
-                            <td
-                              className="euiTableRowCell"
-                              style={
-                                Object {
-                                  "width": undefined,
-                                }
-                              }
-                            >
-                              <div
-                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                              >
-                                Last updated
-                              </div>
-                              <div
-                                className="euiTableCellContent euiTableCellContent--overflowingContent"
-                              >
-                                11/10/2020 09:55:45
-                              </div>
-                            </td>
-                          </EuiTableRowCell>
-                        </tr>
-                      </EuiTableRow>
-                    </tbody>
-                  </EuiTableBody>
-                </table>
-              </EuiTable>
-            </div>
-            <PaginationBar
-              aria-controls="random_html_id"
-              onPageChange={[Function]}
-              onPageSizeChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-            >
-              <div>
-                <EuiSpacer
-                  size="m"
-                >
-                  <div
-                    className="euiSpacer euiSpacer--m"
-                  />
-                </EuiSpacer>
-                <EuiTablePagination
-                  activePage={0}
-                  aria-controls="random_html_id"
-                  itemsPerPage={10}
-                  itemsPerPageOptions={
-                    Array [
-                      5,
-                      10,
-                      15,
-                    ]
-                  }
-                  onChangeItemsPerPage={[Function]}
-                  onChangePage={[Function]}
-                  pageCount={1}
-                >
-                  <EuiFlexGroup
-                    alignItems="center"
-                    justifyContent="spaceBetween"
-                    responsive={false}
-                  >
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-                    >
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPopover
-                            anchorPosition="upRight"
-                            button={
-                              <EuiButtonEmpty
-                                color="text"
-                                data-test-subj="tablePaginationPopoverButton"
-                                iconSide="right"
-                                iconType="arrowDown"
-                                onClick={[Function]}
-                                size="xs"
-                              >
-                                <EuiI18n
-                                  default="Rows per page"
-                                  token="euiTablePagination.rowsPerPage"
-                                />
-                                : 
-                                10
-                              </EuiButtonEmpty>
-                            }
-                            closePopover={[Function]}
-                            display="inlineBlock"
-                            hasArrow={true}
-                            isOpen={false}
-                            ownFocus={true}
-                            panelPaddingSize="none"
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiPopover euiPopover--anchorUpRight"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <div
-                                className="euiPopover__anchor"
+                              <EuiPagination
+                                activePage={0}
+                                aria-controls="random_html_id"
+                                onPageClick={[Function]}
+                                pageCount={1}
                               >
-                                <EuiButtonEmpty
-                                  color="text"
-                                  data-test-subj="tablePaginationPopoverButton"
-                                  iconSide="right"
-                                  iconType="arrowDown"
-                                  onClick={[Function]}
-                                  size="xs"
+                                <nav
+                                  className="euiPagination"
                                 >
-                                  <button
-                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
-                                    data-test-subj="tablePaginationPopoverButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    <EuiButtonContent
-                                      className="euiButtonEmpty__content"
-                                      iconSide="right"
-                                      iconSize="s"
-                                      iconType="arrowDown"
-                                      textProps={
-                                        Object {
-                                          "className": "euiButtonEmpty__text",
-                                        }
+                                  <EuiI18n
+                                    default="Previous page, {page}"
+                                    token="euiPagination.previousPage"
+                                    values={
+                                      Object {
+                                        "page": 0,
                                       }
+                                    }
+                                  >
+                                    <EuiI18n
+                                      default="Previous page"
+                                      token="euiPagination.disabledPreviousPage"
                                     >
-                                      <span
-                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                      <EuiButtonIcon
+                                        aria-label="Previous page"
+                                        color="text"
+                                        data-test-subj="pagination-button-previous"
+                                        disabled={true}
+                                        iconType="arrowLeft"
+                                        onClick={[Function]}
                                       >
-                                        <EuiIcon
-                                          className="euiButtonContent__icon"
-                                          color="inherit"
-                                          size="s"
-                                          type="arrowDown"
+                                        <button
+                                          aria-label="Previous page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-previous"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <EuiIconBeaker
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                            focusable="false"
-                                            role="img"
-                                            style={null}
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowLeft"
                                           >
-                                            <svg
+                                            <EuiIconBeaker
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                               focusable="false"
-                                              height={16}
                                               role="img"
                                               style={null}
-                                              viewBox="0 0 16 16"
-                                              width={16}
-                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <path
-                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                              />
-                                            </svg>
-                                          </EuiIconBeaker>
-                                        </EuiIcon>
-                                        <span
-                                          className="euiButtonEmpty__text"
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
+                                  </EuiI18n>
+                                  <ul
+                                    className="euiPagination__list"
+                                  >
+                                    <PaginationButton
+                                      key="0"
+                                      pageIndex={0}
+                                    >
+                                      <li
+                                        className="euiPagination__item"
+                                      >
+                                        <EuiPaginationButton
+                                          aria-controls="random_html_id"
+                                          hideOnMobile={true}
+                                          isActive={true}
+                                          onClick={[Function]}
+                                          pageIndex={0}
+                                          totalPages={1}
                                         >
                                           <EuiI18n
-                                            default="Rows per page"
-                                            token="euiTablePagination.rowsPerPage"
-                                          >
-                                            Rows per page
-                                          </EuiI18n>
-                                          : 
-                                          10
-                                        </span>
-                                      </span>
-                                    </EuiButtonContent>
-                                  </button>
-                                </EuiButtonEmpty>
-                              </div>
-                            </div>
-                          </EuiPopover>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem
-                        grow={false}
-                      >
-                        <div
-                          className="euiFlexItem euiFlexItem--flexGrowZero"
-                        >
-                          <EuiPagination
-                            activePage={0}
-                            aria-controls="random_html_id"
-                            onPageClick={[Function]}
-                            pageCount={1}
-                          >
-                            <nav
-                              className="euiPagination"
-                            >
-                              <EuiI18n
-                                default="Previous page, {page}"
-                                token="euiPagination.previousPage"
-                                values={
-                                  Object {
-                                    "page": 0,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Previous page"
-                                  token="euiPagination.disabledPreviousPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Previous page"
-                                    color="text"
-                                    data-test-subj="pagination-button-previous"
-                                    disabled={true}
-                                    iconType="arrowLeft"
-                                    onClick={[Function]}
-                                  >
-                                    <button
-                                      aria-label="Previous page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-previous"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowLeft"
-                                      >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
-                                </EuiI18n>
-                              </EuiI18n>
-                              <ul
-                                className="euiPagination__list"
-                              >
-                                <PaginationButton
-                                  key="0"
-                                  pageIndex={0}
-                                >
-                                  <li
-                                    className="euiPagination__item"
-                                  >
-                                    <EuiPaginationButton
-                                      aria-controls="random_html_id"
-                                      hideOnMobile={true}
-                                      isActive={true}
-                                      onClick={[Function]}
-                                      pageIndex={0}
-                                      totalPages={1}
-                                    >
-                                      <EuiI18n
-                                        default="Page {page} of {totalPages}"
-                                        token="euiPaginationButton.longPageString"
-                                        values={
-                                          Object {
-                                            "page": 1,
-                                            "totalPages": 1,
-                                          }
-                                        }
-                                      >
-                                        <EuiI18n
-                                          default="Page {page}"
-                                          token="euiPaginationButton.shortPageString"
-                                          values={
-                                            Object {
-                                              "page": 1,
+                                            default="Page {page} of {totalPages}"
+                                            token="euiPaginationButton.longPageString"
+                                            values={
+                                              Object {
+                                                "page": 1,
+                                                "totalPages": 1,
+                                              }
                                             }
-                                          }
-                                        >
-                                          <EuiButtonEmpty
-                                            aria-controls="random_html_id"
-                                            aria-current={true}
-                                            aria-label="Page 1 of 1"
-                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                            color="text"
-                                            data-test-subj="pagination-button-0"
-                                            href="#random_html_id"
-                                            isDisabled={true}
-                                            onClick={[Function]}
-                                            size="s"
                                           >
-                                            <button
-                                              aria-controls="random_html_id"
-                                              aria-current={true}
-                                              aria-label="Page 1 of 1"
-                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                              data-test-subj="pagination-button-0"
-                                              disabled={true}
-                                              onClick={[Function]}
-                                              type="button"
-                                            >
-                                              <EuiButtonContent
-                                                className="euiButtonEmpty__content"
-                                                iconSide="left"
-                                                iconSize="m"
-                                                textProps={
-                                                  Object {
-                                                    "className": "euiButtonEmpty__text",
-                                                  }
+                                            <EuiI18n
+                                              default="Page {page}"
+                                              token="euiPaginationButton.shortPageString"
+                                              values={
+                                                Object {
+                                                  "page": 1,
                                                 }
+                                              }
+                                            >
+                                              <EuiButtonEmpty
+                                                aria-controls="random_html_id"
+                                                aria-current={true}
+                                                aria-label="Page 1 of 1"
+                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                color="text"
+                                                data-test-subj="pagination-button-0"
+                                                href="#random_html_id"
+                                                isDisabled={true}
+                                                onClick={[Function]}
+                                                size="s"
                                               >
-                                                <span
-                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                <button
+                                                  aria-controls="random_html_id"
+                                                  aria-current={true}
+                                                  aria-label="Page 1 of 1"
+                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                                  data-test-subj="pagination-button-0"
+                                                  disabled={true}
+                                                  onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <span
-                                                    className="euiButtonEmpty__text"
+                                                  <EuiButtonContent
+                                                    className="euiButtonEmpty__content"
+                                                    iconSide="left"
+                                                    iconSize="m"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiButtonEmpty__text",
+                                                      }
+                                                    }
                                                   >
-                                                    1
-                                                  </span>
-                                                </span>
-                                              </EuiButtonContent>
-                                            </button>
-                                          </EuiButtonEmpty>
-                                        </EuiI18n>
-                                      </EuiI18n>
-                                    </EuiPaginationButton>
-                                  </li>
-                                </PaginationButton>
-                              </ul>
-                              <EuiI18n
-                                default="Next page, {page}"
-                                token="euiPagination.nextPage"
-                                values={
-                                  Object {
-                                    "page": 2,
-                                  }
-                                }
-                              >
-                                <EuiI18n
-                                  default="Next page"
-                                  token="euiPagination.disabledNextPage"
-                                >
-                                  <EuiButtonIcon
-                                    aria-label="Next page"
-                                    color="text"
-                                    data-test-subj="pagination-button-next"
-                                    disabled={true}
-                                    iconType="arrowRight"
-                                    onClick={[Function]}
+                                                    <span
+                                                      className="euiButtonContent euiButtonEmpty__content"
+                                                    >
+                                                      <span
+                                                        className="euiButtonEmpty__text"
+                                                      >
+                                                        1
+                                                      </span>
+                                                    </span>
+                                                  </EuiButtonContent>
+                                                </button>
+                                              </EuiButtonEmpty>
+                                            </EuiI18n>
+                                          </EuiI18n>
+                                        </EuiPaginationButton>
+                                      </li>
+                                    </PaginationButton>
+                                  </ul>
+                                  <EuiI18n
+                                    default="Next page, {page}"
+                                    token="euiPagination.nextPage"
+                                    values={
+                                      Object {
+                                        "page": 2,
+                                      }
+                                    }
                                   >
-                                    <button
-                                      aria-label="Next page"
-                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                      data-test-subj="pagination-button-next"
-                                      disabled={true}
-                                      onClick={[Function]}
-                                      type="button"
+                                    <EuiI18n
+                                      default="Next page"
+                                      token="euiPagination.disabledNextPage"
                                     >
-                                      <EuiIcon
-                                        aria-hidden="true"
-                                        className="euiButtonIcon__icon"
-                                        color="inherit"
-                                        size="m"
-                                        type="arrowRight"
+                                      <EuiButtonIcon
+                                        aria-label="Next page"
+                                        color="text"
+                                        data-test-subj="pagination-button-next"
+                                        disabled={true}
+                                        iconType="arrowRight"
+                                        onClick={[Function]}
                                       >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
+                                        <button
+                                          aria-label="Next page"
+                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                          data-test-subj="pagination-button-next"
+                                          disabled={true}
+                                          onClick={[Function]}
+                                          type="button"
                                         >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiButtonIcon__icon"
+                                            color="inherit"
+                                            size="m"
+                                            type="arrowRight"
                                           >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </button>
-                                  </EuiButtonIcon>
-                                </EuiI18n>
-                              </EuiI18n>
-                            </nav>
-                          </EuiPagination>
+                                            <EuiIconBeaker
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                        </button>
+                                      </EuiButtonIcon>
+                                    </EuiI18n>
+                                  </EuiI18n>
+                                </nav>
+                              </EuiPagination>
+                            </div>
+                          </EuiFlexItem>
                         </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </EuiTablePagination>
+                      </EuiFlexGroup>
+                    </EuiTablePagination>
+                  </div>
+                </PaginationBar>
               </div>
-            </PaginationBar>
-          </div>
-        </EuiBasicTable>
-      </EuiInMemoryTable>
+            </EuiBasicTable>
+          </EuiInMemoryTable>
+        </div>
+      </EuiPanel>
     </div>
-  </EuiPanel>
+  </EuiPage>
 </TracesTable>
 `;

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -10,226 +10,218 @@ exports[`Traces table component renders empty traces table message 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPage
-    paddingSize="m"
-  >
+  <EuiPanel>
     <div
-      className="euiPage euiPage--paddingMedium euiPage--grow"
+      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     >
-      <EuiPanel>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="s"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
+          <EuiFlexItem
+            grow={10}
           >
             <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiFlexItem euiFlexItem--flexGrow10"
             >
-              <EuiFlexItem
-                grow={10}
+              <PanelTitle
+                title="Traces"
+                totalItems={0}
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
-                >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <MissingConfigurationMessage
-            mode="data_prepper"
-          >
-            <EuiEmptyPrompt
-              actions={
-                <EuiSmallButtonEmpty
-                  color="primary"
-                  iconSide="right"
-                  iconType="popout"
-                  onClick={[Function]}
-                >
-                  Learn more
-                </EuiSmallButtonEmpty>
-              }
-              body={
                 <EuiText
-                  size="s"
-                >
-                  The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  Trace Analytics not set up
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
                   size="m"
                 >
-                  <h2
-                    className="euiTitle euiTitle--medium"
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    Trace Analytics not set up
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
+                    <span
+                      className="panel-title"
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <EuiText
-                          size="s"
-                        >
-                          <div
-                            className="euiText euiText--small"
-                          >
-                            The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
-                          </div>
-                        </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
+                      Traces
+                    </span>
+                    <span
+                      className="panel-title-count"
+                    >
+                       (0)
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+      <EuiSpacer
+        size="m"
+      >
+        <div
+          className="euiSpacer euiSpacer--m"
+        />
+      </EuiSpacer>
+      <EuiHorizontalRule
+        margin="none"
+      >
+        <hr
+          className="euiHorizontalRule euiHorizontalRule--full"
+        />
+      </EuiHorizontalRule>
+      <MissingConfigurationMessage
+        mode="data_prepper"
+      >
+        <EuiEmptyPrompt
+          actions={
+            <EuiSmallButtonEmpty
+              color="primary"
+              iconSide="right"
+              iconType="popout"
+              onClick={[Function]}
+            >
+              Learn more
+            </EuiSmallButtonEmpty>
+          }
+          body={
+            <EuiText
+              size="s"
+            >
+              The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
+            </EuiText>
+          }
+          title={
+            <h2>
+              Trace Analytics not set up
+            </h2>
+          }
+        >
+          <div
+            className="euiEmptyPrompt"
+          >
+            <EuiTitle
+              size="m"
+            >
+              <h2
+                className="euiTitle euiTitle--medium"
+              >
+                Trace Analytics not set up
+              </h2>
+            </EuiTitle>
+            <EuiTextColor
+              color="subdued"
+            >
+              <span
+                className="euiTextColor euiTextColor--subdued"
+              >
                 <EuiSpacer
-                  size="l"
+                  size="m"
                 >
                   <div
-                    className="euiSpacer euiSpacer--l"
+                    className="euiSpacer euiSpacer--m"
                   />
                 </EuiSpacer>
-                <EuiSmallButtonEmpty
-                  color="primary"
-                  iconSide="right"
-                  iconType="popout"
-                  onClick={[Function]}
-                >
-                  <EuiButtonEmpty
-                    color="primary"
-                    iconSide="right"
-                    iconType="popout"
-                    onClick={[Function]}
-                    size="s"
+                <EuiText>
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    <button
-                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <EuiText
+                      size="s"
                     >
-                      <EuiButtonContent
-                        className="euiButtonEmpty__content"
-                        iconSide="right"
-                        iconSize="m"
-                        iconType="popout"
-                        textProps={
-                          Object {
-                            "className": "euiButtonEmpty__text",
-                          }
-                        }
+                      <div
+                        className="euiText euiText--small"
                       >
-                        <span
-                          className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
+                      </div>
+                    </EuiText>
+                  </div>
+                </EuiText>
+              </span>
+            </EuiTextColor>
+            <EuiSpacer
+              size="l"
+            >
+              <div
+                className="euiSpacer euiSpacer--l"
+              />
+            </EuiSpacer>
+            <EuiSmallButtonEmpty
+              color="primary"
+              iconSide="right"
+              iconType="popout"
+              onClick={[Function]}
+            >
+              <EuiButtonEmpty
+                color="primary"
+                iconSide="right"
+                iconType="popout"
+                onClick={[Function]}
+                size="s"
+              >
+                <button
+                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <EuiButtonContent
+                    className="euiButtonEmpty__content"
+                    iconSide="right"
+                    iconSize="m"
+                    iconType="popout"
+                    textProps={
+                      Object {
+                        "className": "euiButtonEmpty__text",
+                      }
+                    }
+                  >
+                    <span
+                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                    >
+                      <EuiIcon
+                        className="euiButtonContent__icon"
+                        color="inherit"
+                        size="m"
+                        type="popout"
+                      >
+                        <EuiIconBeaker
+                          aria-hidden={true}
+                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                          focusable="false"
+                          role="img"
+                          style={null}
                         >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="popout"
+                          <svg
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                            focusable="false"
+                            height={16}
+                            role="img"
+                            style={null}
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <EuiIconBeaker
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                />
-                              </svg>
-                            </EuiIconBeaker>
-                          </EuiIcon>
-                          <span
-                            className="euiButtonEmpty__text"
-                          >
-                            Learn more
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonEmpty>
-                </EuiSmallButtonEmpty>
-              </div>
-            </EuiEmptyPrompt>
-          </MissingConfigurationMessage>
-        </div>
-      </EuiPanel>
+                            <path
+                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                            />
+                          </svg>
+                        </EuiIconBeaker>
+                      </EuiIcon>
+                      <span
+                        className="euiButtonEmpty__text"
+                      >
+                        Learn more
+                      </span>
+                    </span>
+                  </EuiButtonContent>
+                </button>
+              </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
+          </div>
+        </EuiEmptyPrompt>
+      </MissingConfigurationMessage>
     </div>
-  </EuiPage>
+  </EuiPanel>
 </TracesTable>
 `;
 
@@ -243,150 +235,142 @@ exports[`Traces table component renders empty traces table message 2`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPage
-    paddingSize="m"
-  >
+  <EuiPanel>
     <div
-      className="euiPage euiPage--paddingMedium euiPage--grow"
+      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     >
-      <EuiPanel>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="s"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
+          <EuiFlexItem
+            grow={10}
           >
             <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiFlexItem euiFlexItem--flexGrow10"
             >
-              <EuiFlexItem
-                grow={10}
+              <PanelTitle
+                title="Traces"
+                totalItems={0}
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
-                >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
                 <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
                   size="m"
                 >
-                  <h2
-                    className="euiTitle euiTitle--medium"
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
+                    <span
+                      className="panel-title"
+                    >
+                      Traces
+                    </span>
+                    <span
+                      className="panel-title-count"
+                    >
+                       (0)
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+      <EuiSpacer
+        size="m"
+      >
+        <div
+          className="euiSpacer euiSpacer--m"
+        />
+      </EuiSpacer>
+      <EuiHorizontalRule
+        margin="none"
+      >
+        <hr
+          className="euiHorizontalRule euiHorizontalRule--full"
+        />
+      </EuiHorizontalRule>
+      <NoMatchMessage
+        size="xl"
+      >
+        <EuiSpacer
+          size="xl"
+        >
+          <div
+            className="euiSpacer euiSpacer--xl"
+          />
+        </EuiSpacer>
+        <EuiEmptyPrompt
+          body={
+            <EuiText
+              size="s"
+            >
+              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+            </EuiText>
+          }
+          title={
+            <h2>
+              No matches
+            </h2>
+          }
+        >
+          <div
+            className="euiEmptyPrompt"
+          >
+            <EuiTitle
+              size="m"
+            >
+              <h2
+                className="euiTitle euiTitle--medium"
+              >
+                No matches
+              </h2>
+            </EuiTitle>
+            <EuiTextColor
+              color="subdued"
+            >
+              <span
+                className="euiTextColor euiTextColor--subdued"
+              >
+                <EuiSpacer
+                  size="m"
                 >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                  <div
+                    className="euiSpacer euiSpacer--m"
+                  />
+                </EuiSpacer>
+                <EuiText>
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    <EuiSpacer
-                      size="m"
+                    <EuiText
+                      size="s"
                     >
                       <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
+                        className="euiText euiText--small"
                       >
-                        <EuiText
-                          size="s"
-                        >
-                          <div
-                            className="euiText euiText--small"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
-                        </EuiText>
+                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                       </div>
                     </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
+                  </div>
+                </EuiText>
+              </span>
+            </EuiTextColor>
+          </div>
+        </EuiEmptyPrompt>
+        <EuiSpacer
+          size="xl"
+        >
+          <div
+            className="euiSpacer euiSpacer--xl"
+          />
+        </EuiSpacer>
+      </NoMatchMessage>
     </div>
-  </EuiPage>
+  </EuiPanel>
 </TracesTable>
 `;
 
@@ -411,1030 +395,287 @@ exports[`Traces table component renders jaeger traces table 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPage
-    paddingSize="m"
-  >
+  <EuiPanel>
     <div
-      className="euiPage euiPage--paddingMedium euiPage--grow"
+      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     >
-      <EuiPanel>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="s"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
+          <EuiFlexItem
+            grow={10}
           >
             <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiFlexItem euiFlexItem--flexGrow10"
             >
-              <EuiFlexItem
-                grow={10}
+              <PanelTitle
+                title="Traces"
+                totalItems={1}
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
+                <EuiText
+                  size="m"
                 >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={1}
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    <EuiText
-                      size="m"
+                    <span
+                      className="panel-title"
                     >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (1)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
+                      Traces
+                    </span>
+                    <span
+                      className="panel-title-count"
+                    >
+                       (1)
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
             </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <EuiInMemoryTable
-            columns={
-              Array [
-                Object {
-                  "align": "left",
-                  "field": "trace_id",
-                  "name": "Trace ID",
-                  "render": [Function],
-                  "sortable": true,
-                  "truncateText": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "latency",
-                  "name": "Latency (ms)",
-                  "sortable": true,
-                  "truncateText": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "error_count",
-                  "name": "Errors",
-                  "render": [Function],
-                  "sortable": true,
-                },
-                Object {
-                  "align": "left",
-                  "field": "last_updated",
-                  "name": "Last updated",
-                  "render": [Function],
-                  "sortable": true,
-                },
-              ]
-            }
-            items={
-              Array [
-                Object {
-                  "actions": "#",
-                  "error_count": "Yes",
-                  "last_updated": "11/10/2020 09:55:45",
-                  "latency": 19.91,
-                  "trace_group": "HTTP GET",
-                  "trace_id": "00079a615e31e61766fcb20b557051c1",
-                },
-              ]
-            }
-            loading={false}
-            onTableChange={[Function]}
-            pagination={
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+      <EuiSpacer
+        size="m"
+      >
+        <div
+          className="euiSpacer euiSpacer--m"
+        />
+      </EuiSpacer>
+      <EuiHorizontalRule
+        margin="none"
+      >
+        <hr
+          className="euiHorizontalRule euiHorizontalRule--full"
+        />
+      </EuiHorizontalRule>
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "left",
+              "field": "trace_id",
+              "name": "Trace ID",
+              "render": [Function],
+              "sortable": true,
+              "truncateText": true,
+            },
+            Object {
+              "align": "right",
+              "field": "latency",
+              "name": "Latency (ms)",
+              "sortable": true,
+              "truncateText": true,
+            },
+            Object {
+              "align": "right",
+              "field": "error_count",
+              "name": "Errors",
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "align": "left",
+              "field": "last_updated",
+              "name": "Last updated",
+              "render": [Function],
+              "sortable": true,
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "actions": "#",
+              "error_count": "Yes",
+              "last_updated": "11/10/2020 09:55:45",
+              "latency": 19.91,
+              "trace_group": "HTTP GET",
+              "trace_id": "00079a615e31e61766fcb20b557051c1",
+            },
+          ]
+        }
+        loading={false}
+        onTableChange={[Function]}
+        pagination={
+          Object {
+            "initialPageSize": 10,
+            "pageSizeOptions": Array [
+              5,
+              10,
+              15,
+            ],
+          }
+        }
+        responsive={true}
+        sorting={
+          Object {
+            "sort": Object {
+              "direction": "asc",
+              "field": "trace_id",
+            },
+          }
+        }
+        tableLayout="auto"
+      >
+        <EuiBasicTable
+          columns={
+            Array [
               Object {
-                "initialPageSize": 10,
-                "pageSizeOptions": Array [
-                  5,
-                  10,
-                  15,
-                ],
-              }
-            }
-            responsive={true}
-            sorting={
+                "align": "left",
+                "field": "trace_id",
+                "name": "Trace ID",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": true,
+              },
               Object {
-                "sort": Object {
-                  "direction": "asc",
-                  "field": "trace_id",
-                },
-              }
+                "align": "right",
+                "field": "latency",
+                "name": "Latency (ms)",
+                "sortable": true,
+                "truncateText": true,
+              },
+              Object {
+                "align": "right",
+                "field": "error_count",
+                "name": "Errors",
+                "render": [Function],
+                "sortable": true,
+              },
+              Object {
+                "align": "left",
+                "field": "last_updated",
+                "name": "Last updated",
+                "render": [Function],
+                "sortable": true,
+              },
+            ]
+          }
+          items={
+            Array [
+              Object {
+                "actions": "#",
+                "error_count": "Yes",
+                "last_updated": "11/10/2020 09:55:45",
+                "latency": 19.91,
+                "trace_group": "HTTP GET",
+                "trace_id": "00079a615e31e61766fcb20b557051c1",
+              },
+            ]
+          }
+          loading={false}
+          noItemsMessage="No items found"
+          onChange={[Function]}
+          pagination={
+            Object {
+              "hidePerPageOptions": undefined,
+              "pageIndex": 0,
+              "pageSize": 10,
+              "pageSizeOptions": Array [
+                5,
+                10,
+                15,
+              ],
+              "totalItemCount": 1,
             }
-            tableLayout="auto"
+          }
+          responsive={true}
+          sorting={
+            Object {
+              "allowNeutralSort": true,
+              "sort": Object {
+                "direction": "asc",
+                "field": "Trace ID",
+              },
+            }
+          }
+          tableLayout="auto"
+        >
+          <div
+            className="euiBasicTable"
           >
-            <EuiBasicTable
-              columns={
-                Array [
-                  Object {
-                    "align": "left",
-                    "field": "trace_id",
-                    "name": "Trace ID",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "latency",
-                    "name": "Latency (ms)",
-                    "sortable": true,
-                    "truncateText": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "error_count",
-                    "name": "Errors",
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                  Object {
-                    "align": "left",
-                    "field": "last_updated",
-                    "name": "Last updated",
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                ]
-              }
-              items={
-                Array [
-                  Object {
-                    "actions": "#",
-                    "error_count": "Yes",
-                    "last_updated": "11/10/2020 09:55:45",
-                    "latency": 19.91,
-                    "trace_group": "HTTP GET",
-                    "trace_id": "00079a615e31e61766fcb20b557051c1",
-                  },
-                ]
-              }
-              loading={false}
-              noItemsMessage="No items found"
-              onChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-              responsive={true}
-              sorting={
-                Object {
-                  "allowNeutralSort": true,
-                  "sort": Object {
-                    "direction": "asc",
-                    "field": "Trace ID",
-                  },
-                }
-              }
-              tableLayout="auto"
-            >
-              <div
-                className="euiBasicTable"
-              >
-                <div>
-                  <EuiTableHeaderMobile>
-                    <div
-                      className="euiTableHeaderMobile"
-                    >
-                      <EuiFlexGroup
-                        alignItems="baseline"
-                        justifyContent="spaceBetween"
-                        responsive={false}
-                      >
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-                        >
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                            />
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                            >
-                              <EuiTableSortMobile
-                                items={
-                                  Array [
-                                    Object {
-                                      "isSortAscending": true,
-                                      "isSorted": true,
-                                      "key": "_data_s_trace_id_0",
-                                      "name": "Trace ID",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_latency_1",
-                                      "name": "Latency (ms)",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_error_count_2",
-                                      "name": "Errors",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_last_updated_3",
-                                      "name": "Last updated",
-                                      "onSort": [Function],
-                                    },
-                                  ]
-                                }
-                              >
-                                <div
-                                  className="euiTableSortMobile"
-                                >
-                                  <EuiPopover
-                                    anchorPosition="downRight"
-                                    button={
-                                      <EuiButtonEmpty
-                                        flush="right"
-                                        iconSide="right"
-                                        iconType="arrowDown"
-                                        onClick={[Function]}
-                                        size="xs"
-                                      >
-                                        <EuiI18n
-                                          default="Sorting"
-                                          token="euiTableSortMobile.sorting"
-                                        />
-                                      </EuiButtonEmpty>
-                                    }
-                                    closePopover={[Function]}
-                                    display="inlineBlock"
-                                    hasArrow={true}
-                                    isOpen={false}
-                                    ownFocus={true}
-                                    panelPaddingSize="none"
-                                  >
-                                    <div
-                                      className="euiPopover euiPopover--anchorDownRight"
-                                    >
-                                      <div
-                                        className="euiPopover__anchor"
-                                      >
-                                        <EuiButtonEmpty
-                                          flush="right"
-                                          iconSide="right"
-                                          iconType="arrowDown"
-                                          onClick={[Function]}
-                                          size="xs"
-                                        >
-                                          <button
-                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiButtonContent
-                                              className="euiButtonEmpty__content"
-                                              iconSide="right"
-                                              iconSize="s"
-                                              iconType="arrowDown"
-                                              textProps={
-                                                Object {
-                                                  "className": "euiButtonEmpty__text",
-                                                }
-                                              }
-                                            >
-                                              <span
-                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                              >
-                                                <EuiIcon
-                                                  className="euiButtonContent__icon"
-                                                  color="inherit"
-                                                  size="s"
-                                                  type="arrowDown"
-                                                >
-                                                  <EuiIconArrowDown
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                    focusable="false"
-                                                    role="img"
-                                                    style={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                      focusable="false"
-                                                      height={16}
-                                                      role="img"
-                                                      style={null}
-                                                      viewBox="0 0 16 16"
-                                                      width={16}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                        fillRule="non-zero"
-                                                      />
-                                                    </svg>
-                                                  </EuiIconArrowDown>
-                                                </EuiIcon>
-                                                <span
-                                                  className="euiButtonEmpty__text"
-                                                >
-                                                  <EuiI18n
-                                                    default="Sorting"
-                                                    token="euiTableSortMobile.sorting"
-                                                  >
-                                                    Sorting
-                                                  </EuiI18n>
-                                                </span>
-                                              </span>
-                                            </EuiButtonContent>
-                                          </button>
-                                        </EuiButtonEmpty>
-                                      </div>
-                                    </div>
-                                  </EuiPopover>
-                                </div>
-                              </EuiTableSortMobile>
-                            </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
-                    </div>
-                  </EuiTableHeaderMobile>
-                  <EuiTable
-                    id="random_html_id"
-                    responsive={true}
-                    tableLayout="auto"
-                  >
-                    <table
-                      className="euiTable euiTable--responsive euiTable--auto"
-                      id="random_html_id"
-                      tabIndex={-1}
-                    >
-                      <EuiScreenReaderOnly>
-                        <caption
-                          className="euiScreenReaderOnly euiTableCaption"
-                        >
-                          <EuiDelayRender
-                            delay={500}
-                          />
-                        </caption>
-                      </EuiScreenReaderOnly>
-                      <EuiTableHeader>
-                        <thead>
-                          <tr>
-                            <EuiTableHeaderCell
-                              align="left"
-                              data-test-subj="tableHeaderCell_trace_id_0"
-                              isSortAscending={true}
-                              isSorted={true}
-                              key="_data_h_trace_id_0"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="ascending"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_trace_id_0"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent"
-                                    isSortAscending={true}
-                                    isSorted={true}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Trace ID",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Trace ID"
-                                          >
-                                            Trace ID
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                      <EuiIcon
-                                        className="euiTableSortIcon"
-                                        size="m"
-                                        type="sortUp"
-                                      >
-                                        <EuiIconSortUp
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiTableSortIcon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiTableSortIcon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
-                                            />
-                                          </svg>
-                                        </EuiIconSortUp>
-                                      </EuiIcon>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_latency_1"
-                              isSorted={false}
-                              key="_data_h_latency_1"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_latency_1"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Latency (ms)",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Latency (ms)"
-                                          >
-                                            Latency (ms)
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_error_count_2"
-                              isSorted={false}
-                              key="_data_h_error_count_2"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_error_count_2"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Errors",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Errors"
-                                          >
-                                            Errors
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="left"
-                              data-test-subj="tableHeaderCell_last_updated_3"
-                              isSorted={false}
-                              key="_data_h_last_updated_3"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_last_updated_3"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Last updated",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Last updated"
-                                          >
-                                            Last updated
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                          </tr>
-                        </thead>
-                      </EuiTableHeader>
-                      <EuiTableBody
-                        bodyRef={[Function]}
-                      >
-                        <tbody>
-                          <EuiTableRow
-                            isSelected={false}
-                          >
-                            <tr
-                              className="euiTableRow"
-                            >
-                              <EuiTableRowCell
-                                align="left"
-                                key="_data_column_trace_id_0_0"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Trace ID",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Trace ID
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiFlexGroup
-                                      alignItems="center"
-                                      className=""
-                                      gutterSize="s"
-                                      key=".0"
-                                    >
-                                      <div
-                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                      >
-                                        <EuiFlexItem
-                                          grow={10}
-                                        >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrow10"
-                                          >
-                                            <EuiLink
-                                              onClick={[Function]}
-                                            >
-                                              <button
-                                                className="euiLink euiLink--primary"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <div
-                                                  title="00079a615e31e61766fcb20b557051c1"
-                                                >
-                                                  00079a615e31e61766fcb...
-                                                </div>
-                                              </button>
-                                            </EuiLink>
-                                          </div>
-                                        </EuiFlexItem>
-                                        <EuiFlexItem
-                                          grow={false}
-                                        >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                                          >
-                                            <EuiCopy
-                                              afterMessage="Copied"
-                                              textToCopy="00079a615e31e61766fcb20b557051c1"
-                                            >
-                                              <EuiToolTip
-                                                delay="regular"
-                                                onMouseOut={[Function]}
-                                                position="top"
-                                              >
-                                                <span
-                                                  className="euiToolTipAnchor"
-                                                  onKeyUp={[Function]}
-                                                  onMouseOut={[Function]}
-                                                  onMouseOver={[Function]}
-                                                >
-                                                  <EuiSmallButtonIcon
-                                                    aria-label="Copy trace id"
-                                                    iconType="copyClipboard"
-                                                    onBlur={[Function]}
-                                                    onClick={[Function]}
-                                                    onFocus={[Function]}
-                                                  >
-                                                    <EuiButtonIcon
-                                                      aria-label="Copy trace id"
-                                                      iconType="copyClipboard"
-                                                      onBlur={[Function]}
-                                                      onClick={[Function]}
-                                                      onFocus={[Function]}
-                                                      size="s"
-                                                    >
-                                                      <button
-                                                        aria-label="Copy trace id"
-                                                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                                                        disabled={false}
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onFocus={[Function]}
-                                                        type="button"
-                                                      >
-                                                        <EuiIcon
-                                                          aria-hidden="true"
-                                                          className="euiButtonIcon__icon"
-                                                          color="inherit"
-                                                          size="m"
-                                                          type="copyClipboard"
-                                                        >
-                                                          <EuiIconCopyClipboard
-                                                            aria-hidden={true}
-                                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                            focusable="false"
-                                                            role="img"
-                                                            style={null}
-                                                          >
-                                                            <svg
-                                                              aria-hidden={true}
-                                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                              focusable="false"
-                                                              height={16}
-                                                              role="img"
-                                                              style={null}
-                                                              viewBox="0 0 16 16"
-                                                              width={16}
-                                                              xmlns="http://www.w3.org/2000/svg"
-                                                            >
-                                                              <path
-                                                                d="M0 2.729V2a1 1 0 0 1 1-1h2v1H1v12h4v1H1a1 1 0 0 1-1-1V2.729zM12 5V2a1 1 0 0 0-1-1H9v1h2v3h1zm-1 1h2v9H6V6h5V5H6a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2v1z"
-                                                              />
-                                                              <path
-                                                                d="M7 10h5V9H7zM7 8h5V7H7zM7 12h5v-1H7zM7 14h5v-1H7zM9 2V1a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v1h1V1h4v1h1ZM3 3h6V2H3z"
-                                                              />
-                                                            </svg>
-                                                          </EuiIconCopyClipboard>
-                                                        </EuiIcon>
-                                                      </button>
-                                                    </EuiButtonIcon>
-                                                  </EuiSmallButtonIcon>
-                                                </span>
-                                              </EuiToolTip>
-                                            </EuiCopy>
-                                          </div>
-                                        </EuiFlexItem>
-                                        <EuiFlexItem
-                                          grow={3}
-                                        >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrow3"
-                                          />
-                                        </EuiFlexItem>
-                                      </div>
-                                    </EuiFlexGroup>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_latency_0_1"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Latency (ms)",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={true}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Latency (ms)
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
-                                  >
-                                    <span
-                                      className="euiTableCellContent__text"
-                                    >
-                                      19.91
-                                    </span>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_error_count_0_2"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Errors",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Errors
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                  >
-                                    No
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="left"
-                                key="_data_column_last_updated_0_3"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Last updated",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Last updated
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
-                                  >
-                                    11/10/2020 09:55:45
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                            </tr>
-                          </EuiTableRow>
-                        </tbody>
-                      </EuiTableBody>
-                    </table>
-                  </EuiTable>
-                </div>
-                <PaginationBar
-                  aria-controls="random_html_id"
-                  onPageChange={[Function]}
-                  onPageSizeChange={[Function]}
-                  pagination={
-                    Object {
-                      "hidePerPageOptions": undefined,
-                      "pageIndex": 0,
-                      "pageSize": 10,
-                      "pageSizeOptions": Array [
-                        5,
-                        10,
-                        15,
-                      ],
-                      "totalItemCount": 1,
-                    }
-                  }
+            <div>
+              <EuiTableHeaderMobile>
+                <div
+                  className="euiTableHeaderMobile"
                 >
-                  <div>
-                    <EuiSpacer
-                      size="m"
+                  <EuiFlexGroup
+                    alignItems="baseline"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                     >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiTablePagination
-                      activePage={0}
-                      aria-controls="random_html_id"
-                      itemsPerPage={10}
-                      itemsPerPageOptions={
-                        Array [
-                          5,
-                          10,
-                          15,
-                        ]
-                      }
-                      onChangeItemsPerPage={[Function]}
-                      onChangePage={[Function]}
-                      pageCount={1}
-                    >
-                      <EuiFlexGroup
-                        alignItems="center"
-                        justifyContent="spaceBetween"
-                        responsive={false}
+                      <EuiFlexItem
+                        grow={false}
                       >
                         <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
                         >
-                          <EuiFlexItem
-                            grow={false}
+                          <EuiTableSortMobile
+                            items={
+                              Array [
+                                Object {
+                                  "isSortAscending": true,
+                                  "isSorted": true,
+                                  "key": "_data_s_trace_id_0",
+                                  "name": "Trace ID",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_latency_1",
+                                  "name": "Latency (ms)",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_error_count_2",
+                                  "name": "Errors",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_last_updated_3",
+                                  "name": "Last updated",
+                                  "onSort": [Function],
+                                },
+                              ]
+                            }
                           >
                             <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              className="euiTableSortMobile"
                             >
                               <EuiPopover
-                                anchorPosition="upRight"
+                                anchorPosition="downRight"
                                 button={
                                   <EuiButtonEmpty
-                                    color="text"
-                                    data-test-subj="tablePaginationPopoverButton"
+                                    flush="right"
                                     iconSide="right"
                                     iconType="arrowDown"
                                     onClick={[Function]}
                                     size="xs"
                                   >
                                     <EuiI18n
-                                      default="Rows per page"
-                                      token="euiTablePagination.rowsPerPage"
+                                      default="Sorting"
+                                      token="euiTableSortMobile.sorting"
                                     />
-                                    : 
-                                    10
                                   </EuiButtonEmpty>
                                 }
                                 closePopover={[Function]}
@@ -1445,22 +686,20 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                 panelPaddingSize="none"
                               >
                                 <div
-                                  className="euiPopover euiPopover--anchorUpRight"
+                                  className="euiPopover euiPopover--anchorDownRight"
                                 >
                                   <div
                                     className="euiPopover__anchor"
                                   >
                                     <EuiButtonEmpty
-                                      color="text"
-                                      data-test-subj="tablePaginationPopoverButton"
+                                      flush="right"
                                       iconSide="right"
                                       iconType="arrowDown"
                                       onClick={[Function]}
                                       size="xs"
                                     >
                                       <button
-                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
-                                        data-test-subj="tablePaginationPopoverButton"
+                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
                                         disabled={false}
                                         onClick={[Function]}
                                         type="button"
@@ -1514,13 +753,11 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                               className="euiButtonEmpty__text"
                                             >
                                               <EuiI18n
-                                                default="Rows per page"
-                                                token="euiTablePagination.rowsPerPage"
+                                                default="Sorting"
+                                                token="euiTableSortMobile.sorting"
                                               >
-                                                Rows per page
+                                                Sorting
                                               </EuiI18n>
-                                              : 
-                                              10
                                             </span>
                                           </span>
                                         </EuiButtonContent>
@@ -1530,255 +767,994 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                 </div>
                               </EuiPopover>
                             </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
+                          </EuiTableSortMobile>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiTableHeaderMobile>
+              <EuiTable
+                id="random_html_id"
+                responsive={true}
+                tableLayout="auto"
+              >
+                <table
+                  className="euiTable euiTable--responsive euiTable--auto"
+                  id="random_html_id"
+                  tabIndex={-1}
+                >
+                  <EuiScreenReaderOnly>
+                    <caption
+                      className="euiScreenReaderOnly euiTableCaption"
+                    >
+                      <EuiDelayRender
+                        delay={500}
+                      />
+                    </caption>
+                  </EuiScreenReaderOnly>
+                  <EuiTableHeader>
+                    <thead>
+                      <tr>
+                        <EuiTableHeaderCell
+                          align="left"
+                          data-test-subj="tableHeaderCell_trace_id_0"
+                          isSortAscending={true}
+                          isSorted={true}
+                          key="_data_h_trace_id_0"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="ascending"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_trace_id_0"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent"
+                                isSortAscending={true}
+                                isSorted={true}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Trace ID",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Trace ID"
+                                      >
+                                        Trace ID
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiIcon
+                                    className="euiTableSortIcon"
+                                    size="m"
+                                    type="sortUp"
+                                  >
+                                    <EuiIconSortUp
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiTableSortIcon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiTableSortIcon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M8 4.207v8.237c0 .307-.224.556-.5.556s-.5-.249-.5-.556V4.207L2.904 8.303a.5.5 0 0 1-.707-.707l4.242-4.242a1.5 1.5 0 0 1 2.122 0l4.242 4.242a.5.5 0 1 1-.707.707L8 4.207Z"
+                                        />
+                                      </svg>
+                                    </EuiIconSortUp>
+                                  </EuiIcon>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_latency_1"
+                          isSorted={false}
+                          key="_data_h_latency_1"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_latency_1"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Latency (ms)",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Latency (ms)"
+                                      >
+                                        Latency (ms)
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_error_count_2"
+                          isSorted={false}
+                          key="_data_h_error_count_2"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_error_count_2"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Errors",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Errors"
+                                      >
+                                        Errors
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="left"
+                          data-test-subj="tableHeaderCell_last_updated_3"
+                          isSorted={false}
+                          key="_data_h_last_updated_3"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_last_updated_3"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Last updated",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Last updated"
+                                      >
+                                        Last updated
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                      </tr>
+                    </thead>
+                  </EuiTableHeader>
+                  <EuiTableBody
+                    bodyRef={[Function]}
+                  >
+                    <tbody>
+                      <EuiTableRow
+                        isSelected={false}
+                      >
+                        <tr
+                          className="euiTableRow"
+                        >
+                          <EuiTableRowCell
+                            align="left"
+                            key="_data_column_trace_id_0_0"
+                            mobileOptions={
+                              Object {
+                                "header": "Trace ID",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                            truncateText={true}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Trace ID
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                              >
+                                <EuiFlexGroup
+                                  alignItems="center"
+                                  className=""
+                                  gutterSize="s"
+                                  key=".0"
+                                >
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                  >
+                                    <EuiFlexItem
+                                      grow={10}
+                                    >
+                                      <div
+                                        className="euiFlexItem euiFlexItem--flexGrow10"
+                                      >
+                                        <EuiLink
+                                          onClick={[Function]}
+                                        >
+                                          <button
+                                            className="euiLink euiLink--primary"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <div
+                                              title="00079a615e31e61766fcb20b557051c1"
+                                            >
+                                              00079a615e31e61766fcb...
+                                            </div>
+                                          </button>
+                                        </EuiLink>
+                                      </div>
+                                    </EuiFlexItem>
+                                    <EuiFlexItem
+                                      grow={false}
+                                    >
+                                      <div
+                                        className="euiFlexItem euiFlexItem--flexGrowZero"
+                                      >
+                                        <EuiCopy
+                                          afterMessage="Copied"
+                                          textToCopy="00079a615e31e61766fcb20b557051c1"
+                                        >
+                                          <EuiToolTip
+                                            delay="regular"
+                                            onMouseOut={[Function]}
+                                            position="top"
+                                          >
+                                            <span
+                                              className="euiToolTipAnchor"
+                                              onKeyUp={[Function]}
+                                              onMouseOut={[Function]}
+                                              onMouseOver={[Function]}
+                                            >
+                                              <EuiSmallButtonIcon
+                                                aria-label="Copy trace id"
+                                                iconType="copyClipboard"
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onFocus={[Function]}
+                                              >
+                                                <EuiButtonIcon
+                                                  aria-label="Copy trace id"
+                                                  iconType="copyClipboard"
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onFocus={[Function]}
+                                                  size="s"
+                                                >
+                                                  <button
+                                                    aria-label="Copy trace id"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                    disabled={false}
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onFocus={[Function]}
+                                                    type="button"
+                                                  >
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="copyClipboard"
+                                                    >
+                                                      <EuiIconCopyClipboard
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M0 2.729V2a1 1 0 0 1 1-1h2v1H1v12h4v1H1a1 1 0 0 1-1-1V2.729zM12 5V2a1 1 0 0 0-1-1H9v1h2v3h1zm-1 1h2v9H6V6h5V5H6a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2v1z"
+                                                          />
+                                                          <path
+                                                            d="M7 10h5V9H7zM7 8h5V7H7zM7 12h5v-1H7zM7 14h5v-1H7zM9 2V1a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v1h1V1h4v1h1ZM3 3h6V2H3z"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconCopyClipboard>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </EuiSmallButtonIcon>
+                                            </span>
+                                          </EuiToolTip>
+                                        </EuiCopy>
+                                      </div>
+                                    </EuiFlexItem>
+                                    <EuiFlexItem
+                                      grow={3}
+                                    >
+                                      <div
+                                        className="euiFlexItem euiFlexItem--flexGrow3"
+                                      />
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_latency_0_1"
+                            mobileOptions={
+                              Object {
+                                "header": "Latency (ms)",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={true}
+                            truncateText={true}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Latency (ms)
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  19.91
+                                </span>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_error_count_0_2"
+                            mobileOptions={
+                              Object {
+                                "header": "Errors",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Errors
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                              >
+                                No
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="left"
+                            key="_data_column_last_updated_0_3"
+                            mobileOptions={
+                              Object {
+                                "header": "Last updated",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Last updated
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--overflowingContent"
+                              >
+                                11/10/2020 09:55:45
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                        </tr>
+                      </EuiTableRow>
+                    </tbody>
+                  </EuiTableBody>
+                </table>
+              </EuiTable>
+            </div>
+            <PaginationBar
+              aria-controls="random_html_id"
+              onPageChange={[Function]}
+              onPageSizeChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+            >
+              <div>
+                <EuiSpacer
+                  size="m"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--m"
+                  />
+                </EuiSpacer>
+                <EuiTablePagination
+                  activePage={0}
+                  aria-controls="random_html_id"
+                  itemsPerPage={10}
+                  itemsPerPageOptions={
+                    Array [
+                      5,
+                      10,
+                      15,
+                    ]
+                  }
+                  onChangeItemsPerPage={[Function]}
+                  onChangePage={[Function]}
+                  pageCount={1}
+                >
+                  <EuiFlexGroup
+                    alignItems="center"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiPopover
+                            anchorPosition="upRight"
+                            button={
+                              <EuiButtonEmpty
+                                color="text"
+                                data-test-subj="tablePaginationPopoverButton"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="xs"
+                              >
+                                <EuiI18n
+                                  default="Rows per page"
+                                  token="euiTablePagination.rowsPerPage"
+                                />
+                                : 
+                                10
+                              </EuiButtonEmpty>
+                            }
+                            closePopover={[Function]}
+                            display="inlineBlock"
+                            hasArrow={true}
+                            isOpen={false}
+                            ownFocus={true}
+                            panelPaddingSize="none"
                           >
                             <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              className="euiPopover euiPopover--anchorUpRight"
                             >
-                              <EuiPagination
-                                activePage={0}
-                                aria-controls="random_html_id"
-                                onPageClick={[Function]}
-                                pageCount={1}
+                              <div
+                                className="euiPopover__anchor"
                               >
-                                <nav
-                                  className="euiPagination"
+                                <EuiButtonEmpty
+                                  color="text"
+                                  data-test-subj="tablePaginationPopoverButton"
+                                  iconSide="right"
+                                  iconType="arrowDown"
+                                  onClick={[Function]}
+                                  size="xs"
                                 >
-                                  <EuiI18n
-                                    default="Previous page, {page}"
-                                    token="euiPagination.previousPage"
-                                    values={
-                                      Object {
-                                        "page": 0,
-                                      }
-                                    }
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                    data-test-subj="tablePaginationPopoverButton"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
                                   >
-                                    <EuiI18n
-                                      default="Previous page"
-                                      token="euiPagination.disabledPreviousPage"
+                                    <EuiButtonContent
+                                      className="euiButtonEmpty__content"
+                                      iconSide="right"
+                                      iconSize="s"
+                                      iconType="arrowDown"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButtonEmpty__text",
+                                        }
+                                      }
                                     >
-                                      <EuiButtonIcon
-                                        aria-label="Previous page"
-                                        color="text"
-                                        data-test-subj="pagination-button-previous"
-                                        disabled={true}
-                                        iconType="arrowLeft"
-                                        onClick={[Function]}
+                                      <span
+                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                       >
-                                        <button
-                                          aria-label="Previous page"
-                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                          data-test-subj="pagination-button-previous"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          type="button"
+                                        <EuiIcon
+                                          className="euiButtonContent__icon"
+                                          color="inherit"
+                                          size="s"
+                                          type="arrowDown"
                                         >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="arrowLeft"
+                                          <EuiIconArrowDown
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
                                           >
-                                            <EuiIconArrowLeft
+                                            <svg
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                              className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
                                               focusable="false"
+                                              height={16}
                                               role="img"
                                               style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
-                                                  fillRule="nonzero"
-                                                />
-                                              </svg>
-                                            </EuiIconArrowLeft>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiI18n>
-                                  </EuiI18n>
-                                  <ul
-                                    className="euiPagination__list"
-                                  >
-                                    <PaginationButton
-                                      key="0"
-                                      pageIndex={0}
-                                    >
-                                      <li
-                                        className="euiPagination__item"
-                                      >
-                                        <EuiPaginationButton
-                                          aria-controls="random_html_id"
-                                          hideOnMobile={true}
-                                          isActive={true}
-                                          onClick={[Function]}
-                                          pageIndex={0}
-                                          totalPages={1}
+                                              <path
+                                                d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                fillRule="non-zero"
+                                              />
+                                            </svg>
+                                          </EuiIconArrowDown>
+                                        </EuiIcon>
+                                        <span
+                                          className="euiButtonEmpty__text"
                                         >
                                           <EuiI18n
-                                            default="Page {page} of {totalPages}"
-                                            token="euiPaginationButton.longPageString"
-                                            values={
-                                              Object {
-                                                "page": 1,
-                                                "totalPages": 1,
-                                              }
-                                            }
+                                            default="Rows per page"
+                                            token="euiTablePagination.rowsPerPage"
                                           >
-                                            <EuiI18n
-                                              default="Page {page}"
-                                              token="euiPaginationButton.shortPageString"
-                                              values={
-                                                Object {
-                                                  "page": 1,
-                                                }
-                                              }
-                                            >
-                                              <EuiButtonEmpty
-                                                aria-controls="random_html_id"
-                                                aria-current={true}
-                                                aria-label="Page 1 of 1"
-                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                                color="text"
-                                                data-test-subj="pagination-button-0"
-                                                href="#random_html_id"
-                                                isDisabled={true}
-                                                onClick={[Function]}
-                                                size="s"
-                                              >
-                                                <button
-                                                  aria-controls="random_html_id"
-                                                  aria-current={true}
-                                                  aria-label="Page 1 of 1"
-                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                                  data-test-subj="pagination-button-0"
-                                                  disabled={true}
-                                                  onClick={[Function]}
-                                                  type="button"
-                                                >
-                                                  <EuiButtonContent
-                                                    className="euiButtonEmpty__content"
-                                                    iconSide="left"
-                                                    iconSize="m"
-                                                    textProps={
-                                                      Object {
-                                                        "className": "euiButtonEmpty__text",
-                                                      }
-                                                    }
-                                                  >
-                                                    <span
-                                                      className="euiButtonContent euiButtonEmpty__content"
-                                                    >
-                                                      <span
-                                                        className="euiButtonEmpty__text"
-                                                      >
-                                                        1
-                                                      </span>
-                                                    </span>
-                                                  </EuiButtonContent>
-                                                </button>
-                                              </EuiButtonEmpty>
-                                            </EuiI18n>
+                                            Rows per page
                                           </EuiI18n>
-                                        </EuiPaginationButton>
-                                      </li>
-                                    </PaginationButton>
-                                  </ul>
-                                  <EuiI18n
-                                    default="Next page, {page}"
-                                    token="euiPagination.nextPage"
-                                    values={
-                                      Object {
-                                        "page": 2,
-                                      }
-                                    }
-                                  >
-                                    <EuiI18n
-                                      default="Next page"
-                                      token="euiPagination.disabledNextPage"
-                                    >
-                                      <EuiButtonIcon
-                                        aria-label="Next page"
-                                        color="text"
-                                        data-test-subj="pagination-button-next"
-                                        disabled={true}
-                                        iconType="arrowRight"
-                                        onClick={[Function]}
-                                      >
-                                        <button
-                                          aria-label="Next page"
-                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                          data-test-subj="pagination-button-next"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="arrowRight"
-                                          >
-                                            <EuiIconArrowRight
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                                                  fillRule="nonzero"
-                                                />
-                                              </svg>
-                                            </EuiIconArrowRight>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiI18n>
-                                  </EuiI18n>
-                                </nav>
-                              </EuiPagination>
+                                          : 
+                                          10
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonEmpty>
+                              </div>
                             </div>
-                          </EuiFlexItem>
+                          </EuiPopover>
                         </div>
-                      </EuiFlexGroup>
-                    </EuiTablePagination>
-                  </div>
-                </PaginationBar>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiPagination
+                            activePage={0}
+                            aria-controls="random_html_id"
+                            onPageClick={[Function]}
+                            pageCount={1}
+                          >
+                            <nav
+                              className="euiPagination"
+                            >
+                              <EuiI18n
+                                default="Previous page, {page}"
+                                token="euiPagination.previousPage"
+                                values={
+                                  Object {
+                                    "page": 0,
+                                  }
+                                }
+                              >
+                                <EuiI18n
+                                  default="Previous page"
+                                  token="euiPagination.disabledPreviousPage"
+                                >
+                                  <EuiButtonIcon
+                                    aria-label="Previous page"
+                                    color="text"
+                                    data-test-subj="pagination-button-previous"
+                                    disabled={true}
+                                    iconType="arrowLeft"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      aria-label="Previous page"
+                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      data-test-subj="pagination-button-previous"
+                                      disabled={true}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiButtonIcon__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowLeft"
+                                      >
+                                        <EuiIconArrowLeft
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
+                                              fillRule="nonzero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowLeft>
+                                      </EuiIcon>
+                                    </button>
+                                  </EuiButtonIcon>
+                                </EuiI18n>
+                              </EuiI18n>
+                              <ul
+                                className="euiPagination__list"
+                              >
+                                <PaginationButton
+                                  key="0"
+                                  pageIndex={0}
+                                >
+                                  <li
+                                    className="euiPagination__item"
+                                  >
+                                    <EuiPaginationButton
+                                      aria-controls="random_html_id"
+                                      hideOnMobile={true}
+                                      isActive={true}
+                                      onClick={[Function]}
+                                      pageIndex={0}
+                                      totalPages={1}
+                                    >
+                                      <EuiI18n
+                                        default="Page {page} of {totalPages}"
+                                        token="euiPaginationButton.longPageString"
+                                        values={
+                                          Object {
+                                            "page": 1,
+                                            "totalPages": 1,
+                                          }
+                                        }
+                                      >
+                                        <EuiI18n
+                                          default="Page {page}"
+                                          token="euiPaginationButton.shortPageString"
+                                          values={
+                                            Object {
+                                              "page": 1,
+                                            }
+                                          }
+                                        >
+                                          <EuiButtonEmpty
+                                            aria-controls="random_html_id"
+                                            aria-current={true}
+                                            aria-label="Page 1 of 1"
+                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                            color="text"
+                                            data-test-subj="pagination-button-0"
+                                            href="#random_html_id"
+                                            isDisabled={true}
+                                            onClick={[Function]}
+                                            size="s"
+                                          >
+                                            <button
+                                              aria-controls="random_html_id"
+                                              aria-current={true}
+                                              aria-label="Page 1 of 1"
+                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              data-test-subj="pagination-button-0"
+                                              disabled={true}
+                                              onClick={[Function]}
+                                              type="button"
+                                            >
+                                              <EuiButtonContent
+                                                className="euiButtonEmpty__content"
+                                                iconSide="left"
+                                                iconSize="m"
+                                                textProps={
+                                                  Object {
+                                                    "className": "euiButtonEmpty__text",
+                                                  }
+                                                }
+                                              >
+                                                <span
+                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                >
+                                                  <span
+                                                    className="euiButtonEmpty__text"
+                                                  >
+                                                    1
+                                                  </span>
+                                                </span>
+                                              </EuiButtonContent>
+                                            </button>
+                                          </EuiButtonEmpty>
+                                        </EuiI18n>
+                                      </EuiI18n>
+                                    </EuiPaginationButton>
+                                  </li>
+                                </PaginationButton>
+                              </ul>
+                              <EuiI18n
+                                default="Next page, {page}"
+                                token="euiPagination.nextPage"
+                                values={
+                                  Object {
+                                    "page": 2,
+                                  }
+                                }
+                              >
+                                <EuiI18n
+                                  default="Next page"
+                                  token="euiPagination.disabledNextPage"
+                                >
+                                  <EuiButtonIcon
+                                    aria-label="Next page"
+                                    color="text"
+                                    data-test-subj="pagination-button-next"
+                                    disabled={true}
+                                    iconType="arrowRight"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      aria-label="Next page"
+                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      data-test-subj="pagination-button-next"
+                                      disabled={true}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiButtonIcon__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowRight"
+                                      >
+                                        <EuiIconArrowRight
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                              fillRule="nonzero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowRight>
+                                      </EuiIcon>
+                                    </button>
+                                  </EuiButtonIcon>
+                                </EuiI18n>
+                              </EuiI18n>
+                            </nav>
+                          </EuiPagination>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </EuiTablePagination>
               </div>
-            </EuiBasicTable>
-          </EuiInMemoryTable>
-        </div>
-      </EuiPanel>
+            </PaginationBar>
+          </div>
+        </EuiBasicTable>
+      </EuiInMemoryTable>
     </div>
-  </EuiPage>
+  </EuiPanel>
 </TracesTable>
 `;
 
@@ -1804,1295 +1780,345 @@ exports[`Traces table component renders traces table 1`] = `
   refresh={[MockFunction]}
   traceIdColumnAction={[Function]}
 >
-  <EuiPage
-    paddingSize="m"
-  >
+  <EuiPanel>
     <div
-      className="euiPage euiPage--paddingMedium euiPage--grow"
+      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     >
-      <EuiPanel>
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="s"
+      >
         <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
+          <EuiFlexItem
+            grow={10}
           >
             <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiFlexItem euiFlexItem--flexGrow10"
             >
-              <EuiFlexItem
-                grow={10}
+              <PanelTitle
+                title="Traces"
+                totalItems={1}
               >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
+                <EuiText
+                  size="m"
                 >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={1}
+                  <div
+                    className="euiText euiText--medium"
                   >
-                    <EuiText
-                      size="m"
+                    <span
+                      className="panel-title"
                     >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (1)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
+                      Traces
+                    </span>
+                    <span
+                      className="panel-title-count"
+                    >
+                       (1)
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
             </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <EuiInMemoryTable
-            columns={
-              Array [
-                Object {
-                  "align": "left",
-                  "field": "trace_id",
-                  "name": "Trace ID",
-                  "render": [Function],
-                  "sortable": true,
-                  "truncateText": true,
-                },
-                Object {
-                  "align": "left",
-                  "field": "trace_group",
-                  "name": "Trace group",
-                  "render": [Function],
-                  "sortable": true,
-                  "truncateText": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "latency",
-                  "name": "Duration (ms)",
-                  "sortable": true,
-                  "truncateText": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "percentile_in_trace_group",
-                  "name": <React.Fragment>
-                    <div>
-                      Percentile in trace group
-                    </div>
-                  </React.Fragment>,
-                  "render": [Function],
-                  "sortable": true,
-                },
-                Object {
-                  "align": "right",
-                  "field": "error_count",
-                  "name": "Errors",
-                  "render": [Function],
-                  "sortable": true,
-                },
-                Object {
-                  "align": "left",
-                  "field": "last_updated",
-                  "name": "Last updated",
-                  "render": [Function],
-                  "sortable": true,
-                },
-              ]
-            }
-            items={
-              Array [
-                Object {
-                  "actions": "#",
-                  "error_count": "Yes",
-                  "last_updated": "11/10/2020 09:55:45",
-                  "latency": 19.91,
-                  "percentile_in_trace_group": 30,
-                  "trace_group": "HTTP GET",
-                  "trace_id": "00079a615e31e61766fcb20b557051c1",
-                },
-              ]
-            }
-            loading={false}
-            onTableChange={[Function]}
-            pagination={
-              Object {
-                "initialPageSize": 10,
-                "pageSizeOptions": Array [
-                  5,
-                  10,
-                  15,
-                ],
-              }
-            }
-            responsive={true}
-            sorting={
-              Object {
-                "sort": Object {
-                  "direction": "asc",
-                  "field": "trace_id",
-                },
-              }
-            }
-            tableLayout="auto"
-          >
-            <EuiBasicTable
-              columns={
-                Array [
-                  Object {
-                    "align": "left",
-                    "field": "trace_id",
-                    "name": "Trace ID",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                  },
-                  Object {
-                    "align": "left",
-                    "field": "trace_group",
-                    "name": "Trace group",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "latency",
-                    "name": "Duration (ms)",
-                    "sortable": true,
-                    "truncateText": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "percentile_in_trace_group",
-                    "name": <React.Fragment>
-                      <div>
-                        Percentile in trace group
-                      </div>
-                    </React.Fragment>,
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                  Object {
-                    "align": "right",
-                    "field": "error_count",
-                    "name": "Errors",
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                  Object {
-                    "align": "left",
-                    "field": "last_updated",
-                    "name": "Last updated",
-                    "render": [Function],
-                    "sortable": true,
-                  },
-                ]
-              }
-              items={
-                Array [
-                  Object {
-                    "actions": "#",
-                    "error_count": "Yes",
-                    "last_updated": "11/10/2020 09:55:45",
-                    "latency": 19.91,
-                    "percentile_in_trace_group": 30,
-                    "trace_group": "HTTP GET",
-                    "trace_id": "00079a615e31e61766fcb20b557051c1",
-                  },
-                ]
-              }
-              loading={false}
-              noItemsMessage="No items found"
-              onChange={[Function]}
-              pagination={
-                Object {
-                  "hidePerPageOptions": undefined,
-                  "pageIndex": 0,
-                  "pageSize": 10,
-                  "pageSizeOptions": Array [
-                    5,
-                    10,
-                    15,
-                  ],
-                  "totalItemCount": 1,
-                }
-              }
-              responsive={true}
-              sorting={
-                Object {
-                  "allowNeutralSort": true,
-                  "sort": Object {
-                    "direction": "asc",
-                    "field": "Trace ID",
-                  },
-                }
-              }
-              tableLayout="auto"
-            >
-              <div
-                className="euiBasicTable"
-              >
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+      <EuiSpacer
+        size="m"
+      >
+        <div
+          className="euiSpacer euiSpacer--m"
+        />
+      </EuiSpacer>
+      <EuiHorizontalRule
+        margin="none"
+      >
+        <hr
+          className="euiHorizontalRule euiHorizontalRule--full"
+        />
+      </EuiHorizontalRule>
+      <EuiInMemoryTable
+        columns={
+          Array [
+            Object {
+              "align": "left",
+              "field": "trace_id",
+              "name": "Trace ID",
+              "render": [Function],
+              "sortable": true,
+              "truncateText": true,
+            },
+            Object {
+              "align": "left",
+              "field": "trace_group",
+              "name": "Trace group",
+              "render": [Function],
+              "sortable": true,
+              "truncateText": true,
+            },
+            Object {
+              "align": "right",
+              "field": "latency",
+              "name": "Duration (ms)",
+              "sortable": true,
+              "truncateText": true,
+            },
+            Object {
+              "align": "right",
+              "field": "percentile_in_trace_group",
+              "name": <React.Fragment>
                 <div>
-                  <EuiTableHeaderMobile>
+                  Percentile in trace group
+                </div>
+              </React.Fragment>,
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "align": "right",
+              "field": "error_count",
+              "name": "Errors",
+              "render": [Function],
+              "sortable": true,
+            },
+            Object {
+              "align": "left",
+              "field": "last_updated",
+              "name": "Last updated",
+              "render": [Function],
+              "sortable": true,
+            },
+          ]
+        }
+        items={
+          Array [
+            Object {
+              "actions": "#",
+              "error_count": "Yes",
+              "last_updated": "11/10/2020 09:55:45",
+              "latency": 19.91,
+              "percentile_in_trace_group": 30,
+              "trace_group": "HTTP GET",
+              "trace_id": "00079a615e31e61766fcb20b557051c1",
+            },
+          ]
+        }
+        loading={false}
+        onTableChange={[Function]}
+        pagination={
+          Object {
+            "initialPageSize": 10,
+            "pageSizeOptions": Array [
+              5,
+              10,
+              15,
+            ],
+          }
+        }
+        responsive={true}
+        sorting={
+          Object {
+            "sort": Object {
+              "direction": "asc",
+              "field": "trace_id",
+            },
+          }
+        }
+        tableLayout="auto"
+      >
+        <EuiBasicTable
+          columns={
+            Array [
+              Object {
+                "align": "left",
+                "field": "trace_id",
+                "name": "Trace ID",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": true,
+              },
+              Object {
+                "align": "left",
+                "field": "trace_group",
+                "name": "Trace group",
+                "render": [Function],
+                "sortable": true,
+                "truncateText": true,
+              },
+              Object {
+                "align": "right",
+                "field": "latency",
+                "name": "Duration (ms)",
+                "sortable": true,
+                "truncateText": true,
+              },
+              Object {
+                "align": "right",
+                "field": "percentile_in_trace_group",
+                "name": <React.Fragment>
+                  <div>
+                    Percentile in trace group
+                  </div>
+                </React.Fragment>,
+                "render": [Function],
+                "sortable": true,
+              },
+              Object {
+                "align": "right",
+                "field": "error_count",
+                "name": "Errors",
+                "render": [Function],
+                "sortable": true,
+              },
+              Object {
+                "align": "left",
+                "field": "last_updated",
+                "name": "Last updated",
+                "render": [Function],
+                "sortable": true,
+              },
+            ]
+          }
+          items={
+            Array [
+              Object {
+                "actions": "#",
+                "error_count": "Yes",
+                "last_updated": "11/10/2020 09:55:45",
+                "latency": 19.91,
+                "percentile_in_trace_group": 30,
+                "trace_group": "HTTP GET",
+                "trace_id": "00079a615e31e61766fcb20b557051c1",
+              },
+            ]
+          }
+          loading={false}
+          noItemsMessage="No items found"
+          onChange={[Function]}
+          pagination={
+            Object {
+              "hidePerPageOptions": undefined,
+              "pageIndex": 0,
+              "pageSize": 10,
+              "pageSizeOptions": Array [
+                5,
+                10,
+                15,
+              ],
+              "totalItemCount": 1,
+            }
+          }
+          responsive={true}
+          sorting={
+            Object {
+              "allowNeutralSort": true,
+              "sort": Object {
+                "direction": "asc",
+                "field": "Trace ID",
+              },
+            }
+          }
+          tableLayout="auto"
+        >
+          <div
+            className="euiBasicTable"
+          >
+            <div>
+              <EuiTableHeaderMobile>
+                <div
+                  className="euiTableHeaderMobile"
+                >
+                  <EuiFlexGroup
+                    alignItems="baseline"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
                     <div
-                      className="euiTableHeaderMobile"
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
                     >
-                      <EuiFlexGroup
-                        alignItems="baseline"
-                        justifyContent="spaceBetween"
-                        responsive={false}
+                      <EuiFlexItem
+                        grow={false}
                       >
                         <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-                        >
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                            />
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
-                          >
-                            <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
-                            >
-                              <EuiTableSortMobile
-                                items={
-                                  Array [
-                                    Object {
-                                      "isSortAscending": true,
-                                      "isSorted": true,
-                                      "key": "_data_s_trace_id_0",
-                                      "name": "Trace ID",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_trace_group_1",
-                                      "name": "Trace group",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_latency_2",
-                                      "name": "Duration (ms)",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_percentile_in_trace_group_3",
-                                      "name": <React.Fragment>
-                                        <div>
-                                          Percentile in trace group
-                                        </div>
-                                      </React.Fragment>,
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_error_count_4",
-                                      "name": "Errors",
-                                      "onSort": [Function],
-                                    },
-                                    Object {
-                                      "isSortAscending": undefined,
-                                      "isSorted": false,
-                                      "key": "_data_s_last_updated_5",
-                                      "name": "Last updated",
-                                      "onSort": [Function],
-                                    },
-                                  ]
-                                }
-                              >
-                                <div
-                                  className="euiTableSortMobile"
-                                >
-                                  <EuiPopover
-                                    anchorPosition="downRight"
-                                    button={
-                                      <EuiButtonEmpty
-                                        flush="right"
-                                        iconSide="right"
-                                        iconType="arrowDown"
-                                        onClick={[Function]}
-                                        size="xs"
-                                      >
-                                        <EuiI18n
-                                          default="Sorting"
-                                          token="euiTableSortMobile.sorting"
-                                        />
-                                      </EuiButtonEmpty>
-                                    }
-                                    closePopover={[Function]}
-                                    display="inlineBlock"
-                                    hasArrow={true}
-                                    isOpen={false}
-                                    ownFocus={true}
-                                    panelPaddingSize="none"
-                                  >
-                                    <div
-                                      className="euiPopover euiPopover--anchorDownRight"
-                                    >
-                                      <div
-                                        className="euiPopover__anchor"
-                                      >
-                                        <EuiButtonEmpty
-                                          flush="right"
-                                          iconSide="right"
-                                          iconType="arrowDown"
-                                          onClick={[Function]}
-                                          size="xs"
-                                        >
-                                          <button
-                                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            <EuiButtonContent
-                                              className="euiButtonEmpty__content"
-                                              iconSide="right"
-                                              iconSize="s"
-                                              iconType="arrowDown"
-                                              textProps={
-                                                Object {
-                                                  "className": "euiButtonEmpty__text",
-                                                }
-                                              }
-                                            >
-                                              <span
-                                                className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                                              >
-                                                <EuiIcon
-                                                  className="euiButtonContent__icon"
-                                                  color="inherit"
-                                                  size="s"
-                                                  type="arrowDown"
-                                                >
-                                                  <EuiIconBeaker
-                                                    aria-hidden={true}
-                                                    className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                    focusable="false"
-                                                    role="img"
-                                                    style={null}
-                                                  >
-                                                    <svg
-                                                      aria-hidden={true}
-                                                      className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                      focusable="false"
-                                                      height={16}
-                                                      role="img"
-                                                      style={null}
-                                                      viewBox="0 0 16 16"
-                                                      width={16}
-                                                      xmlns="http://www.w3.org/2000/svg"
-                                                    >
-                                                      <path
-                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                      />
-                                                    </svg>
-                                                  </EuiIconBeaker>
-                                                </EuiIcon>
-                                                <span
-                                                  className="euiButtonEmpty__text"
-                                                >
-                                                  <EuiI18n
-                                                    default="Sorting"
-                                                    token="euiTableSortMobile.sorting"
-                                                  >
-                                                    Sorting
-                                                  </EuiI18n>
-                                                </span>
-                                              </span>
-                                            </EuiButtonContent>
-                                          </button>
-                                        </EuiButtonEmpty>
-                                      </div>
-                                    </div>
-                                  </EuiPopover>
-                                </div>
-                              </EuiTableSortMobile>
-                            </div>
-                          </EuiFlexItem>
-                        </div>
-                      </EuiFlexGroup>
-                    </div>
-                  </EuiTableHeaderMobile>
-                  <EuiTable
-                    id="random_html_id"
-                    responsive={true}
-                    tableLayout="auto"
-                  >
-                    <table
-                      className="euiTable euiTable--responsive euiTable--auto"
-                      id="random_html_id"
-                      tabIndex={-1}
-                    >
-                      <EuiScreenReaderOnly>
-                        <caption
-                          className="euiScreenReaderOnly euiTableCaption"
-                        >
-                          <EuiDelayRender
-                            delay={500}
-                          />
-                        </caption>
-                      </EuiScreenReaderOnly>
-                      <EuiTableHeader>
-                        <thead>
-                          <tr>
-                            <EuiTableHeaderCell
-                              align="left"
-                              data-test-subj="tableHeaderCell_trace_id_0"
-                              isSortAscending={true}
-                              isSorted={true}
-                              key="_data_h_trace_id_0"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="ascending"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_trace_id_0"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton euiTableHeaderButton-isSorted"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent"
-                                    isSortAscending={true}
-                                    isSorted={true}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Trace ID",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Trace ID"
-                                          >
-                                            Trace ID
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                      <EuiIcon
-                                        className="euiTableSortIcon"
-                                        size="m"
-                                        type="sortUp"
-                                      >
-                                        <EuiIconBeaker
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                          focusable="false"
-                                          role="img"
-                                          style={null}
-                                        >
-                                          <svg
-                                            aria-hidden={true}
-                                            className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
-                                            focusable="false"
-                                            height={16}
-                                            role="img"
-                                            style={null}
-                                            viewBox="0 0 16 16"
-                                            width={16}
-                                            xmlns="http://www.w3.org/2000/svg"
-                                          >
-                                            <path
-                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                            />
-                                          </svg>
-                                        </EuiIconBeaker>
-                                      </EuiIcon>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="left"
-                              data-test-subj="tableHeaderCell_trace_group_1"
-                              isSorted={false}
-                              key="_data_h_trace_group_1"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_trace_group_1"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Trace group",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Trace group"
-                                          >
-                                            Trace group
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_latency_2"
-                              isSorted={false}
-                              key="_data_h_latency_2"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_latency_2"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Duration (ms)",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Duration (ms)"
-                                          >
-                                            Duration (ms)
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
-                              isSorted={false}
-                              key="_data_h_percentile_in_trace_group_3"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Percentile in trace group",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Percentile in trace group"
-                                          >
-                                            <div>
-                                              Percentile in trace group
-                                            </div>
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="right"
-                              data-test-subj="tableHeaderCell_error_count_4"
-                              isSorted={false}
-                              key="_data_h_error_count_4"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_error_count_4"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent euiTableCellContent--alignRight"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent euiTableCellContent--alignRight"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Errors",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Errors"
-                                          >
-                                            Errors
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="left"
-                              data-test-subj="tableHeaderCell_last_updated_5"
-                              isSorted={false}
-                              key="_data_h_last_updated_5"
-                              onSort={[Function]}
-                            >
-                              <th
-                                aria-live="polite"
-                                aria-sort="none"
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_last_updated_5"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <button
-                                  className="euiTableHeaderButton"
-                                  data-test-subj="tableHeaderSortButton"
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <CellContents
-                                    className="euiTableCellContent"
-                                    isSorted={false}
-                                    showSortMsg={true}
-                                  >
-                                    <span
-                                      className="euiTableCellContent"
-                                    >
-                                      <EuiInnerText>
-                                        <EuiI18n
-                                          default="{innerText}; {description}"
-                                          token="euiTableHeaderCell.titleTextWithDesc"
-                                          values={
-                                            Object {
-                                              "description": undefined,
-                                              "innerText": "Last updated",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiTableCellContent__text"
-                                            title="Last updated"
-                                          >
-                                            Last updated
-                                          </span>
-                                        </EuiI18n>
-                                      </EuiInnerText>
-                                    </span>
-                                  </CellContents>
-                                </button>
-                              </th>
-                            </EuiTableHeaderCell>
-                          </tr>
-                        </thead>
-                      </EuiTableHeader>
-                      <EuiTableBody
-                        bodyRef={[Function]}
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
                       >
-                        <tbody>
-                          <EuiTableRow
-                            isSelected={false}
-                          >
-                            <tr
-                              className="euiTableRow"
-                            >
-                              <EuiTableRowCell
-                                align="left"
-                                key="_data_column_trace_id_0_0"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Trace ID",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Trace ID
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiFlexGroup
-                                      alignItems="center"
-                                      className=""
-                                      gutterSize="s"
-                                      key=".0"
-                                    >
-                                      <div
-                                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-                                      >
-                                        <EuiFlexItem
-                                          grow={10}
-                                        >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrow10"
-                                          >
-                                            <EuiLink
-                                              data-test-subj="trace-link"
-                                              onClick={[Function]}
-                                            >
-                                              <button
-                                                className="euiLink euiLink--primary"
-                                                data-test-subj="trace-link"
-                                                disabled={false}
-                                                onClick={[Function]}
-                                                type="button"
-                                              >
-                                                <div
-                                                  title="00079a615e31e61766fcb20b557051c1"
-                                                >
-                                                  00079a615e31e61766fcb...
-                                                </div>
-                                              </button>
-                                            </EuiLink>
-                                          </div>
-                                        </EuiFlexItem>
-                                        <EuiFlexItem
-                                          grow={false}
-                                        >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                                          >
-                                            <EuiCopy
-                                              afterMessage="Copied"
-                                              textToCopy="00079a615e31e61766fcb20b557051c1"
-                                            >
-                                              <EuiToolTip
-                                                delay="regular"
-                                                onMouseOut={[Function]}
-                                                position="top"
-                                              >
-                                                <span
-                                                  className="euiToolTipAnchor"
-                                                  onKeyUp={[Function]}
-                                                  onMouseOut={[Function]}
-                                                  onMouseOver={[Function]}
-                                                >
-                                                  <EuiSmallButtonIcon
-                                                    aria-label="Copy trace id"
-                                                    iconType="copyClipboard"
-                                                    onBlur={[Function]}
-                                                    onClick={[Function]}
-                                                    onFocus={[Function]}
-                                                  >
-                                                    <EuiButtonIcon
-                                                      aria-label="Copy trace id"
-                                                      iconType="copyClipboard"
-                                                      onBlur={[Function]}
-                                                      onClick={[Function]}
-                                                      onFocus={[Function]}
-                                                      size="s"
-                                                    >
-                                                      <button
-                                                        aria-label="Copy trace id"
-                                                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                                                        disabled={false}
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onFocus={[Function]}
-                                                        type="button"
-                                                      >
-                                                        <EuiIcon
-                                                          aria-hidden="true"
-                                                          className="euiButtonIcon__icon"
-                                                          color="inherit"
-                                                          size="m"
-                                                          type="copyClipboard"
-                                                        >
-                                                          <EuiIconBeaker
-                                                            aria-hidden={true}
-                                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                            focusable="false"
-                                                            role="img"
-                                                            style={null}
-                                                          >
-                                                            <svg
-                                                              aria-hidden={true}
-                                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                              focusable="false"
-                                                              height={16}
-                                                              role="img"
-                                                              style={null}
-                                                              viewBox="0 0 16 16"
-                                                              width={16}
-                                                              xmlns="http://www.w3.org/2000/svg"
-                                                            >
-                                                              <path
-                                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                              />
-                                                            </svg>
-                                                          </EuiIconBeaker>
-                                                        </EuiIcon>
-                                                      </button>
-                                                    </EuiButtonIcon>
-                                                  </EuiSmallButtonIcon>
-                                                </span>
-                                              </EuiToolTip>
-                                            </EuiCopy>
-                                          </div>
-                                        </EuiFlexItem>
-                                        <EuiFlexItem
-                                          grow={3}
-                                        >
-                                          <div
-                                            className="euiFlexItem euiFlexItem--flexGrow3"
-                                          />
-                                        </EuiFlexItem>
-                                      </div>
-                                    </EuiFlexGroup>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="left"
-                                key="_data_column_trace_group_0_1"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Trace group",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Trace group
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiText
-                                      className=""
-                                      key=".0"
-                                      size="s"
-                                    >
-                                      <div
-                                        className="euiText euiText--small"
-                                      >
-                                        HTTP GET
-                                      </div>
-                                    </EuiText>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_latency_0_2"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Duration (ms)",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={true}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Duration (ms)
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
-                                  >
-                                    <span
-                                      className="euiTableCellContent__text"
-                                    >
-                                      19.91
-                                    </span>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_percentile_in_trace_group_0_3"
-                                mobileOptions={
-                                  Object {
-                                    "header": <React.Fragment>
-                                      <div>
-                                        Percentile in trace group
-                                      </div>
-                                    </React.Fragment>,
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiTableSortMobile
+                            items={
+                              Array [
+                                Object {
+                                  "isSortAscending": true,
+                                  "isSorted": true,
+                                  "key": "_data_s_trace_id_0",
+                                  "name": "Trace ID",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_trace_group_1",
+                                  "name": "Trace group",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_latency_2",
+                                  "name": "Duration (ms)",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_percentile_in_trace_group_3",
+                                  "name": <React.Fragment>
                                     <div>
                                       Percentile in trace group
                                     </div>
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiText
-                                      className=""
-                                      key=".0"
-                                      size="s"
-                                    >
-                                      <div
-                                        className="euiText euiText--small"
-                                      >
-                                        30th
-                                      </div>
-                                    </EuiText>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="right"
-                                key="_data_column_error_count_0_4"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Errors",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Errors
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
-                                  >
-                                    No
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="left"
-                                key="_data_column_last_updated_0_5"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Last updated",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Last updated
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--overflowingContent"
-                                  >
-                                    11/10/2020 09:55:45
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                            </tr>
-                          </EuiTableRow>
-                        </tbody>
-                      </EuiTableBody>
-                    </table>
-                  </EuiTable>
-                </div>
-                <PaginationBar
-                  aria-controls="random_html_id"
-                  onPageChange={[Function]}
-                  onPageSizeChange={[Function]}
-                  pagination={
-                    Object {
-                      "hidePerPageOptions": undefined,
-                      "pageIndex": 0,
-                      "pageSize": 10,
-                      "pageSizeOptions": Array [
-                        5,
-                        10,
-                        15,
-                      ],
-                      "totalItemCount": 1,
-                    }
-                  }
-                >
-                  <div>
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiTablePagination
-                      activePage={0}
-                      aria-controls="random_html_id"
-                      itemsPerPage={10}
-                      itemsPerPageOptions={
-                        Array [
-                          5,
-                          10,
-                          15,
-                        ]
-                      }
-                      onChangeItemsPerPage={[Function]}
-                      onChangePage={[Function]}
-                      pageCount={1}
-                    >
-                      <EuiFlexGroup
-                        alignItems="center"
-                        justifyContent="spaceBetween"
-                        responsive={false}
-                      >
-                        <div
-                          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-                        >
-                          <EuiFlexItem
-                            grow={false}
+                                  </React.Fragment>,
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_error_count_4",
+                                  "name": "Errors",
+                                  "onSort": [Function],
+                                },
+                                Object {
+                                  "isSortAscending": undefined,
+                                  "isSorted": false,
+                                  "key": "_data_s_last_updated_5",
+                                  "name": "Last updated",
+                                  "onSort": [Function],
+                                },
+                              ]
+                            }
                           >
                             <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              className="euiTableSortMobile"
                             >
                               <EuiPopover
-                                anchorPosition="upRight"
+                                anchorPosition="downRight"
                                 button={
                                   <EuiButtonEmpty
-                                    color="text"
-                                    data-test-subj="tablePaginationPopoverButton"
+                                    flush="right"
                                     iconSide="right"
                                     iconType="arrowDown"
                                     onClick={[Function]}
                                     size="xs"
                                   >
                                     <EuiI18n
-                                      default="Rows per page"
-                                      token="euiTablePagination.rowsPerPage"
+                                      default="Sorting"
+                                      token="euiTableSortMobile.sorting"
                                     />
-                                    : 
-                                    10
                                   </EuiButtonEmpty>
                                 }
                                 closePopover={[Function]}
@@ -3103,22 +2129,20 @@ exports[`Traces table component renders traces table 1`] = `
                                 panelPaddingSize="none"
                               >
                                 <div
-                                  className="euiPopover euiPopover--anchorUpRight"
+                                  className="euiPopover euiPopover--anchorDownRight"
                                 >
                                   <div
                                     className="euiPopover__anchor"
                                   >
                                     <EuiButtonEmpty
-                                      color="text"
-                                      data-test-subj="tablePaginationPopoverButton"
+                                      flush="right"
                                       iconSide="right"
                                       iconType="arrowDown"
                                       onClick={[Function]}
                                       size="xs"
                                     >
                                       <button
-                                        className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
-                                        data-test-subj="tablePaginationPopoverButton"
+                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
                                         disabled={false}
                                         onClick={[Function]}
                                         type="button"
@@ -3171,13 +2195,11 @@ exports[`Traces table component renders traces table 1`] = `
                                               className="euiButtonEmpty__text"
                                             >
                                               <EuiI18n
-                                                default="Rows per page"
-                                                token="euiTablePagination.rowsPerPage"
+                                                default="Sorting"
+                                                token="euiTableSortMobile.sorting"
                                               >
-                                                Rows per page
+                                                Sorting
                                               </EuiI18n>
-                                              : 
-                                              10
                                             </span>
                                           </span>
                                         </EuiButtonContent>
@@ -3187,252 +2209,1198 @@ exports[`Traces table component renders traces table 1`] = `
                                 </div>
                               </EuiPopover>
                             </div>
-                          </EuiFlexItem>
-                          <EuiFlexItem
-                            grow={false}
+                          </EuiTableSortMobile>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </div>
+              </EuiTableHeaderMobile>
+              <EuiTable
+                id="random_html_id"
+                responsive={true}
+                tableLayout="auto"
+              >
+                <table
+                  className="euiTable euiTable--responsive euiTable--auto"
+                  id="random_html_id"
+                  tabIndex={-1}
+                >
+                  <EuiScreenReaderOnly>
+                    <caption
+                      className="euiScreenReaderOnly euiTableCaption"
+                    >
+                      <EuiDelayRender
+                        delay={500}
+                      />
+                    </caption>
+                  </EuiScreenReaderOnly>
+                  <EuiTableHeader>
+                    <thead>
+                      <tr>
+                        <EuiTableHeaderCell
+                          align="left"
+                          data-test-subj="tableHeaderCell_trace_id_0"
+                          isSortAscending={true}
+                          isSorted={true}
+                          key="_data_h_trace_id_0"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="ascending"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_trace_id_0"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton euiTableHeaderButton-isSorted"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent"
+                                isSortAscending={true}
+                                isSorted={true}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Trace ID",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Trace ID"
+                                      >
+                                        Trace ID
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                  <EuiIcon
+                                    className="euiTableSortIcon"
+                                    size="m"
+                                    type="sortUp"
+                                  >
+                                    <EuiIconBeaker
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon-isLoading euiTableSortIcon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                    </EuiIconBeaker>
+                                  </EuiIcon>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="left"
+                          data-test-subj="tableHeaderCell_trace_group_1"
+                          isSorted={false}
+                          key="_data_h_trace_group_1"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_trace_group_1"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Trace group",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Trace group"
+                                      >
+                                        Trace group
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_latency_2"
+                          isSorted={false}
+                          key="_data_h_latency_2"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_latency_2"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Duration (ms)",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Duration (ms)"
+                                      >
+                                        Duration (ms)
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
+                          isSorted={false}
+                          key="_data_h_percentile_in_trace_group_3"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_percentile_in_trace_group_3"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Percentile in trace group",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Percentile in trace group"
+                                      >
+                                        <div>
+                                          Percentile in trace group
+                                        </div>
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="right"
+                          data-test-subj="tableHeaderCell_error_count_4"
+                          isSorted={false}
+                          key="_data_h_error_count_4"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_error_count_4"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent euiTableCellContent--alignRight"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent euiTableCellContent--alignRight"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Errors",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Errors"
+                                      >
+                                        Errors
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                        <EuiTableHeaderCell
+                          align="left"
+                          data-test-subj="tableHeaderCell_last_updated_5"
+                          isSorted={false}
+                          key="_data_h_last_updated_5"
+                          onSort={[Function]}
+                        >
+                          <th
+                            aria-live="polite"
+                            aria-sort="none"
+                            className="euiTableHeaderCell"
+                            data-test-subj="tableHeaderCell_last_updated_5"
+                            role="columnheader"
+                            scope="col"
+                            style={
+                              Object {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <button
+                              className="euiTableHeaderButton"
+                              data-test-subj="tableHeaderSortButton"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <CellContents
+                                className="euiTableCellContent"
+                                isSorted={false}
+                                showSortMsg={true}
+                              >
+                                <span
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiInnerText>
+                                    <EuiI18n
+                                      default="{innerText}; {description}"
+                                      token="euiTableHeaderCell.titleTextWithDesc"
+                                      values={
+                                        Object {
+                                          "description": undefined,
+                                          "innerText": "Last updated",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="euiTableCellContent__text"
+                                        title="Last updated"
+                                      >
+                                        Last updated
+                                      </span>
+                                    </EuiI18n>
+                                  </EuiInnerText>
+                                </span>
+                              </CellContents>
+                            </button>
+                          </th>
+                        </EuiTableHeaderCell>
+                      </tr>
+                    </thead>
+                  </EuiTableHeader>
+                  <EuiTableBody
+                    bodyRef={[Function]}
+                  >
+                    <tbody>
+                      <EuiTableRow
+                        isSelected={false}
+                      >
+                        <tr
+                          className="euiTableRow"
+                        >
+                          <EuiTableRowCell
+                            align="left"
+                            key="_data_column_trace_id_0_0"
+                            mobileOptions={
+                              Object {
+                                "header": "Trace ID",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                            truncateText={true}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Trace ID
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                              >
+                                <EuiFlexGroup
+                                  alignItems="center"
+                                  className=""
+                                  gutterSize="s"
+                                  key=".0"
+                                >
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                                  >
+                                    <EuiFlexItem
+                                      grow={10}
+                                    >
+                                      <div
+                                        className="euiFlexItem euiFlexItem--flexGrow10"
+                                      >
+                                        <EuiLink
+                                          data-test-subj="trace-link"
+                                          onClick={[Function]}
+                                        >
+                                          <button
+                                            className="euiLink euiLink--primary"
+                                            data-test-subj="trace-link"
+                                            disabled={false}
+                                            onClick={[Function]}
+                                            type="button"
+                                          >
+                                            <div
+                                              title="00079a615e31e61766fcb20b557051c1"
+                                            >
+                                              00079a615e31e61766fcb...
+                                            </div>
+                                          </button>
+                                        </EuiLink>
+                                      </div>
+                                    </EuiFlexItem>
+                                    <EuiFlexItem
+                                      grow={false}
+                                    >
+                                      <div
+                                        className="euiFlexItem euiFlexItem--flexGrowZero"
+                                      >
+                                        <EuiCopy
+                                          afterMessage="Copied"
+                                          textToCopy="00079a615e31e61766fcb20b557051c1"
+                                        >
+                                          <EuiToolTip
+                                            delay="regular"
+                                            onMouseOut={[Function]}
+                                            position="top"
+                                          >
+                                            <span
+                                              className="euiToolTipAnchor"
+                                              onKeyUp={[Function]}
+                                              onMouseOut={[Function]}
+                                              onMouseOver={[Function]}
+                                            >
+                                              <EuiSmallButtonIcon
+                                                aria-label="Copy trace id"
+                                                iconType="copyClipboard"
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onFocus={[Function]}
+                                              >
+                                                <EuiButtonIcon
+                                                  aria-label="Copy trace id"
+                                                  iconType="copyClipboard"
+                                                  onBlur={[Function]}
+                                                  onClick={[Function]}
+                                                  onFocus={[Function]}
+                                                  size="s"
+                                                >
+                                                  <button
+                                                    aria-label="Copy trace id"
+                                                    className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                    disabled={false}
+                                                    onBlur={[Function]}
+                                                    onClick={[Function]}
+                                                    onFocus={[Function]}
+                                                    type="button"
+                                                  >
+                                                    <EuiIcon
+                                                      aria-hidden="true"
+                                                      className="euiButtonIcon__icon"
+                                                      color="inherit"
+                                                      size="m"
+                                                      type="copyClipboard"
+                                                    >
+                                                      <EuiIconBeaker
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        role="img"
+                                                        style={null}
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                          focusable="false"
+                                                          height={16}
+                                                          role="img"
+                                                          style={null}
+                                                          viewBox="0 0 16 16"
+                                                          width={16}
+                                                          xmlns="http://www.w3.org/2000/svg"
+                                                        >
+                                                          <path
+                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconBeaker>
+                                                    </EuiIcon>
+                                                  </button>
+                                                </EuiButtonIcon>
+                                              </EuiSmallButtonIcon>
+                                            </span>
+                                          </EuiToolTip>
+                                        </EuiCopy>
+                                      </div>
+                                    </EuiFlexItem>
+                                    <EuiFlexItem
+                                      grow={3}
+                                    >
+                                      <div
+                                        className="euiFlexItem euiFlexItem--flexGrow3"
+                                      />
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="left"
+                            key="_data_column_trace_group_0_1"
+                            mobileOptions={
+                              Object {
+                                "header": "Trace group",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                            truncateText={true}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Trace group
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                              >
+                                <EuiText
+                                  className=""
+                                  key=".0"
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    HTTP GET
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_latency_0_2"
+                            mobileOptions={
+                              Object {
+                                "header": "Duration (ms)",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={true}
+                            truncateText={true}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Duration (ms)
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText"
+                              >
+                                <span
+                                  className="euiTableCellContent__text"
+                                >
+                                  19.91
+                                </span>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_percentile_in_trace_group_0_3"
+                            mobileOptions={
+                              Object {
+                                "header": <React.Fragment>
+                                  <div>
+                                    Percentile in trace group
+                                  </div>
+                                </React.Fragment>,
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                <div>
+                                  Percentile in trace group
+                                </div>
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                              >
+                                <EuiText
+                                  className=""
+                                  key=".0"
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    30th
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="right"
+                            key="_data_column_error_count_0_4"
+                            mobileOptions={
+                              Object {
+                                "header": "Errors",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Errors
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+                              >
+                                No
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                          <EuiTableRowCell
+                            align="left"
+                            key="_data_column_last_updated_0_5"
+                            mobileOptions={
+                              Object {
+                                "header": "Last updated",
+                                "render": undefined,
+                              }
+                            }
+                            setScopeRow={false}
+                            textOnly={false}
+                          >
+                            <td
+                              className="euiTableRowCell"
+                              style={
+                                Object {
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                              >
+                                Last updated
+                              </div>
+                              <div
+                                className="euiTableCellContent euiTableCellContent--overflowingContent"
+                              >
+                                11/10/2020 09:55:45
+                              </div>
+                            </td>
+                          </EuiTableRowCell>
+                        </tr>
+                      </EuiTableRow>
+                    </tbody>
+                  </EuiTableBody>
+                </table>
+              </EuiTable>
+            </div>
+            <PaginationBar
+              aria-controls="random_html_id"
+              onPageChange={[Function]}
+              onPageSizeChange={[Function]}
+              pagination={
+                Object {
+                  "hidePerPageOptions": undefined,
+                  "pageIndex": 0,
+                  "pageSize": 10,
+                  "pageSizeOptions": Array [
+                    5,
+                    10,
+                    15,
+                  ],
+                  "totalItemCount": 1,
+                }
+              }
+            >
+              <div>
+                <EuiSpacer
+                  size="m"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--m"
+                  />
+                </EuiSpacer>
+                <EuiTablePagination
+                  activePage={0}
+                  aria-controls="random_html_id"
+                  itemsPerPage={10}
+                  itemsPerPageOptions={
+                    Array [
+                      5,
+                      10,
+                      15,
+                    ]
+                  }
+                  onChangeItemsPerPage={[Function]}
+                  onChangePage={[Function]}
+                  pageCount={1}
+                >
+                  <EuiFlexGroup
+                    alignItems="center"
+                    justifyContent="spaceBetween"
+                    responsive={false}
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiPopover
+                            anchorPosition="upRight"
+                            button={
+                              <EuiButtonEmpty
+                                color="text"
+                                data-test-subj="tablePaginationPopoverButton"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="xs"
+                              >
+                                <EuiI18n
+                                  default="Rows per page"
+                                  token="euiTablePagination.rowsPerPage"
+                                />
+                                : 
+                                10
+                              </EuiButtonEmpty>
+                            }
+                            closePopover={[Function]}
+                            display="inlineBlock"
+                            hasArrow={true}
+                            isOpen={false}
+                            ownFocus={true}
+                            panelPaddingSize="none"
                           >
                             <div
-                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              className="euiPopover euiPopover--anchorUpRight"
                             >
-                              <EuiPagination
-                                activePage={0}
-                                aria-controls="random_html_id"
-                                onPageClick={[Function]}
-                                pageCount={1}
+                              <div
+                                className="euiPopover__anchor"
                               >
-                                <nav
-                                  className="euiPagination"
+                                <EuiButtonEmpty
+                                  color="text"
+                                  data-test-subj="tablePaginationPopoverButton"
+                                  iconSide="right"
+                                  iconType="arrowDown"
+                                  onClick={[Function]}
+                                  size="xs"
                                 >
-                                  <EuiI18n
-                                    default="Previous page, {page}"
-                                    token="euiPagination.previousPage"
-                                    values={
-                                      Object {
-                                        "page": 0,
-                                      }
-                                    }
+                                  <button
+                                    className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                                    data-test-subj="tablePaginationPopoverButton"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
                                   >
-                                    <EuiI18n
-                                      default="Previous page"
-                                      token="euiPagination.disabledPreviousPage"
+                                    <EuiButtonContent
+                                      className="euiButtonEmpty__content"
+                                      iconSide="right"
+                                      iconSize="s"
+                                      iconType="arrowDown"
+                                      textProps={
+                                        Object {
+                                          "className": "euiButtonEmpty__text",
+                                        }
+                                      }
                                     >
-                                      <EuiButtonIcon
-                                        aria-label="Previous page"
-                                        color="text"
-                                        data-test-subj="pagination-button-previous"
-                                        disabled={true}
-                                        iconType="arrowLeft"
-                                        onClick={[Function]}
+                                      <span
+                                        className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                                       >
-                                        <button
-                                          aria-label="Previous page"
-                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                          data-test-subj="pagination-button-previous"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          type="button"
+                                        <EuiIcon
+                                          className="euiButtonContent__icon"
+                                          color="inherit"
+                                          size="s"
+                                          type="arrowDown"
                                         >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="arrowLeft"
+                                          <EuiIconBeaker
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
                                           >
-                                            <EuiIconBeaker
+                                            <svg
                                               aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
                                               focusable="false"
+                                              height={16}
                                               role="img"
                                               style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                />
-                                              </svg>
-                                            </EuiIconBeaker>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiI18n>
-                                  </EuiI18n>
-                                  <ul
-                                    className="euiPagination__list"
-                                  >
-                                    <PaginationButton
-                                      key="0"
-                                      pageIndex={0}
-                                    >
-                                      <li
-                                        className="euiPagination__item"
-                                      >
-                                        <EuiPaginationButton
-                                          aria-controls="random_html_id"
-                                          hideOnMobile={true}
-                                          isActive={true}
-                                          onClick={[Function]}
-                                          pageIndex={0}
-                                          totalPages={1}
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
+                                          </EuiIconBeaker>
+                                        </EuiIcon>
+                                        <span
+                                          className="euiButtonEmpty__text"
                                         >
                                           <EuiI18n
-                                            default="Page {page} of {totalPages}"
-                                            token="euiPaginationButton.longPageString"
-                                            values={
-                                              Object {
-                                                "page": 1,
-                                                "totalPages": 1,
-                                              }
-                                            }
+                                            default="Rows per page"
+                                            token="euiTablePagination.rowsPerPage"
                                           >
-                                            <EuiI18n
-                                              default="Page {page}"
-                                              token="euiPaginationButton.shortPageString"
-                                              values={
-                                                Object {
-                                                  "page": 1,
-                                                }
-                                              }
-                                            >
-                                              <EuiButtonEmpty
-                                                aria-controls="random_html_id"
-                                                aria-current={true}
-                                                aria-label="Page 1 of 1"
-                                                className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                                color="text"
-                                                data-test-subj="pagination-button-0"
-                                                href="#random_html_id"
-                                                isDisabled={true}
-                                                onClick={[Function]}
-                                                size="s"
-                                              >
-                                                <button
-                                                  aria-controls="random_html_id"
-                                                  aria-current={true}
-                                                  aria-label="Page 1 of 1"
-                                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                                                  data-test-subj="pagination-button-0"
-                                                  disabled={true}
-                                                  onClick={[Function]}
-                                                  type="button"
-                                                >
-                                                  <EuiButtonContent
-                                                    className="euiButtonEmpty__content"
-                                                    iconSide="left"
-                                                    iconSize="m"
-                                                    textProps={
-                                                      Object {
-                                                        "className": "euiButtonEmpty__text",
-                                                      }
-                                                    }
-                                                  >
-                                                    <span
-                                                      className="euiButtonContent euiButtonEmpty__content"
-                                                    >
-                                                      <span
-                                                        className="euiButtonEmpty__text"
-                                                      >
-                                                        1
-                                                      </span>
-                                                    </span>
-                                                  </EuiButtonContent>
-                                                </button>
-                                              </EuiButtonEmpty>
-                                            </EuiI18n>
+                                            Rows per page
                                           </EuiI18n>
-                                        </EuiPaginationButton>
-                                      </li>
-                                    </PaginationButton>
-                                  </ul>
-                                  <EuiI18n
-                                    default="Next page, {page}"
-                                    token="euiPagination.nextPage"
-                                    values={
-                                      Object {
-                                        "page": 2,
-                                      }
-                                    }
-                                  >
-                                    <EuiI18n
-                                      default="Next page"
-                                      token="euiPagination.disabledNextPage"
-                                    >
-                                      <EuiButtonIcon
-                                        aria-label="Next page"
-                                        color="text"
-                                        data-test-subj="pagination-button-next"
-                                        disabled={true}
-                                        iconType="arrowRight"
-                                        onClick={[Function]}
-                                      >
-                                        <button
-                                          aria-label="Next page"
-                                          className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                                          data-test-subj="pagination-button-next"
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          <EuiIcon
-                                            aria-hidden="true"
-                                            className="euiButtonIcon__icon"
-                                            color="inherit"
-                                            size="m"
-                                            type="arrowRight"
-                                          >
-                                            <EuiIconBeaker
-                                              aria-hidden={true}
-                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                              focusable="false"
-                                              role="img"
-                                              style={null}
-                                            >
-                                              <svg
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                                focusable="false"
-                                                height={16}
-                                                role="img"
-                                                style={null}
-                                                viewBox="0 0 16 16"
-                                                width={16}
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                />
-                                              </svg>
-                                            </EuiIconBeaker>
-                                          </EuiIcon>
-                                        </button>
-                                      </EuiButtonIcon>
-                                    </EuiI18n>
-                                  </EuiI18n>
-                                </nav>
-                              </EuiPagination>
+                                          : 
+                                          10
+                                        </span>
+                                      </span>
+                                    </EuiButtonContent>
+                                  </button>
+                                </EuiButtonEmpty>
+                              </div>
                             </div>
-                          </EuiFlexItem>
+                          </EuiPopover>
                         </div>
-                      </EuiFlexGroup>
-                    </EuiTablePagination>
-                  </div>
-                </PaginationBar>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiPagination
+                            activePage={0}
+                            aria-controls="random_html_id"
+                            onPageClick={[Function]}
+                            pageCount={1}
+                          >
+                            <nav
+                              className="euiPagination"
+                            >
+                              <EuiI18n
+                                default="Previous page, {page}"
+                                token="euiPagination.previousPage"
+                                values={
+                                  Object {
+                                    "page": 0,
+                                  }
+                                }
+                              >
+                                <EuiI18n
+                                  default="Previous page"
+                                  token="euiPagination.disabledPreviousPage"
+                                >
+                                  <EuiButtonIcon
+                                    aria-label="Previous page"
+                                    color="text"
+                                    data-test-subj="pagination-button-previous"
+                                    disabled={true}
+                                    iconType="arrowLeft"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      aria-label="Previous page"
+                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      data-test-subj="pagination-button-previous"
+                                      disabled={true}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiButtonIcon__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowLeft"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </button>
+                                  </EuiButtonIcon>
+                                </EuiI18n>
+                              </EuiI18n>
+                              <ul
+                                className="euiPagination__list"
+                              >
+                                <PaginationButton
+                                  key="0"
+                                  pageIndex={0}
+                                >
+                                  <li
+                                    className="euiPagination__item"
+                                  >
+                                    <EuiPaginationButton
+                                      aria-controls="random_html_id"
+                                      hideOnMobile={true}
+                                      isActive={true}
+                                      onClick={[Function]}
+                                      pageIndex={0}
+                                      totalPages={1}
+                                    >
+                                      <EuiI18n
+                                        default="Page {page} of {totalPages}"
+                                        token="euiPaginationButton.longPageString"
+                                        values={
+                                          Object {
+                                            "page": 1,
+                                            "totalPages": 1,
+                                          }
+                                        }
+                                      >
+                                        <EuiI18n
+                                          default="Page {page}"
+                                          token="euiPaginationButton.shortPageString"
+                                          values={
+                                            Object {
+                                              "page": 1,
+                                            }
+                                          }
+                                        >
+                                          <EuiButtonEmpty
+                                            aria-controls="random_html_id"
+                                            aria-current={true}
+                                            aria-label="Page 1 of 1"
+                                            className="euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                            color="text"
+                                            data-test-subj="pagination-button-0"
+                                            href="#random_html_id"
+                                            isDisabled={true}
+                                            onClick={[Function]}
+                                            size="s"
+                                          >
+                                            <button
+                                              aria-controls="random_html_id"
+                                              aria-current={true}
+                                              aria-label="Page 1 of 1"
+                                              className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                                              data-test-subj="pagination-button-0"
+                                              disabled={true}
+                                              onClick={[Function]}
+                                              type="button"
+                                            >
+                                              <EuiButtonContent
+                                                className="euiButtonEmpty__content"
+                                                iconSide="left"
+                                                iconSize="m"
+                                                textProps={
+                                                  Object {
+                                                    "className": "euiButtonEmpty__text",
+                                                  }
+                                                }
+                                              >
+                                                <span
+                                                  className="euiButtonContent euiButtonEmpty__content"
+                                                >
+                                                  <span
+                                                    className="euiButtonEmpty__text"
+                                                  >
+                                                    1
+                                                  </span>
+                                                </span>
+                                              </EuiButtonContent>
+                                            </button>
+                                          </EuiButtonEmpty>
+                                        </EuiI18n>
+                                      </EuiI18n>
+                                    </EuiPaginationButton>
+                                  </li>
+                                </PaginationButton>
+                              </ul>
+                              <EuiI18n
+                                default="Next page, {page}"
+                                token="euiPagination.nextPage"
+                                values={
+                                  Object {
+                                    "page": 2,
+                                  }
+                                }
+                              >
+                                <EuiI18n
+                                  default="Next page"
+                                  token="euiPagination.disabledNextPage"
+                                >
+                                  <EuiButtonIcon
+                                    aria-label="Next page"
+                                    color="text"
+                                    data-test-subj="pagination-button-next"
+                                    disabled={true}
+                                    iconType="arrowRight"
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      aria-label="Next page"
+                                      className="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                                      data-test-subj="pagination-button-next"
+                                      disabled={true}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiIcon
+                                        aria-hidden="true"
+                                        className="euiButtonIcon__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowRight"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                    </button>
+                                  </EuiButtonIcon>
+                                </EuiI18n>
+                              </EuiI18n>
+                            </nav>
+                          </EuiPagination>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                </EuiTablePagination>
               </div>
-            </EuiBasicTable>
-          </EuiInMemoryTable>
-        </div>
-      </EuiPanel>
+            </PaginationBar>
+          </div>
+        </EuiBasicTable>
+      </EuiInMemoryTable>
     </div>
-  </EuiPage>
+  </EuiPanel>
 </TracesTable>
 `;

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -165,6 +165,7 @@ exports[`Traces table component renders empty traces table message 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButtonEmpty__content"
+                    iconGap="m"
                     iconSide="right"
                     iconSize="m"
                     iconType="popout"
@@ -706,6 +707,7 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -1445,6 +1447,7 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -1650,6 +1653,7 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={
@@ -2149,6 +2153,7 @@ exports[`Traces table component renders traces table 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -3095,6 +3100,7 @@ exports[`Traces table component renders traces table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -3298,6 +3304,7 @@ exports[`Traces table component renders traces table 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={

--- a/public/components/trace_analytics/components/traces/trace_view.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view.tsx
@@ -38,6 +38,9 @@ import { PanelTitle, filtersToDsl, processTimeStamp } from '../common/helper_fun
 import { ServiceMap, ServiceObject } from '../common/plots/service_map';
 import { ServiceBreakdownPanel } from './service_breakdown_panel';
 import { SpanDetailPanel } from './span_detail_panel';
+import { coreRefs } from '../../../../framework/core_refs';
+
+const newNavigation = coreRefs.chrome?.navGroup.getNavGroupEnabled();
 
 interface TraceViewProps extends TraceAnalyticsCoreDeps {
   traceId: string;
@@ -53,11 +56,13 @@ export function TraceView(props: TraceViewProps) {
   const renderTitle = (traceId: string) => {
     return (
       <>
-        <EuiFlexItem>
-          <EuiText size="s">
-            <h1 className="overview-content">{traceId}</h1>
-          </EuiText>
-        </EuiFlexItem>
+        {!newNavigation && (
+          <EuiFlexItem>
+            <EuiText size="s">
+              <h1 className="overview-content">{traceId}</h1>
+            </EuiText>
+          </EuiFlexItem>
+        )}
       </>
     );
   };

--- a/public/components/trace_analytics/components/traces/traces.tsx
+++ b/public/components/trace_analytics/components/traces/traces.tsx
@@ -8,7 +8,6 @@ import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import React from 'react';
 import { DataSourceOption } from '../../../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
 import { TraceAnalyticsComponentDeps } from '../../home';
-import { DataSourcePicker } from '../dashboard/mode_picker';
 import { TracesContent } from './traces_content';
 
 export interface TracesProps extends TraceAnalyticsComponentDeps {
@@ -22,7 +21,6 @@ export interface TracesProps extends TraceAnalyticsComponentDeps {
 export function Traces(props: TracesProps) {
   return (
     <>
-      <DataSourcePicker modes={props.modes} selectedMode={props.mode} setMode={props.setMode!} />
       <TracesContent {...props} />
     </>
   );

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -4,7 +4,15 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { EuiAccordion, EuiPanel, EuiSpacer, PropertySort } from '@elastic/eui';
+import {
+  EuiAccordion,
+  EuiPanel,
+  EuiSpacer,
+  PropertySort,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPage,
+} from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { coreRefs } from '../../../../framework/core_refs';
 import { handleTracesRequest } from '../../requests/traces_request_handler';
@@ -12,8 +20,10 @@ import { getValidFilterFields } from '../common/filters/filter_helpers';
 import { filtersToDsl, processTimeStamp } from '../common/helper_functions';
 import { SearchBar } from '../common/search_bar';
 import { DashboardContent } from '../dashboard/dashboard_content';
-import { TracesProps } from './traces';
 import { TracesTable } from './traces_table';
+import { TracesProps } from './traces';
+import { DataSourcePicker } from '../dashboard/mode_picker';
+import { Filters } from '../common/filters/filters';
 
 export function TracesContent(props: TracesProps) {
   const {
@@ -109,35 +119,60 @@ export function TracesContent(props: TracesProps) {
 
   return (
     <>
-      <SearchBar
-        query={query}
-        filters={filters}
-        appConfigs={appConfigs}
-        setFilters={setFilters}
-        setQuery={setQuery}
-        startTime={startTime}
-        setStartTime={setStartTime}
-        endTime={endTime}
-        setEndTime={setEndTime}
-        refresh={refresh}
+      <EuiFlexGroup
+        gutterSize="s"
+        alignItems="center"
+        justifyContent="spaceBetween"
+        style={{ padding: '0 16px' }}
+      >
+        <EuiFlexItem grow={false}>
+          <DataSourcePicker
+            modes={props.modes}
+            selectedMode={props.mode}
+            setMode={props.setMode!}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={true}>
+          <SearchBar
+            query={query}
+            filters={filters}
+            appConfigs={appConfigs}
+            setFilters={setFilters}
+            setQuery={setQuery}
+            startTime={startTime}
+            setStartTime={setStartTime}
+            endTime={endTime}
+            setEndTime={setEndTime}
+            refresh={refresh}
+            page={page}
+            mode={mode}
+            attributesFilterFields={attributesFilterFields}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <Filters
         page={page}
+        filters={filters}
+        setFilters={setFilters}
+        appConfigs={appConfigs}
         mode={mode}
         attributesFilterFields={attributesFilterFields}
       />
       <EuiSpacer size="m" />
-      <EuiPanel>
-        <EuiAccordion
-          id="accordion1"
-          buttonContent={mode === 'data_prepper' ? 'Trace Groups' : 'Service and Operations'}
-          forceState={trigger}
-          onToggle={onToggle}
-          data-test-subj="trace-groups-service-operation-accordian"
-        >
-          <EuiSpacer size="m" />
-          {trigger === 'open' && dashboardContent()}
-        </EuiAccordion>
-      </EuiPanel>
-      <EuiSpacer size="m" />
+      <EuiPage paddingSize="m">
+        <EuiPanel>
+          <EuiAccordion
+            id="accordion1"
+            buttonContent={mode === 'data_prepper' ? 'Trace Groups' : 'Service and Operations'}
+            forceState={trigger}
+            onToggle={onToggle}
+            data-test-subj="trace-groups-service-operation-accordian"
+          >
+            <EuiSpacer size="m" />
+            {trigger === 'open' && dashboardContent()}
+          </EuiAccordion>
+        </EuiPanel>
+      </EuiPage>
       <TracesTable
         items={tableItems}
         refresh={refresh}

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -12,6 +12,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiPage,
+  EuiPageBody,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { coreRefs } from '../../../../framework/core_refs';
@@ -119,69 +120,67 @@ export function TracesContent(props: TracesProps) {
 
   return (
     <>
-      <EuiFlexGroup
-        gutterSize="s"
-        alignItems="center"
-        justifyContent="spaceBetween"
-        style={{ padding: '0 24px' }}
-      >
-        <EuiFlexItem grow={false}>
-          <DataSourcePicker
-            modes={props.modes}
-            selectedMode={props.mode}
-            setMode={props.setMode!}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={true}>
-          <SearchBar
-            query={query}
-            filters={filters}
-            appConfigs={appConfigs}
-            setFilters={setFilters}
-            setQuery={setQuery}
-            startTime={startTime}
-            setStartTime={setStartTime}
-            endTime={endTime}
-            setEndTime={setEndTime}
-            refresh={refresh}
+      <EuiPage paddingSize="m">
+        <EuiPageBody>
+          <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <DataSourcePicker
+                modes={props.modes}
+                selectedMode={props.mode}
+                setMode={props.setMode!}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={true}>
+              <SearchBar
+                query={query}
+                filters={filters}
+                appConfigs={appConfigs}
+                setFilters={setFilters}
+                setQuery={setQuery}
+                startTime={startTime}
+                setStartTime={setStartTime}
+                endTime={endTime}
+                setEndTime={setEndTime}
+                refresh={refresh}
+                page={page}
+                mode={mode}
+                attributesFilterFields={attributesFilterFields}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <Filters
             page={page}
+            filters={filters}
+            setFilters={setFilters}
+            appConfigs={appConfigs}
             mode={mode}
             attributesFilterFields={attributesFilterFields}
           />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <Filters
-        page={page}
-        filters={filters}
-        setFilters={setFilters}
-        appConfigs={appConfigs}
-        mode={mode}
-        attributesFilterFields={attributesFilterFields}
-      />
-      <EuiSpacer size="m" />
-      <EuiPage paddingSize="m">
-        <EuiPanel>
-          <EuiAccordion
-            id="accordion1"
-            buttonContent={mode === 'data_prepper' ? 'Trace Groups' : 'Service and Operations'}
-            forceState={trigger}
-            onToggle={onToggle}
-            data-test-subj="trace-groups-service-operation-accordian"
-          >
-            <EuiSpacer size="m" />
-            {trigger === 'open' && dashboardContent()}
-          </EuiAccordion>
-        </EuiPanel>
+          <EuiSpacer size="s" />
+          <EuiPanel>
+            <EuiAccordion
+              id="accordion1"
+              buttonContent={mode === 'data_prepper' ? 'Trace Groups' : 'Service and Operations'}
+              forceState={trigger}
+              onToggle={onToggle}
+              data-test-subj="trace-groups-service-operation-accordian"
+            >
+              <EuiSpacer size="m" />
+              {trigger === 'open' && dashboardContent()}
+            </EuiAccordion>
+          </EuiPanel>
+          <EuiSpacer size="s" />
+          <TracesTable
+            items={tableItems}
+            refresh={refresh}
+            mode={mode}
+            loading={loading}
+            traceIdColumnAction={traceIdColumnAction}
+            jaegerIndicesExist={jaegerIndicesExist}
+            dataPrepperIndicesExist={dataPrepperIndicesExist}
+          />
+        </EuiPageBody>
       </EuiPage>
-      <TracesTable
-        items={tableItems}
-        refresh={refresh}
-        mode={mode}
-        loading={loading}
-        traceIdColumnAction={traceIdColumnAction}
-        jaegerIndicesExist={jaegerIndicesExist}
-        dataPrepperIndicesExist={dataPrepperIndicesExist}
-      />
     </>
   );
 }

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -123,7 +123,7 @@ export function TracesContent(props: TracesProps) {
         gutterSize="s"
         alignItems="center"
         justifyContent="spaceBetween"
-        style={{ padding: '0 16px' }}
+        style={{ padding: '0 24px' }}
       >
         <EuiFlexItem grow={false}>
           <DataSourcePicker

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -17,7 +17,6 @@ import {
   EuiTableFieldDataColumnType,
   EuiText,
   PropertySort,
-  EuiPage,
 } from '@elastic/eui';
 import round from 'lodash/round';
 import truncate from 'lodash/truncate';
@@ -258,34 +257,32 @@ export function TracesTable(props: TracesTableProps) {
 
   return (
     <>
-      <EuiPage paddingSize="m">
-        <EuiPanel>
-          {titleBar}
-          <EuiSpacer size="m" />
-          <EuiHorizontalRule margin="none" />
-          {!(
-            (mode === 'data_prepper' && props.dataPrepperIndicesExist) ||
-            (mode === 'jaeger' && props.jaegerIndicesExist)
-          ) ? (
-            <MissingConfigurationMessage mode={mode} />
-          ) : items?.length > 0 ? (
-            <EuiInMemoryTable
-              tableLayout="auto"
-              items={items}
-              columns={columns}
-              pagination={{
-                initialPageSize: 10,
-                pageSizeOptions: [5, 10, 15],
-              }}
-              sorting={sorting}
-              onTableChange={onTableChange}
-              loading={loading}
-            />
-          ) : (
-            <NoMatchMessage size="xl" />
-          )}
-        </EuiPanel>
-      </EuiPage>
+      <EuiPanel>
+        {titleBar}
+        <EuiSpacer size="m" />
+        <EuiHorizontalRule margin="none" />
+        {!(
+          (mode === 'data_prepper' && props.dataPrepperIndicesExist) ||
+          (mode === 'jaeger' && props.jaegerIndicesExist)
+        ) ? (
+          <MissingConfigurationMessage mode={mode} />
+        ) : items?.length > 0 ? (
+          <EuiInMemoryTable
+            tableLayout="auto"
+            items={items}
+            columns={columns}
+            pagination={{
+              initialPageSize: 10,
+              pageSizeOptions: [5, 10, 15],
+            }}
+            sorting={sorting}
+            onTableChange={onTableChange}
+            loading={loading}
+          />
+        ) : (
+          <NoMatchMessage size="xl" />
+        )}
+      </EuiPanel>
     </>
   );
 }

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -17,6 +17,7 @@ import {
   EuiTableFieldDataColumnType,
   EuiText,
   PropertySort,
+  EuiPage,
 } from '@elastic/eui';
 import round from 'lodash/round';
 import truncate from 'lodash/truncate';
@@ -51,11 +52,9 @@ export function TracesTable(props: TracesTableProps) {
     );
   };
 
-  const columns = useMemo(
-    () => {
-      if (mode === 'data_prepper') {
-        return(
-      [
+  const columns = useMemo(() => {
+    if (mode === 'data_prepper') {
+      return [
         {
           field: 'trace_id',
           name: 'Trace ID',
@@ -65,7 +64,7 @@ export function TracesTable(props: TracesTableProps) {
           render: (item) => (
             <EuiFlexGroup gutterSize="s" alignItems="center">
               <EuiFlexItem grow={10}>
-                <EuiLink data-test-subj='trace-link' onClick={() => traceIdColumnAction(item)}>
+                <EuiLink data-test-subj="trace-link" onClick={() => traceIdColumnAction(item)}>
                   {item.length < 24 ? (
                     item
                   ) : (
@@ -99,11 +98,7 @@ export function TracesTable(props: TracesTableProps) {
           render: (item) =>
             item ? (
               <EuiText size="s">
-                {item.length < 36 ? (
-                  item
-                ) : (
-                  <div title={item}>{truncate(item, { length: 36 })}</div>
-                )}
+                {item.length < 36 ? item : <div title={item}>{truncate(item, { length: 36 })}</div>}
               </EuiText>
             ) : (
               '-'
@@ -152,79 +147,76 @@ export function TracesTable(props: TracesTableProps) {
           sortable: true,
           render: (item) => (item === 0 || item ? item : '-'),
         },
-      ] as Array<EuiTableFieldDataColumnType<any>>)
+      ] as Array<EuiTableFieldDataColumnType<any>>;
     } else {
-      return (
-        [
-          {
-            field: 'trace_id',
-            name: 'Trace ID',
-            align: 'left',
-            sortable: true,
-            truncateText: true,
-            render: (item) => (
-              <EuiFlexGroup gutterSize="s" alignItems="center">
-                <EuiFlexItem grow={10}>
-                  <EuiLink onClick={() => traceIdColumnAction(item)}>
-                    {item.length < 24 ? (
-                      item
-                    ) : (
-                      <div title={item}>{truncate(item, { length: 24 })}</div>
-                    )}
-                  </EuiLink>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiCopy textToCopy={item}>
-                    {(copy) => (
-                      <EuiSmallButtonIcon
-                        aria-label="Copy trace id"
-                        iconType="copyClipboard"
-                        onClick={copy}
-                      >
-                        Click to copy
-                      </EuiSmallButtonIcon>
-                    )}
-                  </EuiCopy>
-                </EuiFlexItem>
-                <EuiFlexItem grow={3} />
-              </EuiFlexGroup>
+      return [
+        {
+          field: 'trace_id',
+          name: 'Trace ID',
+          align: 'left',
+          sortable: true,
+          truncateText: true,
+          render: (item) => (
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiFlexItem grow={10}>
+                <EuiLink onClick={() => traceIdColumnAction(item)}>
+                  {item.length < 24 ? (
+                    item
+                  ) : (
+                    <div title={item}>{truncate(item, { length: 24 })}</div>
+                  )}
+                </EuiLink>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCopy textToCopy={item}>
+                  {(copy) => (
+                    <EuiSmallButtonIcon
+                      aria-label="Copy trace id"
+                      iconType="copyClipboard"
+                      onClick={copy}
+                    >
+                      Click to copy
+                    </EuiSmallButtonIcon>
+                  )}
+                </EuiCopy>
+              </EuiFlexItem>
+              <EuiFlexItem grow={3} />
+            </EuiFlexGroup>
+          ),
+        },
+        {
+          field: 'latency',
+          name: 'Latency (ms)',
+          align: 'right',
+          sortable: true,
+          truncateText: true,
+        },
+        {
+          field: 'error_count',
+          name: 'Errors',
+          align: 'right',
+          sortable: true,
+          render: (item) =>
+            item == null ? (
+              '-'
+            ) : item > 0 ? (
+              <EuiText color="danger" size="s">
+                Yes
+              </EuiText>
+            ) : (
+              'No'
             ),
-          },
-          {
-            field: 'latency',
-            name: 'Latency (ms)',
-            align: 'right',
-            sortable: true,
-            truncateText: true,
-          },
-          {
-            field: 'error_count',
-            name: 'Errors',
-            align: 'right',
-            sortable: true,
-            render: (item) =>
-              item == null ? (
-                '-'
-              ) : item > 0 ? (
-                <EuiText color="danger" size="s">
-                  Yes
-                </EuiText>
-              ) : (
-                'No'
-              ),
-          },
-          {
-            field: 'last_updated',
-            name: 'Last updated',
-            align: 'left',
-            sortable: true,
-            render: (item) => (item === 0 || item ? item : '-'),
-          },
-        ] as Array<EuiTableFieldDataColumnType<any>>)
+        },
+        {
+          field: 'last_updated',
+          name: 'Last updated',
+          align: 'left',
+          sortable: true,
+          render: (item) => (item === 0 || item ? item : '-'),
+        },
+      ] as Array<EuiTableFieldDataColumnType<any>>;
     }
-    },
-    [items]
-  );
+  }, [items]);
 
   const titleBar = useMemo(() => renderTitleBar(items?.length), [items]);
 
@@ -235,7 +227,7 @@ export function TracesTable(props: TracesTableProps) {
     },
   });
 
-  const onTableChange = async ({ currPage, sort }: { currPage: any; sort: any }) => {
+  const onTableChange = async ({ _currPage, sort }: { currPage: any; sort: any }) => {
     if (typeof sort?.field !== 'string') return;
 
     // maps table column key to DSL aggregation name
@@ -266,29 +258,34 @@ export function TracesTable(props: TracesTableProps) {
 
   return (
     <>
-      <EuiPanel>
-        {titleBar}
-        <EuiSpacer size="m" />
-        <EuiHorizontalRule margin="none" />
-        {!((mode === 'data_prepper' && props.dataPrepperIndicesExist) || (mode === 'jaeger' && props.jaegerIndicesExist)) ? (
-          <MissingConfigurationMessage mode={mode}/>
-        ) : items?.length > 0 ? (
-          <EuiInMemoryTable
-            tableLayout="auto"
-            items={items}
-            columns={columns}
-            pagination={{
-              initialPageSize: 10,
-              pageSizeOptions: [5, 10, 15],
-            }}
-            sorting={sorting}
-            onTableChange={onTableChange}
-            loading={loading}
-          />
-        ) : (
-          <NoMatchMessage size="xl" />
-        )}
-      </EuiPanel>
+      <EuiPage paddingSize="m">
+        <EuiPanel>
+          {titleBar}
+          <EuiSpacer size="m" />
+          <EuiHorizontalRule margin="none" />
+          {!(
+            (mode === 'data_prepper' && props.dataPrepperIndicesExist) ||
+            (mode === 'jaeger' && props.jaegerIndicesExist)
+          ) ? (
+            <MissingConfigurationMessage mode={mode} />
+          ) : items?.length > 0 ? (
+            <EuiInMemoryTable
+              tableLayout="auto"
+              items={items}
+              columns={columns}
+              pagination={{
+                initialPageSize: 10,
+                pageSizeOptions: [5, 10, 15],
+              }}
+              sorting={sorting}
+              onTableChange={onTableChange}
+              loading={loading}
+            />
+          ) : (
+            <NoMatchMessage size="xl" />
+          )}
+        </EuiPanel>
+      </EuiPage>
     </>
   );
 }


### PR DESCRIPTION
### Description
1. Updates Traces UI to conform with the header changes.
2. Updates Services UI to conform with the header changes.
3. Fixes a bug with the global filter icon where it would get stuck open if double clicked.

Traces before:
<img width="1278" alt="Screenshot 2024-08-20 at 3 17 08 PM" src="https://github.com/user-attachments/assets/4ffdfea8-ce11-4e86-9a5b-dc4ddd1a4dc0">

After:
<img width="1144" alt="Screenshot 2024-08-21 at 9 35 58 PM" src="https://github.com/user-attachments/assets/0ee0b36e-bdc1-49a7-baae-54ae5994120f">



Services before:
<img width="1271" alt="Screenshot 2024-08-20 at 3 17 32 PM" src="https://github.com/user-attachments/assets/52b67c12-c0b7-4a68-8659-53fc4a4416c3">

After:
<img width="1153" alt="Screenshot 2024-08-21 at 9 35 34 PM" src="https://github.com/user-attachments/assets/6dae2119-72c2-41d2-911f-ec716dfdc3a8">


Fix to filter button - now closes when re-clicked or an option is selected.
<img width="230" alt="Screenshot 2024-08-20 at 3 20 37 PM" src="https://github.com/user-attachments/assets/c1e3a326-aa81-4e1e-a1c1-8163efae6df5">

These changes to UI required the filter to be broken apart.
Video showing it still works while separated:


https://github.com/user-attachments/assets/734f1b15-b09e-4c53-862f-fc67eaf648a8



### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
