### PR TITLE
[query assist] update ml-commons response schema

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -56,6 +56,11 @@ export function setupRoutes({
   registerIntegrationsRoute(router);
   registerDataConnectionsRoute(router, dataSourceEnabled);
   registerDatasourcesRoute(router, dataSourceEnabled);
-  registerQueryAssistRoutes(router);
+
+  // query assist is part of log explorer, which will be disabled if datasource is enabled
+  if (!dataSourceEnabled) {
+    registerQueryAssistRoutes(router);
+  }
+
   registerGettingStartedRoutes(router);
 }

--- a/server/routes/query_assist/routes.ts
+++ b/server/routes/query_assist/routes.ts
@@ -83,11 +83,15 @@ export function registerQueryAssistRoutes(router: IRouter) {
         if (
           isResponseError(error) &&
           error.statusCode === 400 &&
-          error.body.includes(ERROR_DETAILS.GUARDRAILS_TRIGGERED)
+          // on opensearch >= 2.17, error.body is an object https://github.com/opensearch-project/ml-commons/pull/2858
+          JSON.stringify(error.body).includes(ERROR_DETAILS.GUARDRAILS_TRIGGERED)
         ) {
           return response.badRequest({ body: ERROR_DETAILS.GUARDRAILS_TRIGGERED });
         }
-        return response.custom({ statusCode: error.statusCode || 500, body: error.message });
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: typeof error.body === 'string' ? error.body : JSON.stringify(error.body),
+        });
       }
     }
   );
@@ -155,11 +159,15 @@ export function registerQueryAssistRoutes(router: IRouter) {
         if (
           isResponseError(error) &&
           error.statusCode === 400 &&
-          error.body.includes(ERROR_DETAILS.GUARDRAILS_TRIGGERED)
+          // on opensearch >= 2.17, error.body is an object https://github.com/opensearch-project/ml-commons/pull/2858
+          JSON.stringify(error.body).includes(ERROR_DETAILS.GUARDRAILS_TRIGGERED)
         ) {
           return response.badRequest({ body: ERROR_DETAILS.GUARDRAILS_TRIGGERED });
         }
-        return response.custom({ statusCode: error.statusCode || 500, body: error.message });
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: typeof error.body === 'string' ? error.body : JSON.stringify(error.body),
+        });
       }
     }
   );


### PR DESCRIPTION
### Description
update logic to process ml-commons response schema. `error.body` was a string before, now it is a JSON object. converting to string for backward compatibility

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
