### PR TITLE
[Manual Backport 2.x] Add support for register data sources during the absence of local cluster

### DIFF
--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -169,6 +169,7 @@ export class ObservabilityPlugin
   constructor(initializerContext: PluginInitializerContext) {
     this.config = initializerContext.config.get<PublicConfig>();
   }
+  private mdsFlagStatus: boolean = false;
 
   public setup(
     core: CoreSetup<AppPluginStartDependencies>,
@@ -184,6 +185,7 @@ export class ObservabilityPlugin
     });
 
     setupOverviewPage(setupDeps.contentManagement!);
+    this.mdsFlagStatus = !!setupDeps.dataSource;
 
     // redirect legacy notebooks URL to current URL under observability
     if (window.location.pathname.includes('notebooks-dashboards')) {
@@ -459,7 +461,8 @@ export class ObservabilityPlugin
       return `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
     };
 
-    // register all s3 datasources
+    // register all s3 datasources only if mds feature flag is disabled
+    if (!this.mdsFlagStatus) {
     const registerDataSources = () => {
       try {
         core.http.get(`${DATACONNECTIONS_BASE}`).then((s3DataSources) => {
@@ -509,6 +512,7 @@ export class ObservabilityPlugin
     } else {
       registerDataSources();
     }
+  }
 
     core.http.intercept({
       request: catalogRequestIntercept(),

--- a/release-notes/opensearch-observability.release-notes-2.17.0.0.md
+++ b/release-notes/opensearch-observability.release-notes-2.17.0.0.md
@@ -24,6 +24,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 2.17.0
 * [query assist] update api handler to accommodate new ml-commons config response ([#2111](https://github.com/opensearch-project/dashboards-observability/pull/2111))
 * Update trace analytics landing page ([#2125](https://github.com/opensearch-project/dashboards-observability/pull/2125))
 * [query assist] update ml-commons response schema ([#2124](https://github.com/opensearch-project/dashboards-observability/pull/2124))
+* [MDS] Add support for register data sources during the absence of local cluster ([#2140](https://github.com/opensearch-project/dashboards-observability/pull/2140))
 
 ### Bug Fixes
 * [Bug] Trace Analytics bug fix for local cluster being rendered ([#2006](https://github.com/opensearch-project/dashboards-observability/pull/2006))


### PR DESCRIPTION
### Description
Add support for register data sources during the absence of local cluster

### Issues Resolved
- Resolve the 500 errors when there is no backend plugins to consume the requests

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
