### PR TITLE
Fix getting started cards re-direction to integrations

### DIFF
--- a/public/components/getting_started/components/getting_started_integrationCards.tsx
+++ b/public/components/getting_started/components/getting_started_integrationCards.tsx
@@ -3,21 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect } from 'react';
 import {
+  EuiBadge,
+  EuiCard,
   EuiFieldSearch,
   EuiFilterButton,
   EuiFilterGroup,
   EuiFilterSelectItem,
-  EuiPopover,
-  EuiPopoverTitle,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiCard,
-  EuiText,
-  EuiBadge,
+  EuiPopover,
+  EuiPopoverTitle,
   EuiSpacer,
+  EuiText,
 } from '@elastic/eui';
+import React, { useEffect, useState } from 'react';
+import { observabilityIntegrationsID } from '../../../../common/constants/shared';
 import { coreRefs } from '../../../../public/framework/core_refs';
 
 export const IntegrationCards = () => {
@@ -148,7 +149,11 @@ export const IntegrationCards = () => {
               description={integration.description}
               data-test-subj={`integration_card_${integration.name.toLowerCase()}`}
               titleElement="span"
-              href={`/app/integrations#/available/${integration.name}`}
+              onClick={() =>
+                coreRefs?.application?.navigateToApp(observabilityIntegrationsID, {
+                  path: `#/available/${integration.name}`,
+                })
+              }
               footer={
                 <div>
                   {integration.labels &&


### PR DESCRIPTION
### Description
Today getting started plugin uses href to navigate to integrations plugin using the EuiCards for integrations catalog. This becomes an issue when `workspaces` is enabled in OSD core as workspaces relies on url in browser for saved object scoping. 

### Issues Resolved
Removed the `href` call and replaced it with `navigateToApp` from core. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
