### PR TITLE
Fix cloudtrail field name mismatch

### DIFF
--- a/server/adaptors/integrations/__data__/repository/aws_cloudtrail/assets/create_mv_cloud-trail-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_cloudtrail/assets/create_mv_cloud-trail-1.0.0.sql
@@ -26,7 +26,7 @@ SELECT
 
    awsRegion AS `aws.cloudtrail.awsRegion`,
    sourceIPAddress AS `aws.cloudtrail.sourceIPAddress`,
-   userAgent AS `aws.cloudtrail.userAgent`,
+   userAgent AS `userAgent`,
    errorCode AS `errorCode`,
    errorMessage AS `errorMessage`,
    requestParameters AS `aws.cloudtrail.requestParameter`,

--- a/server/adaptors/integrations/__data__/repository/aws_cloudtrail/assets/create_mv_cloud-trail-records-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_cloudtrail/assets/create_mv_cloud-trail-records-1.0.0.sql
@@ -26,7 +26,7 @@ SELECT
 
   rec.awsRegion AS `aws.cloudtrail.awsRegion`,
   rec.sourceIPAddress AS `aws.cloudtrail.sourceIPAddress`,
-  rec.userAgent AS `aws.cloudtrail.userAgent`,
+  rec.userAgent AS `userAgent`,
   rec.errorCode AS `errorCode`,
   rec.errorMessage AS `errorMessage`,
   rec.requestParameters AS `aws.cloudtrail.requestParameter`,


### PR DESCRIPTION
### Description
Assets expect `userAgent`, not `aws.cloudtrail.userAgent`.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
