### PR TITLE
[Backport 2.x] [Feature] Traces/Services UI update (#2078)

### DIFF
--- a/public/components/application_analytics/__tests__/__snapshots__/flyout.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/flyout.test.tsx.snap
@@ -874,6 +874,7 @@ exports[`Trace Detail Render Flyout component render trace detail 1`] = `
                           >
                             <EuiButtonContent
                               className="euiButton__content"
+                              iconGap="m"
                               iconSide="left"
                               textProps={
                                 Object {
@@ -954,6 +955,7 @@ exports[`Trace Detail Render Flyout component render trace detail 1`] = `
                           >
                             <EuiButtonContent
                               className="euiButton__content"
+                              iconGap="m"
                               iconSide="left"
                               textProps={
                                 Object {

--- a/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
@@ -327,6 +327,7 @@ exports[`Log Config component renders empty log config 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -994,6 +995,7 @@ exports[`Log Config component renders with query 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {

--- a/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -371,6 +371,7 @@ exports[`Service Config component renders empty service config 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -776,6 +777,7 @@ exports[`Service Config component renders empty service config 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {
@@ -856,6 +858,7 @@ exports[`Service Config component renders empty service config 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {
@@ -936,6 +939,7 @@ exports[`Service Config component renders empty service config 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {
@@ -1595,6 +1599,7 @@ exports[`Service Config component renders with one service selected 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -2001,6 +2006,7 @@ exports[`Service Config component renders with one service selected 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {
@@ -2081,6 +2087,7 @@ exports[`Service Config component renders with one service selected 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {
@@ -2161,6 +2168,7 @@ exports[`Service Config component renders with one service selected 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     textProps={
                                       Object {

--- a/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
@@ -367,6 +367,7 @@ exports[`Trace Config component renders empty trace config 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {
@@ -1304,6 +1305,7 @@ exports[`Trace Config component renders with one trace selected 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {

--- a/public/components/common/live_tail/__tests__/__snapshots__/live_tail_button.test.tsx.snap
+++ b/public/components/common/live_tail/__tests__/__snapshots__/live_tail_button.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`Live tail button change live tail to 10s interval 1`] = `
         >
           <EuiButtonContent
             className="euiButton__content"
+            iconGap="m"
             iconSide="left"
             iconType="stop"
             textProps={
@@ -150,6 +151,7 @@ exports[`Live tail button starts live tail with 5s interval 1`] = `
         >
           <EuiButtonContent
             className="euiButton__content"
+            iconGap="m"
             iconSide="left"
             iconType="stop"
             textProps={
@@ -249,6 +251,7 @@ exports[`Live tail off button stop live tail 1`] = `
         >
           <EuiButtonContent
             className="euiButton__content"
+            iconGap="m"
             iconSide="left"
             iconType="stop"
             textProps={

--- a/public/components/common/search/__tests__/__snapshots__/search.test.tsx.snap
+++ b/public/components/common/search/__tests__/__snapshots__/search.test.tsx.snap
@@ -111,6 +111,7 @@ exports[`Explorer Search component renders basic component 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButton__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconType="arrowDown"
                                       textProps={
@@ -645,6 +646,7 @@ exports[`Explorer Search component renders basic component 1`] = `
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButtonEmpty__content"
+                                                    iconGap="m"
                                                     iconSide="right"
                                                     iconSize="s"
                                                     iconType="arrowDown"
@@ -840,6 +842,7 @@ exports[`Explorer Search component renders basic component 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButton__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     iconType="play"
                                     textProps={
@@ -963,6 +966,7 @@ exports[`Explorer Search component renders basic component 1`] = `
                                     >
                                       <EuiButtonContent
                                         className="euiButton__content"
+                                        iconGap="m"
                                         iconSide="left"
                                         iconType="clock"
                                         textProps={

--- a/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
+++ b/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
@@ -1440,6 +1440,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                     >
                                       <EuiButtonContent
                                         className="euiButton__content"
+                                        iconGap="m"
                                         iconSide="left"
                                         iconType="pencil"
                                         textProps={
@@ -1569,6 +1570,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                           >
                                             <EuiButtonContent
                                               className="euiButton__content"
+                                              iconGap="m"
                                               iconSide="right"
                                               iconType="arrowDown"
                                               textProps={
@@ -1706,6 +1708,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                             >
                                               <EuiButtonContent
                                                 className="euiButton__content"
+                                                iconGap="m"
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 textProps={
@@ -2276,6 +2279,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                                   >
                                                     <EuiButtonContent
                                                       className="euiButtonEmpty__content"
+                                                      iconGap="m"
                                                       iconSide="right"
                                                       iconSize="s"
                                                       iconType="arrowDown"
@@ -2479,6 +2483,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   iconType="refresh"
                                                   isLoading={false}
@@ -2706,6 +2711,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                                             >
                                               <EuiButtonContent
                                                 className="euiButton__content"
+                                                iconGap="m"
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 textProps={
@@ -3794,6 +3800,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                     >
                                       <EuiButtonContent
                                         className="euiButton__content"
+                                        iconGap="m"
                                         iconSide="left"
                                         iconType="pencil"
                                         textProps={
@@ -3923,6 +3930,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                           >
                                             <EuiButtonContent
                                               className="euiButton__content"
+                                              iconGap="m"
                                               iconSide="right"
                                               iconType="arrowDown"
                                               textProps={
@@ -4059,6 +4067,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                             >
                                               <EuiButtonContent
                                                 className="euiButton__content"
+                                                iconGap="m"
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 textProps={
@@ -4628,6 +4637,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                                   >
                                                     <EuiButtonContent
                                                       className="euiButtonEmpty__content"
+                                                      iconGap="m"
                                                       iconSide="right"
                                                       iconSize="s"
                                                       iconType="arrowDown"
@@ -4829,6 +4839,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   iconType="refresh"
                                                   isLoading={false}
@@ -5056,6 +5067,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                                             >
                                               <EuiButtonContent
                                                 className="euiButton__content"
+                                                iconGap="m"
                                                 iconSide="right"
                                                 iconType="arrowDown"
                                                 textProps={

--- a/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`Empty panel view component renders empty panel view with disabled popov
                           >
                             <EuiButtonContent
                               className="euiButton__content"
+                              iconGap="m"
                               iconSide="right"
                               iconType="arrowDown"
                               textProps={
@@ -375,6 +376,7 @@ exports[`Empty panel view component renders empty panel view with enabled popove
                           >
                             <EuiButtonContent
                               className="euiButton__content"
+                              iconGap="m"
                               iconSide="right"
                               iconType="arrowDown"
                               textProps={

--- a/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
@@ -1127,6 +1127,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   textProps={
                                                     Object {
@@ -1192,6 +1193,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   textProps={
                                                     Object {
@@ -2446,6 +2448,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   textProps={
                                                     Object {
@@ -2511,6 +2514,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                               >
                                                 <EuiButtonContent
                                                   className="euiButton__content"
+                                                  iconGap="m"
                                                   iconSide="left"
                                                   textProps={
                                                     Object {

--- a/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout_so.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout_so.test.tsx.snap
@@ -1138,6 +1138,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButton__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     textProps={
                                                       Object {
@@ -1203,6 +1204,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButton__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     textProps={
                                                       Object {
@@ -2452,6 +2454,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButton__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     textProps={
                                                       Object {
@@ -2517,6 +2520,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButton__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     textProps={
                                                       Object {

--- a/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
@@ -264,6 +264,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             iconType="refresh"
                             isLoading={false}
@@ -363,6 +364,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             textProps={
                               Object {
@@ -1275,6 +1277,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButtonEmpty__content"
+                                                    iconGap="m"
                                                     iconSide="right"
                                                     iconSize="m"
                                                     iconType="arrowDown"
@@ -1632,6 +1635,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                   >
                                                     <EuiButtonContent
                                                       className="euiButtonEmpty__content"
+                                                      iconGap="m"
                                                       iconSide="right"
                                                       iconSize="s"
                                                       iconType="arrowDown"
@@ -4574,6 +4578,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                               >
                                                 <EuiButtonContent
                                                   className="euiButtonEmpty__content"
+                                                  iconGap="m"
                                                   iconSide="right"
                                                   iconSize="s"
                                                   iconType="arrowDown"
@@ -4777,6 +4782,7 @@ exports[`AssociatedObjectsTab Component renders correctly with associated object
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButtonEmpty__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             iconSize="m"
                                                             textProps={
@@ -5158,6 +5164,7 @@ exports[`AssociatedObjectsTab Component renders tab with no databases or objects
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             iconType="refresh"
                             isLoading={false}
@@ -5257,6 +5264,7 @@ exports[`AssociatedObjectsTab Component renders tab with no databases or objects
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             textProps={
                               Object {
@@ -5386,6 +5394,7 @@ exports[`AssociatedObjectsTab Component renders tab with no databases or objects
                   >
                     <EuiButtonContent
                       className="euiButton__content"
+                      iconGap="m"
                       iconSide="right"
                       iconType="popout"
                       textProps={

--- a/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
@@ -140,6 +140,7 @@ exports[`Installed Integrations Table test Renders the empty installed integrati
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             textProps={
                               Object {
@@ -368,6 +369,7 @@ exports[`Installed Integrations Table test Renders the installed integrations ta
                       >
                         <EuiButtonContent
                           className="euiButton__content"
+                          iconGap="m"
                           iconSide="left"
                           textProps={
                             Object {

--- a/public/components/datasources/components/__tests__/__snapshots__/manage_data_connections_description.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/manage_data_connections_description.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`Manage Data Connections Description test Renders manage data connection
                   >
                     <EuiButtonContent
                       className="euiButton__content"
+                      iconGap="m"
                       iconSide="left"
                       iconType="refresh"
                       textProps={

--- a/public/components/datasources/components/__tests__/__snapshots__/no_access.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/no_access.test.tsx.snap
@@ -146,6 +146,7 @@ exports[`No access test Renders no access view of data source 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {

--- a/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_header.test.tsx.snap
+++ b/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_header.test.tsx.snap
@@ -689,6 +689,7 @@ exports[`Patterns header component Renders header of log patterns 1`] = `
                                                     >
                                                       <EuiButtonContent
                                                         className="euiButtonEmpty__content"
+                                                        iconGap="m"
                                                         iconSide="left"
                                                         iconSize="m"
                                                         textProps={
@@ -745,6 +746,7 @@ exports[`Patterns header component Renders header of log patterns 1`] = `
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {

--- a/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_table.test.tsx.snap
+++ b/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_table.test.tsx.snap
@@ -331,6 +331,7 @@ exports[`Pattern table component Renders pattern table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -1001,6 +1002,7 @@ exports[`Pattern table component Renders pattern table 1`] = `
                               >
                                 <EuiButtonContent
                                   className="euiButtonEmpty__content"
+                                  iconGap="m"
                                   iconSide="right"
                                   iconSize="s"
                                   iconType="arrowDown"
@@ -1204,6 +1206,7 @@ exports[`Pattern table component Renders pattern table 1`] = `
                                         >
                                           <EuiButtonContent
                                             className="euiButtonEmpty__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconSize="m"
                                             textProps={

--- a/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/__snapshots__/config_panel.test.tsx.snap
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/__snapshots__/config_panel.test.tsx.snap
@@ -9270,6 +9270,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButton__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             textProps={
                                                               Object {
@@ -9350,6 +9351,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButton__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             textProps={
                                                               Object {
@@ -9563,6 +9565,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButton__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             textProps={
                                                               Object {
@@ -9643,6 +9646,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButton__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             textProps={
                                                               Object {
@@ -9723,6 +9727,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                         >
                                                           <EuiButtonContent
                                                             className="euiButton__content"
+                                                            iconGap="m"
                                                             iconSide="left"
                                                             textProps={
                                                               Object {
@@ -10748,6 +10753,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -10828,6 +10834,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -11022,6 +11029,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -11102,6 +11110,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -12262,6 +12271,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -12342,6 +12352,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                                       >
                                                         <EuiButtonContent
                                                           className="euiButton__content"
+                                                          iconGap="m"
                                                           iconSide="left"
                                                           textProps={
                                                             Object {
@@ -15242,6 +15253,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                             >
                                               <EuiButtonContent
                                                 className="euiButton__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 textProps={
                                                   Object {

--- a/public/components/event_analytics/home/__tests__/__snapshots__/saved_query_table.test.tsx.snap
+++ b/public/components/event_analytics/home/__tests__/__snapshots__/saved_query_table.test.tsx.snap
@@ -496,6 +496,7 @@ exports[`Saved query table component Renders saved query table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="m"
                                       iconType="arrowDown"
@@ -1467,6 +1468,7 @@ exports[`Saved query table component Renders saved query table 1`] = `
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
                                     iconSize="s"
                                     iconType="arrowDown"
@@ -1670,6 +1672,7 @@ exports[`Saved query table component Renders saved query table 1`] = `
                                           >
                                             <EuiButtonContent
                                               className="euiButtonEmpty__content"
+                                              iconGap="m"
                                               iconSide="left"
                                               iconSize="m"
                                               textProps={

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -824,6 +824,7 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                                               >
                                                 <EuiButtonContent
                                                   className="euiButtonEmpty__content"
+                                                  iconGap="m"
                                                   iconSide="right"
                                                   iconSize="m"
                                                   iconType="arrowDown"

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration_flyout.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration_flyout.test.tsx.snap
@@ -1792,6 +1792,7 @@ exports[`Add Integration Flyout Test Renders add integration flyout with dummy i
                                                           >
                                                             <EuiButtonContent
                                                               className="euiButton__content"
+                                                              iconGap="m"
                                                               iconSide="left"
                                                               textProps={
                                                                 Object {
@@ -1986,6 +1987,7 @@ exports[`Add Integration Flyout Test Renders add integration flyout with dummy i
                                           >
                                             <EuiButtonContent
                                               className="euiButton__content"
+                                              iconGap="m"
                                               iconSide="left"
                                               textProps={
                                                 Object {
@@ -2055,6 +2057,7 @@ exports[`Add Integration Flyout Test Renders add integration flyout with dummy i
                                           >
                                             <EuiButtonContent
                                               className="euiButton__content"
+                                              iconGap="m"
                                               iconSide="left"
                                               textProps={
                                                 Object {

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration_table.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration_table.test.tsx.snap
@@ -477,6 +477,7 @@ exports[`Added Integration Table View Test Renders added integration table view 
                                         >
                                           <EuiButtonContent
                                             className="euiButtonEmpty__content"
+                                            iconGap="m"
                                             iconSide="right"
                                             iconSize="m"
                                             iconType="arrowDown"
@@ -1189,6 +1190,7 @@ exports[`Added Integration Table View Test Renders added integration table view 
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -1392,6 +1394,7 @@ exports[`Added Integration Table View Test Renders added integration table view 
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButtonEmpty__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     iconSize="m"
                                                     textProps={

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
@@ -257,6 +257,7 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             iconType="list"
                             textProps={
@@ -379,6 +380,7 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             iconType="grid"
                             textProps={

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
@@ -457,6 +457,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                         >
                                           <EuiButtonContent
                                             className="euiButton__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconType="list"
                                             textProps={
@@ -579,6 +580,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                         >
                                           <EuiButtonContent
                                             className="euiButton__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconType="grid"
                                             textProps={
@@ -1222,6 +1224,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -1425,6 +1428,7 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                                                 >
                                                   <EuiButtonContent
                                                     className="euiButtonEmpty__content"
+                                                    iconGap="m"
                                                     iconSide="left"
                                                     iconSize="m"
                                                     textProps={

--- a/public/components/integrations/components/__tests__/__snapshots__/integration_header.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/integration_header.test.tsx.snap
@@ -94,6 +94,7 @@ exports[`Integration Header Test Renders integration header as expected 1`] = `
                           >
                             <EuiButtonContent
                               className="euiButton__content"
+                              iconGap="m"
                               iconSide="left"
                               iconType="arrowDown"
                               textProps={

--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -982,6 +982,7 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                                     >
                                       <EuiButtonContent
                                         className="euiButtonEmpty__content"
+                                        iconGap="m"
                                         iconSide="left"
                                         iconSize="m"
                                         iconType="cross"
@@ -1089,6 +1090,7 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                                       >
                                         <EuiButtonContent
                                           className="euiButton__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconType="arrowRight"
                                           isLoading={false}

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`Export Metrics Panel Component renders Export Metrics Panel Component 1
                     >
                       <EuiButtonContent
                         className="euiButton__content"
+                        iconGap="m"
                         iconSide="right"
                         iconType="arrowDown"
                         textProps={

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/top_menu.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/top_menu.test.tsx.snap
@@ -645,6 +645,7 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="right"
                                                 iconSize="s"
                                                 iconType="arrowDown"
@@ -846,6 +847,7 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                                         >
                                           <EuiButtonContent
                                             className="euiButton__content"
+                                            iconGap="m"
                                             iconSide="left"
                                             iconType="refresh"
                                             isLoading={false}
@@ -980,6 +982,7 @@ exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] 
                                       >
                                         <EuiButtonContent
                                           className="euiButton__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconType="arrowDown"
                                           textProps={

--- a/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -255,6 +255,7 @@ exports[`Search bar components renders date picker 1`] = `
                         >
                           <EuiButtonContent
                             className="euiButtonEmpty__content"
+                            iconGap="m"
                             iconSide="right"
                             iconSize="s"
                             iconType="arrowDown"
@@ -399,10 +400,11 @@ exports[`Search bar components renders search bar 1`] = `
   startTime="now-5m"
 >
   <EuiFlexGroup
+    alignItems="center"
     gutterSize="s"
   >
     <div
-      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <EuiFlexItem>
         <div
@@ -418,6 +420,12 @@ exports[`Search bar components renders search bar 1`] = `
             onChange={[Function]}
             onSearch={[MockFunction]}
             placeholder="Trace ID, trace group name, service name"
+            prepend={
+              <GlobalFilterButton
+                filters={Array []}
+                setFilters={[MockFunction]}
+              />
+            }
             value="test"
           >
             <EuiFormControlLayout
@@ -425,16 +433,112 @@ exports[`Search bar components renders search bar 1`] = `
               fullWidth={true}
               icon="search"
               isLoading={false}
+              prepend={
+                <GlobalFilterButton
+                  filters={Array []}
+                  setFilters={[MockFunction]}
+                />
+              }
             >
               <div
-                className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
               >
+                <GlobalFilterButton
+                  className="euiFormControlLayout__prepend"
+                  filters={Array []}
+                  key="0/.0"
+                  setFilters={[MockFunction]}
+                >
+                  <EuiPopover
+                    anchorPosition="rightUp"
+                    button={
+                      <EuiSmallButtonIcon
+                        aria-label="Change all filters"
+                        iconType="filter"
+                        onClick={[Function]}
+                        title="Change all filters"
+                      />
+                    }
+                    closePopover={[Function]}
+                    data-test-subj="global-filter-button"
+                    display="inlineBlock"
+                    hasArrow={true}
+                    isOpen={false}
+                    ownFocus={true}
+                    panelPaddingSize="none"
+                  >
+                    <div
+                      className="euiPopover euiPopover--anchorRightUp"
+                      data-test-subj="global-filter-button"
+                    >
+                      <div
+                        className="euiPopover__anchor"
+                      >
+                        <EuiSmallButtonIcon
+                          aria-label="Change all filters"
+                          iconType="filter"
+                          onClick={[Function]}
+                          title="Change all filters"
+                        >
+                          <EuiButtonIcon
+                            aria-label="Change all filters"
+                            iconType="filter"
+                            onClick={[Function]}
+                            size="s"
+                            title="Change all filters"
+                          >
+                            <button
+                              aria-label="Change all filters"
+                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                              disabled={false}
+                              onClick={[Function]}
+                              title="Change all filters"
+                              type="button"
+                            >
+                              <EuiIcon
+                                aria-hidden="true"
+                                className="euiButtonIcon__icon"
+                                color="inherit"
+                                size="m"
+                                type="filter"
+                              >
+                                <EuiIconBeaker
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  role="img"
+                                  style={null}
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                    focusable="false"
+                                    height={16}
+                                    role="img"
+                                    style={null}
+                                    viewBox="0 0 16 16"
+                                    width={16}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
+                                </EuiIconBeaker>
+                              </EuiIcon>
+                            </button>
+                          </EuiButtonIcon>
+                        </EuiSmallButtonIcon>
+                      </div>
+                    </div>
+                  </EuiPopover>
+                </GlobalFilterButton>
                 <div
                   className="euiFormControlLayout__childrenWrapper"
                 >
                   <EuiValidatableControl>
                     <input
-                      className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
+                      className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
                       data-test-subj="search-bar-input-box"
                       onChange={[Function]}
                       onKeyUp={[Function]}
@@ -502,7 +606,7 @@ exports[`Search bar components renders search bar 1`] = `
         grow={false}
         style={
           Object {
-            "maxWidth": "40vw",
+            "maxWidth": "30vw",
           }
         }
       >
@@ -510,7 +614,7 @@ exports[`Search bar components renders search bar 1`] = `
           className="euiFlexItem euiFlexItem--flexGrowZero"
           style={
             Object {
-              "maxWidth": "40vw",
+              "maxWidth": "30vw",
             }
           }
         >
@@ -559,8 +663,8 @@ exports[`Search bar components renders search bar 1`] = `
                 },
               ]
             }
-            compressed={false}
-            dateFormat=""
+            compressed={true}
+            dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
             end="now"
             isAutoRefreshOnly={false}
             isDisabled={false}
@@ -586,7 +690,7 @@ exports[`Search bar components renders search bar 1`] = `
                   >
                     <EuiFormControlLayout
                       className="euiSuperDatePicker"
-                      compressed={false}
+                      compressed={true}
                       isDisabled={false}
                       prepend={
                         <EuiQuickSelectPopover
@@ -635,7 +739,7 @@ exports[`Search bar components renders search bar 1`] = `
                               },
                             ]
                           }
-                          dateFormat=""
+                          dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
                           end="now"
                           isAutoRefreshOnly={false}
                           isDisabled={false}
@@ -647,7 +751,7 @@ exports[`Search bar components renders search bar 1`] = `
                       }
                     >
                       <div
-                        className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                        className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
                       >
                         <EuiQuickSelectPopover
                           applyTime={[Function]}
@@ -696,7 +800,7 @@ exports[`Search bar components renders search bar 1`] = `
                               },
                             ]
                           }
-                          dateFormat=""
+                          dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
                           end="now"
                           isAutoRefreshOnly={false}
                           isDisabled={false}
@@ -768,6 +872,7 @@ exports[`Search bar components renders search bar 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -865,7 +970,7 @@ exports[`Search bar components renders search bar 1`] = `
                               className="euiDatePickerRange euiDatePickerRange--inGroup"
                             >
                               <button
-                                className="euiSuperDatePicker__prettyFormat"
+                                className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
                                 data-test-subj="superDatePickerShowDatesButton"
                                 disabled={false}
                                 onClick={[Function]}
@@ -885,7 +990,7 @@ exports[`Search bar components renders search bar 1`] = `
                             </div>
                           </EuiDatePickerRange>
                           <EuiFormControlLayoutIcons
-                            compressed={false}
+                            compressed={true}
                           />
                         </div>
                       </div>
@@ -903,304 +1008,60 @@ exports[`Search bar components renders search bar 1`] = `
         <div
           className="euiFlexItem euiFlexItem--flexGrowZero"
         >
-          <EuiSmallButton
+          <EuiButtonIcon
+            aria-label="Refresh"
             data-click-metric-element="trace_analytics.refresh_button"
             data-test-subj="superDatePickerApplyTimeButton"
+            display="base"
             iconType="refresh"
             onClick={[Function]}
+            size="s"
           >
-            <EuiButton
+            <button
+              aria-label="Refresh"
+              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
               data-click-metric-element="trace_analytics.refresh_button"
               data-test-subj="superDatePickerApplyTimeButton"
-              iconType="refresh"
+              disabled={false}
               onClick={[Function]}
-              size="s"
+              type="button"
             >
-              <EuiButtonDisplay
-                baseClassName="euiButton"
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                disabled={false}
-                element="button"
-                iconType="refresh"
-                isDisabled={false}
-                onClick={[Function]}
-                size="s"
-                type="button"
+              <EuiIcon
+                aria-hidden="true"
+                className="euiButtonIcon__icon"
+                color="inherit"
+                size="m"
+                type="refresh"
               >
-                <button
-                  className="euiButton euiButton--primary euiButton--small"
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  disabled={false}
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "minWidth": undefined,
-                    }
-                  }
-                  type="button"
+                <EuiIconBeaker
+                  aria-hidden={true}
+                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                  focusable="false"
+                  role="img"
+                  style={null}
                 >
-                  <EuiButtonContent
-                    className="euiButton__content"
-                    iconSide="left"
-                    iconType="refresh"
-                    textProps={
-                      Object {
-                        "className": "euiButton__text",
-                      }
-                    }
+                  <svg
+                    aria-hidden={true}
+                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                    focusable="false"
+                    height={16}
+                    role="img"
+                    style={null}
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <span
-                      className="euiButtonContent euiButton__content"
-                    >
-                      <EuiIcon
-                        className="euiButtonContent__icon"
-                        color="inherit"
-                        size="m"
-                        type="refresh"
-                      >
-                        <EuiIconBeaker
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                          focusable="false"
-                          role="img"
-                          style={null}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                            focusable="false"
-                            height={16}
-                            role="img"
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                            />
-                          </svg>
-                        </EuiIconBeaker>
-                      </EuiIcon>
-                      <span
-                        className="euiButton__text"
-                      >
-                        Refresh
-                      </span>
-                    </span>
-                  </EuiButtonContent>
-                </button>
-              </EuiButtonDisplay>
-            </EuiButton>
-          </EuiSmallButton>
+                    <path
+                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                    />
+                  </svg>
+                </EuiIconBeaker>
+              </EuiIcon>
+            </button>
+          </EuiButtonIcon>
         </div>
       </EuiFlexItem>
     </div>
   </EuiFlexGroup>
-  <EuiSpacer
-    size="s"
-  >
-    <div
-      className="euiSpacer euiSpacer--s"
-    />
-  </EuiSpacer>
-  <Filters
-    appConfigs={Array []}
-    attributesFilterFields={Array []}
-    filters={Array []}
-    mode="data_prepper"
-    page="dashboard"
-    setFilters={[MockFunction]}
-  >
-    <EuiFlexGroup
-      alignItems="center"
-      gutterSize="xs"
-      responsive={false}
-      style={
-        Object {
-          "minHeight": 32,
-        }
-      }
-    >
-      <div
-        className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-        style={
-          Object {
-            "minHeight": 32,
-          }
-        }
-      >
-        <EuiFlexItem
-          grow={false}
-        >
-          <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <GlobalFilterButton>
-              <EuiPopover
-                anchorPosition="rightUp"
-                button={
-                  <EuiSmallButtonIcon
-                    aria-label="Change all filters"
-                    iconType="filter"
-                    onClick={[Function]}
-                    title="Change all filters"
-                  />
-                }
-                closePopover={[Function]}
-                data-test-subj="global-filter-button"
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="none"
-                withTitle={true}
-              >
-                <div
-                  className="euiPopover euiPopover--anchorRightUp"
-                  data-test-subj="global-filter-button"
-                  withTitle={true}
-                >
-                  <div
-                    className="euiPopover__anchor"
-                  >
-                    <EuiSmallButtonIcon
-                      aria-label="Change all filters"
-                      iconType="filter"
-                      onClick={[Function]}
-                      title="Change all filters"
-                    >
-                      <EuiButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        size="s"
-                        title="Change all filters"
-                      >
-                        <button
-                          aria-label="Change all filters"
-                          className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                          disabled={false}
-                          onClick={[Function]}
-                          title="Change all filters"
-                          type="button"
-                        >
-                          <EuiIcon
-                            aria-hidden="true"
-                            className="euiButtonIcon__icon"
-                            color="inherit"
-                            size="m"
-                            type="filter"
-                          >
-                            <EuiIconBeaker
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                />
-                              </svg>
-                            </EuiIconBeaker>
-                          </EuiIcon>
-                        </button>
-                      </EuiButtonIcon>
-                    </EuiSmallButtonIcon>
-                  </div>
-                </div>
-              </EuiPopover>
-            </GlobalFilterButton>
-          </div>
-        </EuiFlexItem>
-        <EuiFlexItem
-          grow={false}
-        >
-          <div
-            className="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <AddFilterButton>
-              <EuiPopover
-                anchorPosition="downLeft"
-                button={
-                  <EuiButtonEmpty
-                    onClick={[Function]}
-                    size="xs"
-                  >
-                    + Add filter
-                  </EuiButtonEmpty>
-                }
-                closePopover={[Function]}
-                data-test-subj="addfilter"
-                display="inlineBlock"
-                hasArrow={true}
-                isOpen={false}
-                ownFocus={true}
-                panelPaddingSize="m"
-                withTitle={true}
-              >
-                <div
-                  className="euiPopover euiPopover--anchorDownLeft"
-                  data-test-subj="addfilter"
-                  withTitle={true}
-                >
-                  <div
-                    className="euiPopover__anchor"
-                  >
-                    <EuiButtonEmpty
-                      onClick={[Function]}
-                      size="xs"
-                    >
-                      <button
-                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                        disabled={false}
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <EuiButtonContent
-                          className="euiButtonEmpty__content"
-                          iconSide="left"
-                          iconSize="s"
-                          textProps={
-                            Object {
-                              "className": "euiButtonEmpty__text",
-                            }
-                          }
-                        >
-                          <span
-                            className="euiButtonContent euiButtonEmpty__content"
-                          >
-                            <span
-                              className="euiButtonEmpty__text"
-                            >
-                              + Add filter
-                            </span>
-                          </span>
-                        </EuiButtonContent>
-                      </button>
-                    </EuiButtonEmpty>
-                  </div>
-                </div>
-              </EuiPopover>
-            </AddFilterButton>
-          </div>
-        </EuiFlexItem>
-      </div>
-    </EuiFlexGroup>
-  </Filters>
 </ForwardRef>
 `;

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
@@ -637,6 +637,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButtonEmpty__content"
+                    iconGap="m"
                     iconSide="left"
                     iconSize="m"
                     textProps={
@@ -700,6 +701,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                   >
                     <EuiButtonContent
                       className="euiButton__content"
+                      iconGap="m"
                       iconSide="left"
                       textProps={
                         Object {

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
@@ -11,115 +11,10 @@ exports[`Filter component renders filters 1`] = `
     alignItems="center"
     gutterSize="xs"
     responsive={false}
-    style={
-      Object {
-        "minHeight": 32,
-      }
-    }
   >
     <div
       className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-      style={
-        Object {
-          "minHeight": 32,
-        }
-      }
     >
-      <EuiFlexItem
-        grow={false}
-      >
-        <div
-          className="euiFlexItem euiFlexItem--flexGrowZero"
-        >
-          <GlobalFilterButton>
-            <EuiPopover
-              anchorPosition="rightUp"
-              button={
-                <EuiSmallButtonIcon
-                  aria-label="Change all filters"
-                  iconType="filter"
-                  onClick={[Function]}
-                  title="Change all filters"
-                />
-              }
-              closePopover={[Function]}
-              data-test-subj="global-filter-button"
-              display="inlineBlock"
-              hasArrow={true}
-              isOpen={false}
-              ownFocus={true}
-              panelPaddingSize="none"
-              withTitle={true}
-            >
-              <div
-                className="euiPopover euiPopover--anchorRightUp"
-                data-test-subj="global-filter-button"
-                withTitle={true}
-              >
-                <div
-                  className="euiPopover__anchor"
-                >
-                  <EuiSmallButtonIcon
-                    aria-label="Change all filters"
-                    iconType="filter"
-                    onClick={[Function]}
-                    title="Change all filters"
-                  >
-                    <EuiButtonIcon
-                      aria-label="Change all filters"
-                      iconType="filter"
-                      onClick={[Function]}
-                      size="s"
-                      title="Change all filters"
-                    >
-                      <button
-                        aria-label="Change all filters"
-                        className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                        disabled={false}
-                        onClick={[Function]}
-                        title="Change all filters"
-                        type="button"
-                      >
-                        <EuiIcon
-                          aria-hidden="true"
-                          className="euiButtonIcon__icon"
-                          color="inherit"
-                          size="m"
-                          type="filter"
-                        >
-                          <EuiIconBeaker
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                              />
-                            </svg>
-                          </EuiIconBeaker>
-                        </EuiIcon>
-                      </button>
-                    </EuiButtonIcon>
-                  </EuiSmallButtonIcon>
-                </div>
-              </div>
-            </EuiPopover>
-          </GlobalFilterButton>
-        </div>
-      </EuiFlexItem>
       <EuiFlexItem
         grow={false}
       >
@@ -131,6 +26,7 @@ exports[`Filter component renders filters 1`] = `
               anchorPosition="downLeft"
               button={
                 <EuiButtonEmpty
+                  flush="left"
                   onClick={[Function]}
                   size="xs"
                 >
@@ -144,28 +40,28 @@ exports[`Filter component renders filters 1`] = `
               isOpen={false}
               ownFocus={true}
               panelPaddingSize="m"
-              withTitle={true}
             >
               <div
                 className="euiPopover euiPopover--anchorDownLeft"
                 data-test-subj="addfilter"
-                withTitle={true}
               >
                 <div
                   className="euiPopover__anchor"
                 >
                   <EuiButtonEmpty
+                    flush="left"
                     onClick={[Function]}
                     size="xs"
                   >
                     <button
-                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
                       disabled={false}
                       onClick={[Function]}
                       type="button"
                     >
                       <EuiButtonContent
                         className="euiButtonEmpty__content"
+                        iconGap="m"
                         iconSide="left"
                         iconSize="s"
                         textProps={

--- a/public/components/trace_analytics/components/common/filters/filters.tsx
+++ b/public/components/trace_analytics/components/common/filters/filters.tsx
@@ -65,75 +65,6 @@ export function Filters(props: FiltersOwnProps) {
     [props.page, props.mode, props.attributesFilterFields]
   );
 
-  const globalPopoverPanels = [
-    {
-      id: 0,
-      title: 'Change all filters',
-      items: [
-        {
-          name: 'Enable all',
-          icon: <EuiIcon type="eye" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              props.filters.map((filter) => ({
-                ...filter,
-                disabled: filter.locked ? filter.disabled : false,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Disable all',
-          icon: <EuiIcon type="eyeClosed" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              props.filters.map((filter) => ({
-                ...filter,
-                disabled: filter.locked ? filter.disabled : true,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Invert inclusion',
-          icon: <EuiIcon type="invert" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              // if filter.custom.query exists, it's a customized filter and "inverted" is alwasy false
-              props.filters.map((filter) => ({
-                ...filter,
-                inverted: filter.locked
-                  ? filter.inverted
-                  : filter.custom?.query
-                  ? false
-                  : !filter.inverted,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Invert enabled/disabled',
-          icon: <EuiIcon type="eye" size="m" />,
-          onClick: () => {
-            props.setFilters(
-              props.filters.map((filter) => ({
-                ...filter,
-                disabled: filter.locked ? filter.disabled : !filter.disabled,
-              }))
-            );
-          },
-        },
-        {
-          name: 'Remove all',
-          icon: <EuiIcon type="trash" size="m" />,
-          onClick: () => {
-            props.setFilters([]);
-          },
-        },
-      ],
-    },
-  ];
-
   const getFilterPopoverPanels = (
     filter: FilterType,
     index: number,
@@ -191,35 +122,12 @@ export function Filters(props: FiltersOwnProps) {
     },
   ];
 
-  const GlobalFilterButton = () => {
-    const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-    return (
-      <EuiPopover
-        isOpen={isPopoverOpen}
-        closePopover={() => setIsPopoverOpen(false)}
-        button={
-          <EuiSmallButtonIcon
-            onClick={() => setIsPopoverOpen(true)}
-            iconType="filter"
-            title="Change all filters"
-            aria-label="Change all filters"
-          />
-        }
-        anchorPosition="rightUp"
-        panelPaddingSize="none"
-        withTitle
-        data-test-subj="global-filter-button"
-      >
-        <EuiContextMenu initialPanelId={0} panels={globalPopoverPanels} size="s" />
-      </EuiPopover>
-    );
-  };
-
   const AddFilterButton = () => {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
     const button = (
       <EuiButtonEmpty
         size="xs"
+        flush="left"
         onClick={() => {
           setIsPopoverOpen(true);
         }}
@@ -235,7 +143,6 @@ export function Filters(props: FiltersOwnProps) {
         closePopover={() => setIsPopoverOpen(false)}
         anchorPosition="downLeft"
         data-test-subj="addfilter"
-        withTitle
       >
         <EuiPopoverTitle>{'Add filter'}</EuiPopoverTitle>
         <FilterEditPopover
@@ -318,10 +225,7 @@ export function Filters(props: FiltersOwnProps) {
   const filterComponents = useMemo(() => renderFilters(), [props.filters]);
 
   return (
-    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} style={{ minHeight: 32 }}>
-      <EuiFlexItem grow={false}>
-        <GlobalFilterButton />
-      </EuiFlexItem>
+    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
       {filterComponents}
       <EuiFlexItem grow={false}>
         <AddFilterButton />
@@ -329,3 +233,104 @@ export function Filters(props: FiltersOwnProps) {
     </EuiFlexGroup>
   );
 }
+
+export const GlobalFilterButton = ({ filters, setFilters }) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const togglePopover = () => {
+    setIsPopoverOpen(!isPopoverOpen);
+  };
+
+  const globalPopoverPanels = [
+    {
+      id: 0,
+      title: 'Change all filters',
+      items: [
+        {
+          name: 'Enable all',
+          icon: <EuiIcon type="eye" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                disabled: filter.locked ? filter.disabled : false,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Disable all',
+          icon: <EuiIcon type="eyeClosed" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                disabled: filter.locked ? filter.disabled : true,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Invert inclusion',
+          icon: <EuiIcon type="invert" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                inverted: filter.locked
+                  ? filter.inverted
+                  : filter.custom?.query
+                  ? false
+                  : !filter.inverted,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Invert enabled/disabled',
+          icon: <EuiIcon type="eye" size="m" />,
+          onClick: () => {
+            setFilters(
+              filters.map((filter) => ({
+                ...filter,
+                disabled: filter.locked ? filter.disabled : !filter.disabled,
+              }))
+            );
+            togglePopover();
+          },
+        },
+        {
+          name: 'Remove all',
+          icon: <EuiIcon type="trash" size="m" />,
+          onClick: () => {
+            setFilters([]);
+            togglePopover();
+          },
+        },
+      ],
+    },
+  ];
+
+  return (
+    <EuiPopover
+      isOpen={isPopoverOpen}
+      closePopover={() => setIsPopoverOpen(false)}
+      button={
+        <EuiSmallButtonIcon
+          onClick={togglePopover}
+          iconType="filter"
+          title="Change all filters"
+          aria-label="Change all filters"
+        />
+      }
+      anchorPosition="rightUp"
+      panelPaddingSize="none"
+      data-test-subj="global-filter-button"
+    >
+      <EuiContextMenu initialPanelId={0} panels={globalPopoverPanels} size="s" />
+    </EuiPopover>
+  );
+};

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -5,13 +5,13 @@
 
 import {
   EuiButtonGroup,
-  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
   EuiPanel,
   EuiSpacer,
   EuiText,
+  EuiCompressedFieldSearch,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 // @ts-ignore

--- a/public/components/trace_analytics/components/common/search_bar.tsx
+++ b/public/components/trace_analytics/components/common/search_bar.tsx
@@ -4,17 +4,18 @@
  */
 
 import {
-  EuiSmallButton,
-  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSpacer,
   EuiSuperDatePicker,
+  EuiButtonIcon,
+  EuiCompressedFieldSearch,
 } from '@elastic/eui';
 import debounce from 'lodash/debounce';
 import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import { i18n } from '@osd/i18n';
 import { uiSettingsService } from '../../../../../common/utils';
-import { Filters, FiltersProps } from './filters/filters';
+import { FiltersProps } from './filters/filters';
+import { GlobalFilterButton } from './filters/filters';
 
 export const renderDatePicker = (
   startTime: string,
@@ -69,13 +70,17 @@ export const SearchBar = forwardRef((props: SearchBarOwnProps, ref) => {
 
   return (
     <>
-      <EuiFlexGroup gutterSize="s">
+      <EuiFlexGroup gutterSize="s" alignItems="center">
         {!props.datepickerOnly && (
           <EuiFlexItem>
             <EuiCompressedFieldSearch
+              prepend={<GlobalFilterButton filters={props.filters} setFilters={props.setFilters} />}
+              compressed
               fullWidth
               isClearable={false}
-              placeholder="Trace ID, trace group name, service name"
+              placeholder={i18n.translate('traceAnalytics.searchBar.placeholder', {
+                defaultMessage: 'Trace ID, trace group name, service name',
+              })}
               data-test-subj="search-bar-input-box"
               value={query}
               onChange={(e) => {
@@ -86,34 +91,30 @@ export const SearchBar = forwardRef((props: SearchBarOwnProps, ref) => {
             />
           </EuiFlexItem>
         )}
-        <EuiFlexItem grow={false} style={{ maxWidth: '40vw' }}>
-          {renderDatePicker(props.startTime, props.setStartTime, props.endTime, props.setEndTime)}
+        <EuiFlexItem grow={false} style={{ maxWidth: '30vw' }}>
+          <EuiSuperDatePicker
+            compressed
+            start={props.startTime}
+            end={props.endTime}
+            onTimeChange={(e) => {
+              props.setStartTime(e.start);
+              props.setEndTime(e.end);
+            }}
+            showUpdateButton={false}
+          />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiSmallButton
+          <EuiButtonIcon
+            iconType="refresh"
+            aria-label="Refresh"
+            display="base"
+            onClick={() => props.refresh()}
+            size="s"
             data-test-subj="superDatePickerApplyTimeButton"
             data-click-metric-element="trace_analytics.refresh_button"
-            iconType="refresh"
-            onClick={() => props.refresh()}
-          >
-            Refresh
-          </EuiSmallButton>
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
-
-      {!props.datepickerOnly && (
-        <>
-          <EuiSpacer size="s" />
-          <Filters
-            page={props.page}
-            filters={props.filters}
-            setFilters={props.setFilters}
-            appConfigs={props.appConfigs}
-            mode={props.mode}
-            attributesFilterFields={props.attributesFilterFields}
-          />
-        </>
-      )}
     </>
   );
 });

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -327,6 +327,7 @@ exports[`Dashboard component renders dashboard 1`] = `
               >
                 <EuiButtonContent
                   className="euiButtonEmpty__content"
+                  iconGap="m"
                   iconSide="right"
                   iconSize="m"
                   iconType="arrowDown"
@@ -1572,6 +1573,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
               >
                 <EuiButtonContent
                   className="euiButtonEmpty__content"
+                  iconGap="m"
                   iconSide="right"
                   iconSize="m"
                   iconType="arrowDown"
@@ -2817,6 +2819,7 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
               >
                 <EuiButtonContent
                   className="euiButtonEmpty__content"
+                  iconGap="m"
                   iconSide="right"
                   iconSize="m"
                   iconType="arrowDown"
@@ -3292,6 +3295,7 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButton__content"
+                                iconGap="m"
                                 iconSide="left"
                                 textProps={
                                   Object {
@@ -3375,6 +3379,7 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButton__content"
+                                iconGap="m"
                                 iconSide="left"
                                 textProps={
                                   Object {

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
@@ -966,6 +966,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -2954,6 +2955,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -3157,6 +3159,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/mode_picker.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/mode_picker.test.tsx.snap
@@ -79,6 +79,7 @@ exports[`Mode picker component renders mode picker 1`] = `
             >
               <EuiButtonContent
                 className="euiButtonEmpty__content"
+                iconGap="m"
                 iconSide="right"
                 iconSize="m"
                 iconType="arrowDown"
@@ -216,6 +217,7 @@ exports[`Mode picker component renders mode picker 2`] = `
             >
               <EuiButtonContent
                 className="euiButtonEmpty__content"
+                iconGap="m"
                 iconSide="right"
                 iconSize="m"
                 iconType="arrowDown"

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_error_rates_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_error_rates_table.test.tsx.snap
@@ -791,6 +791,7 @@ exports[`Error Rates Table component renders top error rates table with data 1`]
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -1936,6 +1937,7 @@ exports[`Error Rates Table component renders top error rates table with data 1`]
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -2139,6 +2141,7 @@ exports[`Error Rates Table component renders top error rates table with data 1`]
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_latency_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_latency_table.test.tsx.snap
@@ -1150,6 +1150,7 @@ exports[`Latency Table component renders top error rates table with data 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -2920,6 +2921,7 @@ exports[`Latency Table component renders top error rates table with data 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -3123,6 +3125,7 @@ exports[`Latency Table component renders top error rates table with data 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -229,139 +229,6 @@ exports[`Services component renders empty services page 1`] = `
   startTime="now-5m"
   traceColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="data_prepper"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="data_prepper"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconBeaker
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                          />
-                        </svg>
-                      </EuiIconBeaker>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Data Prepper
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <ServicesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -590,463 +457,421 @@ exports[`Services component renders empty services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <ForwardRef
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      endTime="now"
-      filters={Array []}
-      mode="data_prepper"
-      page="services"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
+    <EuiPage
+      paddingSize="m"
     >
-      <EuiFlexGroup
-        gutterSize="s"
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
+        <EuiPageBody>
+          <div
+            className="euiPageBody euiPageBody--borderRadiusNone"
+          >
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="data_prepper"
                     >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
+                            iconSide="right"
+                            iconType="arrowDown"
+                            onClick={[Function]}
+                            title="data_prepper"
+                          >
+                            Data Prepper
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
                       >
                         <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                            className="euiPopover__anchor eui-textTruncate"
                           >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="data_prepper"
                             >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="data_prepper"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="data_prepper"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
+                                    iconSize="m"
                                     iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
                                     textProps={
                                       Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
+                                        "className": "euiButtonEmpty__text",
                                       }
                                     }
                                   >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Data Prepper
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="data_prepper"
+                      page="services"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
                                 }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
+                                value=""
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
                                 >
                                   <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
                                   >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
+                                    <GlobalFilterButton
                                       className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
                                         }
                                       }
                                     >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          <div
+                                            className="euiPopover__anchor"
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
                                             >
-                                              <EuiIconBeaker
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
                                               >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
                                                 >
-                                                  <path
-                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconBeaker>
-                                            </EuiIcon>
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconBeaker
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
                                             <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                              className="euiFormControlLayoutCustomIcon"
                                             >
                                               <EuiIcon
-                                                type="calendar"
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
                                               >
                                                 <EuiIconBeaker
                                                   aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                  className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                   focusable="false"
                                                   role="img"
                                                   style={null}
                                                 >
                                                   <svg
                                                     aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                     focusable="false"
                                                     height={16}
                                                     role="img"
@@ -1062,1066 +887,454 @@ exports[`Services component renders empty services page 1`] = `
                                                 </EuiIconBeaker>
                                               </EuiIcon>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
                             </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
-                  >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
+                              Object {
+                                "maxWidth": "30vw",
+                              }
+                            }
                           >
-                            <EuiIconBeaker
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                />
-                              </svg>
-                            </EuiIconBeaker>
-                          </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="services"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
-          }
-        }
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
-          style={
-            Object {
-              "minHeight": 32,
-            }
-          }
-        >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
-          >
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
-                          onClick={[Function]}
-                          size="xs"
-                        >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
                                 Object {
-                                  "className": "euiButtonEmpty__text",
+                                  "maxWidth": "30vw",
                                 }
                               }
                             >
-                              <span
-                                className="euiButtonContent euiButtonEmpty__content"
-                              >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
-                              </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <ServicesTable
-      addFilter={[Function]}
-      addServicesGroupFilter={[Function]}
-      dataPrepperIndicesExist={true}
-      isServiceTrendEnabled={false}
-      items={Array []}
-      loading={true}
-      mode="data_prepper"
-      selectedItems={Array []}
-      serviceTrends={Object {}}
-      setIsServiceTrendEnabled={[Function]}
-      setRedirect={[Function]}
-      setSelectedItems={[Function]}
-      traceColumnAction={[Function]}
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
-                          >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                            >
-                              <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                size="xs"
-                              >
-                                <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  type="button"
-                                >
-                                  <EuiButtonContent
-                                    className="euiButtonEmpty__content"
-                                    iconSide="left"
-                                    iconSize="s"
-                                    textProps={
-                                      Object {
-                                        "className": "euiButtonEmpty__text",
-                                      }
-                                    }
-                                  >
-                                    <span
-                                      className="euiButtonContent euiButtonEmpty__content"
-                                    >
-                                      <span
-                                        className="euiButtonEmpty__text"
-                                      >
-                                        Filter services
-                                      </span>
-                                    </span>
-                                  </EuiButtonContent>
-                                </button>
-                              </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
-                        </div>
-                      </EuiFlexItem>
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiButtonEmpty
-                            onClick={[Function]}
-                            size="xs"
-                          >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
                                 }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  <span
-                                    className="euiButtonEmpty__text"
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
                                   >
-                                    Show 24 hour trends
-                                  </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
-                        </div>
-                      </EuiFlexItem>
-                    </div>
-                  </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <EuiText
-                          size="s"
-                        >
-                          <div
-                            className="euiText euiText--small"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
-                        </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
-    </ServicesTable>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <ServiceMap
-      addFilter={[Function]}
-      currService=""
-      idSelected="latency"
-      page="services"
-      serviceMap={Object {}}
-      setIdSelected={[Function]}
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <PanelTitle
-            title="Service map"
-          >
-            <EuiText
-              size="m"
-            >
-              <div
-                className="euiText euiText--medium"
-              >
-                <span
-                  className="panel-title"
-                >
-                  Service map
-                </span>
-              </div>
-            </EuiText>
-          </PanelTitle>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiButtonGroup
-            buttonSize="s"
-            color="text"
-            idSelected="latency"
-            onChange={[Function]}
-            options={
-              Array [
-                Object {
-                  "id": "latency",
-                  "label": "Duration",
-                },
-                Object {
-                  "id": "error_rate",
-                  "label": "Errors",
-                },
-                Object {
-                  "id": "throughput",
-                  "label": "Request Rate",
-                },
-              ]
-            }
-          >
-            <fieldset
-              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-              disabled={false}
-            >
-              <EuiScreenReaderOnly>
-                <legend
-                  className="euiScreenReaderOnly"
-                />
-              </EuiScreenReaderOnly>
-              <div
-                className="euiButtonGroup__buttons"
-              >
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="latency"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={true}
-                  key="0"
-                  label="Duration"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className="euiButtonGroupButton-isSelected"
-                    color="text"
-                    element="label"
-                    fill={true}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Duration",
-                        "ref": [Function],
-                        "title": "Duration",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Duration",
-                            "ref": [Function],
-                            "title": "Duration",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Duration"
-                            title="Duration"
-                          >
-                            <input
-                              checked={true}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="latency"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Duration
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="error_rate"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="1"
-                  label="Errors"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Errors",
-                        "ref": [Function],
-                        "title": "Errors",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Errors",
-                            "ref": [Function],
-                            "title": "Errors",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Errors"
-                            title="Errors"
-                          >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="error_rate"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Errors
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="throughput"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="2"
-                  label="Request Rate"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Request Rate",
-                        "ref": [Function],
-                        "title": "Request Rate",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Request Rate",
-                            "ref": [Function],
-                            "title": "Request Rate",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Request Rate"
-                            title="Request Rate"
-                          >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="throughput"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Request Rate
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-              </div>
-            </fieldset>
-          </EuiButtonGroup>
-          <EuiHorizontalRule
-            margin="m"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-            />
-          </EuiHorizontalRule>
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiText>
-                    <div
-                      className="euiText euiText--medium"
-                    >
-                      Focus on
-                    </div>
-                  </EuiText>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiCompressedFieldSearch
-                    compressed={true}
-                    fullWidth={false}
-                    incremental={false}
-                    isClearable={true}
-                    isInvalid={false}
-                    isLoading={false}
-                    onChange={[Function]}
-                    onSearch={[Function]}
-                    placeholder="Service name"
-                    value=""
-                  >
-                    <EuiFormControlLayout
-                      compressed={true}
-                      fullWidth={false}
-                      icon="search"
-                      isLoading={false}
-                    >
-                      <div
-                        className="euiFormControlLayout euiFormControlLayout--compressed"
-                      >
-                        <div
-                          className="euiFormControlLayout__childrenWrapper"
-                        >
-                          <EuiValidatableControl
-                            isInvalid={false}
-                          >
-                            <input
-                              className="euiFieldSearch euiFieldSearch--compressed"
-                              onChange={[Function]}
-                              onKeyUp={[Function]}
-                              placeholder="Service name"
-                              type="search"
-                              value=""
-                            />
-                          </EuiValidatableControl>
-                          <EuiFormControlLayoutIcons
-                            compressed={true}
-                            icon="search"
-                            isLoading={false}
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
+                                      >
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconGap="m"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconBeaker
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconBeaker>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconBeaker
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconBeaker>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
                           >
                             <div
-                              className="euiFormControlLayoutIcons"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <EuiFormControlLayoutCustomIcon
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
                                 size="s"
-                                type="search"
                               >
-                                <span
-                                  className="euiFormControlLayoutCustomIcon"
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
                                 >
                                   <EuiIcon
                                     aria-hidden="true"
-                                    className="euiFormControlLayoutCustomIcon__icon"
-                                    size="s"
-                                    type="search"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
                                   >
                                     <EuiIconBeaker
                                       aria-hidden={true}
-                                      className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                       focusable="false"
                                       role="img"
                                       style={null}
                                     >
                                       <svg
                                         aria-hidden={true}
-                                        className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                         focusable="false"
                                         height={16}
                                         role="img"
@@ -2136,117 +1349,943 @@ exports[`Services component renders empty services page 1`] = `
                                       </svg>
                                     </EuiIconBeaker>
                                   </EuiIcon>
-                                </span>
-                              </EuiFormControlLayoutCustomIcon>
+                                </button>
+                              </EuiButtonIcon>
                             </div>
-                          </EuiFormControlLayoutIcons>
+                          </EuiFlexItem>
                         </div>
-                      </div>
-                    </EuiFormControlLayout>
-                  </EuiCompressedFieldSearch>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer>
-            <div
-              className="euiSpacer euiSpacer--l"
-            />
-          </EuiSpacer>
-          <div
-            style={
-              Object {
-                "minHeight": 434,
+                      </EuiFlexGroup>
+                    </ForwardRef>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              filters={Array []}
+              mode="data_prepper"
+              page="services"
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
               }
-            }
-          >
-            <NoMatchMessage
-              size="s"
             >
-              <EuiSpacer
-                size="s"
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="xs"
+                responsive={false}
               >
                 <div
-                  className="euiSpacer euiSpacer--s"
-                />
-              </EuiSpacer>
-              <EuiEmptyPrompt
-                body={
-                  <EuiText
-                    size="s"
-                  >
-                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                  </EuiText>
-                }
-                title={
-                  <h2>
-                    No matches
-                  </h2>
-                }
-              >
-                <div
-                  className="euiEmptyPrompt"
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
                 >
-                  <EuiTitle
-                    size="m"
+                  <EuiFlexItem
+                    grow={false}
                   >
-                    <h2
-                      className="euiTitle euiTitle--medium"
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
                     >
-                      No matches
-                    </h2>
-                  </EuiTitle>
-                  <EuiTextColor
-                    color="subdued"
-                  >
-                    <span
-                      className="euiTextColor euiTextColor--subdued"
-                    >
-                      <EuiSpacer
-                        size="m"
-                      >
-                        <div
-                          className="euiSpacer euiSpacer--m"
-                        />
-                      </EuiSpacer>
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              flush="left"
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
+                          }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
                         >
-                          <EuiText
-                            size="s"
+                          <div
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
                           >
                             <div
-                              className="euiText euiText--small"
+                              className="euiPopover__anchor"
                             >
-                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              <EuiButtonEmpty
+                                flush="left"
+                                onClick={[Function]}
+                                size="xs"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconGap="m"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
+                                    >
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        + Add filter
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </div>
+                          </div>
+                        </EuiPopover>
+                      </AddFilterButton>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </Filters>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <ServicesTable
+              addFilter={[Function]}
+              addServicesGroupFilter={[Function]}
+              dataPrepperIndicesExist={true}
+              isServiceTrendEnabled={false}
+              items={Array []}
+              loading={true}
+              mode="data_prepper"
+              selectedItems={Array []}
+              serviceTrends={Object {}}
+              setIsServiceTrendEnabled={[Function]}
+              setRedirect={[Function]}
+              setSelectedItems={[Function]}
+              traceColumnAction={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <EuiFlexGroup
+                    justifyContent="spaceBetween"
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <PanelTitle
+                            title="Services"
+                            totalItems={0}
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <span
+                                  className="panel-title"
+                                >
+                                  Services
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiFlexGroup>
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiToolTip
+                                    content="Select services to filter"
+                                    delay="regular"
+                                    position="top"
+                                  >
+                                    <span
+                                      className="euiToolTipAnchor"
+                                      onKeyUp={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                    >
+                                      <EuiButtonEmpty
+                                        isDisabled={true}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        size="xs"
+                                      >
+                                        <button
+                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                          disabled={true}
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          type="button"
+                                        >
+                                          <EuiButtonContent
+                                            className="euiButtonEmpty__content"
+                                            iconGap="m"
+                                            iconSide="left"
+                                            iconSize="s"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButtonEmpty__text",
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              className="euiButtonContent euiButtonEmpty__content"
+                                            >
+                                              <span
+                                                className="euiButtonEmpty__text"
+                                              >
+                                                Filter services
+                                              </span>
+                                            </span>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonEmpty>
+                                    </span>
+                                  </EuiToolTip>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiButtonEmpty
+                                    onClick={[Function]}
+                                    size="xs"
+                                  >
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconGap="m"
+                                        iconSide="left"
+                                        iconSize="s"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonEmpty__content"
+                                        >
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            Show 24 hour trends
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
+                  >
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                    <EuiEmptyPrompt
+                      body={
+                        <EuiText
+                          size="s"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
+                      </div>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </ServicesTable>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <ServiceMap
+              addFilter={[Function]}
+              currService=""
+              idSelected="latency"
+              page="services"
+              serviceMap={Object {}}
+              setIdSelected={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <PanelTitle
+                    title="Service map"
+                  >
+                    <EuiText
+                      size="m"
+                    >
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <span
+                          className="panel-title"
+                        >
+                          Service map
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiButtonGroup
+                    buttonSize="s"
+                    color="text"
+                    idSelected="latency"
+                    onChange={[Function]}
+                    options={
+                      Array [
+                        Object {
+                          "id": "latency",
+                          "label": "Duration",
+                        },
+                        Object {
+                          "id": "error_rate",
+                          "label": "Errors",
+                        },
+                        Object {
+                          "id": "throughput",
+                          "label": "Request Rate",
+                        },
+                      ]
+                    }
+                  >
+                    <fieldset
+                      className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                      disabled={false}
+                    >
+                      <EuiScreenReaderOnly>
+                        <legend
+                          className="euiScreenReaderOnly"
+                        />
+                      </EuiScreenReaderOnly>
+                      <div
+                        className="euiButtonGroup__buttons"
+                      >
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="latency"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={true}
+                          key="0"
+                          label="Duration"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
+                        >
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className="euiButtonGroupButton-isSelected"
+                            color="text"
+                            element="label"
+                            fill={true}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonGroupButton__textShift",
+                                "data-text": "Duration",
+                                "ref": [Function],
+                                "title": "Duration",
+                              }
+                            }
+                          >
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
+                            >
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconGap="m"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Duration",
+                                    "ref": [Function],
+                                    "title": "Duration",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked={true}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="error_rate"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={false}
+                          key="1"
+                          label="Errors"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
+                        >
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className=""
+                            color="text"
+                            element="label"
+                            fill={false}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonGroupButton__textShift",
+                                "data-text": "Errors",
+                                "ref": [Function],
+                                "title": "Errors",
+                              }
+                            }
+                          >
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
+                            >
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconGap="m"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Errors",
+                                    "ref": [Function],
+                                    "title": "Errors",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      checked={false}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="throughput"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={false}
+                          key="2"
+                          label="Request Rate"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
+                        >
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className=""
+                            color="text"
+                            element="label"
+                            fill={false}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonGroupButton__textShift",
+                                "data-text": "Request Rate",
+                                "ref": [Function],
+                                "title": "Request Rate",
+                              }
+                            }
+                          >
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
+                            >
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconGap="m"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Request Rate",
+                                    "ref": [Function],
+                                    "title": "Request Rate",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      checked={false}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                      </div>
+                    </fieldset>
+                  </EuiButtonGroup>
+                  <EuiHorizontalRule
+                    margin="m"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                    />
+                  </EuiHorizontalRule>
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              Focus on
                             </div>
                           </EuiText>
                         </div>
-                      </EuiText>
-                    </span>
-                  </EuiTextColor>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <div
+                          className="euiFlexItem"
+                        >
+                          <EuiCompressedFieldSearch
+                            compressed={true}
+                            fullWidth={false}
+                            incremental={false}
+                            isClearable={true}
+                            isInvalid={false}
+                            isLoading={false}
+                            onChange={[Function]}
+                            onSearch={[Function]}
+                            placeholder="Service name"
+                            value=""
+                          >
+                            <EuiFormControlLayout
+                              compressed={true}
+                              fullWidth={false}
+                              icon="search"
+                              isLoading={false}
+                            >
+                              <div
+                                className="euiFormControlLayout euiFormControlLayout--compressed"
+                              >
+                                <div
+                                  className="euiFormControlLayout__childrenWrapper"
+                                >
+                                  <EuiValidatableControl
+                                    isInvalid={false}
+                                  >
+                                    <input
+                                      className="euiFieldSearch euiFieldSearch--compressed"
+                                      onChange={[Function]}
+                                      onKeyUp={[Function]}
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                  </EuiValidatableControl>
+                                  <EuiFormControlLayoutIcons
+                                    compressed={true}
+                                    icon="search"
+                                    isLoading={false}
+                                  >
+                                    <div
+                                      className="euiFormControlLayoutIcons"
+                                    >
+                                      <EuiFormControlLayoutCustomIcon
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <span
+                                          className="euiFormControlLayoutCustomIcon"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiFormControlLayoutCustomIcon__icon"
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <EuiIconBeaker
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
+                                            </EuiIconBeaker>
+                                          </EuiIcon>
+                                        </span>
+                                      </EuiFormControlLayoutCustomIcon>
+                                    </div>
+                                  </EuiFormControlLayoutIcons>
+                                </div>
+                              </div>
+                            </EuiFormControlLayout>
+                          </EuiCompressedFieldSearch>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer>
+                    <div
+                      className="euiSpacer euiSpacer--l"
+                    />
+                  </EuiSpacer>
+                  <div
+                    style={
+                      Object {
+                        "minHeight": 434,
+                      }
+                    }
+                  >
+                    <NoMatchMessage
+                      size="s"
+                    >
+                      <EuiSpacer
+                        size="s"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--s"
+                        />
+                      </EuiSpacer>
+                      <EuiEmptyPrompt
+                        body={
+                          <EuiText
+                            size="s"
+                          >
+                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                          </EuiText>
+                        }
+                        title={
+                          <h2>
+                            No matches
+                          </h2>
+                        }
+                      >
+                        <div
+                          className="euiEmptyPrompt"
+                        >
+                          <EuiTitle
+                            size="m"
+                          >
+                            <h2
+                              className="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                          </EuiTitle>
+                          <EuiTextColor
+                            color="subdued"
+                          >
+                            <span
+                              className="euiTextColor euiTextColor--subdued"
+                            >
+                              <EuiSpacer
+                                size="m"
+                              >
+                                <div
+                                  className="euiSpacer euiSpacer--m"
+                                />
+                              </EuiSpacer>
+                              <EuiText>
+                                <div
+                                  className="euiText euiText--medium"
+                                >
+                                  <EuiText
+                                    size="s"
+                                  >
+                                    <div
+                                      className="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </EuiText>
+                                </div>
+                              </EuiText>
+                            </span>
+                          </EuiTextColor>
+                        </div>
+                      </EuiEmptyPrompt>
+                      <EuiSpacer
+                        size="s"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--s"
+                        />
+                      </EuiSpacer>
+                    </NoMatchMessage>
+                  </div>
                 </div>
-              </EuiEmptyPrompt>
+              </EuiPanel>
               <EuiSpacer
-                size="s"
+                size="xl"
               >
                 <div
-                  className="euiSpacer euiSpacer--s"
+                  className="euiSpacer euiSpacer--xl"
                 />
               </EuiSpacer>
-            </NoMatchMessage>
+            </ServiceMap>
           </div>
-        </div>
-      </EuiPanel>
-      <EuiSpacer
-        size="xl"
-      >
-        <div
-          className="euiSpacer euiSpacer--xl"
-        />
-      </EuiSpacer>
-    </ServiceMap>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </ServicesContent>
 </Services>
 `;
@@ -2480,140 +2519,6 @@ exports[`Services component renders jaeger services page 1`] = `
   startTime="now-5m"
   traceColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="jaeger"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="jaeger"
-        >
-          Jaeger
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="jaeger"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="jaeger"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="jaeger"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconArrowDown
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                            fillRule="non-zero"
-                          />
-                        </svg>
-                      </EuiIconArrowDown>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Jaeger
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <ServicesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -2842,464 +2747,423 @@ exports[`Services component renders jaeger services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <ForwardRef
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      endTime="now"
-      filters={Array []}
-      mode="jaeger"
-      page="services"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
+    <EuiPage
+      paddingSize="m"
     >
-      <EuiFlexGroup
-        gutterSize="s"
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
+        <EuiPageBody>
+          <div
+            className="euiPageBody euiPageBody--borderRadiusNone"
+          >
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="jaeger"
                     >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
+                            iconSide="right"
+                            iconType="arrowDown"
+                            onClick={[Function]}
+                            title="jaeger"
+                          >
+                            Jaeger
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
                       >
                         <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                            className="euiPopover__anchor eui-textTruncate"
                           >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="jaeger"
                             >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="jaeger"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="jaeger"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
+                                    iconSize="m"
                                     iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
                                     textProps={
                                       Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
+                                        "className": "euiButtonEmpty__text",
                                       }
                                     }
                                   >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconArrowDown
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                              fillRule="non-zero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowDown>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Jaeger
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="jaeger"
+                      page="services"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
                                 }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
+                                value=""
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
                                 >
                                   <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
                                   >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
+                                    <GlobalFilterButton
                                       className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
                                         }
                                       }
                                     >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          <div
+                                            className="euiPopover__anchor"
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
                                             >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
                                               >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
                                                 >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconFilter
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                          fillRule="evenodd"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconFilter>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
                                             <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                              className="euiFormControlLayoutCustomIcon"
                                             >
                                               <EuiIcon
-                                                type="calendar"
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
                                               >
-                                                <EuiIconCalendar
+                                                <EuiIconSearch
                                                   aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
+                                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                                   focusable="false"
                                                   role="img"
                                                   style={null}
                                                 >
                                                   <svg
                                                     aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
+                                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                                     focusable="false"
                                                     height={16}
                                                     role="img"
@@ -3309,494 +3173,564 @@ exports[`Services component renders jaeger services page 1`] = `
                                                     xmlns="http://www.w3.org/2000/svg"
                                                   >
                                                     <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
+                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
                                                     />
                                                   </svg>
-                                                </EuiIconCalendar>
+                                                </EuiIconSearch>
                                               </EuiIcon>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
                             </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
-                  >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
+                              Object {
+                                "maxWidth": "30vw",
+                              }
+                            }
                           >
-                            <EuiIconRefresh
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                                />
-                              </svg>
-                            </EuiIconRefresh>
-                          </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="jaeger"
-        page="services"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
-          }
-        }
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
-          style={
-            Object {
-              "minHeight": 32,
-            }
-          }
-        >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
-          >
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconFilter
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                      fillRule="evenodd"
-                                    />
-                                  </svg>
-                                </EuiIconFilter>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
-                          onClick={[Function]}
-                          size="xs"
-                        >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
                                 Object {
-                                  "className": "euiButtonEmpty__text",
+                                  "maxWidth": "30vw",
                                 }
                               }
                             >
-                              <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  + Add filter
-                                </span>
-                              </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <ServicesTable
-      addFilter={[Function]}
-      addServicesGroupFilter={[Function]}
-      dataPrepperIndicesExist={false}
-      isServiceTrendEnabled={false}
-      items={Array []}
-      jaegerIndicesExist={true}
-      loading={true}
-      mode="jaeger"
-      selectedItems={Array []}
-      serviceTrends={Object {}}
-      setIsServiceTrendEnabled={[Function]}
-      setRedirect={[Function]}
-      setSelectedItems={[Function]}
-      traceColumnAction={[Function]}
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  >
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
+                                      >
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconGap="m"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconArrowDown
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                                    fillRule="non-zero"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconArrowDown>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconCalendar
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                                      fillRule="evenodd"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconCalendar>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
                           >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
+                              >
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconRefresh
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                        />
+                                      </svg>
+                                    </EuiIconRefresh>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              filters={Array []}
+              mode="jaeger"
+              page="services"
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="xs"
+                responsive={false}
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                >
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              flush="left"
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
+                          }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
+                        >
+                          <div
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
+                          >
+                            <div
+                              className="euiPopover__anchor"
                             >
                               <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
+                                flush="left"
                                 onClick={[Function]}
-                                onFocus={[Function]}
                                 size="xs"
                               >
                                 <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
-                                  onBlur={[Function]}
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
+                                  disabled={false}
                                   onClick={[Function]}
-                                  onFocus={[Function]}
                                   type="button"
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     iconSize="s"
                                     textProps={
@@ -3811,123 +3745,263 @@ exports[`Services component renders jaeger services page 1`] = `
                                       <span
                                         className="euiButtonEmpty__text"
                                       >
-                                        Filter services
+                                        + Add filter
                                       </span>
                                     </span>
                                   </EuiButtonContent>
                                 </button>
                               </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
+                            </div>
+                          </div>
+                        </EuiPopover>
+                      </AddFilterButton>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </Filters>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <ServicesTable
+              addFilter={[Function]}
+              addServicesGroupFilter={[Function]}
+              dataPrepperIndicesExist={false}
+              isServiceTrendEnabled={false}
+              items={Array []}
+              jaegerIndicesExist={true}
+              loading={true}
+              mode="jaeger"
+              selectedItems={Array []}
+              serviceTrends={Object {}}
+              setIsServiceTrendEnabled={[Function]}
+              setRedirect={[Function]}
+              setSelectedItems={[Function]}
+              traceColumnAction={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <EuiFlexGroup
+                    justifyContent="spaceBetween"
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <PanelTitle
+                            title="Services"
+                            totalItems={0}
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <span
+                                  className="panel-title"
+                                >
+                                  Services
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiFlexGroup>
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiToolTip
+                                    content="Select services to filter"
+                                    delay="regular"
+                                    position="top"
+                                  >
+                                    <span
+                                      className="euiToolTipAnchor"
+                                      onKeyUp={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                    >
+                                      <EuiButtonEmpty
+                                        isDisabled={true}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        size="xs"
+                                      >
+                                        <button
+                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                          disabled={true}
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          type="button"
+                                        >
+                                          <EuiButtonContent
+                                            className="euiButtonEmpty__content"
+                                            iconGap="m"
+                                            iconSide="left"
+                                            iconSize="s"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButtonEmpty__text",
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              className="euiButtonContent euiButtonEmpty__content"
+                                            >
+                                              <span
+                                                className="euiButtonEmpty__text"
+                                              >
+                                                Filter services
+                                              </span>
+                                            </span>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonEmpty>
+                                    </span>
+                                  </EuiToolTip>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
                         </div>
                       </EuiFlexItem>
                     </div>
                   </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
+                  <EuiSpacer
+                    size="m"
                   >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
                   >
                     <EuiSpacer
-                      size="m"
+                      size="xl"
                     >
                       <div
-                        className="euiSpacer euiSpacer--m"
+                        className="euiSpacer euiSpacer--xl"
                       />
                     </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
+                    <EuiEmptyPrompt
+                      body={
                         <EuiText
                           size="s"
                         >
-                          <div
-                            className="euiText euiText--small"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                         </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
                       </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </ServicesTable>
             <EuiSpacer
-              size="xl"
+              size="s"
             >
               <div
-                className="euiSpacer euiSpacer--xl"
+                className="euiSpacer euiSpacer--s"
               />
             </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
-    </ServicesTable>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <div />
+            <div />
+          </div>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </ServicesContent>
 </Services>
 `;
@@ -4160,140 +4234,6 @@ exports[`Services component renders services page 1`] = `
   startTime="now-5m"
   traceColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="data_prepper"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="data_prepper"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconArrowDown
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                            fillRule="non-zero"
-                          />
-                        </svg>
-                      </EuiIconArrowDown>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Data Prepper
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <ServicesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -4521,464 +4461,423 @@ exports[`Services component renders services page 1`] = `
     startTime="now-5m"
     traceColumnAction={[Function]}
   >
-    <ForwardRef
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      endTime="now"
-      filters={Array []}
-      mode="data_prepper"
-      page="services"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
+    <EuiPage
+      paddingSize="m"
     >
-      <EuiFlexGroup
-        gutterSize="s"
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
+        <EuiPageBody>
+          <div
+            className="euiPageBody euiPageBody--borderRadiusNone"
+          >
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="data_prepper"
                     >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
+                            iconSide="right"
+                            iconType="arrowDown"
+                            onClick={[Function]}
+                            title="data_prepper"
+                          >
+                            Data Prepper
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
                       >
                         <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                            className="euiPopover__anchor eui-textTruncate"
                           >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="data_prepper"
                             >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="data_prepper"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="data_prepper"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
+                                    iconSize="m"
                                     iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
                                     textProps={
                                       Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
+                                        "className": "euiButtonEmpty__text",
                                       }
                                     }
                                   >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconArrowDown
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                              fillRule="non-zero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowDown>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Data Prepper
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="data_prepper"
+                      page="services"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
                                 }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
+                                value=""
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
                                 >
                                   <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
                                   >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
+                                    <GlobalFilterButton
                                       className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
                                         }
                                       }
                                     >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          <div
+                                            className="euiPopover__anchor"
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
                                             >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
                                               >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
                                                 >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconFilter
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                          fillRule="evenodd"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconFilter>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
                                             <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                              className="euiFormControlLayoutCustomIcon"
                                             >
                                               <EuiIcon
-                                                type="calendar"
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
                                               >
-                                                <EuiIconCalendar
+                                                <EuiIconSearch
                                                   aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
+                                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                                   focusable="false"
                                                   role="img"
                                                   style={null}
                                                 >
                                                   <svg
                                                     aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
+                                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                                     focusable="false"
                                                     height={16}
                                                     role="img"
@@ -4988,493 +4887,564 @@ exports[`Services component renders services page 1`] = `
                                                     xmlns="http://www.w3.org/2000/svg"
                                                   >
                                                     <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
+                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
                                                     />
                                                   </svg>
-                                                </EuiIconCalendar>
+                                                </EuiIconSearch>
                                               </EuiIcon>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
-                            <div
-                              className="euiFormControlLayout__childrenWrapper"
-                            >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
-                              >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
-                                >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                  >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
-                                      >
-                                        Show dates
-                                      </EuiI18n>
-                                    </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
                             </div>
-                          </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
-              >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
-                  >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
-                            size="m"
-                            type="refresh"
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
+                              Object {
+                                "maxWidth": "30vw",
+                              }
+                            }
                           >
-                            <EuiIconRefresh
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                              focusable="false"
-                              role="img"
-                              style={null}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                                focusable="false"
-                                height={16}
-                                role="img"
-                                style={null}
-                                viewBox="0 0 16 16"
-                                width={16}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                                />
-                              </svg>
-                            </EuiIconRefresh>
-                          </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="services"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
-          }
-        }
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
-          style={
-            Object {
-              "minHeight": 32,
-            }
-          }
-        >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
-          >
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
-                        >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconFilter
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                      fillRule="evenodd"
-                                    />
-                                  </svg>
-                                </EuiIconFilter>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiButtonEmpty
-                          onClick={[Function]}
-                          size="xs"
-                        >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
                                 Object {
-                                  "className": "euiButtonEmpty__text",
+                                  "maxWidth": "30vw",
                                 }
                               }
                             >
-                              <span
-                                className="euiButtonContent euiButtonEmpty__content"
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <span
-                                  className="euiButtonEmpty__text"
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  + Add filter
-                                </span>
-                              </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
-                    </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <ServicesTable
-      addFilter={[Function]}
-      addServicesGroupFilter={[Function]}
-      dataPrepperIndicesExist={true}
-      isServiceTrendEnabled={false}
-      items={Array []}
-      loading={true}
-      mode="data_prepper"
-      selectedItems={Array []}
-      serviceTrends={Object {}}
-      setIsServiceTrendEnabled={[Function]}
-      setRedirect={[Function]}
-      setSelectedItems={[Function]}
-      traceColumnAction={[Function]}
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            justifyContent="spaceBetween"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <PanelTitle
-                    title="Services"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Services
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiFlexGroup>
-                    <div
-                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-                    >
-                      <EuiFlexItem>
-                        <div
-                          className="euiFlexItem"
-                        >
-                          <EuiToolTip
-                            content="Select services to filter"
-                            delay="regular"
-                            position="top"
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  >
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
+                                      >
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconGap="m"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconArrowDown
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                                    fillRule="non-zero"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconArrowDown>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconCalendar
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                                      fillRule="evenodd"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconCalendar>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
                           >
-                            <span
-                              className="euiToolTipAnchor"
-                              onKeyUp={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
+                              >
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconRefresh
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                        />
+                                      </svg>
+                                    </EuiIconRefresh>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              filters={Array []}
+              mode="data_prepper"
+              page="services"
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="xs"
+                responsive={false}
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                >
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              flush="left"
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
+                          }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
+                        >
+                          <div
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
+                          >
+                            <div
+                              className="euiPopover__anchor"
                             >
                               <EuiButtonEmpty
-                                isDisabled={true}
-                                onBlur={[Function]}
+                                flush="left"
                                 onClick={[Function]}
-                                onFocus={[Function]}
                                 size="xs"
                               >
                                 <button
-                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
-                                  disabled={true}
-                                  onBlur={[Function]}
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
+                                  disabled={false}
                                   onClick={[Function]}
-                                  onFocus={[Function]}
                                   type="button"
                                 >
                                   <EuiButtonContent
                                     className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="left"
                                     iconSize="s"
                                     textProps={
@@ -5489,698 +5459,841 @@ exports[`Services component renders services page 1`] = `
                                       <span
                                         className="euiButtonEmpty__text"
                                       >
-                                        Filter services
+                                        + Add filter
                                       </span>
                                     </span>
                                   </EuiButtonContent>
                                 </button>
                               </EuiButtonEmpty>
-                            </span>
-                          </EuiToolTip>
+                            </div>
+                          </div>
+                        </EuiPopover>
+                      </AddFilterButton>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </Filters>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <ServicesTable
+              addFilter={[Function]}
+              addServicesGroupFilter={[Function]}
+              dataPrepperIndicesExist={true}
+              isServiceTrendEnabled={false}
+              items={Array []}
+              loading={true}
+              mode="data_prepper"
+              selectedItems={Array []}
+              serviceTrends={Object {}}
+              setIsServiceTrendEnabled={[Function]}
+              setRedirect={[Function]}
+              setSelectedItems={[Function]}
+              traceColumnAction={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <EuiFlexGroup
+                    justifyContent="spaceBetween"
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <PanelTitle
+                            title="Services"
+                            totalItems={0}
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <span
+                                  className="panel-title"
+                                >
+                                  Services
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiFlexGroup>
+                            <div
+                              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                            >
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiToolTip
+                                    content="Select services to filter"
+                                    delay="regular"
+                                    position="top"
+                                  >
+                                    <span
+                                      className="euiToolTipAnchor"
+                                      onKeyUp={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                    >
+                                      <EuiButtonEmpty
+                                        isDisabled={true}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        size="xs"
+                                      >
+                                        <button
+                                          className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty-isDisabled"
+                                          disabled={true}
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          type="button"
+                                        >
+                                          <EuiButtonContent
+                                            className="euiButtonEmpty__content"
+                                            iconGap="m"
+                                            iconSide="left"
+                                            iconSize="s"
+                                            textProps={
+                                              Object {
+                                                "className": "euiButtonEmpty__text",
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              className="euiButtonContent euiButtonEmpty__content"
+                                            >
+                                              <span
+                                                className="euiButtonEmpty__text"
+                                              >
+                                                Filter services
+                                              </span>
+                                            </span>
+                                          </EuiButtonContent>
+                                        </button>
+                                      </EuiButtonEmpty>
+                                    </span>
+                                  </EuiToolTip>
+                                </div>
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <div
+                                  className="euiFlexItem"
+                                >
+                                  <EuiButtonEmpty
+                                    onClick={[Function]}
+                                    size="xs"
+                                  >
+                                    <button
+                                      className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      <EuiButtonContent
+                                        className="euiButtonEmpty__content"
+                                        iconGap="m"
+                                        iconSide="left"
+                                        iconSize="s"
+                                        textProps={
+                                          Object {
+                                            "className": "euiButtonEmpty__text",
+                                          }
+                                        }
+                                      >
+                                        <span
+                                          className="euiButtonContent euiButtonEmpty__content"
+                                        >
+                                          <span
+                                            className="euiButtonEmpty__text"
+                                          >
+                                            Show 24 hour trends
+                                          </span>
+                                        </span>
+                                      </EuiButtonContent>
+                                    </button>
+                                  </EuiButtonEmpty>
+                                </div>
+                              </EuiFlexItem>
+                            </div>
+                          </EuiFlexGroup>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
+                  >
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                    <EuiEmptyPrompt
+                      body={
+                        <EuiText
+                          size="s"
+                        >
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
+                      </div>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </ServicesTable>
+            <EuiSpacer
+              size="s"
+            >
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <ServiceMap
+              addFilter={[Function]}
+              currService=""
+              idSelected="latency"
+              page="services"
+              serviceMap={Object {}}
+              setIdSelected={[Function]}
+            >
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                >
+                  <PanelTitle
+                    title="Service map"
+                  >
+                    <EuiText
+                      size="m"
+                    >
+                      <div
+                        className="euiText euiText--medium"
+                      >
+                        <span
+                          className="panel-title"
+                        >
+                          Service map
+                        </span>
+                      </div>
+                    </EuiText>
+                  </PanelTitle>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiButtonGroup
+                    buttonSize="s"
+                    color="text"
+                    idSelected="latency"
+                    onChange={[Function]}
+                    options={
+                      Array [
+                        Object {
+                          "id": "latency",
+                          "label": "Duration",
+                        },
+                        Object {
+                          "id": "error_rate",
+                          "label": "Errors",
+                        },
+                        Object {
+                          "id": "throughput",
+                          "label": "Request Rate",
+                        },
+                      ]
+                    }
+                  >
+                    <fieldset
+                      className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                      disabled={false}
+                    >
+                      <EuiScreenReaderOnly>
+                        <legend
+                          className="euiScreenReaderOnly"
+                        />
+                      </EuiScreenReaderOnly>
+                      <div
+                        className="euiButtonGroup__buttons"
+                      >
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="latency"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={true}
+                          key="0"
+                          label="Duration"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
+                        >
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className="euiButtonGroupButton-isSelected"
+                            color="text"
+                            element="label"
+                            fill={true}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonGroupButton__textShift",
+                                "data-text": "Duration",
+                                "ref": [Function],
+                                "title": "Duration",
+                              }
+                            }
+                          >
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
+                            >
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconGap="m"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Duration",
+                                    "ref": [Function],
+                                    "title": "Duration",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Duration"
+                                    title="Duration"
+                                  >
+                                    <input
+                                      checked={true}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="latency"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Duration
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="error_rate"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={false}
+                          key="1"
+                          label="Errors"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
+                        >
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className=""
+                            color="text"
+                            element="label"
+                            fill={false}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonGroupButton__textShift",
+                                "data-text": "Errors",
+                                "ref": [Function],
+                                "title": "Errors",
+                              }
+                            }
+                          >
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
+                            >
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconGap="m"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Errors",
+                                    "ref": [Function],
+                                    "title": "Errors",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Errors"
+                                    title="Errors"
+                                  >
+                                    <input
+                                      checked={false}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="error_rate"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Errors
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                        <EuiButtonGroupButton
+                          color="text"
+                          element="label"
+                          id="throughput"
+                          isDisabled={false}
+                          isIconOnly={false}
+                          isSelected={false}
+                          key="2"
+                          label="Request Rate"
+                          name="random_html_id"
+                          onChange={[Function]}
+                          size="s"
+                        >
+                          <EuiButtonDisplay
+                            baseClassName="euiButtonGroupButton"
+                            className=""
+                            color="text"
+                            element="label"
+                            fill={false}
+                            htmlFor="random_html_id"
+                            isDisabled={false}
+                            onClick={[Function]}
+                            size="s"
+                            textProps={
+                              Object {
+                                "className": "euiButtonGroupButton__textShift",
+                                "data-text": "Request Rate",
+                                "ref": [Function],
+                                "title": "Request Rate",
+                              }
+                            }
+                          >
+                            <label
+                              className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              disabled={false}
+                              htmlFor="random_html_id"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "minWidth": undefined,
+                                }
+                              }
+                            >
+                              <EuiButtonContent
+                                className="euiButton__content"
+                                iconGap="m"
+                                iconSide="left"
+                                textProps={
+                                  Object {
+                                    "className": "euiButton__text euiButtonGroupButton__textShift",
+                                    "data-text": "Request Rate",
+                                    "ref": [Function],
+                                    "title": "Request Rate",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="euiButtonContent euiButton__content"
+                                >
+                                  <span
+                                    className="euiButton__text euiButtonGroupButton__textShift"
+                                    data-text="Request Rate"
+                                    title="Request Rate"
+                                  >
+                                    <input
+                                      checked={false}
+                                      className="euiScreenReaderOnly"
+                                      data-test-subj="throughput"
+                                      disabled={false}
+                                      id="random_html_id"
+                                      name="random_html_id"
+                                      onChange={[Function]}
+                                      type="radio"
+                                    />
+                                    Request Rate
+                                  </span>
+                                </span>
+                              </EuiButtonContent>
+                            </label>
+                          </EuiButtonDisplay>
+                        </EuiButtonGroupButton>
+                      </div>
+                    </fieldset>
+                  </EuiButtonGroup>
+                  <EuiHorizontalRule
+                    margin="m"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                    />
+                  </EuiHorizontalRule>
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
+                  >
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={false}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrowZero"
+                        >
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              Focus on
+                            </div>
+                          </EuiText>
                         </div>
                       </EuiFlexItem>
                       <EuiFlexItem>
                         <div
                           className="euiFlexItem"
                         >
-                          <EuiButtonEmpty
-                            onClick={[Function]}
-                            size="xs"
+                          <EuiCompressedFieldSearch
+                            compressed={true}
+                            fullWidth={false}
+                            incremental={false}
+                            isClearable={true}
+                            isInvalid={false}
+                            isLoading={false}
+                            onChange={[Function]}
+                            onSearch={[Function]}
+                            placeholder="Service name"
+                            value=""
                           >
-                            <button
-                              className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="button"
+                            <EuiFormControlLayout
+                              compressed={true}
+                              fullWidth={false}
+                              icon="search"
+                              isLoading={false}
                             >
-                              <EuiButtonContent
-                                className="euiButtonEmpty__content"
-                                iconSide="left"
-                                iconSize="s"
-                                textProps={
-                                  Object {
-                                    "className": "euiButtonEmpty__text",
-                                  }
-                                }
+                              <div
+                                className="euiFormControlLayout euiFormControlLayout--compressed"
                               >
-                                <span
-                                  className="euiButtonContent euiButtonEmpty__content"
+                                <div
+                                  className="euiFormControlLayout__childrenWrapper"
                                 >
-                                  <span
-                                    className="euiButtonEmpty__text"
+                                  <EuiValidatableControl
+                                    isInvalid={false}
                                   >
-                                    Show 24 hour trends
-                                  </span>
-                                </span>
-                              </EuiButtonContent>
-                            </button>
-                          </EuiButtonEmpty>
+                                    <input
+                                      className="euiFieldSearch euiFieldSearch--compressed"
+                                      onChange={[Function]}
+                                      onKeyUp={[Function]}
+                                      placeholder="Service name"
+                                      type="search"
+                                      value=""
+                                    />
+                                  </EuiValidatableControl>
+                                  <EuiFormControlLayoutIcons
+                                    compressed={true}
+                                    icon="search"
+                                    isLoading={false}
+                                  >
+                                    <div
+                                      className="euiFormControlLayoutIcons"
+                                    >
+                                      <EuiFormControlLayoutCustomIcon
+                                        size="s"
+                                        type="search"
+                                      >
+                                        <span
+                                          className="euiFormControlLayoutCustomIcon"
+                                        >
+                                          <EuiIcon
+                                            aria-hidden="true"
+                                            className="euiFormControlLayoutCustomIcon__icon"
+                                            size="s"
+                                            type="search"
+                                          >
+                                            <EuiIconSearch
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                              focusable="false"
+                                              role="img"
+                                              style={null}
+                                            >
+                                              <svg
+                                                aria-hidden={true}
+                                                className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                                focusable="false"
+                                                height={16}
+                                                role="img"
+                                                style={null}
+                                                viewBox="0 0 16 16"
+                                                width={16}
+                                                xmlns="http://www.w3.org/2000/svg"
+                                              >
+                                                <path
+                                                  d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
+                                                />
+                                              </svg>
+                                            </EuiIconSearch>
+                                          </EuiIcon>
+                                        </span>
+                                      </EuiFormControlLayoutCustomIcon>
+                                    </div>
+                                  </EuiFormControlLayoutIcons>
+                                </div>
+                              </div>
+                            </EuiFormControlLayout>
+                          </EuiCompressedFieldSearch>
                         </div>
                       </EuiFlexItem>
                     </div>
                   </EuiFlexGroup>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
-                >
-                  <h2
-                    className="euiTitle euiTitle--medium"
-                  >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <EuiText
-                          size="s"
-                        >
-                          <div
-                            className="euiText euiText--small"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
-                        </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
-    </ServicesTable>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <ServiceMap
-      addFilter={[Function]}
-      currService=""
-      idSelected="latency"
-      page="services"
-      serviceMap={Object {}}
-      setIdSelected={[Function]}
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <PanelTitle
-            title="Service map"
-          >
-            <EuiText
-              size="m"
-            >
-              <div
-                className="euiText euiText--medium"
-              >
-                <span
-                  className="panel-title"
-                >
-                  Service map
-                </span>
-              </div>
-            </EuiText>
-          </PanelTitle>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiButtonGroup
-            buttonSize="s"
-            color="text"
-            idSelected="latency"
-            onChange={[Function]}
-            options={
-              Array [
-                Object {
-                  "id": "latency",
-                  "label": "Duration",
-                },
-                Object {
-                  "id": "error_rate",
-                  "label": "Errors",
-                },
-                Object {
-                  "id": "throughput",
-                  "label": "Request Rate",
-                },
-              ]
-            }
-          >
-            <fieldset
-              className="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
-              disabled={false}
-            >
-              <EuiScreenReaderOnly>
-                <legend
-                  className="euiScreenReaderOnly"
-                />
-              </EuiScreenReaderOnly>
-              <div
-                className="euiButtonGroup__buttons"
-              >
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="latency"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={true}
-                  key="0"
-                  label="Duration"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className="euiButtonGroupButton-isSelected"
-                    color="text"
-                    element="label"
-                    fill={true}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Duration",
-                        "ref": [Function],
-                        "title": "Duration",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Duration",
-                            "ref": [Function],
-                            "title": "Duration",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Duration"
-                            title="Duration"
-                          >
-                            <input
-                              checked={true}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="latency"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Duration
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="error_rate"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="1"
-                  label="Errors"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Errors",
-                        "ref": [Function],
-                        "title": "Errors",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Errors",
-                            "ref": [Function],
-                            "title": "Errors",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Errors"
-                            title="Errors"
-                          >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="error_rate"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Errors
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-                <EuiButtonGroupButton
-                  color="text"
-                  element="label"
-                  id="throughput"
-                  isDisabled={false}
-                  isIconOnly={false}
-                  isSelected={false}
-                  key="2"
-                  label="Request Rate"
-                  name="random_html_id"
-                  onChange={[Function]}
-                  size="s"
-                >
-                  <EuiButtonDisplay
-                    baseClassName="euiButtonGroupButton"
-                    className=""
-                    color="text"
-                    element="label"
-                    fill={false}
-                    htmlFor="random_html_id"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    textProps={
-                      Object {
-                        "className": "euiButtonGroupButton__textShift",
-                        "data-text": "Request Rate",
-                        "ref": [Function],
-                        "title": "Request Rate",
-                      }
-                    }
-                  >
-                    <label
-                      className="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
-                      disabled={false}
-                      htmlFor="random_html_id"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                    >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text euiButtonGroupButton__textShift",
-                            "data-text": "Request Rate",
-                            "ref": [Function],
-                            "title": "Request Rate",
-                          }
-                        }
-                      >
-                        <span
-                          className="euiButtonContent euiButton__content"
-                        >
-                          <span
-                            className="euiButton__text euiButtonGroupButton__textShift"
-                            data-text="Request Rate"
-                            title="Request Rate"
-                          >
-                            <input
-                              checked={false}
-                              className="euiScreenReaderOnly"
-                              data-test-subj="throughput"
-                              disabled={false}
-                              id="random_html_id"
-                              name="random_html_id"
-                              onChange={[Function]}
-                              type="radio"
-                            />
-                            Request Rate
-                          </span>
-                        </span>
-                      </EuiButtonContent>
-                    </label>
-                  </EuiButtonDisplay>
-                </EuiButtonGroupButton>
-              </div>
-            </fieldset>
-          </EuiButtonGroup>
-          <EuiHorizontalRule
-            margin="m"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-            />
-          </EuiHorizontalRule>
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={false}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <EuiText>
+                  <EuiSpacer>
                     <div
-                      className="euiText euiText--medium"
-                    >
-                      Focus on
-                    </div>
-                  </EuiText>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiCompressedFieldSearch
-                    compressed={true}
-                    fullWidth={false}
-                    incremental={false}
-                    isClearable={true}
-                    isInvalid={false}
-                    isLoading={false}
-                    onChange={[Function]}
-                    onSearch={[Function]}
-                    placeholder="Service name"
-                    value=""
+                      className="euiSpacer euiSpacer--l"
+                    />
+                  </EuiSpacer>
+                  <div
+                    style={
+                      Object {
+                        "minHeight": 434,
+                      }
+                    }
                   >
-                    <EuiFormControlLayout
-                      compressed={true}
-                      fullWidth={false}
-                      icon="search"
-                      isLoading={false}
-                    >
-                      <div
-                        className="euiFormControlLayout euiFormControlLayout--compressed"
-                      >
-                        <div
-                          className="euiFormControlLayout__childrenWrapper"
-                        >
-                          <EuiValidatableControl
-                            isInvalid={false}
-                          >
-                            <input
-                              className="euiFieldSearch euiFieldSearch--compressed"
-                              onChange={[Function]}
-                              onKeyUp={[Function]}
-                              placeholder="Service name"
-                              type="search"
-                              value=""
-                            />
-                          </EuiValidatableControl>
-                          <EuiFormControlLayoutIcons
-                            compressed={true}
-                            icon="search"
-                            isLoading={false}
-                          >
-                            <div
-                              className="euiFormControlLayoutIcons"
-                            >
-                              <EuiFormControlLayoutCustomIcon
-                                size="s"
-                                type="search"
-                              >
-                                <span
-                                  className="euiFormControlLayoutCustomIcon"
-                                >
-                                  <EuiIcon
-                                    aria-hidden="true"
-                                    className="euiFormControlLayoutCustomIcon__icon"
-                                    size="s"
-                                    type="search"
-                                  >
-                                    <EuiIconSearch
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      role="img"
-                                      style={null}
-                                    >
-                                      <svg
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                        focusable="false"
-                                        height={16}
-                                        role="img"
-                                        style={null}
-                                        viewBox="0 0 16 16"
-                                        width={16}
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                        />
-                                      </svg>
-                                    </EuiIconSearch>
-                                  </EuiIcon>
-                                </span>
-                              </EuiFormControlLayoutCustomIcon>
-                            </div>
-                          </EuiFormControlLayoutIcons>
-                        </div>
-                      </div>
-                    </EuiFormControlLayout>
-                  </EuiCompressedFieldSearch>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer>
-            <div
-              className="euiSpacer euiSpacer--l"
-            />
-          </EuiSpacer>
-          <div
-            style={
-              Object {
-                "minHeight": 434,
-              }
-            }
-          >
-            <NoMatchMessage
-              size="s"
-            >
-              <EuiSpacer
-                size="s"
-              >
-                <div
-                  className="euiSpacer euiSpacer--s"
-                />
-              </EuiSpacer>
-              <EuiEmptyPrompt
-                body={
-                  <EuiText
-                    size="s"
-                  >
-                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                  </EuiText>
-                }
-                title={
-                  <h2>
-                    No matches
-                  </h2>
-                }
-              >
-                <div
-                  className="euiEmptyPrompt"
-                >
-                  <EuiTitle
-                    size="m"
-                  >
-                    <h2
-                      className="euiTitle euiTitle--medium"
-                    >
-                      No matches
-                    </h2>
-                  </EuiTitle>
-                  <EuiTextColor
-                    color="subdued"
-                  >
-                    <span
-                      className="euiTextColor euiTextColor--subdued"
+                    <NoMatchMessage
+                      size="s"
                     >
                       <EuiSpacer
-                        size="m"
+                        size="s"
                       >
                         <div
-                          className="euiSpacer euiSpacer--m"
+                          className="euiSpacer euiSpacer--s"
                         />
                       </EuiSpacer>
-                      <EuiText>
-                        <div
-                          className="euiText euiText--medium"
-                        >
+                      <EuiEmptyPrompt
+                        body={
                           <EuiText
                             size="s"
                           >
-                            <div
-                              className="euiText euiText--small"
-                            >
-                              No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                            </div>
+                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                           </EuiText>
+                        }
+                        title={
+                          <h2>
+                            No matches
+                          </h2>
+                        }
+                      >
+                        <div
+                          className="euiEmptyPrompt"
+                        >
+                          <EuiTitle
+                            size="m"
+                          >
+                            <h2
+                              className="euiTitle euiTitle--medium"
+                            >
+                              No matches
+                            </h2>
+                          </EuiTitle>
+                          <EuiTextColor
+                            color="subdued"
+                          >
+                            <span
+                              className="euiTextColor euiTextColor--subdued"
+                            >
+                              <EuiSpacer
+                                size="m"
+                              >
+                                <div
+                                  className="euiSpacer euiSpacer--m"
+                                />
+                              </EuiSpacer>
+                              <EuiText>
+                                <div
+                                  className="euiText euiText--medium"
+                                >
+                                  <EuiText
+                                    size="s"
+                                  >
+                                    <div
+                                      className="euiText euiText--small"
+                                    >
+                                      No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                    </div>
+                                  </EuiText>
+                                </div>
+                              </EuiText>
+                            </span>
+                          </EuiTextColor>
                         </div>
-                      </EuiText>
-                    </span>
-                  </EuiTextColor>
+                      </EuiEmptyPrompt>
+                      <EuiSpacer
+                        size="s"
+                      >
+                        <div
+                          className="euiSpacer euiSpacer--s"
+                        />
+                      </EuiSpacer>
+                    </NoMatchMessage>
+                  </div>
                 </div>
-              </EuiEmptyPrompt>
+              </EuiPanel>
               <EuiSpacer
-                size="s"
+                size="xl"
               >
                 <div
-                  className="euiSpacer euiSpacer--s"
+                  className="euiSpacer euiSpacer--xl"
                 />
               </EuiSpacer>
-            </NoMatchMessage>
+            </ServiceMap>
           </div>
-        </div>
-      </EuiPanel>
-      <EuiSpacer
-        size="xl"
-      >
-        <div
-          className="euiSpacer euiSpacer--xl"
-        />
-      </EuiSpacer>
-    </ServiceMap>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </ServicesContent>
 </Services>
 `;

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`Services table component renders empty jaeger services table message 1`
                             >
                               <EuiButtonContent
                                 className="euiButtonEmpty__content"
+                                iconGap="m"
                                 iconSide="left"
                                 iconSize="s"
                                 textProps={
@@ -311,6 +312,7 @@ exports[`Services table component renders empty services table message 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButtonEmpty__content"
+                                iconGap="m"
                                 iconSide="left"
                                 iconSize="s"
                                 textProps={
@@ -351,6 +353,7 @@ exports[`Services table component renders empty services table message 1`] = `
                         >
                           <EuiButtonContent
                             className="euiButtonEmpty__content"
+                            iconGap="m"
                             iconSide="left"
                             iconSize="s"
                             textProps={
@@ -577,6 +580,7 @@ exports[`Services table component renders jaeger services table 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButtonEmpty__content"
+                                iconGap="m"
                                 iconSide="left"
                                 iconSize="s"
                                 textProps={
@@ -959,6 +963,7 @@ exports[`Services table component renders jaeger services table 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -2098,6 +2103,7 @@ exports[`Services table component renders jaeger services table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -2303,6 +2309,7 @@ exports[`Services table component renders jaeger services table 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={
@@ -2519,6 +2526,7 @@ exports[`Services table component renders services table 1`] = `
                             >
                               <EuiButtonContent
                                 className="euiButtonEmpty__content"
+                                iconGap="m"
                                 iconSide="left"
                                 iconSize="s"
                                 textProps={
@@ -2559,6 +2567,7 @@ exports[`Services table component renders services table 1`] = `
                         >
                           <EuiButtonContent
                             className="euiButtonEmpty__content"
+                            iconGap="m"
                             iconSide="left"
                             iconSize="s"
                             textProps={
@@ -2997,6 +3006,7 @@ exports[`Services table component renders services table 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -4344,6 +4354,7 @@ exports[`Services table component renders services table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -4547,6 +4558,7 @@ exports[`Services table component renders services table 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={

--- a/public/components/trace_analytics/components/services/services.tsx
+++ b/public/components/trace_analytics/components/services/services.tsx
@@ -8,7 +8,6 @@ import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import React from 'react';
 import { DataSourceOption } from '../../../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
 import { TraceAnalyticsComponentDeps } from '../../home';
-import { DataSourcePicker } from '../dashboard/mode_picker';
 import { ServicesContent } from './services_content';
 
 export interface ServicesProps extends TraceAnalyticsComponentDeps {
@@ -23,7 +22,6 @@ export interface ServicesProps extends TraceAnalyticsComponentDeps {
 export function Services(props: ServicesProps) {
   return (
     <>
-      <DataSourcePicker modes={props.modes} selectedMode={props.mode} setMode={props.setMode!} />
       <ServicesContent {...props} />
     </>
   );

--- a/public/components/trace_analytics/components/services/services_content.tsx
+++ b/public/components/trace_analytics/components/services/services_content.tsx
@@ -4,7 +4,7 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiPage, EuiPageBody, EuiSpacer } from '@elastic/eui';
 import cloneDeep from 'lodash/cloneDeep';
 import React, { useEffect, useRef, useState } from 'react';
 import { ServiceTrends } from '../../../../../common/types/trace_analytics';
@@ -14,13 +14,14 @@ import {
   handleServiceTrendsRequest,
 } from '../../requests/services_request_handler';
 import { getValidFilterFields } from '../common/filters/filter_helpers';
-import { FilterType } from '../common/filters/filters';
+import { FilterType, Filters } from '../common/filters/filters';
 import { filtersToDsl, processTimeStamp } from '../common/helper_functions';
 import { ServiceMap, ServiceObject } from '../common/plots/service_map';
 import { SearchBar } from '../common/search_bar';
 import { ServicesProps } from './services';
 import { ServicesTable } from './services_table';
 import { coreRefs } from '../../../../framework/core_refs';
+import { DataSourcePicker } from '../dashboard/mode_picker';
 
 export function ServicesContent(props: ServicesProps) {
   const {
@@ -174,54 +175,76 @@ export function ServicesContent(props: ServicesProps) {
 
   return (
     <>
-      <SearchBar
-        ref={searchBarRef}
-        query={query}
-        filters={filters}
-        appConfigs={appConfigs}
-        setFilters={setFilters}
-        setQuery={setQuery}
-        startTime={startTime}
-        setStartTime={setStartTime}
-        endTime={endTime}
-        setEndTime={setEndTime}
-        refresh={refresh}
-        page={page}
-        mode={mode}
-        attributesFilterFields={attributesFilterFields}
-      />
-      <EuiSpacer size="m" />
-      <ServicesTable
-        items={tableItems}
-        selectedItems={selectedItems}
-        setSelectedItems={setSelectedItems}
-        addServicesGroupFilter={addServicesGroupFilter}
-        addFilter={addFilter}
-        setRedirect={setRedirect}
-        mode={mode}
-        loading={loading}
-        traceColumnAction={traceColumnAction}
-        setCurrentSelectedService={setCurrentSelectedService}
-        jaegerIndicesExist={jaegerIndicesExist}
-        dataPrepperIndicesExist={dataPrepperIndicesExist}
-        isServiceTrendEnabled={isServiceTrendEnabled}
-        setIsServiceTrendEnabled={setIsServiceTrendEnabled}
-        serviceTrends={serviceTrends}
-      />
-      <EuiSpacer size="m" />
-      {mode === 'data_prepper' && dataPrepperIndicesExist ? (
-        <ServiceMap
-          addFilter={addFilter}
-          serviceMap={serviceMap}
-          idSelected={serviceMapIdSelected}
-          setIdSelected={setServiceMapIdSelected}
-          currService={filteredService}
-          page={page}
-          setCurrentSelectedService={setCurrentSelectedService}
-        />
-      ) : (
-        <div />
-      )}
+      <EuiPage paddingSize="m">
+        <EuiPageBody>
+          <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <DataSourcePicker
+                modes={props.modes}
+                selectedMode={props.mode}
+                setMode={props.setMode!}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={true}>
+              <SearchBar
+                ref={searchBarRef}
+                filters={filters}
+                setFilters={setFilters}
+                query={query}
+                setQuery={setQuery}
+                startTime={startTime}
+                setStartTime={setStartTime}
+                endTime={endTime}
+                setEndTime={setEndTime}
+                refresh={refresh}
+                page={page}
+                mode={mode}
+                attributesFilterFields={attributesFilterFields}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <Filters
+            page={page}
+            filters={filters}
+            setFilters={setFilters}
+            appConfigs={appConfigs}
+            mode={mode}
+            attributesFilterFields={attributesFilterFields}
+          />
+          <EuiSpacer size="s" />
+          <ServicesTable
+            items={tableItems}
+            selectedItems={selectedItems}
+            setSelectedItems={setSelectedItems}
+            addServicesGroupFilter={addServicesGroupFilter}
+            addFilter={addFilter}
+            setRedirect={setRedirect}
+            mode={mode}
+            loading={loading}
+            traceColumnAction={traceColumnAction}
+            setCurrentSelectedService={setCurrentSelectedService}
+            jaegerIndicesExist={jaegerIndicesExist}
+            dataPrepperIndicesExist={dataPrepperIndicesExist}
+            isServiceTrendEnabled={isServiceTrendEnabled}
+            setIsServiceTrendEnabled={setIsServiceTrendEnabled}
+            serviceTrends={serviceTrends}
+          />
+          <EuiSpacer size="s" />
+          {mode === 'data_prepper' && dataPrepperIndicesExist ? (
+            <ServiceMap
+              addFilter={addFilter}
+              serviceMap={serviceMap}
+              idSelected={serviceMapIdSelected}
+              setIdSelected={setServiceMapIdSelected}
+              currService={filteredService}
+              page={page}
+              setCurrentSelectedService={setCurrentSelectedService}
+            />
+          ) : (
+            <div />
+          )}
+        </EuiPageBody>
+      </EuiPage>
     </>
   );
 }

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_flyout.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_flyout.test.tsx.snap
@@ -775,6 +775,7 @@ exports[`<SpanDetailFlyout /> spec renders the empty component 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="left"
                                           iconSize="s"
                                           textProps={

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_panel.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_panel.test.tsx.snap
@@ -185,6 +185,7 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             textProps={
                               Object {
@@ -265,6 +266,7 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
                         >
                           <EuiButtonContent
                             className="euiButton__content"
+                            iconGap="m"
                             iconSide="left"
                             textProps={
                               Object {

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -238,139 +238,6 @@ exports[`Traces component renders empty traces page 1`] = `
   startTime="now-5m"
   traceIdColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="data_prepper"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="data_prepper"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconBeaker
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                          />
-                        </svg>
-                      </EuiIconBeaker>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Data Prepper
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <TracesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -608,463 +475,422 @@ exports[`Traces component renders empty traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <ForwardRef
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      endTime="now"
-      filters={Array []}
-      mode="data_prepper"
-      page="traces"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
+    <EuiPage
+      paddingSize="m"
     >
-      <EuiFlexGroup
-        gutterSize="s"
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
+        <EuiPageBody>
+          <div
+            className="euiPageBody euiPageBody--borderRadiusNone"
+          >
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="data_prepper"
                     >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
+                            iconSide="right"
+                            iconType="arrowDown"
+                            onClick={[Function]}
+                            title="data_prepper"
+                          >
+                            Data Prepper
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
                       >
                         <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                            className="euiPopover__anchor eui-textTruncate"
                           >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="data_prepper"
                             >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="data_prepper"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="data_prepper"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
+                                    iconSize="m"
                                     iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
                                     textProps={
                                       Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
+                                        "className": "euiButtonEmpty__text",
                                       }
                                     }
                                   >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconBeaker
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Data Prepper
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      appConfigs={Array []}
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="data_prepper"
+                      page="traces"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
                                 }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
+                                value=""
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
                                 >
                                   <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
                                   >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
+                                    <GlobalFilterButton
                                       className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
                                         }
                                       }
                                     >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          <div
+                                            className="euiPopover__anchor"
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
                                             >
-                                              <EuiIconBeaker
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
                                               >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
                                                 >
-                                                  <path
-                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                                  />
-                                                </svg>
-                                              </EuiIconBeaker>
-                                            </EuiIcon>
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconBeaker
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
                                             <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                              className="euiFormControlLayoutCustomIcon"
                                             >
                                               <EuiIcon
-                                                type="calendar"
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
                                               >
                                                 <EuiIconBeaker
                                                   aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                  className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                   focusable="false"
                                                   role="img"
                                                   style={null}
                                                 >
                                                   <svg
                                                     aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                    className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                     focusable="false"
                                                     height={16}
                                                     role="img"
@@ -1080,133 +906,642 @@ exports[`Traces component renders empty traces page 1`] = `
                                                 </EuiIconBeaker>
                                               </EuiIcon>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
+                              Object {
+                                "maxWidth": "30vw",
+                              }
+                            }
+                          >
                             <div
-                              className="euiFormControlLayout__childrenWrapper"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
+                                Object {
+                                  "maxWidth": "30vw",
+                                }
+                              }
                             >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
                                   >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
                                       >
-                                        Show dates
-                                      </EuiI18n>
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconGap="m"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconBeaker
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconBeaker>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconBeaker
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium euiIcon-isLoading"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconBeaker>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
+                              >
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconBeaker
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                    </EuiIconBeaker>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              filters={Array []}
+              mode="data_prepper"
+              page="traces"
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="xs"
+                responsive={false}
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                >
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              flush="left"
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
+                          }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
+                        >
+                          <div
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
+                          >
+                            <div
+                              className="euiPopover__anchor"
+                            >
+                              <EuiButtonEmpty
+                                flush="left"
+                                onClick={[Function]}
+                                size="xs"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconGap="m"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
+                                    >
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        + Add filter
+                                      </span>
                                     </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
                             </div>
                           </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+                        </EuiPopover>
+                      </AddFilterButton>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </Filters>
+            <EuiSpacer
+              size="s"
             >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <EuiPanel>
+              <div
+                className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
               >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
+                <EuiAccordion
+                  arrowDisplay="left"
+                  buttonContent="Trace Groups"
+                  data-test-subj="trace-groups-service-operation-accordian"
+                  forceState="closed"
+                  id="accordion1"
+                  initialIsOpen={false}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
                 >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
+                  <div
+                    className="euiAccordion"
+                    data-test-subj="trace-groups-service-operation-accordian"
+                    onToggle={[Function]}
                   >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
+                    <div
+                      className="euiAccordion__triggerWrapper"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
+                      <button
+                        aria-controls="accordion1"
+                        aria-expanded={false}
+                        className="euiAccordion__button"
+                        id="random_html_id"
+                        onClick={[Function]}
+                        type="button"
                       >
                         <span
-                          className="euiButtonContent euiButton__content"
+                          className="euiAccordion__iconWrapper"
                         >
                           <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
+                            className="euiAccordion__icon"
                             size="m"
-                            type="refresh"
+                            type="arrowRight"
                           >
                             <EuiIconBeaker
                               aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                              className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
                               focusable="false"
                               role="img"
                               style={null}
                             >
                               <svg
                                 aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                                className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
                                 focusable="false"
                                 height={16}
                                 role="img"
@@ -1221,499 +1556,199 @@ exports[`Traces component renders empty traces page 1`] = `
                               </svg>
                             </EuiIconBeaker>
                           </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
                         </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="traces"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
-          }
-        }
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
-          style={
-            Object {
-              "minHeight": 32,
-            }
-          }
-        >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
-          >
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
+                        <span
+                          className="euiIEFlexWrapFix"
                         >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconBeaker
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                    />
-                                  </svg>
-                                </EuiIconBeaker>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
+                          Trace Groups
+                        </span>
+                      </button>
                     </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
                     <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
+                      aria-labelledby="random_html_id"
+                      className="euiAccordion__childWrapper"
+                      id="accordion1"
+                      role="region"
+                      tabIndex={-1}
                     >
-                      <div
-                        className="euiPopover__anchor"
+                      <EuiResizeObserver
+                        onResize={[Function]}
                       >
-                        <EuiButtonEmpty
-                          onClick={[Function]}
-                          size="xs"
-                        >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
+                        <div>
+                          <div
+                            className=""
                           >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
-                              }
+                            <EuiSpacer
+                              size="m"
                             >
-                              <span
-                                className="euiButtonContent euiButtonEmpty__content"
-                              >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
-                              </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiAccordion
-          arrowDisplay="left"
-          buttonContent="Trace Groups"
-          data-test-subj="trace-groups-service-operation-accordian"
-          forceState="closed"
-          id="accordion1"
-          initialIsOpen={false}
-          isLoading={false}
-          isLoadingMessage={false}
-          onToggle={[Function]}
-          paddingSize="none"
-        >
-          <div
-            className="euiAccordion"
-            data-test-subj="trace-groups-service-operation-accordian"
-            onToggle={[Function]}
-          >
-            <div
-              className="euiAccordion__triggerWrapper"
-            >
-              <button
-                aria-controls="accordion1"
-                aria-expanded={false}
-                className="euiAccordion__button"
-                id="random_html_id"
-                onClick={[Function]}
-                type="button"
-              >
-                <span
-                  className="euiAccordion__iconWrapper"
-                >
-                  <EuiIcon
-                    className="euiAccordion__icon"
-                    size="m"
-                    type="arrowRight"
-                  >
-                    <EuiIconBeaker
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon-isLoading euiAccordion__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                        />
-                      </svg>
-                    </EuiIconBeaker>
-                  </EuiIcon>
-                </span>
-                <span
-                  className="euiIEFlexWrapFix"
-                >
-                  Trace Groups
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="random_html_id"
-              className="euiAccordion__childWrapper"
-              id="accordion1"
-              role="region"
-              tabIndex={-1}
-            >
-              <EuiResizeObserver
-                onResize={[Function]}
-              >
-                <div>
-                  <div
-                    className=""
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
                   </div>
-                </div>
-              </EuiResizeObserver>
-            </div>
-          </div>
-        </EuiAccordion>
-      </div>
-    </EuiPanel>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <TracesTable
-      dataPrepperIndicesExist={true}
-      items={Array []}
-      loading={true}
-      mode="data_prepper"
-      refresh={[Function]}
-      traceIdColumnAction={[Function]}
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={10}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
-                >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
+                </EuiAccordion>
+              </div>
+            </EuiPanel>
             <EuiSpacer
-              size="xl"
+              size="s"
             >
               <div
-                className="euiSpacer euiSpacer--xl"
+                className="euiSpacer euiSpacer--s"
               />
             </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
+            <TracesTable
+              dataPrepperIndicesExist={true}
+              items={Array []}
+              loading={true}
+              mode="data_prepper"
+              refresh={[Function]}
+              traceIdColumnAction={[Function]}
             >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                 >
-                  <h2
-                    className="euiTitle euiTitle--medium"
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
                   >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={10}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrow10"
+                        >
+                          <PanelTitle
+                            title="Traces"
+                            totalItems={0}
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <span
+                                  className="panel-title"
+                                >
+                                  Traces
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
                   >
                     <EuiSpacer
-                      size="m"
+                      size="xl"
                     >
                       <div
-                        className="euiSpacer euiSpacer--m"
+                        className="euiSpacer euiSpacer--xl"
                       />
                     </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
+                    <EuiEmptyPrompt
+                      body={
                         <EuiText
                           size="s"
                         >
-                          <div
-                            className="euiText euiText--small"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                         </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
                       </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
-    </TracesTable>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </TracesTable>
+          </div>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </TracesContent>
 </Traces>
 `;
@@ -1956,140 +1991,6 @@ exports[`Traces component renders jaeger traces page 1`] = `
   startTime="now-5m"
   traceIdColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="jaeger"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="jaeger"
-        >
-          Jaeger
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="jaeger"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="jaeger"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="jaeger"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconArrowDown
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                            fillRule="non-zero"
-                          />
-                        </svg>
-                      </EuiIconArrowDown>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Jaeger
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <TracesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -2327,464 +2228,424 @@ exports[`Traces component renders jaeger traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <ForwardRef
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      endTime="now"
-      filters={Array []}
-      mode="jaeger"
-      page="traces"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
+    <EuiPage
+      paddingSize="m"
     >
-      <EuiFlexGroup
-        gutterSize="s"
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
+        <EuiPageBody>
+          <div
+            className="euiPageBody euiPageBody--borderRadiusNone"
+          >
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="jaeger"
                     >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
+                            iconSide="right"
+                            iconType="arrowDown"
+                            onClick={[Function]}
+                            title="jaeger"
+                          >
+                            Jaeger
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
                       >
                         <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                            className="euiPopover__anchor eui-textTruncate"
                           >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="jaeger"
                             >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="jaeger"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="jaeger"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
+                                    iconSize="m"
                                     iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
                                     textProps={
                                       Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
+                                        "className": "euiButtonEmpty__text",
                                       }
                                     }
                                   >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconArrowDown
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                              fillRule="non-zero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowDown>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Jaeger
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      appConfigs={Array []}
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="jaeger"
+                      page="traces"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
                                 }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
+                                value=""
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
                                 >
                                   <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
                                   >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
+                                    <GlobalFilterButton
                                       className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
                                         }
                                       }
                                     >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          <div
+                                            className="euiPopover__anchor"
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
                                             >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
                                               >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
                                                 >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconFilter
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                          fillRule="evenodd"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconFilter>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
                                             <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                              className="euiFormControlLayoutCustomIcon"
                                             >
                                               <EuiIcon
-                                                type="calendar"
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
                                               >
-                                                <EuiIconCalendar
+                                                <EuiIconSearch
                                                   aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
+                                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                                   focusable="false"
                                                   role="img"
                                                   style={null}
                                                 >
                                                   <svg
                                                     aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
+                                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                                     focusable="false"
                                                     height={16}
                                                     role="img"
@@ -2794,140 +2655,650 @@ exports[`Traces component renders jaeger traces page 1`] = `
                                                     xmlns="http://www.w3.org/2000/svg"
                                                   >
                                                     <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
+                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
                                                     />
                                                   </svg>
-                                                </EuiIconCalendar>
+                                                </EuiIconSearch>
                                               </EuiIcon>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
+                              Object {
+                                "maxWidth": "30vw",
+                              }
+                            }
+                          >
                             <div
-                              className="euiFormControlLayout__childrenWrapper"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
+                                Object {
+                                  "maxWidth": "30vw",
+                                }
+                              }
                             >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
                                   >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
                                       >
-                                        Show dates
-                                      </EuiI18n>
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconGap="m"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconArrowDown
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                                    fillRule="non-zero"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconArrowDown>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconCalendar
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                                      fillRule="evenodd"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconCalendar>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
+                              >
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconRefresh
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                        />
+                                      </svg>
+                                    </EuiIconRefresh>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              filters={Array []}
+              mode="jaeger"
+              page="traces"
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="xs"
+                responsive={false}
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                >
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              flush="left"
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
+                          }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
+                        >
+                          <div
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
+                          >
+                            <div
+                              className="euiPopover__anchor"
+                            >
+                              <EuiButtonEmpty
+                                flush="left"
+                                onClick={[Function]}
+                                size="xs"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconGap="m"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
+                                    >
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        + Add filter
+                                      </span>
                                     </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
                             </div>
                           </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+                        </EuiPopover>
+                      </AddFilterButton>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </Filters>
+            <EuiSpacer
+              size="s"
             >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <EuiPanel>
+              <div
+                className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
               >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
+                <EuiAccordion
+                  arrowDisplay="left"
+                  buttonContent="Service and Operations"
+                  data-test-subj="trace-groups-service-operation-accordian"
+                  forceState="closed"
+                  id="accordion1"
+                  initialIsOpen={false}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
                 >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
+                  <div
+                    className="euiAccordion"
+                    data-test-subj="trace-groups-service-operation-accordian"
+                    onToggle={[Function]}
                   >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
+                    <div
+                      className="euiAccordion__triggerWrapper"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
+                      <button
+                        aria-controls="accordion1"
+                        aria-expanded={false}
+                        className="euiAccordion__button"
+                        id="random_html_id"
+                        onClick={[Function]}
+                        type="button"
                       >
                         <span
-                          className="euiButtonContent euiButton__content"
+                          className="euiAccordion__iconWrapper"
                         >
                           <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
+                            className="euiAccordion__icon"
                             size="m"
-                            type="refresh"
+                            type="arrowRight"
                           >
-                            <EuiIconRefresh
+                            <EuiIconArrowRight
                               aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                              className="euiIcon euiIcon--medium euiAccordion__icon"
                               focusable="false"
                               role="img"
                               style={null}
                             >
                               <svg
                                 aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                className="euiIcon euiIcon--medium euiAccordion__icon"
                                 focusable="false"
                                 height={16}
                                 role="img"
@@ -2937,507 +3308,206 @@ exports[`Traces component renders jaeger traces page 1`] = `
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                  fillRule="nonzero"
                                 />
                               </svg>
-                            </EuiIconRefresh>
+                            </EuiIconArrowRight>
                           </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
                         </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="jaeger"
-        page="traces"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
-          }
-        }
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
-          style={
-            Object {
-              "minHeight": 32,
-            }
-          }
-        >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
-          >
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
+                        <span
+                          className="euiIEFlexWrapFix"
                         >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconFilter
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                      fillRule="evenodd"
-                                    />
-                                  </svg>
-                                </EuiIconFilter>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
+                          Service and Operations
+                        </span>
+                      </button>
                     </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
                     <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
+                      aria-labelledby="random_html_id"
+                      className="euiAccordion__childWrapper"
+                      id="accordion1"
+                      role="region"
+                      tabIndex={-1}
                     >
-                      <div
-                        className="euiPopover__anchor"
+                      <EuiResizeObserver
+                        onResize={[Function]}
                       >
-                        <EuiButtonEmpty
-                          onClick={[Function]}
-                          size="xs"
-                        >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
+                        <div>
+                          <div
+                            className=""
                           >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
-                              }
+                            <EuiSpacer
+                              size="m"
                             >
-                              <span
-                                className="euiButtonContent euiButtonEmpty__content"
-                              >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
-                              </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiAccordion
-          arrowDisplay="left"
-          buttonContent="Service and Operations"
-          data-test-subj="trace-groups-service-operation-accordian"
-          forceState="closed"
-          id="accordion1"
-          initialIsOpen={false}
-          isLoading={false}
-          isLoadingMessage={false}
-          onToggle={[Function]}
-          paddingSize="none"
-        >
-          <div
-            className="euiAccordion"
-            data-test-subj="trace-groups-service-operation-accordian"
-            onToggle={[Function]}
-          >
-            <div
-              className="euiAccordion__triggerWrapper"
-            >
-              <button
-                aria-controls="accordion1"
-                aria-expanded={false}
-                className="euiAccordion__button"
-                id="random_html_id"
-                onClick={[Function]}
-                type="button"
-              >
-                <span
-                  className="euiAccordion__iconWrapper"
-                >
-                  <EuiIcon
-                    className="euiAccordion__icon"
-                    size="m"
-                    type="arrowRight"
-                  >
-                    <EuiIconArrowRight
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiAccordion__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiAccordion__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                          fillRule="nonzero"
-                        />
-                      </svg>
-                    </EuiIconArrowRight>
-                  </EuiIcon>
-                </span>
-                <span
-                  className="euiIEFlexWrapFix"
-                >
-                  Service and Operations
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="random_html_id"
-              className="euiAccordion__childWrapper"
-              id="accordion1"
-              role="region"
-              tabIndex={-1}
-            >
-              <EuiResizeObserver
-                onResize={[Function]}
-              >
-                <div>
-                  <div
-                    className=""
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
                   </div>
-                </div>
-              </EuiResizeObserver>
-            </div>
-          </div>
-        </EuiAccordion>
-      </div>
-    </EuiPanel>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <TracesTable
-      dataPrepperIndicesExist={false}
-      items={Array []}
-      jaegerIndicesExist={true}
-      loading={true}
-      mode="jaeger"
-      refresh={[Function]}
-      traceIdColumnAction={[Function]}
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={10}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
-                >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
+                </EuiAccordion>
+              </div>
+            </EuiPanel>
             <EuiSpacer
-              size="xl"
+              size="s"
             >
               <div
-                className="euiSpacer euiSpacer--xl"
+                className="euiSpacer euiSpacer--s"
               />
             </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
+            <TracesTable
+              dataPrepperIndicesExist={false}
+              items={Array []}
+              jaegerIndicesExist={true}
+              loading={true}
+              mode="jaeger"
+              refresh={[Function]}
+              traceIdColumnAction={[Function]}
             >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                 >
-                  <h2
-                    className="euiTitle euiTitle--medium"
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
                   >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={10}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrow10"
+                        >
+                          <PanelTitle
+                            title="Traces"
+                            totalItems={0}
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <span
+                                  className="panel-title"
+                                >
+                                  Traces
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
                   >
                     <EuiSpacer
-                      size="m"
+                      size="xl"
                     >
                       <div
-                        className="euiSpacer euiSpacer--m"
+                        className="euiSpacer euiSpacer--xl"
                       />
                     </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
+                    <EuiEmptyPrompt
+                      body={
                         <EuiText
                           size="s"
                         >
-                          <div
-                            className="euiText euiText--small"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                         </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
                       </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
-    </TracesTable>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </TracesTable>
+          </div>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </TracesContent>
 </Traces>
 `;
@@ -3679,140 +3749,6 @@ exports[`Traces component renders traces page 1`] = `
   startTime="now-5m"
   traceIdColumnAction={[Function]}
 >
-  <DataSourcePicker
-    modes={
-      Array [
-        Object {
-          "id": "jaeger",
-          "title": "Jaeger",
-        },
-        Object {
-          "id": "data_prepper",
-          "title": "Data Prepper",
-        },
-      ]
-    }
-    selectedMode="data_prepper"
-  >
-    <EuiPopover
-      anchorClassName="eui-textTruncate"
-      anchorPosition="downCenter"
-      button={
-        <EuiSmallButtonEmpty
-          className="dscIndexPattern__triggerButton"
-          color="text"
-          data-test-subj="indexPattern-switch-link"
-          flush="left"
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[Function]}
-          title="data_prepper"
-        >
-          Data Prepper
-        </EuiSmallButtonEmpty>
-      }
-      className="eui-textTruncate"
-      closePopover={[Function]}
-      display="inlineBlock"
-      hasArrow={true}
-      isOpen={false}
-      ownFocus={true}
-      panelPaddingSize="s"
-    >
-      <div
-        className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
-      >
-        <div
-          className="euiPopover__anchor eui-textTruncate"
-        >
-          <EuiSmallButtonEmpty
-            className="dscIndexPattern__triggerButton"
-            color="text"
-            data-test-subj="indexPattern-switch-link"
-            flush="left"
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={[Function]}
-            title="data_prepper"
-          >
-            <EuiButtonEmpty
-              className="dscIndexPattern__triggerButton"
-              color="text"
-              data-test-subj="indexPattern-switch-link"
-              flush="left"
-              iconSide="right"
-              iconType="arrowDown"
-              onClick={[Function]}
-              size="s"
-              title="data_prepper"
-            >
-              <button
-                className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
-                data-test-subj="indexPattern-switch-link"
-                disabled={false}
-                onClick={[Function]}
-                title="data_prepper"
-                type="button"
-              >
-                <EuiButtonContent
-                  className="euiButtonEmpty__content"
-                  iconSide="right"
-                  iconSize="m"
-                  iconType="arrowDown"
-                  textProps={
-                    Object {
-                      "className": "euiButtonEmpty__text",
-                    }
-                  }
-                >
-                  <span
-                    className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                  >
-                    <EuiIcon
-                      className="euiButtonContent__icon"
-                      color="inherit"
-                      size="m"
-                      type="arrowDown"
-                    >
-                      <EuiIconArrowDown
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                        focusable="false"
-                        role="img"
-                        style={null}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                          focusable="false"
-                          height={16}
-                          role="img"
-                          style={null}
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                            fillRule="non-zero"
-                          />
-                        </svg>
-                      </EuiIconArrowDown>
-                    </EuiIcon>
-                    <span
-                      className="euiButtonEmpty__text"
-                    >
-                      Data Prepper
-                    </span>
-                  </span>
-                </EuiButtonContent>
-              </button>
-            </EuiButtonEmpty>
-          </EuiSmallButtonEmpty>
-        </div>
-      </div>
-    </EuiPopover>
-  </DataSourcePicker>
   <TracesContent
     appConfigs={Array []}
     attributesFilterFields={Array []}
@@ -4049,464 +3985,424 @@ exports[`Traces component renders traces page 1`] = `
     startTime="now-5m"
     traceIdColumnAction={[Function]}
   >
-    <ForwardRef
-      appConfigs={Array []}
-      attributesFilterFields={Array []}
-      endTime="now"
-      filters={Array []}
-      mode="data_prepper"
-      page="traces"
-      query=""
-      refresh={[Function]}
-      setEndTime={[MockFunction]}
-      setFilters={
-        [MockFunction] {
-          "calls": Array [
-            Array [
-              Array [],
-            ],
-          ],
-          "results": Array [
-            Object {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        }
-      }
-      setQuery={[MockFunction]}
-      setStartTime={[MockFunction]}
-      startTime="now-5m"
+    <EuiPage
+      paddingSize="m"
     >
-      <EuiFlexGroup
-        gutterSize="s"
+      <div
+        className="euiPage euiPage--paddingMedium euiPage--grow"
       >
-        <div
-          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
-        >
-          <EuiFlexItem>
-            <div
-              className="euiFlexItem"
+        <EuiPageBody>
+          <div
+            className="euiPageBody euiPageBody--borderRadiusNone"
+          >
+            <EuiFlexGroup
+              alignItems="center"
+              gutterSize="s"
+              justifyContent="spaceBetween"
             >
-              <EuiCompressedFieldSearch
-                compressed={true}
-                data-test-subj="search-bar-input-box"
-                fullWidth={true}
-                incremental={false}
-                isClearable={false}
-                isLoading={false}
-                onChange={[Function]}
-                onSearch={[Function]}
-                placeholder="Trace ID, trace group name, service name"
-                value=""
+              <div
+                className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <EuiFormControlLayout
-                  compressed={true}
-                  fullWidth={true}
-                  icon="search"
-                  isLoading={false}
+                <EuiFlexItem
+                  grow={false}
                 >
                   <div
-                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <div
-                      className="euiFormControlLayout__childrenWrapper"
+                    <DataSourcePicker
+                      modes={
+                        Array [
+                          Object {
+                            "id": "jaeger",
+                            "title": "Jaeger",
+                          },
+                          Object {
+                            "id": "data_prepper",
+                            "title": "Data Prepper",
+                          },
+                        ]
+                      }
+                      selectedMode="data_prepper"
                     >
-                      <EuiValidatableControl>
-                        <input
-                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-                          data-test-subj="search-bar-input-box"
-                          onChange={[Function]}
-                          onKeyUp={[Function]}
-                          placeholder="Trace ID, trace group name, service name"
-                          type="search"
-                          value=""
-                        />
-                      </EuiValidatableControl>
-                      <EuiFormControlLayoutIcons
-                        compressed={true}
-                        icon="search"
-                        isLoading={false}
+                      <EuiPopover
+                        anchorClassName="eui-textTruncate"
+                        anchorPosition="downCenter"
+                        button={
+                          <EuiSmallButtonEmpty
+                            className="dscIndexPattern__triggerButton"
+                            color="text"
+                            data-test-subj="indexPattern-switch-link"
+                            flush="left"
+                            iconSide="right"
+                            iconType="arrowDown"
+                            onClick={[Function]}
+                            title="data_prepper"
+                          >
+                            Data Prepper
+                          </EuiSmallButtonEmpty>
+                        }
+                        className="eui-textTruncate"
+                        closePopover={[Function]}
+                        display="inlineBlock"
+                        hasArrow={true}
+                        isOpen={false}
+                        ownFocus={true}
+                        panelPaddingSize="s"
                       >
                         <div
-                          className="euiFormControlLayoutIcons"
-                        >
-                          <EuiFormControlLayoutCustomIcon
-                            size="s"
-                            type="search"
-                          >
-                            <span
-                              className="euiFormControlLayoutCustomIcon"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiFormControlLayoutCustomIcon__icon"
-                                size="s"
-                                type="search"
-                              >
-                                <EuiIconSearch
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                                    />
-                                  </svg>
-                                </EuiIconSearch>
-                              </EuiIcon>
-                            </span>
-                          </EuiFormControlLayoutCustomIcon>
-                        </div>
-                      </EuiFormControlLayoutIcons>
-                    </div>
-                  </div>
-                </EuiFormControlLayout>
-              </EuiCompressedFieldSearch>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-            style={
-              Object {
-                "maxWidth": "40vw",
-              }
-            }
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
-              style={
-                Object {
-                  "maxWidth": "40vw",
-                }
-              }
-            >
-              <EuiSuperDatePicker
-                commonlyUsedRanges={
-                  Array [
-                    Object {
-                      "end": "now/d",
-                      "label": "Today",
-                      "start": "now/d",
-                    },
-                    Object {
-                      "end": "now/w",
-                      "label": "This week",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now/M",
-                      "label": "This month",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now/y",
-                      "label": "This year",
-                      "start": "now/y",
-                    },
-                    Object {
-                      "end": "now-1d/d",
-                      "label": "Yesterday",
-                      "start": "now-1d/d",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Week to date",
-                      "start": "now/w",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Month to date",
-                      "start": "now/M",
-                    },
-                    Object {
-                      "end": "now",
-                      "label": "Year to date",
-                      "start": "now/y",
-                    },
-                  ]
-                }
-                compressed={false}
-                dateFormat=""
-                end="now"
-                isAutoRefreshOnly={false}
-                isDisabled={false}
-                isPaused={true}
-                onTimeChange={[Function]}
-                recentlyUsedRanges={Array []}
-                refreshInterval={0}
-                showUpdateButton={false}
-                start="now-5m"
-                timeFormat="HH:mm"
-              >
-                <EuiFlexGroup
-                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  gutterSize="s"
-                  responsive={false}
-                >
-                  <div
-                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
-                  >
-                    <EuiFlexItem>
-                      <div
-                        className="euiFlexItem"
-                      >
-                        <EuiFormControlLayout
-                          className="euiSuperDatePicker"
-                          compressed={false}
-                          isDisabled={false}
-                          prepend={
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
-                            />
-                          }
+                          className="euiPopover euiPopover--anchorDownCenter eui-textTruncate"
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                            className="euiPopover__anchor eui-textTruncate"
                           >
-                            <EuiQuickSelectPopover
-                              applyTime={[Function]}
-                              className="euiFormControlLayout__prepend"
-                              commonlyUsedRanges={
-                                Array [
-                                  Object {
-                                    "end": "now/d",
-                                    "label": "Today",
-                                    "start": "now/d",
-                                  },
-                                  Object {
-                                    "end": "now/w",
-                                    "label": "This week",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now/M",
-                                    "label": "This month",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now/y",
-                                    "label": "This year",
-                                    "start": "now/y",
-                                  },
-                                  Object {
-                                    "end": "now-1d/d",
-                                    "label": "Yesterday",
-                                    "start": "now-1d/d",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Week to date",
-                                    "start": "now/w",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Month to date",
-                                    "start": "now/M",
-                                  },
-                                  Object {
-                                    "end": "now",
-                                    "label": "Year to date",
-                                    "start": "now/y",
-                                  },
-                                ]
-                              }
-                              dateFormat=""
-                              end="now"
-                              isAutoRefreshOnly={false}
-                              isDisabled={false}
-                              isPaused={true}
-                              key="0/.0"
-                              recentlyUsedRanges={Array []}
-                              refreshInterval={0}
-                              start="now-5m"
+                            <EuiSmallButtonEmpty
+                              className="dscIndexPattern__triggerButton"
+                              color="text"
+                              data-test-subj="indexPattern-switch-link"
+                              flush="left"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              onClick={[Function]}
+                              title="data_prepper"
                             >
-                              <EuiPopover
-                                anchorClassName="euiQuickSelectPopover__anchor"
-                                anchorPosition="downLeft"
-                                button={
-                                  <EuiButtonEmpty
-                                    aria-label="Date quick select"
-                                    className="euiFormControlLayout__prepend"
-                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                              <EuiButtonEmpty
+                                className="dscIndexPattern__triggerButton"
+                                color="text"
+                                data-test-subj="indexPattern-switch-link"
+                                flush="left"
+                                iconSide="right"
+                                iconType="arrowDown"
+                                onClick={[Function]}
+                                size="s"
+                                title="data_prepper"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty--flushLeft dscIndexPattern__triggerButton"
+                                  data-test-subj="indexPattern-switch-link"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  title="data_prepper"
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconGap="m"
                                     iconSide="right"
+                                    iconSize="m"
                                     iconType="arrowDown"
-                                    isDisabled={false}
-                                    onClick={[Function]}
-                                    size="xs"
                                     textProps={
                                       Object {
-                                        "className": "euiQuickSelectPopover__buttonText",
+                                        "className": "euiButtonEmpty__text",
                                       }
                                     }
                                   >
-                                    <EuiIcon
-                                      type="calendar"
-                                    />
-                                  </EuiButtonEmpty>
+                                    <span
+                                      className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                    >
+                                      <EuiIcon
+                                        className="euiButtonContent__icon"
+                                        color="inherit"
+                                        size="m"
+                                        type="arrowDown"
+                                      >
+                                        <EuiIconArrowDown
+                                          aria-hidden={true}
+                                          className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                          focusable="false"
+                                          role="img"
+                                          style={null}
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                            focusable="false"
+                                            height={16}
+                                            role="img"
+                                            style={null}
+                                            viewBox="0 0 16 16"
+                                            width={16}
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                              fillRule="non-zero"
+                                            />
+                                          </svg>
+                                        </EuiIconArrowDown>
+                                      </EuiIcon>
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        Data Prepper
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
+                            </EuiSmallButtonEmpty>
+                          </div>
+                        </div>
+                      </EuiPopover>
+                    </DataSourcePicker>
+                  </div>
+                </EuiFlexItem>
+                <EuiFlexItem
+                  grow={true}
+                >
+                  <div
+                    className="euiFlexItem"
+                  >
+                    <ForwardRef
+                      appConfigs={Array []}
+                      attributesFilterFields={Array []}
+                      endTime="now"
+                      filters={Array []}
+                      mode="data_prepper"
+                      page="traces"
+                      query=""
+                      refresh={[Function]}
+                      setEndTime={[MockFunction]}
+                      setFilters={
+                        [MockFunction] {
+                          "calls": Array [
+                            Array [
+                              Array [],
+                            ],
+                          ],
+                          "results": Array [
+                            Object {
+                              "type": "return",
+                              "value": undefined,
+                            },
+                          ],
+                        }
+                      }
+                      setQuery={[MockFunction]}
+                      setStartTime={[MockFunction]}
+                      startTime="now-5m"
+                    >
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="s"
+                      >
+                        <div
+                          className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                        >
+                          <EuiFlexItem>
+                            <div
+                              className="euiFlexItem"
+                            >
+                              <EuiCompressedFieldSearch
+                                compressed={true}
+                                data-test-subj="search-bar-input-box"
+                                fullWidth={true}
+                                incremental={false}
+                                isClearable={false}
+                                isLoading={false}
+                                onChange={[Function]}
+                                onSearch={[Function]}
+                                placeholder="Trace ID, trace group name, service name"
+                                prepend={
+                                  <GlobalFilterButton
+                                    filters={Array []}
+                                    setFilters={
+                                      [MockFunction] {
+                                        "calls": Array [
+                                          Array [
+                                            Array [],
+                                          ],
+                                        ],
+                                        "results": Array [
+                                          Object {
+                                            "type": "return",
+                                            "value": undefined,
+                                          },
+                                        ],
+                                      }
+                                    }
+                                  />
                                 }
-                                closePopover={[Function]}
-                                display="inlineBlock"
-                                hasArrow={true}
-                                isOpen={false}
-                                ownFocus={true}
-                                panelPaddingSize="s"
+                                value=""
                               >
-                                <div
-                                  className="euiPopover euiPopover--anchorDownLeft"
+                                <EuiFormControlLayout
+                                  compressed={true}
+                                  fullWidth={true}
+                                  icon="search"
+                                  isLoading={false}
+                                  prepend={
+                                    <GlobalFilterButton
+                                      filters={Array []}
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    />
+                                  }
                                 >
                                   <div
-                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed euiFormControlLayout--group"
                                   >
-                                    <EuiButtonEmpty
-                                      aria-label="Date quick select"
+                                    <GlobalFilterButton
                                       className="euiFormControlLayout__prepend"
-                                      data-test-subj="superDatePickerToggleQuickMenuButton"
-                                      iconSide="right"
-                                      iconType="arrowDown"
-                                      isDisabled={false}
-                                      onClick={[Function]}
-                                      size="xs"
-                                      textProps={
-                                        Object {
-                                          "className": "euiQuickSelectPopover__buttonText",
+                                      filters={Array []}
+                                      key="0/.0"
+                                      setFilters={
+                                        [MockFunction] {
+                                          "calls": Array [
+                                            Array [
+                                              Array [],
+                                            ],
+                                          ],
+                                          "results": Array [
+                                            Object {
+                                              "type": "return",
+                                              "value": undefined,
+                                            },
+                                          ],
                                         }
                                       }
                                     >
-                                      <button
-                                        aria-label="Date quick select"
-                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
+                                      <EuiPopover
+                                        anchorPosition="rightUp"
+                                        button={
+                                          <EuiSmallButtonIcon
+                                            aria-label="Change all filters"
+                                            iconType="filter"
+                                            onClick={[Function]}
+                                            title="Change all filters"
+                                          />
+                                        }
+                                        closePopover={[Function]}
+                                        data-test-subj="global-filter-button"
+                                        display="inlineBlock"
+                                        hasArrow={true}
+                                        isOpen={false}
+                                        ownFocus={true}
+                                        panelPaddingSize="none"
                                       >
-                                        <EuiButtonContent
-                                          className="euiButtonEmpty__content"
-                                          iconSide="right"
-                                          iconSize="s"
-                                          iconType="arrowDown"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
-                                            }
-                                          }
+                                        <div
+                                          className="euiPopover euiPopover--anchorRightUp"
+                                          data-test-subj="global-filter-button"
                                         >
-                                          <span
-                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                          <div
+                                            className="euiPopover__anchor"
                                           >
-                                            <EuiIcon
-                                              className="euiButtonContent__icon"
-                                              color="inherit"
-                                              size="s"
-                                              type="arrowDown"
+                                            <EuiSmallButtonIcon
+                                              aria-label="Change all filters"
+                                              iconType="filter"
+                                              onClick={[Function]}
+                                              title="Change all filters"
                                             >
-                                              <EuiIconArrowDown
-                                                aria-hidden={true}
-                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                focusable="false"
-                                                role="img"
-                                                style={null}
+                                              <EuiButtonIcon
+                                                aria-label="Change all filters"
+                                                iconType="filter"
+                                                onClick={[Function]}
+                                                size="s"
+                                                title="Change all filters"
                                               >
-                                                <svg
-                                                  aria-hidden={true}
-                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                                                  focusable="false"
-                                                  height={16}
-                                                  role="img"
-                                                  style={null}
-                                                  viewBox="0 0 16 16"
-                                                  width={16}
-                                                  xmlns="http://www.w3.org/2000/svg"
+                                                <button
+                                                  aria-label="Change all filters"
+                                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
+                                                  disabled={false}
+                                                  onClick={[Function]}
+                                                  title="Change all filters"
+                                                  type="button"
                                                 >
-                                                  <path
-                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                                    fillRule="non-zero"
-                                                  />
-                                                </svg>
-                                              </EuiIconArrowDown>
-                                            </EuiIcon>
+                                                  <EuiIcon
+                                                    aria-hidden="true"
+                                                    className="euiButtonIcon__icon"
+                                                    color="inherit"
+                                                    size="m"
+                                                    type="filter"
+                                                  >
+                                                    <EuiIconFilter
+                                                      aria-hidden={true}
+                                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                      focusable="false"
+                                                      role="img"
+                                                      style={null}
+                                                    >
+                                                      <svg
+                                                        aria-hidden={true}
+                                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                                        focusable="false"
+                                                        height={16}
+                                                        role="img"
+                                                        style={null}
+                                                        viewBox="0 0 16 16"
+                                                        width={16}
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                      >
+                                                        <path
+                                                          d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
+                                                          fillRule="evenodd"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconFilter>
+                                                  </EuiIcon>
+                                                </button>
+                                              </EuiButtonIcon>
+                                            </EuiSmallButtonIcon>
+                                          </div>
+                                        </div>
+                                      </EuiPopover>
+                                    </GlobalFilterButton>
+                                    <div
+                                      className="euiFormControlLayout__childrenWrapper"
+                                    >
+                                      <EuiValidatableControl>
+                                        <input
+                                          className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiFieldSearch--inGroup"
+                                          data-test-subj="search-bar-input-box"
+                                          onChange={[Function]}
+                                          onKeyUp={[Function]}
+                                          placeholder="Trace ID, trace group name, service name"
+                                          type="search"
+                                          value=""
+                                        />
+                                      </EuiValidatableControl>
+                                      <EuiFormControlLayoutIcons
+                                        compressed={true}
+                                        icon="search"
+                                        isLoading={false}
+                                      >
+                                        <div
+                                          className="euiFormControlLayoutIcons"
+                                        >
+                                          <EuiFormControlLayoutCustomIcon
+                                            size="s"
+                                            type="search"
+                                          >
                                             <span
-                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                              className="euiFormControlLayoutCustomIcon"
                                             >
                                               <EuiIcon
-                                                type="calendar"
+                                                aria-hidden="true"
+                                                className="euiFormControlLayoutCustomIcon__icon"
+                                                size="s"
+                                                type="search"
                                               >
-                                                <EuiIconCalendar
+                                                <EuiIconSearch
                                                   aria-hidden={true}
-                                                  className="euiIcon euiIcon--medium"
+                                                  className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                                   focusable="false"
                                                   role="img"
                                                   style={null}
                                                 >
                                                   <svg
                                                     aria-hidden={true}
-                                                    className="euiIcon euiIcon--medium"
+                                                    className="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                                     focusable="false"
                                                     height={16}
                                                     role="img"
@@ -4516,140 +4412,650 @@ exports[`Traces component renders traces page 1`] = `
                                                     xmlns="http://www.w3.org/2000/svg"
                                                   >
                                                     <path
-                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                                      fillRule="evenodd"
+                                                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
                                                     />
                                                   </svg>
-                                                </EuiIconCalendar>
+                                                </EuiIconSearch>
                                               </EuiIcon>
                                             </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonEmpty>
+                                          </EuiFormControlLayoutCustomIcon>
+                                        </div>
+                                      </EuiFormControlLayoutIcons>
+                                    </div>
                                   </div>
-                                </div>
-                              </EuiPopover>
-                            </EuiQuickSelectPopover>
+                                </EuiFormControlLayout>
+                              </EuiCompressedFieldSearch>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                            style={
+                              Object {
+                                "maxWidth": "30vw",
+                              }
+                            }
+                          >
                             <div
-                              className="euiFormControlLayout__childrenWrapper"
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                              style={
+                                Object {
+                                  "maxWidth": "30vw",
+                                }
+                              }
                             >
-                              <EuiDatePickerRange
-                                className="euiDatePickerRange--inGroup"
-                                endDateControl={<div />}
-                                iconType={false}
-                                isCustom={true}
-                                startDateControl={<div />}
+                              <EuiSuperDatePicker
+                                commonlyUsedRanges={
+                                  Array [
+                                    Object {
+                                      "end": "now/d",
+                                      "label": "Today",
+                                      "start": "now/d",
+                                    },
+                                    Object {
+                                      "end": "now/w",
+                                      "label": "This week",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now/M",
+                                      "label": "This month",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now/y",
+                                      "label": "This year",
+                                      "start": "now/y",
+                                    },
+                                    Object {
+                                      "end": "now-1d/d",
+                                      "label": "Yesterday",
+                                      "start": "now-1d/d",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Week to date",
+                                      "start": "now/w",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Month to date",
+                                      "start": "now/M",
+                                    },
+                                    Object {
+                                      "end": "now",
+                                      "label": "Year to date",
+                                      "start": "now/y",
+                                    },
+                                  ]
+                                }
+                                compressed={true}
+                                dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                end="now"
+                                isAutoRefreshOnly={false}
+                                isDisabled={false}
+                                isPaused={true}
+                                onTimeChange={[Function]}
+                                recentlyUsedRanges={Array []}
+                                refreshInterval={0}
+                                showUpdateButton={false}
+                                start="now-5m"
+                                timeFormat="HH:mm"
                               >
-                                <div
-                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                <EuiFlexGroup
+                                  className="euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+                                  gutterSize="s"
+                                  responsive={false}
                                 >
-                                  <button
-                                    className="euiSuperDatePicker__prettyFormat"
-                                    data-test-subj="superDatePickerShowDatesButton"
-                                    disabled={false}
-                                    onClick={[Function]}
+                                  <div
+                                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
                                   >
-                                    Last 5 minutes
-                                    <span
-                                      className="euiSuperDatePicker__prettyFormatLink"
-                                    >
-                                      <EuiI18n
-                                        default="Show dates"
-                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                    <EuiFlexItem>
+                                      <div
+                                        className="euiFlexItem"
                                       >
-                                        Show dates
-                                      </EuiI18n>
+                                        <EuiFormControlLayout
+                                          className="euiSuperDatePicker"
+                                          compressed={true}
+                                          isDisabled={false}
+                                          prepend={
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            />
+                                          }
+                                        >
+                                          <div
+                                            className="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayout--group euiSuperDatePicker"
+                                          >
+                                            <EuiQuickSelectPopover
+                                              applyTime={[Function]}
+                                              className="euiFormControlLayout__prepend"
+                                              commonlyUsedRanges={
+                                                Array [
+                                                  Object {
+                                                    "end": "now/d",
+                                                    "label": "Today",
+                                                    "start": "now/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now/w",
+                                                    "label": "This week",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now/M",
+                                                    "label": "This month",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now/y",
+                                                    "label": "This year",
+                                                    "start": "now/y",
+                                                  },
+                                                  Object {
+                                                    "end": "now-1d/d",
+                                                    "label": "Yesterday",
+                                                    "start": "now-1d/d",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Week to date",
+                                                    "start": "now/w",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Month to date",
+                                                    "start": "now/M",
+                                                  },
+                                                  Object {
+                                                    "end": "now",
+                                                    "label": "Year to date",
+                                                    "start": "now/y",
+                                                  },
+                                                ]
+                                              }
+                                              dateFormat="MMM D, YYYY @ HH:mm:ss.SSS"
+                                              end="now"
+                                              isAutoRefreshOnly={false}
+                                              isDisabled={false}
+                                              isPaused={true}
+                                              key="0/.0"
+                                              recentlyUsedRanges={Array []}
+                                              refreshInterval={0}
+                                              start="now-5m"
+                                            >
+                                              <EuiPopover
+                                                anchorClassName="euiQuickSelectPopover__anchor"
+                                                anchorPosition="downLeft"
+                                                button={
+                                                  <EuiButtonEmpty
+                                                    aria-label="Date quick select"
+                                                    className="euiFormControlLayout__prepend"
+                                                    data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                    iconSide="right"
+                                                    iconType="arrowDown"
+                                                    isDisabled={false}
+                                                    onClick={[Function]}
+                                                    size="xs"
+                                                    textProps={
+                                                      Object {
+                                                        "className": "euiQuickSelectPopover__buttonText",
+                                                      }
+                                                    }
+                                                  >
+                                                    <EuiIcon
+                                                      type="calendar"
+                                                    />
+                                                  </EuiButtonEmpty>
+                                                }
+                                                closePopover={[Function]}
+                                                display="inlineBlock"
+                                                hasArrow={true}
+                                                isOpen={false}
+                                                ownFocus={true}
+                                                panelPaddingSize="s"
+                                              >
+                                                <div
+                                                  className="euiPopover euiPopover--anchorDownLeft"
+                                                >
+                                                  <div
+                                                    className="euiPopover__anchor euiQuickSelectPopover__anchor"
+                                                  >
+                                                    <EuiButtonEmpty
+                                                      aria-label="Date quick select"
+                                                      className="euiFormControlLayout__prepend"
+                                                      data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                      iconSide="right"
+                                                      iconType="arrowDown"
+                                                      isDisabled={false}
+                                                      onClick={[Function]}
+                                                      size="xs"
+                                                      textProps={
+                                                        Object {
+                                                          "className": "euiQuickSelectPopover__buttonText",
+                                                        }
+                                                      }
+                                                    >
+                                                      <button
+                                                        aria-label="Date quick select"
+                                                        className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                                                        data-test-subj="superDatePickerToggleQuickMenuButton"
+                                                        disabled={false}
+                                                        onClick={[Function]}
+                                                        type="button"
+                                                      >
+                                                        <EuiButtonContent
+                                                          className="euiButtonEmpty__content"
+                                                          iconGap="m"
+                                                          iconSide="right"
+                                                          iconSize="s"
+                                                          iconType="arrowDown"
+                                                          textProps={
+                                                            Object {
+                                                              "className": "euiButtonEmpty__text euiQuickSelectPopover__buttonText",
+                                                            }
+                                                          }
+                                                        >
+                                                          <span
+                                                            className="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                                                          >
+                                                            <EuiIcon
+                                                              className="euiButtonContent__icon"
+                                                              color="inherit"
+                                                              size="s"
+                                                              type="arrowDown"
+                                                            >
+                                                              <EuiIconArrowDown
+                                                                aria-hidden={true}
+                                                                className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                focusable="false"
+                                                                role="img"
+                                                                style={null}
+                                                              >
+                                                                <svg
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                                                                  focusable="false"
+                                                                  height={16}
+                                                                  role="img"
+                                                                  style={null}
+                                                                  viewBox="0 0 16 16"
+                                                                  width={16}
+                                                                  xmlns="http://www.w3.org/2000/svg"
+                                                                >
+                                                                  <path
+                                                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                                                    fillRule="non-zero"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconArrowDown>
+                                                            </EuiIcon>
+                                                            <span
+                                                              className="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                                                            >
+                                                              <EuiIcon
+                                                                type="calendar"
+                                                              >
+                                                                <EuiIconCalendar
+                                                                  aria-hidden={true}
+                                                                  className="euiIcon euiIcon--medium"
+                                                                  focusable="false"
+                                                                  role="img"
+                                                                  style={null}
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="euiIcon euiIcon--medium"
+                                                                    focusable="false"
+                                                                    height={16}
+                                                                    role="img"
+                                                                    style={null}
+                                                                    viewBox="0 0 16 16"
+                                                                    width={16}
+                                                                    xmlns="http://www.w3.org/2000/svg"
+                                                                  >
+                                                                    <path
+                                                                      d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0 1 12.994 15H3.006A2.005 2.005 0 0 1 1 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                                                      fillRule="evenodd"
+                                                                    />
+                                                                  </svg>
+                                                                </EuiIconCalendar>
+                                                              </EuiIcon>
+                                                            </span>
+                                                          </span>
+                                                        </EuiButtonContent>
+                                                      </button>
+                                                    </EuiButtonEmpty>
+                                                  </div>
+                                                </div>
+                                              </EuiPopover>
+                                            </EuiQuickSelectPopover>
+                                            <div
+                                              className="euiFormControlLayout__childrenWrapper"
+                                            >
+                                              <EuiDatePickerRange
+                                                className="euiDatePickerRange--inGroup"
+                                                endDateControl={<div />}
+                                                iconType={false}
+                                                isCustom={true}
+                                                startDateControl={<div />}
+                                              >
+                                                <div
+                                                  className="euiDatePickerRange euiDatePickerRange--inGroup"
+                                                >
+                                                  <button
+                                                    className="euiSuperDatePicker__prettyFormat euiSuperDatePicker__prettyFormat--compressed"
+                                                    data-test-subj="superDatePickerShowDatesButton"
+                                                    disabled={false}
+                                                    onClick={[Function]}
+                                                  >
+                                                    Last 5 minutes
+                                                    <span
+                                                      className="euiSuperDatePicker__prettyFormatLink"
+                                                    >
+                                                      <EuiI18n
+                                                        default="Show dates"
+                                                        token="euiSuperDatePicker.showDatesButtonLabel"
+                                                      >
+                                                        Show dates
+                                                      </EuiI18n>
+                                                    </span>
+                                                  </button>
+                                                </div>
+                                              </EuiDatePickerRange>
+                                              <EuiFormControlLayoutIcons
+                                                compressed={true}
+                                              />
+                                            </div>
+                                          </div>
+                                        </EuiFormControlLayout>
+                                      </div>
+                                    </EuiFlexItem>
+                                  </div>
+                                </EuiFlexGroup>
+                              </EuiSuperDatePicker>
+                            </div>
+                          </EuiFlexItem>
+                          <EuiFlexItem
+                            grow={false}
+                          >
+                            <div
+                              className="euiFlexItem euiFlexItem--flexGrowZero"
+                            >
+                              <EuiButtonIcon
+                                aria-label="Refresh"
+                                data-click-metric-element="trace_analytics.refresh_button"
+                                data-test-subj="superDatePickerApplyTimeButton"
+                                display="base"
+                                iconType="refresh"
+                                onClick={[Function]}
+                                size="s"
+                              >
+                                <button
+                                  aria-label="Refresh"
+                                  className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--small"
+                                  data-click-metric-element="trace_analytics.refresh_button"
+                                  data-test-subj="superDatePickerApplyTimeButton"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiIcon
+                                    aria-hidden="true"
+                                    className="euiButtonIcon__icon"
+                                    color="inherit"
+                                    size="m"
+                                    type="refresh"
+                                  >
+                                    <EuiIconRefresh
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                      focusable="false"
+                                      role="img"
+                                      style={null}
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                                        focusable="false"
+                                        height={16}
+                                        role="img"
+                                        style={null}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <path
+                                          d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                        />
+                                      </svg>
+                                    </EuiIconRefresh>
+                                  </EuiIcon>
+                                </button>
+                              </EuiButtonIcon>
+                            </div>
+                          </EuiFlexItem>
+                        </div>
+                      </EuiFlexGroup>
+                    </ForwardRef>
+                  </div>
+                </EuiFlexItem>
+              </div>
+            </EuiFlexGroup>
+            <Filters
+              appConfigs={Array []}
+              attributesFilterFields={Array []}
+              filters={Array []}
+              mode="data_prepper"
+              page="traces"
+              setFilters={
+                [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Array [],
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                }
+              }
+            >
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="xs"
+                responsive={false}
+              >
+                <div
+                  className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                >
+                  <EuiFlexItem
+                    grow={false}
+                  >
+                    <div
+                      className="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <AddFilterButton>
+                        <EuiPopover
+                          anchorPosition="downLeft"
+                          button={
+                            <EuiButtonEmpty
+                              flush="left"
+                              onClick={[Function]}
+                              size="xs"
+                            >
+                              + Add filter
+                            </EuiButtonEmpty>
+                          }
+                          closePopover={[Function]}
+                          data-test-subj="addfilter"
+                          display="inlineBlock"
+                          hasArrow={true}
+                          isOpen={false}
+                          ownFocus={true}
+                          panelPaddingSize="m"
+                        >
+                          <div
+                            className="euiPopover euiPopover--anchorDownLeft"
+                            data-test-subj="addfilter"
+                          >
+                            <div
+                              className="euiPopover__anchor"
+                            >
+                              <EuiButtonEmpty
+                                flush="left"
+                                onClick={[Function]}
+                                size="xs"
+                              >
+                                <button
+                                  className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushLeft"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButtonEmpty__content"
+                                    iconGap="m"
+                                    iconSide="left"
+                                    iconSize="s"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButtonEmpty__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButtonEmpty__content"
+                                    >
+                                      <span
+                                        className="euiButtonEmpty__text"
+                                      >
+                                        + Add filter
+                                      </span>
                                     </span>
-                                  </button>
-                                </div>
-                              </EuiDatePickerRange>
-                              <EuiFormControlLayoutIcons
-                                compressed={false}
-                              />
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonEmpty>
                             </div>
                           </div>
-                        </EuiFormControlLayout>
-                      </div>
-                    </EuiFlexItem>
-                  </div>
-                </EuiFlexGroup>
-              </EuiSuperDatePicker>
-            </div>
-          </EuiFlexItem>
-          <EuiFlexItem
-            grow={false}
-          >
-            <div
-              className="euiFlexItem euiFlexItem--flexGrowZero"
+                        </EuiPopover>
+                      </AddFilterButton>
+                    </div>
+                  </EuiFlexItem>
+                </div>
+              </EuiFlexGroup>
+            </Filters>
+            <EuiSpacer
+              size="s"
             >
-              <EuiSmallButton
-                data-click-metric-element="trace_analytics.refresh_button"
-                data-test-subj="superDatePickerApplyTimeButton"
-                iconType="refresh"
-                onClick={[Function]}
+              <div
+                className="euiSpacer euiSpacer--s"
+              />
+            </EuiSpacer>
+            <EuiPanel>
+              <div
+                className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
               >
-                <EuiButton
-                  data-click-metric-element="trace_analytics.refresh_button"
-                  data-test-subj="superDatePickerApplyTimeButton"
-                  iconType="refresh"
-                  onClick={[Function]}
-                  size="s"
+                <EuiAccordion
+                  arrowDisplay="left"
+                  buttonContent="Trace Groups"
+                  data-test-subj="trace-groups-service-operation-accordian"
+                  forceState="closed"
+                  id="accordion1"
+                  initialIsOpen={false}
+                  isLoading={false}
+                  isLoadingMessage={false}
+                  onToggle={[Function]}
+                  paddingSize="none"
                 >
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    data-click-metric-element="trace_analytics.refresh_button"
-                    data-test-subj="superDatePickerApplyTimeButton"
-                    disabled={false}
-                    element="button"
-                    iconType="refresh"
-                    isDisabled={false}
-                    onClick={[Function]}
-                    size="s"
-                    type="button"
+                  <div
+                    className="euiAccordion"
+                    data-test-subj="trace-groups-service-operation-accordian"
+                    onToggle={[Function]}
                   >
-                    <button
-                      className="euiButton euiButton--primary euiButton--small"
-                      data-click-metric-element="trace_analytics.refresh_button"
-                      data-test-subj="superDatePickerApplyTimeButton"
-                      disabled={false}
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
-                      type="button"
+                    <div
+                      className="euiAccordion__triggerWrapper"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconSide="left"
-                        iconType="refresh"
-                        textProps={
-                          Object {
-                            "className": "euiButton__text",
-                          }
-                        }
+                      <button
+                        aria-controls="accordion1"
+                        aria-expanded={false}
+                        className="euiAccordion__button"
+                        id="random_html_id"
+                        onClick={[Function]}
+                        type="button"
                       >
                         <span
-                          className="euiButtonContent euiButton__content"
+                          className="euiAccordion__iconWrapper"
                         >
                           <EuiIcon
-                            className="euiButtonContent__icon"
-                            color="inherit"
+                            className="euiAccordion__icon"
                             size="m"
-                            type="refresh"
+                            type="arrowRight"
                           >
-                            <EuiIconRefresh
+                            <EuiIconArrowRight
                               aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                              className="euiIcon euiIcon--medium euiAccordion__icon"
                               focusable="false"
                               role="img"
                               style={null}
                             >
                               <svg
                                 aria-hidden={true}
-                                className="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                                className="euiIcon euiIcon--medium euiAccordion__icon"
                                 focusable="false"
                                 height={16}
                                 role="img"
@@ -4659,506 +5065,205 @@ exports[`Traces component renders traces page 1`] = `
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
+                                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                                  fillRule="nonzero"
                                 />
                               </svg>
-                            </EuiIconRefresh>
+                            </EuiIconArrowRight>
                           </EuiIcon>
-                          <span
-                            className="euiButton__text"
-                          >
-                            Refresh
-                          </span>
                         </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
-              </EuiSmallButton>
-            </div>
-          </EuiFlexItem>
-        </div>
-      </EuiFlexGroup>
-      <EuiSpacer
-        size="s"
-      >
-        <div
-          className="euiSpacer euiSpacer--s"
-        />
-      </EuiSpacer>
-      <Filters
-        appConfigs={Array []}
-        attributesFilterFields={Array []}
-        filters={Array []}
-        mode="data_prepper"
-        page="traces"
-        setFilters={
-          [MockFunction] {
-            "calls": Array [
-              Array [
-                Array [],
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
-            ],
-          }
-        }
-      >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="xs"
-          responsive={false}
-          style={
-            Object {
-              "minHeight": 32,
-            }
-          }
-        >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-            style={
-              Object {
-                "minHeight": 32,
-              }
-            }
-          >
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <GlobalFilterButton>
-                  <EuiPopover
-                    anchorPosition="rightUp"
-                    button={
-                      <EuiSmallButtonIcon
-                        aria-label="Change all filters"
-                        iconType="filter"
-                        onClick={[Function]}
-                        title="Change all filters"
-                      />
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="global-filter-button"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="none"
-                    withTitle={true}
-                  >
-                    <div
-                      className="euiPopover euiPopover--anchorRightUp"
-                      data-test-subj="global-filter-button"
-                      withTitle={true}
-                    >
-                      <div
-                        className="euiPopover__anchor"
-                      >
-                        <EuiSmallButtonIcon
-                          aria-label="Change all filters"
-                          iconType="filter"
-                          onClick={[Function]}
-                          title="Change all filters"
+                        <span
+                          className="euiIEFlexWrapFix"
                         >
-                          <EuiButtonIcon
-                            aria-label="Change all filters"
-                            iconType="filter"
-                            onClick={[Function]}
-                            size="s"
-                            title="Change all filters"
-                          >
-                            <button
-                              aria-label="Change all filters"
-                              className="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--small"
-                              disabled={false}
-                              onClick={[Function]}
-                              title="Change all filters"
-                              type="button"
-                            >
-                              <EuiIcon
-                                aria-hidden="true"
-                                className="euiButtonIcon__icon"
-                                color="inherit"
-                                size="m"
-                                type="filter"
-                              >
-                                <EuiIconFilter
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
-                                    focusable="false"
-                                    height={16}
-                                    role="img"
-                                    style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M7.999 15.999a8 8 0 1 1 0-16 8 8 0 0 1 0 16ZM8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14ZM3.5 5h9a.5.5 0 1 1 0 1h-9a.5.5 0 0 1 0-1Zm2 3h5a.5.5 0 1 1 0 1h-5a.5.5 0 0 1 0-1Zm2 3h1a.5.5 0 1 1 0 1h-1a.5.5 0 1 1 0-1Z"
-                                      fillRule="evenodd"
-                                    />
-                                  </svg>
-                                </EuiIconFilter>
-                              </EuiIcon>
-                            </button>
-                          </EuiButtonIcon>
-                        </EuiSmallButtonIcon>
-                      </div>
+                          Trace Groups
+                        </span>
+                      </button>
                     </div>
-                  </EuiPopover>
-                </GlobalFilterButton>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <AddFilterButton>
-                  <EuiPopover
-                    anchorPosition="downLeft"
-                    button={
-                      <EuiButtonEmpty
-                        onClick={[Function]}
-                        size="xs"
-                      >
-                        + Add filter
-                      </EuiButtonEmpty>
-                    }
-                    closePopover={[Function]}
-                    data-test-subj="addfilter"
-                    display="inlineBlock"
-                    hasArrow={true}
-                    isOpen={false}
-                    ownFocus={true}
-                    panelPaddingSize="m"
-                    withTitle={true}
-                  >
                     <div
-                      className="euiPopover euiPopover--anchorDownLeft"
-                      data-test-subj="addfilter"
-                      withTitle={true}
+                      aria-labelledby="random_html_id"
+                      className="euiAccordion__childWrapper"
+                      id="accordion1"
+                      role="region"
+                      tabIndex={-1}
                     >
-                      <div
-                        className="euiPopover__anchor"
+                      <EuiResizeObserver
+                        onResize={[Function]}
                       >
-                        <EuiButtonEmpty
-                          onClick={[Function]}
-                          size="xs"
-                        >
-                          <button
-                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
+                        <div>
+                          <div
+                            className=""
                           >
-                            <EuiButtonContent
-                              className="euiButtonEmpty__content"
-                              iconSide="left"
-                              iconSize="s"
-                              textProps={
-                                Object {
-                                  "className": "euiButtonEmpty__text",
-                                }
-                              }
+                            <EuiSpacer
+                              size="m"
                             >
-                              <span
-                                className="euiButtonContent euiButtonEmpty__content"
-                              >
-                                <span
-                                  className="euiButtonEmpty__text"
-                                >
-                                  + Add filter
-                                </span>
-                              </span>
-                            </EuiButtonContent>
-                          </button>
-                        </EuiButtonEmpty>
-                      </div>
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                          </div>
+                        </div>
+                      </EuiResizeObserver>
                     </div>
-                  </EuiPopover>
-                </AddFilterButton>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-      </Filters>
-    </ForwardRef>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-      >
-        <EuiAccordion
-          arrowDisplay="left"
-          buttonContent="Trace Groups"
-          data-test-subj="trace-groups-service-operation-accordian"
-          forceState="closed"
-          id="accordion1"
-          initialIsOpen={false}
-          isLoading={false}
-          isLoadingMessage={false}
-          onToggle={[Function]}
-          paddingSize="none"
-        >
-          <div
-            className="euiAccordion"
-            data-test-subj="trace-groups-service-operation-accordian"
-            onToggle={[Function]}
-          >
-            <div
-              className="euiAccordion__triggerWrapper"
-            >
-              <button
-                aria-controls="accordion1"
-                aria-expanded={false}
-                className="euiAccordion__button"
-                id="random_html_id"
-                onClick={[Function]}
-                type="button"
-              >
-                <span
-                  className="euiAccordion__iconWrapper"
-                >
-                  <EuiIcon
-                    className="euiAccordion__icon"
-                    size="m"
-                    type="arrowRight"
-                  >
-                    <EuiIconArrowRight
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiAccordion__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiAccordion__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                          fillRule="nonzero"
-                        />
-                      </svg>
-                    </EuiIconArrowRight>
-                  </EuiIcon>
-                </span>
-                <span
-                  className="euiIEFlexWrapFix"
-                >
-                  Trace Groups
-                </span>
-              </button>
-            </div>
-            <div
-              aria-labelledby="random_html_id"
-              className="euiAccordion__childWrapper"
-              id="accordion1"
-              role="region"
-              tabIndex={-1}
-            >
-              <EuiResizeObserver
-                onResize={[Function]}
-              >
-                <div>
-                  <div
-                    className=""
-                  >
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
                   </div>
-                </div>
-              </EuiResizeObserver>
-            </div>
-          </div>
-        </EuiAccordion>
-      </div>
-    </EuiPanel>
-    <EuiSpacer
-      size="m"
-    >
-      <div
-        className="euiSpacer euiSpacer--m"
-      />
-    </EuiSpacer>
-    <TracesTable
-      dataPrepperIndicesExist={true}
-      items={Array []}
-      loading={true}
-      mode="data_prepper"
-      refresh={[Function]}
-      traceIdColumnAction={[Function]}
-    >
-      <EuiPanel>
-        <div
-          className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-          >
-            <div
-              className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-            >
-              <EuiFlexItem
-                grow={10}
-              >
-                <div
-                  className="euiFlexItem euiFlexItem--flexGrow10"
-                >
-                  <PanelTitle
-                    title="Traces"
-                    totalItems={0}
-                  >
-                    <EuiText
-                      size="m"
-                    >
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <span
-                          className="panel-title"
-                        >
-                          Traces
-                        </span>
-                        <span
-                          className="panel-title-count"
-                        >
-                           (0)
-                        </span>
-                      </div>
-                    </EuiText>
-                  </PanelTitle>
-                </div>
-              </EuiFlexItem>
-            </div>
-          </EuiFlexGroup>
-          <EuiSpacer
-            size="m"
-          >
-            <div
-              className="euiSpacer euiSpacer--m"
-            />
-          </EuiSpacer>
-          <EuiHorizontalRule
-            margin="none"
-          >
-            <hr
-              className="euiHorizontalRule euiHorizontalRule--full"
-            />
-          </EuiHorizontalRule>
-          <NoMatchMessage
-            size="xl"
-          >
+                </EuiAccordion>
+              </div>
+            </EuiPanel>
             <EuiSpacer
-              size="xl"
+              size="s"
             >
               <div
-                className="euiSpacer euiSpacer--xl"
+                className="euiSpacer euiSpacer--s"
               />
             </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText
-                  size="s"
-                >
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
+            <TracesTable
+              dataPrepperIndicesExist={true}
+              items={Array []}
+              loading={true}
+              mode="data_prepper"
+              refresh={[Function]}
+              traceIdColumnAction={[Function]}
             >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTitle
-                  size="m"
+              <EuiPanel>
+                <div
+                  className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
                 >
-                  <h2
-                    className="euiTitle euiTitle--medium"
+                  <EuiFlexGroup
+                    alignItems="center"
+                    gutterSize="s"
                   >
-                    No matches
-                  </h2>
-                </EuiTitle>
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
+                    <div
+                      className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <EuiFlexItem
+                        grow={10}
+                      >
+                        <div
+                          className="euiFlexItem euiFlexItem--flexGrow10"
+                        >
+                          <PanelTitle
+                            title="Traces"
+                            totalItems={0}
+                          >
+                            <EuiText
+                              size="m"
+                            >
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <span
+                                  className="panel-title"
+                                >
+                                  Traces
+                                </span>
+                                <span
+                                  className="panel-title-count"
+                                >
+                                   (0)
+                                </span>
+                              </div>
+                            </EuiText>
+                          </PanelTitle>
+                        </div>
+                      </EuiFlexItem>
+                    </div>
+                  </EuiFlexGroup>
+                  <EuiSpacer
+                    size="m"
+                  >
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiHorizontalRule
+                    margin="none"
+                  >
+                    <hr
+                      className="euiHorizontalRule euiHorizontalRule--full"
+                    />
+                  </EuiHorizontalRule>
+                  <NoMatchMessage
+                    size="xl"
                   >
                     <EuiSpacer
-                      size="m"
+                      size="xl"
                     >
                       <div
-                        className="euiSpacer euiSpacer--m"
+                        className="euiSpacer euiSpacer--xl"
                       />
                     </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
+                    <EuiEmptyPrompt
+                      body={
                         <EuiText
                           size="s"
                         >
-                          <div
-                            className="euiText euiText--small"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
                         </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTitle
+                          size="m"
+                        >
+                          <h2
+                            className="euiTitle euiTitle--medium"
+                          >
+                            No matches
+                          </h2>
+                        </EuiTitle>
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText
+                                  size="s"
+                                >
+                                  <div
+                                    className="euiText euiText--small"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
                       </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="xl"
-            >
-              <div
-                className="euiSpacer euiSpacer--xl"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </EuiPanel>
-    </TracesTable>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="xl"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--xl"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
+              </EuiPanel>
+            </TracesTable>
+          </div>
+        </EuiPageBody>
+      </div>
+    </EuiPage>
   </TracesContent>
 </Traces>
 `;

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -165,6 +165,7 @@ exports[`Traces table component renders empty traces table message 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButtonEmpty__content"
+                    iconGap="m"
                     iconSide="right"
                     iconSize="m"
                     iconType="popout"
@@ -706,6 +707,7 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -1445,6 +1447,7 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -1650,6 +1653,7 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={
@@ -2149,6 +2153,7 @@ exports[`Traces table component renders traces table 1`] = `
                                       >
                                         <EuiButtonContent
                                           className="euiButtonEmpty__content"
+                                          iconGap="m"
                                           iconSide="right"
                                           iconSize="s"
                                           iconType="arrowDown"
@@ -3095,6 +3100,7 @@ exports[`Traces table component renders traces table 1`] = `
                                   >
                                     <EuiButtonContent
                                       className="euiButtonEmpty__content"
+                                      iconGap="m"
                                       iconSide="right"
                                       iconSize="s"
                                       iconType="arrowDown"
@@ -3298,6 +3304,7 @@ exports[`Traces table component renders traces table 1`] = `
                                             >
                                               <EuiButtonContent
                                                 className="euiButtonEmpty__content"
+                                                iconGap="m"
                                                 iconSide="left"
                                                 iconSize="m"
                                                 textProps={

--- a/public/components/trace_analytics/components/traces/trace_view.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view.tsx
@@ -38,6 +38,9 @@ import { PanelTitle, filtersToDsl, processTimeStamp } from '../common/helper_fun
 import { ServiceMap, ServiceObject } from '../common/plots/service_map';
 import { ServiceBreakdownPanel } from './service_breakdown_panel';
 import { SpanDetailPanel } from './span_detail_panel';
+import { coreRefs } from '../../../../framework/core_refs';
+
+const newNavigation = coreRefs.chrome?.navGroup.getNavGroupEnabled();
 
 interface TraceViewProps extends TraceAnalyticsCoreDeps {
   traceId: string;
@@ -53,11 +56,13 @@ export function TraceView(props: TraceViewProps) {
   const renderTitle = (traceId: string) => {
     return (
       <>
-        <EuiFlexItem>
-          <EuiText size="s">
-            <h1 className="overview-content">{traceId}</h1>
-          </EuiText>
-        </EuiFlexItem>
+        {!newNavigation && (
+          <EuiFlexItem>
+            <EuiText size="s">
+              <h1 className="overview-content">{traceId}</h1>
+            </EuiText>
+          </EuiFlexItem>
+        )}
       </>
     );
   };

--- a/public/components/trace_analytics/components/traces/traces.tsx
+++ b/public/components/trace_analytics/components/traces/traces.tsx
@@ -8,7 +8,6 @@ import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import React from 'react';
 import { DataSourceOption } from '../../../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
 import { TraceAnalyticsComponentDeps } from '../../home';
-import { DataSourcePicker } from '../dashboard/mode_picker';
 import { TracesContent } from './traces_content';
 
 export interface TracesProps extends TraceAnalyticsComponentDeps {
@@ -22,7 +21,6 @@ export interface TracesProps extends TraceAnalyticsComponentDeps {
 export function Traces(props: TracesProps) {
   return (
     <>
-      <DataSourcePicker modes={props.modes} selectedMode={props.mode} setMode={props.setMode!} />
       <TracesContent {...props} />
     </>
   );

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -4,7 +4,16 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { EuiAccordion, EuiPanel, EuiSpacer, PropertySort } from '@elastic/eui';
+import {
+  EuiAccordion,
+  EuiPanel,
+  EuiSpacer,
+  PropertySort,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPage,
+  EuiPageBody,
+} from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { coreRefs } from '../../../../framework/core_refs';
 import { handleTracesRequest } from '../../requests/traces_request_handler';
@@ -12,8 +21,10 @@ import { getValidFilterFields } from '../common/filters/filter_helpers';
 import { filtersToDsl, processTimeStamp } from '../common/helper_functions';
 import { SearchBar } from '../common/search_bar';
 import { DashboardContent } from '../dashboard/dashboard_content';
-import { TracesProps } from './traces';
 import { TracesTable } from './traces_table';
+import { TracesProps } from './traces';
+import { DataSourcePicker } from '../dashboard/mode_picker';
+import { Filters } from '../common/filters/filters';
 
 export function TracesContent(props: TracesProps) {
   const {
@@ -109,44 +120,67 @@ export function TracesContent(props: TracesProps) {
 
   return (
     <>
-      <SearchBar
-        query={query}
-        filters={filters}
-        appConfigs={appConfigs}
-        setFilters={setFilters}
-        setQuery={setQuery}
-        startTime={startTime}
-        setStartTime={setStartTime}
-        endTime={endTime}
-        setEndTime={setEndTime}
-        refresh={refresh}
-        page={page}
-        mode={mode}
-        attributesFilterFields={attributesFilterFields}
-      />
-      <EuiSpacer size="m" />
-      <EuiPanel>
-        <EuiAccordion
-          id="accordion1"
-          buttonContent={mode === 'data_prepper' ? 'Trace Groups' : 'Service and Operations'}
-          forceState={trigger}
-          onToggle={onToggle}
-          data-test-subj="trace-groups-service-operation-accordian"
-        >
-          <EuiSpacer size="m" />
-          {trigger === 'open' && dashboardContent()}
-        </EuiAccordion>
-      </EuiPanel>
-      <EuiSpacer size="m" />
-      <TracesTable
-        items={tableItems}
-        refresh={refresh}
-        mode={mode}
-        loading={loading}
-        traceIdColumnAction={traceIdColumnAction}
-        jaegerIndicesExist={jaegerIndicesExist}
-        dataPrepperIndicesExist={dataPrepperIndicesExist}
-      />
+      <EuiPage paddingSize="m">
+        <EuiPageBody>
+          <EuiFlexGroup gutterSize="s" alignItems="center" justifyContent="spaceBetween">
+            <EuiFlexItem grow={false}>
+              <DataSourcePicker
+                modes={props.modes}
+                selectedMode={props.mode}
+                setMode={props.setMode!}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={true}>
+              <SearchBar
+                query={query}
+                filters={filters}
+                appConfigs={appConfigs}
+                setFilters={setFilters}
+                setQuery={setQuery}
+                startTime={startTime}
+                setStartTime={setStartTime}
+                endTime={endTime}
+                setEndTime={setEndTime}
+                refresh={refresh}
+                page={page}
+                mode={mode}
+                attributesFilterFields={attributesFilterFields}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <Filters
+            page={page}
+            filters={filters}
+            setFilters={setFilters}
+            appConfigs={appConfigs}
+            mode={mode}
+            attributesFilterFields={attributesFilterFields}
+          />
+          <EuiSpacer size="s" />
+          <EuiPanel>
+            <EuiAccordion
+              id="accordion1"
+              buttonContent={mode === 'data_prepper' ? 'Trace Groups' : 'Service and Operations'}
+              forceState={trigger}
+              onToggle={onToggle}
+              data-test-subj="trace-groups-service-operation-accordian"
+            >
+              <EuiSpacer size="m" />
+              {trigger === 'open' && dashboardContent()}
+            </EuiAccordion>
+          </EuiPanel>
+          <EuiSpacer size="s" />
+          <TracesTable
+            items={tableItems}
+            refresh={refresh}
+            mode={mode}
+            loading={loading}
+            traceIdColumnAction={traceIdColumnAction}
+            jaegerIndicesExist={jaegerIndicesExist}
+            dataPrepperIndicesExist={dataPrepperIndicesExist}
+          />
+        </EuiPageBody>
+      </EuiPage>
     </>
   );
 }

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -50,9 +50,11 @@ export function TracesTable(props: TracesTableProps) {
     );
   };
 
-  const columns = useMemo(() => {
-    if (mode === 'data_prepper') {
-      return [
+  const columns = useMemo(
+    () => {
+      if (mode === 'data_prepper') {
+        return(
+      [
         {
           field: 'trace_id',
           name: 'Trace ID',
@@ -62,7 +64,7 @@ export function TracesTable(props: TracesTableProps) {
           render: (item) => (
             <EuiFlexGroup gutterSize="s" alignItems="center">
               <EuiFlexItem grow={10}>
-                <EuiLink data-test-subj="trace-link" onClick={() => traceIdColumnAction(item)}>
+                <EuiLink data-test-subj='trace-link' onClick={() => traceIdColumnAction(item)}>
                   {item.length < 24 ? (
                     item
                   ) : (
@@ -149,7 +151,7 @@ export function TracesTable(props: TracesTableProps) {
           sortable: true,
           render: (item) => (item === 0 || item ? item : '-'),
         },
-      ] as Array<EuiTableFieldDataColumnType<any>>;
+      ] as Array<EuiTableFieldDataColumnType<any>>)
     } else {
       return (
         [
@@ -219,7 +221,9 @@ export function TracesTable(props: TracesTableProps) {
           },
         ] as Array<EuiTableFieldDataColumnType<any>>)
     }
-  }, [items]);
+    },
+    [items]
+  );
 
   const titleBar = useMemo(() => renderTitleBar(items?.length), [items]);
 
@@ -230,7 +234,7 @@ export function TracesTable(props: TracesTableProps) {
     },
   });
 
-  const onTableChange = async ({ _currPage, sort }: { currPage: any; sort: any }) => {
+  const onTableChange = async ({ _currPage, sort }: { _currPage: any; sort: any }) => {
     if (typeof sort?.field !== 'string') return;
 
     // maps table column key to DSL aggregation name
@@ -265,11 +269,8 @@ export function TracesTable(props: TracesTableProps) {
         {titleBar}
         <EuiSpacer size="m" />
         <EuiHorizontalRule margin="none" />
-        {!(
-          (mode === 'data_prepper' && props.dataPrepperIndicesExist) ||
-          (mode === 'jaeger' && props.jaegerIndicesExist)
-        ) ? (
-          <MissingConfigurationMessage mode={mode} />
+        {!((mode === 'data_prepper' && props.dataPrepperIndicesExist) || (mode === 'jaeger' && props.jaegerIndicesExist)) ? (
+          <MissingConfigurationMessage mode={mode}/>
         ) : items?.length > 0 ? (
           <EuiInMemoryTable
             tableLayout="auto"

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -50,11 +50,9 @@ export function TracesTable(props: TracesTableProps) {
     );
   };
 
-  const columns = useMemo(
-    () => {
-      if (mode === 'data_prepper') {
-        return(
-      [
+  const columns = useMemo(() => {
+    if (mode === 'data_prepper') {
+      return [
         {
           field: 'trace_id',
           name: 'Trace ID',
@@ -64,7 +62,7 @@ export function TracesTable(props: TracesTableProps) {
           render: (item) => (
             <EuiFlexGroup gutterSize="s" alignItems="center">
               <EuiFlexItem grow={10}>
-                <EuiLink data-test-subj='trace-link' onClick={() => traceIdColumnAction(item)}>
+                <EuiLink data-test-subj="trace-link" onClick={() => traceIdColumnAction(item)}>
                   {item.length < 24 ? (
                     item
                   ) : (
@@ -151,7 +149,7 @@ export function TracesTable(props: TracesTableProps) {
           sortable: true,
           render: (item) => (item === 0 || item ? item : '-'),
         },
-      ] as Array<EuiTableFieldDataColumnType<any>>)
+      ] as Array<EuiTableFieldDataColumnType<any>>;
     } else {
       return (
         [
@@ -221,9 +219,7 @@ export function TracesTable(props: TracesTableProps) {
           },
         ] as Array<EuiTableFieldDataColumnType<any>>)
     }
-    },
-    [items]
-  );
+  }, [items]);
 
   const titleBar = useMemo(() => renderTitleBar(items?.length), [items]);
 
@@ -234,7 +230,7 @@ export function TracesTable(props: TracesTableProps) {
     },
   });
 
-  const onTableChange = async ({ currPage, sort }: { currPage: any; sort: any }) => {
+  const onTableChange = async ({ _currPage, sort }: { currPage: any; sort: any }) => {
     if (typeof sort?.field !== 'string') return;
 
     // maps table column key to DSL aggregation name
@@ -269,8 +265,11 @@ export function TracesTable(props: TracesTableProps) {
         {titleBar}
         <EuiSpacer size="m" />
         <EuiHorizontalRule margin="none" />
-        {!((mode === 'data_prepper' && props.dataPrepperIndicesExist) || (mode === 'jaeger' && props.jaegerIndicesExist)) ? (
-          <MissingConfigurationMessage mode={mode}/>
+        {!(
+          (mode === 'data_prepper' && props.dataPrepperIndicesExist) ||
+          (mode === 'jaeger' && props.jaegerIndicesExist)
+        ) ? (
+          <MissingConfigurationMessage mode={mode} />
         ) : items?.length > 0 ? (
           <EuiInMemoryTable
             tableLayout="auto"

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -18,7 +18,8 @@ import {
   EuiText,
   PropertySort,
 } from '@elastic/eui';
-import _ from 'lodash';
+import round from 'lodash/round';
+import truncate from 'lodash/truncate';
 import React, { useMemo, useState } from 'react';
 import { TRACES_MAX_NUM } from '../../../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode } from '../../home';
@@ -50,11 +51,9 @@ export function TracesTable(props: TracesTableProps) {
     );
   };
 
-  const columns = useMemo(
-    () => {
-      if (mode === 'data_prepper') {
-        return(
-      [
+  const columns = useMemo(() => {
+    if (mode === 'data_prepper') {
+      return [
         {
           field: 'trace_id',
           name: 'Trace ID',
@@ -64,11 +63,11 @@ export function TracesTable(props: TracesTableProps) {
           render: (item) => (
             <EuiFlexGroup gutterSize="s" alignItems="center">
               <EuiFlexItem grow={10}>
-                <EuiLink data-test-subj='trace-link' onClick={() => traceIdColumnAction(item)}>
+                <EuiLink data-test-subj="trace-link" onClick={() => traceIdColumnAction(item)}>
                   {item.length < 24 ? (
                     item
                   ) : (
-                    <div title={item}>{_.truncate(item, { length: 24 })}</div>
+                    <div title={item}>{truncate(item, { length: 24 })}</div>
                   )}
                 </EuiLink>
               </EuiFlexItem>
@@ -98,11 +97,7 @@ export function TracesTable(props: TracesTableProps) {
           render: (item) =>
             item ? (
               <EuiText size="s">
-                {item.length < 36 ? (
-                  item
-                ) : (
-                  <div title={item}>{_.truncate(item, { length: 36 })}</div>
-                )}
+                {item.length < 36 ? item : <div title={item}>{truncate(item, { length: 36 })}</div>}
               </EuiText>
             ) : (
               '-'
@@ -126,7 +121,7 @@ export function TracesTable(props: TracesTableProps) {
           align: 'right',
           sortable: true,
           render: (item) =>
-            item === 0 || item ? <EuiText size="s">{`${_.round(item, 2)}th`}</EuiText> : '-',
+            item === 0 || item ? <EuiText size="s">{`${round(item, 2)}th`}</EuiText> : '-',
         },
         {
           field: 'error_count',
@@ -151,79 +146,76 @@ export function TracesTable(props: TracesTableProps) {
           sortable: true,
           render: (item) => (item === 0 || item ? item : '-'),
         },
-      ] as Array<EuiTableFieldDataColumnType<any>>)
+      ] as Array<EuiTableFieldDataColumnType<any>>;
     } else {
-      return (
-        [
-          {
-            field: 'trace_id',
-            name: 'Trace ID',
-            align: 'left',
-            sortable: true,
-            truncateText: true,
-            render: (item) => (
-              <EuiFlexGroup gutterSize="s" alignItems="center">
-                <EuiFlexItem grow={10}>
-                  <EuiLink onClick={() => traceIdColumnAction(item)}>
-                    {item.length < 24 ? (
-                      item
-                    ) : (
-                      <div title={item}>{_.truncate(item, { length: 24 })}</div>
-                    )}
-                  </EuiLink>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiCopy textToCopy={item}>
-                    {(copy) => (
-                      <EuiSmallButtonIcon
-                        aria-label="Copy trace id"
-                        iconType="copyClipboard"
-                        onClick={copy}
-                      >
-                        Click to copy
-                      </EuiSmallButtonIcon>
-                    )}
-                  </EuiCopy>
-                </EuiFlexItem>
-                <EuiFlexItem grow={3} />
-              </EuiFlexGroup>
+      return [
+        {
+          field: 'trace_id',
+          name: 'Trace ID',
+          align: 'left',
+          sortable: true,
+          truncateText: true,
+          render: (item) => (
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiFlexItem grow={10}>
+                <EuiLink onClick={() => traceIdColumnAction(item)}>
+                  {item.length < 24 ? (
+                    item
+                  ) : (
+                    <div title={item}>{truncate(item, { length: 24 })}</div>
+                  )}
+                </EuiLink>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiCopy textToCopy={item}>
+                  {(copy) => (
+                    <EuiSmallButtonIcon
+                      aria-label="Copy trace id"
+                      iconType="copyClipboard"
+                      onClick={copy}
+                    >
+                      Click to copy
+                    </EuiSmallButtonIcon>
+                  )}
+                </EuiCopy>
+              </EuiFlexItem>
+              <EuiFlexItem grow={3} />
+            </EuiFlexGroup>
+          ),
+        },
+        {
+          field: 'latency',
+          name: 'Latency (ms)',
+          align: 'right',
+          sortable: true,
+          truncateText: true,
+        },
+        {
+          field: 'error_count',
+          name: 'Errors',
+          align: 'right',
+          sortable: true,
+          render: (item) =>
+            item == null ? (
+              '-'
+            ) : item > 0 ? (
+              <EuiText color="danger" size="s">
+                Yes
+              </EuiText>
+            ) : (
+              'No'
             ),
-          },
-          {
-            field: 'latency',
-            name: 'Latency (ms)',
-            align: 'right',
-            sortable: true,
-            truncateText: true,
-          },
-          {
-            field: 'error_count',
-            name: 'Errors',
-            align: 'right',
-            sortable: true,
-            render: (item) =>
-              item == null ? (
-                '-'
-              ) : item > 0 ? (
-                <EuiText color="danger" size="s">
-                  Yes
-                </EuiText>
-              ) : (
-                'No'
-              ),
-          },
-          {
-            field: 'last_updated',
-            name: 'Last updated',
-            align: 'left',
-            sortable: true,
-            render: (item) => (item === 0 || item ? item : '-'),
-          },
-        ] as Array<EuiTableFieldDataColumnType<any>>)
+        },
+        {
+          field: 'last_updated',
+          name: 'Last updated',
+          align: 'left',
+          sortable: true,
+          render: (item) => (item === 0 || item ? item : '-'),
+        },
+      ] as Array<EuiTableFieldDataColumnType<any>>;
     }
-    },
-    [items]
-  );
+  }, [items]);
 
   const titleBar = useMemo(() => renderTitleBar(items?.length), [items]);
 
@@ -234,7 +226,7 @@ export function TracesTable(props: TracesTableProps) {
     },
   });
 
-  const onTableChange = async ({ _currPage, sort }: { _currPage: any; sort: any }) => {
+  const onTableChange = async ({ _currPage, sort }: { currPage: any; sort: any }) => {
     if (typeof sort?.field !== 'string') return;
 
     // maps table column key to DSL aggregation name
@@ -269,8 +261,11 @@ export function TracesTable(props: TracesTableProps) {
         {titleBar}
         <EuiSpacer size="m" />
         <EuiHorizontalRule margin="none" />
-        {!((mode === 'data_prepper' && props.dataPrepperIndicesExist) || (mode === 'jaeger' && props.jaegerIndicesExist)) ? (
-          <MissingConfigurationMessage mode={mode}/>
+        {!(
+          (mode === 'data_prepper' && props.dataPrepperIndicesExist) ||
+          (mode === 'jaeger' && props.jaegerIndicesExist)
+        ) ? (
+          <MissingConfigurationMessage mode={mode} />
         ) : items?.length > 0 ? (
           <EuiInMemoryTable
             tableLayout="auto"


### PR DESCRIPTION
* traces and services UI update

Signed-off-by: Adam Tackett <tackadam@amazon.com>

* small ui adjustments to match mocks, update snapshots

Signed-off-by: Adam Tackett <tackadam@amazon.com>

* remove all custom styling

Signed-off-by: Adam Tackett <tackadam@amazon.com>

* remove comment

Signed-off-by: Adam Tackett <tackadam@amazon.com>

* allign add filter and mode picker using flush-left

Signed-off-by: Adam Tackett <tackadam@amazon.com>

* update snapshots

Signed-off-by: Adam Tackett <tackadam@amazon.com>

* update snapshots from osd

Signed-off-by: Adam Tackett <tackadam@amazon.com>

---------

Signed-off-by: Adam Tackett <tackadam@amazon.com>
Signed-off-by: Adam Tackett <105462877+TackAdam@users.noreply.github.com>
Co-authored-by: Adam Tackett <tackadam@amazon.com>
(cherry picked from commit de3acb06378334cc61714bf4d95fc7602ecf9714)

### Description
Backport 2078 Traces/Services UI update to 2.x

### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
