### PR TITLE
fix(log explorer): show PPL errors in toasts correctly

### DIFF
--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -811,8 +811,9 @@ export const Explorer = ({
     if (availability !== true) {
       await updateQueryInStore(searchedQuery);
     }
-    await fetchData(undefined, undefined, setSummaryStatus);
-    setEventsLoading(false);
+    await fetchData(undefined, undefined, setSummaryStatus).finally(() => {
+      setEventsLoading(false);
+    });
   };
 
   const handleQueryChange = async (newQuery: string) => setTempQuery(newQuery);

--- a/public/components/event_analytics/explorer/query_assist/input.tsx
+++ b/public/components/event_analytics/explorer/query_assist/input.tsx
@@ -7,8 +7,6 @@ import {
   EuiSmallButton,
   EuiComboBoxOptionOption,
   EuiCompressedFieldText,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiIcon,
   EuiInputPopover,
   EuiListGroup,
@@ -325,62 +323,58 @@ export const QueryAssistInput: React.FC<React.PropsWithChildren<Props>> = (props
 
   return (
     <>
-      <EuiFlexGroup gutterSize="none" alignItems="center" justifyContent="center">
-        <EuiFlexItem grow={false}>
-          <EuiIcon
-            className="euiFieldText"
-            style={{ padding: 8 }}
-            size="original"
-            type={chatLogo}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiInputPopover
-            input={
-              <EuiCompressedFieldText
-                inputRef={inputRef}
-                placeholder="Ask me a question"
-                disabled={loading}
-                value={props.nlqInput}
-                onChange={(e) => {
-                  props.setNlqInput(e.target.value);
-                  dismissCallOut();
-                }}
-                onKeyDown={(e) => {
-                  // listen to enter key manually. the cursor jumps to CodeEditor with EuiForm's onSubmit
-                  if (e.key === 'Enter') runAndSummarize();
-                }}
-                fullWidth
-                onFocus={() => {
-                  props.setNeedsUpdate(false);
-                  props.setLastFocusedInput('nlq_input');
-                  if (props.nlqInput.length === 0) setIsPopoverOpen(true);
-                }}
+      <EuiInputPopover
+        input={
+          <EuiCompressedFieldText
+            inputRef={inputRef}
+            placeholder="Ask me a question"
+            disabled={loading}
+            value={props.nlqInput}
+            onChange={(e) => {
+              props.setNlqInput(e.target.value);
+              dismissCallOut();
+            }}
+            prepend={
+              <EuiIcon
+                className="euiFieldText"
+                style={{ padding: 8 }}
+                size="original"
+                type={chatLogo}
               />
             }
-            disableFocusTrap
-            fullWidth={true}
-            isOpen={isPopoverOpen}
-            closePopover={() => {
-              setIsPopoverOpen(false);
+            onKeyDown={(e) => {
+              // listen to enter key manually. the cursor jumps to CodeEditor with EuiForm's onSubmit
+              if (e.key === 'Enter') runAndSummarize();
             }}
-          >
-            <EuiListGroup flush={true} bordered={false} wrapText={true} maxWidth={false}>
-              {HARDCODED_SUGGESTIONS[selectedIndex]?.map((question, i) => (
-                <EuiListGroupItem
-                  key={i}
-                  onClick={() => {
-                    props.setNlqInput(question);
-                    inputRef.current?.focus();
-                    setIsPopoverOpen(false);
-                  }}
-                  label={question}
-                />
-              ))}
-            </EuiListGroup>
-          </EuiInputPopover>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+            fullWidth
+            onFocus={() => {
+              props.setNeedsUpdate(false);
+              props.setLastFocusedInput('nlq_input');
+              if (props.nlqInput.length === 0) setIsPopoverOpen(true);
+            }}
+          />
+        }
+        disableFocusTrap
+        fullWidth={true}
+        isOpen={isPopoverOpen}
+        closePopover={() => {
+          setIsPopoverOpen(false);
+        }}
+      >
+        <EuiListGroup flush={true} bordered={false} wrapText={true} maxWidth={false}>
+          {HARDCODED_SUGGESTIONS[selectedIndex]?.map((question, i) => (
+            <EuiListGroupItem
+              key={i}
+              onClick={() => {
+                props.setNlqInput(question);
+                inputRef.current?.focus();
+                setIsPopoverOpen(false);
+              }}
+              label={question}
+            />
+          ))}
+        </EuiListGroup>
+      </EuiInputPopover>
       {props.callOut}
       <EuiSpacer size="s" />
       {props.children}

--- a/public/components/event_analytics/hooks/use_fetch_events.ts
+++ b/public/components/event_analytics/hooks/use_fetch_events.ts
@@ -52,7 +52,7 @@ export const useFetchEvents = ({ pplService, requestParams }: IFetchEventsParams
   ) => {
     setIsEventsLoading(true);
     return pplService
-      .fetch({ query, format }, errorHandler)
+      .fetch({ query, format }, undefined, errorHandler)
       .then((res: any) => handler(res))
       .catch((err: any) => {
         console.error(err);


### PR DESCRIPTION
### Description
This PR has these fixes
- fix(log explorer): set loading state to false if query failed 
   - this is a regression caused by https://github.com/opensearch-project/dashboards-observability/pull/1902
- update fetch call to pass in data source id 
   - data source id is always undefined because log explorer doesn't support multi-datasource. passing undefined fixes the parameters so UI shows PPL errors in toasts
- revert icon to use prepend
   - using `prepend` property the icon will be smaller than its original size, but since the text field is now `compact` and original size doesn't fit anymore, we can revert back to use `prepend`.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
