### PR TITLE
Fix integration imports for table and card view

### DIFF
--- a/public/components/integrations/components/added_integration_table.tsx
+++ b/public/components/integrations/components/added_integration_table.tsx
@@ -94,7 +94,7 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
       truncateText: true,
       render: (value, record) => (
         <EuiText data-test-subj={`${record.templateName}IntegrationDescription`}>
-          {truncate(record.dataSourceMDSLabel || 'Local cluster', { length: 100 })}
+          {_.truncate(record.dataSourceMDSLabel || 'Local cluster', { length: 100 })}
         </EuiText>
       ),
     });

--- a/public/components/integrations/components/available_integration_card_view.tsx
+++ b/public/components/integrations/components/available_integration_card_view.tsx
@@ -4,23 +4,19 @@
  */
 
 import {
-  EuiPanel,
+  EuiButtonGroup,
   EuiCard,
+  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiPanel,
   EuiSpacer,
-  EuiCompressedFieldSearch,
-  EuiButtonGroup,
 } from '@elastic/eui';
-import _ from 'lodash';
 import React, { useState } from 'react';
-import {
-  AvailableIntegrationsCardViewProps,
-  AvailableIntegrationType,
-} from './available_integration_overview_page';
 import { INTEGRATIONS_BASE } from '../../../../common/constants/shared';
-import { badges } from './integration_category_badge_group';
 import { basePathLink } from '../../../../common/utils/shared';
+import { AvailableIntegrationsCardViewProps } from './available_integration_overview_page';
+import { badges } from './integration_category_badge_group';
 
 export function AvailableIntegrationsCardView(props: AvailableIntegrationsCardViewProps) {
   const [toggleIconIdSelected, setToggleIconIdSelected] = useState('1');
@@ -57,7 +53,7 @@ export function AvailableIntegrationsCardView(props: AvailableIntegrationsCardVi
     }
   };
 
-  const renderRows = (integrations: AvailableIntegrationType[]) => {
+  const renderRows = (integrations: IntegrationConfig[]) => {
     if (!integrations || !integrations.length) return null;
     return (
       <>
@@ -68,11 +64,11 @@ export function AvailableIntegrationsCardView(props: AvailableIntegrationsCardVi
                 <EuiCard
                   icon={getImage(
                     basePathLink(
-                      `${INTEGRATIONS_BASE}/repository/${i.name}/static/${i.statics.logo.path}`
+                      `${INTEGRATIONS_BASE}/repository/${i.name}/static/${i.statics?.logo?.path}`
                     )
                   )}
                   title={i.displayName ? i.displayName : i.name}
-                  description={i.description}
+                  description={i.description ?? ''}
                   data-test-subj={`integration_card_${i.name.toLowerCase()}`}
                   titleElement="span"
                   href={basePathLink(`/app/integrations#/available/${i.name}`)}


### PR DESCRIPTION
### Description
Latest Observability on 2.x/2.17 fails to load the integrations plugin due to import error. 

### Issues Resolved
Fix integration imports for table and card view
* Updated loadash import
* Updated available integration type import

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
