### PR TITLE
Adding Ryan, Sean and Adam as dashboards-observability maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @pjfitzgibbons @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @anirudha @paulstn @sumukhswamy
+
+- @pjfitzgibbons @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @anirudha @paulstn @sumukhswamy @sejli @TackAdam @RyanL1997

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
 
-- @pjfitzgibbons @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @anirudha @paulstn @sumukhswamy @sejli @TackAdam @RyanL1997
+- @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @anirudha @paulstn @sumukhswamy @sejli @TackAdam @RyanL1997

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,14 +22,16 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Anirudha Jadhav         | [anirudha](https://github.com/anirudha)           | Amazon      |
 | Paul Sebastian          | [paulstn](https://github.com/paulstn)             | Amazon      |
 | Sumukh Hanumantha Swamy | [sumukhswamy](https://github.com/sumukhswamy)     | Amazon      |
+| Sean Li                 | [sejli](https://github.com/sejli)                 | Amazon      |
+| Adam Tackett            | [TackAdam](https://github.com/TackAdam)           | Amazon      |
+| Jialiang Liang          | [RyanL1997](https://github.com/sumukhswamy)       | Amazon      |
 
 ## Emeritus Maintainers
 
-| Maintainer        | GitHub ID                                               | Affiliation |
-| ----------------- | ------------------------------------------------------- | ----------- |
-| Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
-| Nick Knize        | [nknize](https://github.com/nknize)                     | Amazon      |
-| David Cui         | [davidcui1225](https://github.com/davidcui1225)         | Amazon      |
-| Eugene Lee        | [eugenesk24](https://github.com/eugenesk24)             | Amazon      |
-| Zhongnan Su       | [zhongnansu](https://github.com/zhongnansu)             | Amazon      |
-| Sean Li           | [sejli](https://github.com/sejli)                       | Amazon      |
+| Maintainer       | GitHub ID                                       | Affiliation |
+| ---------------- | ----------------------------------------------- | ----------- |
+| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE)         | Amazon      |
+| Nick Knize       | [nknize](https://github.com/nknize)             | Amazon      |
+| David Cui        | [davidcui1225](https://github.com/davidcui1225) | Amazon      |
+| Eugene Lee       | [eugenesk24](https://github.com/eugenesk24)     | Amazon      |
+| Zhongnan Su      | [zhongnansu](https://github.com/zhongnansu)     | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,34 +4,34 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer              | GitHub ID                                         | Affiliation |
-| ----------------------- | ------------------------------------------------- | ----------- |
-| Eric Wei                | [mengweieric](https://github.com/mengweieric)     | Amazon      |
-| Joshua Li               | [joshuali925](https://github.com/joshuali925)     | Amazon      |
-| Shenoy Pratik           | [ps48](https://github.com/ps48)                   | Amazon      |
-| Kavitha Mohan           | [kavithacm](https://github.com/kavithacm)         | Amazon      |
-| Rupal Mahajan           | [rupal-bq](https://github.com/rupal-bq)           | Amazon      |
-| Derek Ho                | [derek-ho](https://github.com/derek-ho)           | Amazon      |
-| Lior Perry              | [YANG-DB](https://github.com/YANG-DB)             | Amazon      |
-| Peter Fitzgibbons       | [pjfitzgibbons](https://github.com/pjfitzgibbons) | Amazon      |
-| Simeon Widdis           | [swiddis](https://github.com/swiddis)             | Amazon      |
-| Chen Dai                | [dai-chen](https://github.com/dai-chen)           | Amazon      |
-| Vamsi Manohar           | [vamsi-amazon](https://github.com/vamsi-amazon)   | Amazon      |
-| Peng Huo                | [penghuo](https://github.com/penghuo)             | Amazon      |
-| Sean Kao                | [seankao-az](https://github.com/seankao-az)       | Amazon      |
-| Anirudha Jadhav         | [anirudha](https://github.com/anirudha)           | Amazon      |
-| Paul Sebastian          | [paulstn](https://github.com/paulstn)             | Amazon      |
-| Sumukh Hanumantha Swamy | [sumukhswamy](https://github.com/sumukhswamy)     | Amazon      |
-| Sean Li                 | [sejli](https://github.com/sejli)                 | Amazon      |
-| Adam Tackett            | [TackAdam](https://github.com/TackAdam)           | Amazon      |
-| Jialiang Liang          | [RyanL1997](https://github.com/sumukhswamy)       | Amazon      |
+| Maintainer              | GitHub ID                                       | Affiliation |
+| ----------------------- | ----------------------------------------------- | ----------- |
+| Eric Wei                | [mengweieric](https://github.com/mengweieric)   | Amazon      |
+| Joshua Li               | [joshuali925](https://github.com/joshuali925)   | Amazon      |
+| Shenoy Pratik           | [ps48](https://github.com/ps48)                 | Amazon      |
+| Kavitha Mohan           | [kavithacm](https://github.com/kavithacm)       | Amazon      |
+| Rupal Mahajan           | [rupal-bq](https://github.com/rupal-bq)         | Amazon      |
+| Derek Ho                | [derek-ho](https://github.com/derek-ho)         | Amazon      |
+| Lior Perry              | [YANG-DB](https://github.com/YANG-DB)           | Amazon      |
+| Simeon Widdis           | [swiddis](https://github.com/swiddis)           | Amazon      |
+| Chen Dai                | [dai-chen](https://github.com/dai-chen)         | Amazon      |
+| Vamsi Manohar           | [vamsi-amazon](https://github.com/vamsi-amazon) | Amazon      |
+| Peng Huo                | [penghuo](https://github.com/penghuo)           | Amazon      |
+| Sean Kao                | [seankao-az](https://github.com/seankao-az)     | Amazon      |
+| Anirudha Jadhav         | [anirudha](https://github.com/anirudha)         | Amazon      |
+| Paul Sebastian          | [paulstn](https://github.com/paulstn)           | Amazon      |
+| Sumukh Hanumantha Swamy | [sumukhswamy](https://github.com/sumukhswamy)   | Amazon      |
+| Sean Li                 | [sejli](https://github.com/sejli)               | Amazon      |
+| Adam Tackett            | [TackAdam](https://github.com/TackAdam)         | Amazon      |
+| Jialiang Liang          | [RyanL1997](https://github.com/RyanL1997)       | Amazon      |
 
 ## Emeritus Maintainers
 
-| Maintainer       | GitHub ID                                       | Affiliation |
-| ---------------- | ----------------------------------------------- | ----------- |
-| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE)         | Amazon      |
-| Nick Knize       | [nknize](https://github.com/nknize)             | Amazon      |
-| David Cui        | [davidcui1225](https://github.com/davidcui1225) | Amazon      |
-| Eugene Lee       | [eugenesk24](https://github.com/eugenesk24)     | Amazon      |
-| Zhongnan Su      | [zhongnansu](https://github.com/zhongnansu)     | Amazon      |
+| Maintainer        | GitHub ID                                         | Affiliation |
+| ----------------- | ------------------------------------------------- | ----------- |
+| Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)           | Amazon      |
+| Nick Knize        | [nknize](https://github.com/nknize)               | Amazon      |
+| David Cui         | [davidcui1225](https://github.com/davidcui1225)   | Amazon      |
+| Eugene Lee        | [eugenesk24](https://github.com/eugenesk24)       | Amazon      |
+| Zhongnan Su       | [zhongnansu](https://github.com/zhongnansu)       | Amazon      |
+| Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons) | Amazon      |


### PR DESCRIPTION
### Description
Adding Ryan, Sean and Adam as dashboards-observability maintainers

### Issues Resolved
PRs contributed by each of them to this repository is as mentioned below:

Ryan: https://github.com/opensearch-project/dashboards-observability/pulls?q=is%3Apr+author%3ARyanL1997
Sean: https://github.com/opensearch-project/dashboards-observability/pulls?q=is%3Apr+author%3Asejli
Adam: https://github.com/opensearch-project/dashboards-observability/pulls?q=is%3Apr+author%3Atackadam


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
