### PR TITLE
[Bug] UI changes for overview page, fix re-direction for workspaces

### DIFF
--- a/common/constants/shared.ts
+++ b/common/constants/shared.ts
@@ -33,7 +33,7 @@ export const DATACONNECTIONS_ENDPOINT = '/_plugins/_query/_datasources';
 export const JOBS_ENDPOINT_BASE = '/_plugins/_async_query';
 export const JOB_RESULT_ENDPOINT = '/result';
 
-export const IMPORT_SAMPLE_DATA_APP_ID = 'import_sample_data';
+export const tutorialSampleDataPluginId = 'import_sample_data';
 
 export const observabilityID = 'observability-logs';
 export const observabilityTitle = 'Observability';

--- a/common/constants/shared.ts
+++ b/common/constants/shared.ts
@@ -33,6 +33,8 @@ export const DATACONNECTIONS_ENDPOINT = '/_plugins/_query/_datasources';
 export const JOBS_ENDPOINT_BASE = '/_plugins/_async_query';
 export const JOB_RESULT_ENDPOINT = '/result';
 
+export const IMPORT_SAMPLE_DATA_APP_ID = 'import_sample_data';
+
 export const observabilityID = 'observability-logs';
 export const observabilityTitle = 'Observability';
 export const observabilityPluginOrder = 1500;

--- a/common/constants/shared.ts
+++ b/common/constants/shared.ts
@@ -44,7 +44,7 @@ export const observabilityOverviewTitle = 'Observability overview';
 export const observabilityOverviewPluginOrder = 5088;
 
 export const observabilityGettingStartedID = 'observability-gettingStarted';
-export const observabilityGettingStartedTitle = 'Getting Started';
+export const observabilityGettingStartedTitle = 'Get started';
 export const observabilityGettingStartedPluginOrder = 5089;
 
 export const observabilityApplicationsID = 'observability-applications';

--- a/public/components/getting_started/components/getting_started.tsx
+++ b/public/components/getting_started/components/getting_started.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useState } from 'react';
 import { HomeProps } from 'public/components/getting_started/home';
 import { CollectAndShipData } from './getting_started_collectData';
 import { QueryAndAnalyze } from './getting_started_queryAndAnalyze';
+import { observabilityGettingStartedTitle } from '../../../../common/constants/shared';
 
 interface ExtendedHomeProps extends HomeProps {
   selectedDataSourceId: string;
@@ -24,7 +25,7 @@ export const NewGettingStarted = (props: ExtendedHomeProps) => {
   useEffect(() => {
     chrome.setBreadcrumbs([
       {
-        text: 'Get started',
+        text: observabilityGettingStartedTitle,
         href: '#/',
       },
     ]);

--- a/public/components/getting_started/components/getting_started.tsx
+++ b/public/components/getting_started/components/getting_started.tsx
@@ -24,7 +24,7 @@ export const NewGettingStarted = (props: ExtendedHomeProps) => {
   useEffect(() => {
     chrome.setBreadcrumbs([
       {
-        text: 'Getting Started',
+        text: 'Get started',
         href: '#/',
       },
     ]);

--- a/public/components/getting_started/components/getting_started_collectData.tsx
+++ b/public/components/getting_started/components/getting_started_collectData.tsx
@@ -103,7 +103,7 @@ export const CollectAndShipData: React.FC<CollectAndShipDataProps> = ({
     setSelectedWorkflow('');
     setGettingStarted(null);
     setWorkflows([]);
-    onCardSelectionChange(value === 'Use a sample dataset');
+    onCardSelectionChange(value === 'Configure use-case based content');
 
     if (value === 'Configure collectors') {
       setCollectorOptions([
@@ -349,12 +349,12 @@ export const CollectAndShipData: React.FC<CollectAndShipDataProps> = ({
           <EuiFlexItem>
             <EuiCheckableCard
               id="use_sample_dataset"
-              label="Use a sample dataset"
+              label="Configure use-case based content"
               checkableType="radio"
-              checked={selectedCard === 'Use a sample dataset'}
+              checked={selectedCard === 'Configure use-case based content'}
               onChange={() => {
-                handleCollectionMethodChange('Use a sample dataset');
-                setSelectedCard('Use a sample dataset');
+                handleCollectionMethodChange('Configure use-case based content');
+                setSelectedCard('Configure use-case based content');
               }}
             >
               Explore with a log dataset
@@ -362,7 +362,7 @@ export const CollectAndShipData: React.FC<CollectAndShipDataProps> = ({
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiSpacer size="m" />
-        {collectionMethod === 'Use a sample dataset' ? (
+        {collectionMethod === 'Configure use-case based content' ? (
           <IntegrationCards />
         ) : (
           <>

--- a/public/components/getting_started/components/getting_started_collectData.tsx
+++ b/public/components/getting_started/components/getting_started_collectData.tsx
@@ -152,7 +152,7 @@ export const CollectAndShipData: React.FC<CollectAndShipDataProps> = ({
     return (
       <>
         <EuiText>
-          <h3>Collector</h3>
+          <h3>Select a collector</h3>
         </EuiText>
         <EuiSpacer size="s" />
         <EuiSelectable

--- a/public/components/getting_started/components/getting_started_collectData.tsx
+++ b/public/components/getting_started/components/getting_started_collectData.tsx
@@ -33,6 +33,10 @@ import javaJson from '../getting_started_artifacts/java_client/java_client-1.0.0
 import { IntegrationCards } from './getting_started_integrationCards';
 import { UploadAssets } from './utils';
 
+const cardOne = 'Collector';
+const cardTwo = 'File Upload';
+const cardThree = 'Configure use-case based content';
+
 interface CollectAndShipDataProps {
   isOpen: boolean;
   onToggle: (isOpen: boolean) => void;
@@ -103,9 +107,9 @@ export const CollectAndShipData: React.FC<CollectAndShipDataProps> = ({
     setSelectedWorkflow('');
     setGettingStarted(null);
     setWorkflows([]);
-    onCardSelectionChange(value === 'Configure use-case based content');
+    onCardSelectionChange(value === cardThree);
 
-    if (value === 'Configure collectors') {
+    if (value === cardOne) {
       setCollectorOptions([
         { label: 'Open Telemetry (structured)', value: 'otel' },
         { label: 'Nginx (structured)', value: 'nginx' },
@@ -113,7 +117,7 @@ export const CollectAndShipData: React.FC<CollectAndShipDataProps> = ({
         { label: 'Python (unstructured)', value: 'python' },
         { label: 'Golang (unstructured)', value: 'golang' },
       ]);
-    } else if (value === 'Upload a file CSV or JSON') {
+    } else if (value === cardTwo) {
       setCollectorOptions([{ label: 'Fluent Bit', value: 'csv' }]);
     }
   };
@@ -148,7 +152,7 @@ export const CollectAndShipData: React.FC<CollectAndShipDataProps> = ({
     return (
       <>
         <EuiText>
-          <strong>Select a collector</strong>
+          <h3>Collector</h3>
         </EuiText>
         <EuiSpacer size="s" />
         <EuiSelectable
@@ -301,68 +305,64 @@ export const CollectAndShipData: React.FC<CollectAndShipDataProps> = ({
   }));
 
   return (
-    <EuiAccordion
-      id="collect-and-ship-data"
-      buttonContent="Collect and ship data"
-      paddingSize="m"
-      forceState={isOpen ? 'open' : 'closed'}
-      onToggle={onToggle}
-    >
-      <EuiPanel>
+    <EuiPanel paddingSize="m">
+      <EuiAccordion
+        id="collect-and-ingest-data"
+        buttonContent="Collect and ingest data"
+        paddingSize="m"
+        forceState={isOpen ? 'open' : 'closed'}
+        onToggle={onToggle}
+      >
         <EuiText>
-          <h3>Collect your data</h3>
-        </EuiText>
-        <EuiSpacer size="m" />
-        <EuiText>
-          <strong>Select a collection method</strong>
+          <h2>Collection method</h2>
         </EuiText>
         <EuiSpacer size="s" />
         <EuiFlexGroup>
           <EuiFlexItem>
             <EuiCheckableCard
               id="configure_collectors"
-              label="Configure collectors"
+              label={cardOne}
               checkableType="radio"
-              checked={selectedCard === 'Configure collectors'}
+              checked={selectedCard === cardOne}
               onChange={() => {
-                handleCollectionMethodChange('Configure collectors');
-                setSelectedCard('Configure collectors');
+                handleCollectionMethodChange(cardOne);
+                setSelectedCard(cardOne);
               }}
             >
-              Configure agents and ingestion pipeline
+              <EuiText size="s">Configure agents and ingestion pipeline</EuiText>
             </EuiCheckableCard>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiCheckableCard
               id="upload_file"
-              label="Upload a file CSV"
+              label={cardTwo}
               checkableType="radio"
-              checked={selectedCard === 'Upload a file CSV or JSON'}
+              checked={selectedCard === cardTwo}
               onChange={() => {
-                handleCollectionMethodChange('Upload a file CSV or JSON');
-                setSelectedCard('Upload a file CSV or JSON');
+                handleCollectionMethodChange(cardTwo);
+                setSelectedCard(cardTwo);
               }}
             >
-              Upload your data
+              <EuiText size="s">Upload your data</EuiText>
             </EuiCheckableCard>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiCheckableCard
               id="use_sample_dataset"
-              label="Configure use-case based content"
+              label={cardThree}
               checkableType="radio"
-              checked={selectedCard === 'Configure use-case based content'}
+              checked={selectedCard === cardThree}
               onChange={() => {
-                handleCollectionMethodChange('Configure use-case based content');
-                setSelectedCard('Configure use-case based content');
+                handleCollectionMethodChange(cardThree);
+                setSelectedCard(cardThree);
               }}
             >
-              Explore with a log dataset
+              <EuiText size="s">Explore with a log dataset</EuiText>
             </EuiCheckableCard>
           </EuiFlexItem>
         </EuiFlexGroup>
         <EuiSpacer size="m" />
-        {collectionMethod === 'Configure use-case based content' ? (
+        {collectionMethod === cardThree ? (
           <IntegrationCards />
         ) : (
           <>
@@ -382,7 +382,7 @@ export const CollectAndShipData: React.FC<CollectAndShipDataProps> = ({
             )}
           </>
         )}
-      </EuiPanel>
-    </EuiAccordion>
+      </EuiAccordion>
+    </EuiPanel>
   );
 };

--- a/public/components/getting_started/components/getting_started_queryAndAnalyze.tsx
+++ b/public/components/getting_started/components/getting_started_queryAndAnalyze.tsx
@@ -18,6 +18,7 @@ import {
 } from '@elastic/eui';
 import { coreRefs } from '../../../../public/framework/core_refs';
 import { fetchDashboardIds, fetchIndexPatternIds, redirectToDashboards } from './utils';
+import { getWorkspaceIdFromUrl } from '../../../../../../src/core/public/utils/index';
 
 interface Pattern {
   id: string;
@@ -75,8 +76,15 @@ export const QueryAndAnalyze: React.FC<QueryAndAnalyzeProps> = ({
       ? `mds-${selectedDataSourceId}-objectId-${patternId}`
       : patternId;
 
+    const currentUrl = window.location.href;
+    const workspaceId = getWorkspaceIdFromUrl(currentUrl, coreRefs?.http!.basePath.getBasePath());
+
+    const workspacePatternId = workspaceId
+      ? `workspaceId-${workspaceId}-${finalPatternId}`
+      : finalPatternId;
+
     coreRefs?.application!.navigateToApp('data-explorer', {
-      path: `discover#?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'${finalPatternId}',view:discover))&_q=(filters:!(),query:(language:kuery,query:''))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))`,
+      path: `discover#?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'${workspacePatternId}',view:discover))&_q=(filters:!(),query:(language:kuery,query:''))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))`,
     });
   };
 
@@ -85,8 +93,16 @@ export const QueryAndAnalyze: React.FC<QueryAndAnalyzeProps> = ({
       ? `mds-${selectedDataSourceId}-objectId-${dashboardId}`
       : dashboardId;
 
+    const currentUrl = window.location.href;
+    const workspaceId = getWorkspaceIdFromUrl(currentUrl, coreRefs?.http!.basePath.getBasePath());
+
+    const workspaceDashboardId = workspaceId
+      ? `workspaceId-${workspaceId}-${finalDashboardId}`
+      : finalDashboardId;
+    const dashboardUrl = `#/view/${workspaceDashboardId}`;
+
     coreRefs?.application!.navigateToApp('dashboards', {
-      path: `#/view/${finalDashboardId}`,
+      path: dashboardUrl,
     });
   };
 

--- a/public/components/getting_started/components/getting_started_queryAndAnalyze.tsx
+++ b/public/components/getting_started/components/getting_started_queryAndAnalyze.tsx
@@ -14,7 +14,6 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import { coreRefs } from '../../../../public/framework/core_refs';
 import { fetchDashboardIds, fetchIndexPatternIds, redirectToDashboards } from './utils';
@@ -107,20 +106,17 @@ export const QueryAndAnalyze: React.FC<QueryAndAnalyzeProps> = ({
   };
 
   return (
-    <EuiAccordion
-      id="query-and-analyze"
-      buttonContent={`Query and analyze data: ${selectedTechnology}`}
-      paddingSize="m"
-      forceState={isOpen ? 'open' : 'closed'}
-      onToggle={onToggle}
-    >
-      <EuiPanel>
-        <EuiTitle size="m">
-          <h3>Query data</h3>
-        </EuiTitle>
+    <EuiPanel paddingSize="m">
+      <EuiAccordion
+        id="query-and-analyze"
+        buttonContent={`Query and analyze data: ${selectedTechnology}`}
+        paddingSize="m"
+        forceState={isOpen ? 'open' : 'closed'}
+        onToggle={onToggle}
+      >
         <EuiText>
           <p>
-            <strong>Explore your data</strong>
+            <h2>Explore your data</h2>
           </p>
         </EuiText>
         <EuiSpacer size="m" />
@@ -135,12 +131,9 @@ export const QueryAndAnalyze: React.FC<QueryAndAnalyzeProps> = ({
             ))}
         </EuiFlexGroup>
         <EuiHorizontalRule />
-        <EuiTitle size="m">
-          <h3>Analyze data</h3>
-        </EuiTitle>
         <EuiText>
           <p>
-            <strong>Visualize your data</strong>
+            <h2>Visualize your data</h2>
           </p>
         </EuiText>
         <EuiSpacer size="m" />
@@ -170,7 +163,7 @@ export const QueryAndAnalyze: React.FC<QueryAndAnalyzeProps> = ({
             />
           </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiPanel>
-    </EuiAccordion>
+      </EuiAccordion>
+    </EuiPanel>
   );
 };

--- a/public/components/getting_started/components/getting_started_queryAndAnalyze.tsx
+++ b/public/components/getting_started/components/getting_started_queryAndAnalyze.tsx
@@ -18,7 +18,7 @@ import {
 } from '@elastic/eui';
 import { coreRefs } from '../../../../public/framework/core_refs';
 import { fetchDashboardIds, fetchIndexPatternIds, redirectToDashboards } from './utils';
-import { getWorkspaceIdFromUrl } from '../../../../../../src/core/public/utils/index';
+import { getWorkspaceIdFromUrl } from '../../../../../../src/core/public/utils';
 
 interface Pattern {
   id: string;

--- a/public/components/integrations/components/integration_overview_panel.tsx
+++ b/public/components/integrations/components/integration_overview_panel.tsx
@@ -36,7 +36,7 @@ export function IntegrationOverview(props: any) {
           data-test-subj="try-it-button"
           data-click-metric-element="integrations.create_from_try_it"
         >
-          Try It
+          Try with sample data
         </EuiSmallButton>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>

--- a/public/components/overview/components/__tests__/__snapshots__/add_dashboard_callout.test.tsx.snap
+++ b/public/components/overview/components/__tests__/__snapshots__/add_dashboard_callout.test.tsx.snap
@@ -95,47 +95,52 @@ exports[`Add dashboard callout renders add dashboard callout 1`] = `
                   className="euiSpacer euiSpacer--l"
                 />
               </EuiSpacer>
-              <EuiButton>
-                <EuiButtonDisplay
-                  baseClassName="euiButton"
-                  disabled={false}
-                  element="button"
-                  isDisabled={false}
-                  type="button"
+              <EuiSmallButton>
+                <EuiButton
+                  size="s"
                 >
-                  <button
-                    className="euiButton euiButton--primary"
+                  <EuiButtonDisplay
+                    baseClassName="euiButton"
                     disabled={false}
-                    style={
-                      Object {
-                        "minWidth": undefined,
-                      }
-                    }
+                    element="button"
+                    isDisabled={false}
+                    size="s"
                     type="button"
                   >
-                    <EuiButtonContent
-                      className="euiButton__content"
-                      iconGap="m"
-                      iconSide="left"
-                      textProps={
+                    <button
+                      className="euiButton euiButton--primary euiButton--small"
+                      disabled={false}
+                      style={
                         Object {
-                          "className": "euiButton__text",
+                          "minWidth": undefined,
                         }
                       }
+                      type="button"
                     >
-                      <span
-                        className="euiButtonContent euiButton__content"
+                      <EuiButtonContent
+                        className="euiButton__content"
+                        iconGap="m"
+                        iconSide="left"
+                        textProps={
+                          Object {
+                            "className": "euiButton__text",
+                          }
+                        }
                       >
                         <span
-                          className="euiButton__text"
+                          className="euiButtonContent euiButton__content"
                         >
-                          Select
+                          <span
+                            className="euiButton__text"
+                          >
+                            Select
+                          </span>
                         </span>
-                      </span>
-                    </EuiButtonContent>
-                  </button>
-                </EuiButtonDisplay>
-              </EuiButton>
+                      </EuiButtonContent>
+                    </button>
+                  </EuiButtonDisplay>
+                </EuiButton>
+              </EuiSmallButton>
             </div>
           </EuiTextColor>
         </div>

--- a/public/components/overview/components/__tests__/__snapshots__/dashboard_controls.test.tsx.snap
+++ b/public/components/overview/components/__tests__/__snapshots__/dashboard_controls.test.tsx.snap
@@ -96,47 +96,52 @@ exports[`Dashboard controls should render 1`] = `
                     className="euiSpacer euiSpacer--l"
                   />
                 </EuiSpacer>
-                <EuiButton>
-                  <EuiButtonDisplay
-                    baseClassName="euiButton"
-                    disabled={false}
-                    element="button"
-                    isDisabled={false}
-                    type="button"
+                <EuiSmallButton>
+                  <EuiButton
+                    size="s"
                   >
-                    <button
-                      className="euiButton euiButton--primary"
+                    <EuiButtonDisplay
+                      baseClassName="euiButton"
                       disabled={false}
-                      style={
-                        Object {
-                          "minWidth": undefined,
-                        }
-                      }
+                      element="button"
+                      isDisabled={false}
+                      size="s"
                       type="button"
                     >
-                      <EuiButtonContent
-                        className="euiButton__content"
-                        iconGap="m"
-                        iconSide="left"
-                        textProps={
+                      <button
+                        className="euiButton euiButton--primary euiButton--small"
+                        disabled={false}
+                        style={
                           Object {
-                            "className": "euiButton__text",
+                            "minWidth": undefined,
                           }
                         }
+                        type="button"
                       >
-                        <span
-                          className="euiButtonContent euiButton__content"
+                        <EuiButtonContent
+                          className="euiButton__content"
+                          iconGap="m"
+                          iconSide="left"
+                          textProps={
+                            Object {
+                              "className": "euiButton__text",
+                            }
+                          }
                         >
                           <span
-                            className="euiButton__text"
+                            className="euiButtonContent euiButton__content"
                           >
-                            Select
+                            <span
+                              className="euiButton__text"
+                            >
+                              Select
+                            </span>
                           </span>
-                        </span>
-                      </EuiButtonContent>
-                    </button>
-                  </EuiButtonDisplay>
-                </EuiButton>
+                        </EuiButtonContent>
+                      </button>
+                    </EuiButtonDisplay>
+                  </EuiButton>
+                </EuiSmallButton>
               </div>
             </EuiTextColor>
           </div>

--- a/public/components/overview/components/__tests__/__snapshots__/select_dashboard_flyout.test.tsx.snap
+++ b/public/components/overview/components/__tests__/__snapshots__/select_dashboard_flyout.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`Select dashboard flyout should render 1`] = `
                         class="euiSelectable euiSelectable-fullHeight"
                       >
                         <div
-                          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                         >
                           <div
                             class="euiFormControlLayout__childrenWrapper"
@@ -94,7 +94,7 @@ exports[`Select dashboard flyout should render 1`] = `
                               aria-haspopup="listbox"
                               aria-label="Filter options"
                               autocomplete="off"
-                              class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch"
+                              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiSelectableSearch"
                               placeholder="Search for a dashboard..."
                               type="search"
                               value=""
@@ -107,7 +107,7 @@ exports[`Select dashboard flyout should render 1`] = `
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                  class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                   focusable="false"
                                   height="16"
                                   role="img"
@@ -347,7 +347,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                 class="euiSelectable euiSelectable-fullHeight"
                               >
                                 <div
-                                  class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                  class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                                 >
                                   <div
                                     class="euiFormControlLayout__childrenWrapper"
@@ -357,7 +357,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                       aria-haspopup="listbox"
                                       aria-label="Filter options"
                                       autocomplete="off"
-                                      class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch"
+                                      class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiSelectableSearch"
                                       placeholder="Search for a dashboard..."
                                       type="search"
                                       value=""
@@ -370,7 +370,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                       >
                                         <svg
                                           aria-hidden="true"
-                                          class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                          class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                           focusable="false"
                                           height="16"
                                           role="img"
@@ -542,7 +542,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                   class="euiSelectable euiSelectable-fullHeight"
                                 >
                                   <div
-                                    class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                    class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                                   >
                                     <div
                                       class="euiFormControlLayout__childrenWrapper"
@@ -552,7 +552,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                         aria-haspopup="listbox"
                                         aria-label="Filter options"
                                         autocomplete="off"
-                                        class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch"
+                                        class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiSelectableSearch"
                                         placeholder="Search for a dashboard..."
                                         type="search"
                                         value=""
@@ -565,7 +565,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                         >
                                           <svg
                                             aria-hidden="true"
-                                            class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                            class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                             focusable="false"
                                             height="16"
                                             role="img"
@@ -737,7 +737,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                     class="euiSelectable euiSelectable-fullHeight"
                                   >
                                     <div
-                                      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                                     >
                                       <div
                                         class="euiFormControlLayout__childrenWrapper"
@@ -747,7 +747,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                           aria-haspopup="listbox"
                                           aria-label="Filter options"
                                           autocomplete="off"
-                                          class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch"
+                                          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiSelectableSearch"
                                           placeholder="Search for a dashboard..."
                                           type="search"
                                           value=""
@@ -760,7 +760,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                           >
                                             <svg
                                               aria-hidden="true"
-                                              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                              class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                               focusable="false"
                                               height="16"
                                               role="img"
@@ -920,7 +920,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                       class="euiSelectable euiSelectable-fullHeight"
                                     >
                                       <div
-                                        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                                       >
                                         <div
                                           class="euiFormControlLayout__childrenWrapper"
@@ -930,7 +930,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                             aria-haspopup="listbox"
                                             aria-label="Filter options"
                                             autocomplete="off"
-                                            class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch"
+                                            class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiSelectableSearch"
                                             placeholder="Search for a dashboard..."
                                             type="search"
                                             value=""
@@ -943,7 +943,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                             >
                                               <svg
                                                 aria-hidden="true"
-                                                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                 focusable="false"
                                                 height="16"
                                                 role="img"
@@ -1177,6 +1177,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                   options={Array []}
                                   searchProps={
                                     Object {
+                                      "compressed": true,
                                       "placeholder": "Search for a dashboard...",
                                     }
                                   }
@@ -1196,6 +1197,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                       <EuiSelectableSearch
                                         aria-activedescendant=""
                                         aria-label="Filter options"
+                                        compressed={true}
                                         defaultValue=""
                                         isPreFiltered={false}
                                         key="listSearch"
@@ -1209,7 +1211,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                           aria-label="Filter options"
                                           autoComplete="off"
                                           className="euiSelectableSearch"
-                                          compressed={false}
+                                          compressed={true}
                                           defaultValue=""
                                           fullWidth={true}
                                           incremental={true}
@@ -1219,13 +1221,13 @@ exports[`Select dashboard flyout should render 1`] = `
                                           placeholder="Search for a dashboard..."
                                         >
                                           <EuiFormControlLayout
-                                            compressed={false}
+                                            compressed={true}
                                             fullWidth={true}
                                             icon="search"
                                             isLoading={false}
                                           >
                                             <div
-                                              className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                                              className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                                             >
                                               <div
                                                 className="euiFormControlLayout__childrenWrapper"
@@ -1236,7 +1238,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                                     aria-haspopup="listbox"
                                                     aria-label="Filter options"
                                                     autoComplete="off"
-                                                    className="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch"
+                                                    className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed euiSelectableSearch"
                                                     defaultValue=""
                                                     onKeyUp={[Function]}
                                                     placeholder="Search for a dashboard..."
@@ -1244,7 +1246,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                                   />
                                                 </EuiValidatableControl>
                                                 <EuiFormControlLayoutIcons
-                                                  compressed={false}
+                                                  compressed={true}
                                                   icon="search"
                                                   isLoading={false}
                                                 >
@@ -1252,7 +1254,7 @@ exports[`Select dashboard flyout should render 1`] = `
                                                     className="euiFormControlLayoutIcons"
                                                   >
                                                     <EuiFormControlLayoutCustomIcon
-                                                      size="m"
+                                                      size="s"
                                                       type="search"
                                                     >
                                                       <span
@@ -1261,19 +1263,19 @@ exports[`Select dashboard flyout should render 1`] = `
                                                         <EuiIcon
                                                           aria-hidden="true"
                                                           className="euiFormControlLayoutCustomIcon__icon"
-                                                          size="m"
+                                                          size="s"
                                                           type="search"
                                                         >
                                                           <EuiIconBeaker
                                                             aria-hidden={true}
-                                                            className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                            className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                             focusable="false"
                                                             role="img"
                                                             style={null}
                                                           >
                                                             <svg
                                                               aria-hidden={true}
-                                                              className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                                              className="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                               focusable="false"
                                                               height={16}
                                                               role="img"

--- a/public/components/overview/components/add_dashboard_callout.tsx
+++ b/public/components/overview/components/add_dashboard_callout.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiCallOut, EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiSmallButton, EuiCallOut, EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
 import React from 'react';
 import { useObservable } from 'react-use';
 import { coreRefs } from '../../../framework/core_refs';
@@ -30,7 +30,7 @@ export function AddDashboardCallout() {
           </p>
         </EuiText>
         <EuiSpacer />
-        <EuiButton onClick={showFlyout}>Select</EuiButton>
+        <EuiSmallButton onClick={showFlyout}>Select</EuiSmallButton>
       </EuiCallOut>
     </>
   );

--- a/public/components/overview/components/card_configs.tsx
+++ b/public/components/overview/components/card_configs.tsx
@@ -12,7 +12,7 @@ import {
   alertingPluginID,
   anomalyDetectionPluginID,
   discoverPluginID,
-  IMPORT_SAMPLE_DATA_APP_ID,
+  tutorialSampleDataPluginId,
 } from '../../../../common/constants/shared';
 
 export interface GettingStartedConfig {
@@ -24,28 +24,28 @@ export interface GettingStartedConfig {
   url: string;
 }
 
-const SAMPLEDATA_CONFIG: GettingStartedConfig = {
-  id: 'sample_data',
-  order: 1,
-  description: i18n.translate('home.sampleData.card.description', {
-    defaultMessage: 'You can install sample data to experiment with OpenSearch Dashboards.',
-  }),
-  title: i18n.translate('home.sampleData.card.title', {
-    defaultMessage: 'Try OpenSearch',
-  }),
-  url: IMPORT_SAMPLE_DATA_APP_ID,
-  footer: 'Sample Datasets',
-};
-
 const GETTING_STARTED_CONFIG: GettingStartedConfig = {
   id: 'getting_started',
-  order: 2,
+  order: 1,
   title: i18n.translate('observability.overview.card.gettingStarted.title', {
     defaultMessage: 'Add your data',
   }),
   description: 'Get started collecting and analyzing data.',
   footer: 'Getting Started Guide',
   url: observabilityGettingStartedID,
+};
+
+const SAMPLEDATA_CONFIG: GettingStartedConfig = {
+  id: 'sample_data',
+  order: 2,
+  description: i18n.translate('home.sampleData.card.description', {
+    defaultMessage: 'You can install sample data to experiment with OpenSearch Dashboards.',
+  }),
+  title: i18n.translate('home.sampleData.card.title', {
+    defaultMessage: 'Try OpenSearch',
+  }),
+  url: tutorialSampleDataPluginId,
+  footer: 'Sample Datasets',
 };
 
 const DISCOVER_CONFIG: GettingStartedConfig = {
@@ -115,8 +115,8 @@ const ANOMALY_CONFIG: GettingStartedConfig = {
 };
 
 export const cardConfigs = [
-  SAMPLEDATA_CONFIG,
   GETTING_STARTED_CONFIG,
+  SAMPLEDATA_CONFIG,
   DISCOVER_CONFIG,
   METRICS_CONFIG,
   TRACES_CONFIG,

--- a/public/components/overview/components/card_configs.tsx
+++ b/public/components/overview/components/card_configs.tsx
@@ -12,6 +12,7 @@ import {
   alertingPluginID,
   anomalyDetectionPluginID,
   discoverPluginID,
+  IMPORT_SAMPLE_DATA_APP_ID,
 } from '../../../../common/constants/shared';
 
 export interface GettingStartedConfig {
@@ -23,9 +24,22 @@ export interface GettingStartedConfig {
   url: string;
 }
 
+const SAMPLEDATA_CONFIG: GettingStartedConfig = {
+  id: 'sample_data',
+  order: 1,
+  description: i18n.translate('home.sampleData.card.description', {
+    defaultMessage: 'You can install sample data to experiment with OpenSearch Dashboards.',
+  }),
+  title: i18n.translate('home.sampleData.card.title', {
+    defaultMessage: 'Try OpenSearch',
+  }),
+  url: IMPORT_SAMPLE_DATA_APP_ID,
+  footer: 'Sample Datasets',
+};
+
 const GETTING_STARTED_CONFIG: GettingStartedConfig = {
   id: 'getting_started',
-  order: 1,
+  order: 2,
   title: i18n.translate('observability.overview.card.gettingStarted.title', {
     defaultMessage: 'Add your data',
   }),
@@ -36,7 +50,7 @@ const GETTING_STARTED_CONFIG: GettingStartedConfig = {
 
 const DISCOVER_CONFIG: GettingStartedConfig = {
   id: 'discover',
-  order: 2,
+  order: 3,
   title: i18n.translate('observability.overview.card.discover.title', {
     defaultMessage: 'Discover insights',
   }),
@@ -47,7 +61,7 @@ const DISCOVER_CONFIG: GettingStartedConfig = {
 
 const METRICS_CONFIG: GettingStartedConfig = {
   id: 'metrics',
-  order: 3,
+  order: 4,
   title: i18n.translate('observability.overview.card.metrics.title', {
     defaultMessage: 'Monitor system performance',
   }),
@@ -58,7 +72,7 @@ const METRICS_CONFIG: GettingStartedConfig = {
 
 const TRACES_CONFIG: GettingStartedConfig = {
   id: 'traces',
-  order: 4,
+  order: 5,
   title: i18n.translate('observability.overview.card.traces.title', {
     defaultMessage: 'Identify performance issues',
   }),
@@ -69,7 +83,7 @@ const TRACES_CONFIG: GettingStartedConfig = {
 
 const SERVICES_CONFIG: GettingStartedConfig = {
   id: 'services',
-  order: 5,
+  order: 6,
   title: i18n.translate('observability.overview.card.services.title', {
     defaultMessage: 'Monitor service health',
   }),
@@ -80,7 +94,7 @@ const SERVICES_CONFIG: GettingStartedConfig = {
 
 const ALERTS_CONFIG: GettingStartedConfig = {
   id: 'alerts',
-  order: 6,
+  order: 7,
   title: i18n.translate('observability.overview.card.alerts.title', {
     defaultMessage: 'Get notified',
   }),
@@ -91,7 +105,7 @@ const ALERTS_CONFIG: GettingStartedConfig = {
 
 const ANOMALY_CONFIG: GettingStartedConfig = {
   id: 'anomaly',
-  order: 7,
+  order: 8,
   title: i18n.translate('observability.overview.card.anomaly.title', {
     defaultMessage: 'Detect anomalies in your data',
   }),
@@ -101,6 +115,7 @@ const ANOMALY_CONFIG: GettingStartedConfig = {
 };
 
 export const cardConfigs = [
+  SAMPLEDATA_CONFIG,
   GETTING_STARTED_CONFIG,
   DISCOVER_CONFIG,
   METRICS_CONFIG,

--- a/public/components/overview/components/card_configs.tsx
+++ b/public/components/overview/components/card_configs.tsx
@@ -11,7 +11,6 @@ import {
   observabilityServicesNewNavURL,
   alertingPluginID,
   anomalyDetectionPluginID,
-  discoverPluginID,
   tutorialSampleDataPluginId,
 } from '../../../../common/constants/shared';
 
@@ -22,17 +21,19 @@ export interface GettingStartedConfig {
   description: string;
   footer: string;
   url: string;
+  path: string;
 }
 
 const GETTING_STARTED_CONFIG: GettingStartedConfig = {
   id: 'getting_started',
   order: 1,
   title: i18n.translate('observability.overview.card.gettingStarted.title', {
-    defaultMessage: 'Add your data',
+    defaultMessage: 'Set up your Observability workspace',
   }),
-  description: 'Get started collecting and analyzing data.',
+  description: 'Get started by collecting and analyzing your metrics, logs, and traces.',
   footer: 'Getting Started Guide',
   url: observabilityGettingStartedID,
+  path: '#/',
 };
 
 const SAMPLEDATA_CONFIG: GettingStartedConfig = {
@@ -46,6 +47,7 @@ const SAMPLEDATA_CONFIG: GettingStartedConfig = {
   }),
   url: tutorialSampleDataPluginId,
   footer: 'Sample Datasets',
+  path: '#/',
 };
 
 const DISCOVER_CONFIG: GettingStartedConfig = {
@@ -54,9 +56,10 @@ const DISCOVER_CONFIG: GettingStartedConfig = {
   title: i18n.translate('observability.overview.card.discover.title', {
     defaultMessage: 'Discover insights',
   }),
-  description: 'Uncover insights with raw data exploration.',
+  description: 'Uncover logs with raw data exploration.',
   footer: 'Discover',
-  url: discoverPluginID,
+  url: 'data-explorer',
+  path: '/discover',
 };
 
 const METRICS_CONFIG: GettingStartedConfig = {
@@ -68,6 +71,7 @@ const METRICS_CONFIG: GettingStartedConfig = {
   description: 'Transform logs into actionable visualizations by extracting metrics.',
   footer: 'Metrics',
   url: observabilityMetricsID,
+  path: '#/',
 };
 
 const TRACES_CONFIG: GettingStartedConfig = {
@@ -79,6 +83,7 @@ const TRACES_CONFIG: GettingStartedConfig = {
   description: 'Analyze performance bottlenecks using event flow visualizations.',
   footer: 'Traces',
   url: observabilityTracesNewNavURL,
+  path: '#/',
 };
 
 const SERVICES_CONFIG: GettingStartedConfig = {
@@ -90,6 +95,7 @@ const SERVICES_CONFIG: GettingStartedConfig = {
   description: 'Identify service performance issues with comprehensive monitoring and analysis.',
   footer: 'Services',
   url: observabilityServicesNewNavURL,
+  path: '#/',
 };
 
 const ALERTS_CONFIG: GettingStartedConfig = {
@@ -101,6 +107,7 @@ const ALERTS_CONFIG: GettingStartedConfig = {
   description: 'Receive timely notifications by configuring alert triggers.',
   footer: 'Alerting',
   url: alertingPluginID,
+  path: '#/',
 };
 
 const ANOMALY_CONFIG: GettingStartedConfig = {
@@ -112,6 +119,7 @@ const ANOMALY_CONFIG: GettingStartedConfig = {
   description: 'Gain near real-time anomaly detection using the Random Cut Forest (RCF) algorithm.',
   footer: 'Anomaly Detection',
   url: anomalyDetectionPluginID,
+  path: '#/',
 };
 
 export const cardConfigs = [

--- a/public/components/overview/components/select_dashboard_flyout.tsx
+++ b/public/components/overview/components/select_dashboard_flyout.tsx
@@ -90,6 +90,7 @@ export function SelectDashboardFlyout({ closeFlyout, dashboardsSavedObjects, rel
           searchable
           searchProps={{
             placeholder: 'Search for a dashboard...',
+            compressed: true,
           }}
           singleSelection="always"
           options={options}

--- a/public/components/overview/home.tsx
+++ b/public/components/overview/home.tsx
@@ -75,7 +75,7 @@ export const Home = () => {
                     default={card.footer || 'Documentation'}
                   />
                 ),
-                onClick: () => coreRefs.application?.navigateToApp(card.url, { path: '#/' }),
+                onClick: () => coreRefs.application?.navigateToApp(card.url, { path: card.path }),
                 isSelected: false,
               },
             },

--- a/public/components/overview/home.tsx
+++ b/public/components/overview/home.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiI18n } from '@elastic/eui';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { HashRouter, Route, Switch } from 'react-router-dom';
+import { FormattedMessage } from '@osd/i18n/react';
 import { alertsPluginID, anomalyPluginID } from '../../../common/constants/overview';
 import { DashboardSavedObjectsType } from '../../../common/types/overview';
 import { setNavBreadCrumbs } from '../../../common/utils/set_nav_bread_crumbs';
@@ -70,9 +70,9 @@ export const Home = () => {
             cardProps: {
               selectable: {
                 children: (
-                  <EuiI18n
-                    token="home.sampleData.card.footer"
-                    default={card.footer || 'Documentation'}
+                  <FormattedMessage
+                    id="home.sampleData.card.footer"
+                    defaultMessage={card.footer || 'Documentation'}
                   />
                 ),
                 onClick: () => coreRefs.application?.navigateToApp(card.url, { path: card.path }),

--- a/public/components/overview/home.tsx
+++ b/public/components/overview/home.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiText } from '@elastic/eui';
+import { EuiI18n } from '@elastic/eui';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 import { alertsPluginID, anomalyPluginID } from '../../../common/constants/overview';
@@ -67,13 +67,17 @@ export const Home = () => {
             order: card.order,
             description: card.description,
             title: card.title,
-            onClick: () => coreRefs.application?.navigateToApp(card.url, { path: '#/' }),
-            getFooter: () => {
-              return (
-                <EuiText size="s" textAlign="center">
-                  {card.footer}
-                </EuiText>
-              );
+            cardProps: {
+              selectable: {
+                children: (
+                  <EuiI18n
+                    token="home.sampleData.card.footer"
+                    default={card.footer || 'Documentation'}
+                  />
+                ),
+                onClick: () => coreRefs.application?.navigateToApp(card.url, { path: '#/' }),
+                isSelected: false,
+              },
             },
           }),
           getTargetArea: () => HOME_CONTENT_AREAS.GET_STARTED,

--- a/public/plugin_helpers/plugin_overview.tsx
+++ b/public/plugin_helpers/plugin_overview.tsx
@@ -28,6 +28,7 @@ export const setupOverviewPage = (contentManagement: ContentManagementPluginSetu
       {
         id: SECTIONS.GET_STARTED,
         order: 1000,
+        title: 'Get started',
         kind: 'card',
         wrap: false,
         columns: 5,


### PR DESCRIPTION
### Description
1. Fix discover re-direction bug of buttons missing.
2. Update UI of overview page to include sample data card.
3. Fix re-direction cards for content made while in a workspace in getting started.
4. Rename getting started sample data card.
5. Rename 'Try it' integration button.

Now lands on page with correct UI

https://github.com/user-attachments/assets/ba712bc6-6983-4827-8d66-a317c98b881d


Added Try OpenSearch card that directs user to add sample data, updated footer of cards.

<img width="1268" alt="Screenshot 2024-09-10 at 11 31 30 AM" src="https://github.com/user-attachments/assets/01128ca0-f50f-4b33-9769-ac3bcdbe2b10">
<img width="1413" alt="Screenshot 2024-09-10 at 11 32 17 AM" src="https://github.com/user-attachments/assets/b0eddb3b-b430-42bd-b48f-b5f3e5560797">

| Before | After |
| ------ | ----- |
| ![Before Image 1](https://github.com/user-attachments/assets/988846ba-ce42-49fc-8b1c-814006217953) | ![After Image 1](https://github.com/user-attachments/assets/2bc6a472-0663-42df-97a4-f1b8aed814c4) |

| Before | After |
| ------ | ----- |
| ![Before Image 1](https://github.com/user-attachments/assets/1a2fe26b-d9b9-49c4-9ff6-d6a0da5d2f43) | ![After Image 1](https://github.com/user-attachments/assets/75665ae5-c821-441c-97a4-102d8dc41969) |


### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
