### PR TITLE
HeaderControl update style, UI Adjustments Integrations

### DIFF
--- a/.cypress/integration/integrations_test/integrations.spec.js
+++ b/.cypress/integration/integrations_test/integrations.spec.js
@@ -107,7 +107,7 @@ describe('Add nginx integration instance flow', () => {
 
     cy.get('button[data-test-subj="popoverModal__deleteButton"]').should('be.disabled');
 
-    cy.get(`input.euiFieldText[placeholder="${testInstance}"]`).focus().type(testInstance, {
+    cy.get(`input.euiFieldText[placeholder="delete"]`).focus().type("delete", {
       delay: 50,
     });
     cy.get('button[data-test-subj="popoverModal__deleteButton"]').should('not.be.disabled');

--- a/public/components/application_analytics/components/app_table.tsx
+++ b/public/components/application_analytics/components/app_table.tsx
@@ -40,6 +40,7 @@ import { setNavBreadCrumbs } from '../../../../common/utils/set_nav_bread_crumbs
 import { DeleteModal } from '../../common/helpers/delete_modal';
 import { HeaderControlledComponentsWrapper } from '../../../../public/plugin_helpers/plugin_headerControl';
 import { coreRefs } from '../../../framework/core_refs';
+import { TopNavControlButtonData } from '../../../../../../src/plugins/navigation/public';
 
 const newNavigation = coreRefs.chrome?.navGroup.getNavGroupEnabled();
 
@@ -234,6 +235,30 @@ export function AppTable(props: AppTableProps) {
                 <h3>Applications {` (${applications.length})`}</h3>
               </EuiTitle>
             )}
+            <EuiFlexItem grow={false}>
+              <HeaderControlledComponentsWrapper
+                components={
+                  newNavigation
+                    ? [
+                        {
+                          label: createButtonText,
+                          run: () => {
+                            window.location.href = '#/create';
+                          },
+                          iconType: 'plus',
+                          iconSide: 'left',
+                          fill: true,
+                          controlType: 'button',
+                        } as TopNavControlButtonData,
+                      ]
+                    : [
+                        <EuiSmallButton fill href="#/create" iconType="plus" iconSide="left">
+                          {createButtonText}
+                        </EuiSmallButton>,
+                      ]
+                }
+              />
+            </EuiFlexItem>
           </EuiPageHeader>
           <EuiPageContent id="applicationArea" paddingSize="m">
             <EuiPageContentHeader>
@@ -247,15 +272,6 @@ export function AppTable(props: AppTableProps) {
                     onChange={(e) => setSearchQuery(e.target.value)}
                     isClearable={true}
                     aria-label="Search applications"
-                  />
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <HeaderControlledComponentsWrapper
-                    components={[
-                      <EuiSmallButton fill href="#/create" iconType="plus" iconSide="left">
-                        {createButtonText}
-                      </EuiSmallButton>,
-                    ]}
                   />
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/public/components/getting_started/components/getting_started_integrationCards.tsx
+++ b/public/components/getting_started/components/getting_started_integrationCards.tsx
@@ -136,13 +136,12 @@ export const IntegrationCards = () => {
               icon={
                 integration.statics && integration.statics.logo && integration.statics.logo.path ? (
                   <img
-                    style={{ height: 60, width: 60 }}
                     alt=""
                     className="synopsisIcon"
                     src={`/api/integrations/repository/${integration.name}/static/${integration.statics.logo.path}`}
                   />
                 ) : (
-                  <div style={{ height: 60, width: 60, backgroundColor: '#ccc' }} />
+                  <div className="synopsisIcon" style={{ backgroundColor: '#ccc' }} />
                 )
               }
               title={integration.displayName || integration.name}

--- a/public/components/getting_started/components/getting_started_integrationCards.tsx
+++ b/public/components/getting_started/components/getting_started_integrationCards.tsx
@@ -136,13 +136,13 @@ export const IntegrationCards = () => {
               icon={
                 integration.statics && integration.statics.logo && integration.statics.logo.path ? (
                   <img
-                    style={{ height: 100, width: 100 }}
+                    style={{ height: 60, width: 60 }}
                     alt=""
                     className="synopsisIcon"
                     src={`/api/integrations/repository/${integration.name}/static/${integration.statics.logo.path}`}
                   />
                 ) : (
-                  <div style={{ height: 100, width: 100, backgroundColor: '#ccc' }} />
+                  <div style={{ height: 60, width: 60, backgroundColor: '#ccc' }} />
                 )
               }
               title={integration.displayName || integration.name}

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -325,15 +325,17 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiTitle
-                        size="s"
+                      <EuiText
+                        size="m"
                       >
-                        <h3
-                          className="euiTitle euiTitle--small"
+                        <div
+                          className="euiText euiText--medium"
                         >
-                          Template
-                        </h3>
-                      </EuiTitle>
+                          <h4>
+                            Template
+                          </h4>
+                        </div>
+                      </EuiText>
                       <EuiLink
                         href="#/available/undefined"
                       >
@@ -349,15 +351,17 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                     <div
                       className="euiFlexItem"
                     >
-                      <EuiTitle
-                        size="s"
+                      <EuiText
+                        size="m"
                       >
-                        <h3
-                          className="euiTitle euiTitle--small"
+                        <div
+                          className="euiText euiText--medium"
                         >
-                          Date Added
-                        </h3>
-                      </EuiTitle>
+                          <h4>
+                            Date Added
+                          </h4>
+                        </div>
+                      </EuiText>
                       <EuiText
                         size="m"
                       >

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -219,63 +219,90 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                             <div
                               className="euiFlexItem euiFlexItem--flexGrowZero"
                             >
-                              <EuiSmallButtonIcon
-                                aria-label="Delete"
-                                color="danger"
-                                data-test-subj="deleteInstanceButton"
-                                iconType="trash"
-                                onClick={[Function]}
+                              <EuiToolTip
+                                content={
+                                  <FormattedMessage
+                                    defaultMessage="Delete this instance"
+                                    id="integration.deleteButtonTooltip"
+                                    values={Object {}}
+                                  />
+                                }
+                                delay="regular"
+                                position="top"
                               >
-                                <EuiButtonIcon
-                                  aria-label="Delete"
-                                  color="danger"
-                                  data-test-subj="deleteInstanceButton"
-                                  iconType="trash"
-                                  onClick={[Function]}
-                                  size="s"
+                                <span
+                                  className="euiToolTipAnchor"
+                                  onKeyUp={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
                                 >
-                                  <button
+                                  <EuiSmallButtonIcon
                                     aria-label="Delete"
-                                    className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--small"
+                                    color="danger"
                                     data-test-subj="deleteInstanceButton"
-                                    disabled={false}
+                                    display="base"
+                                    iconType="trash"
+                                    onBlur={[Function]}
                                     onClick={[Function]}
-                                    type="button"
+                                    onFocus={[Function]}
                                   >
-                                    <EuiIcon
-                                      aria-hidden="true"
-                                      className="euiButtonIcon__icon"
-                                      color="inherit"
-                                      size="m"
-                                      type="trash"
+                                    <EuiButtonIcon
+                                      aria-label="Delete"
+                                      color="danger"
+                                      data-test-subj="deleteInstanceButton"
+                                      display="base"
+                                      iconType="trash"
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      size="s"
                                     >
-                                      <EuiIconBeaker
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                        focusable="false"
-                                        role="img"
-                                        style={null}
+                                      <button
+                                        aria-label="Delete"
+                                        className="euiButtonIcon euiButtonIcon--danger euiButtonIcon--small"
+                                        data-test-subj="deleteInstanceButton"
+                                        disabled={false}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        type="button"
                                       >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
-                                          focusable="false"
-                                          height={16}
-                                          role="img"
-                                          style={null}
-                                          viewBox="0 0 16 16"
-                                          width={16}
-                                          xmlns="http://www.w3.org/2000/svg"
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiButtonIcon__icon"
+                                          color="inherit"
+                                          size="m"
+                                          type="trash"
                                         >
-                                          <path
-                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                          />
-                                        </svg>
-                                      </EuiIconBeaker>
-                                    </EuiIcon>
-                                  </button>
-                                </EuiButtonIcon>
-                              </EuiSmallButtonIcon>
+                                          <EuiIconBeaker
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
+                                          </EuiIconBeaker>
+                                        </EuiIcon>
+                                      </button>
+                                    </EuiButtonIcon>
+                                  </EuiSmallButtonIcon>
+                                </span>
+                              </EuiToolTip>
                             </div>
                           </EuiFlexItem>
                         </div>
@@ -286,58 +313,64 @@ exports[`Added Integration View Test Renders added integration view using dummy 
               </EuiPageHeaderSection>
             </header>
           </EuiPageHeader>
-          <EuiFlexGroup>
+          <EuiPanel>
             <div
-              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+              className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <EuiFlexItem>
+              <EuiFlexGroup>
                 <div
-                  className="euiFlexItem"
+                  className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
                 >
-                  <EuiText>
+                  <EuiFlexItem>
                     <div
-                      className="euiText euiText--medium"
+                      className="euiFlexItem"
                     >
-                      <h4>
-                        Template
-                      </h4>
+                      <EuiTitle
+                        size="s"
+                      >
+                        <h3
+                          className="euiTitle euiTitle--small"
+                        >
+                          Template
+                        </h3>
+                      </EuiTitle>
+                      <EuiLink
+                        href="#/available/undefined"
+                      >
+                        <a
+                          className="euiLink euiLink--primary"
+                          href="#/available/undefined"
+                          rel="noreferrer"
+                        />
+                      </EuiLink>
                     </div>
-                  </EuiText>
-                  <EuiLink
-                    href="#/available/undefined"
-                  >
-                    <a
-                      className="euiLink euiLink--primary"
-                      href="#/available/undefined"
-                      rel="noreferrer"
-                    />
-                  </EuiLink>
-                </div>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <div
-                  className="euiFlexItem"
-                >
-                  <EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
                     <div
-                      className="euiText euiText--medium"
+                      className="euiFlexItem"
                     >
-                      <h4>
-                        Date Added
-                      </h4>
+                      <EuiTitle
+                        size="s"
+                      >
+                        <h3
+                          className="euiTitle euiTitle--small"
+                        >
+                          Date Added
+                        </h3>
+                      </EuiTitle>
+                      <EuiText
+                        size="m"
+                      >
+                        <div
+                          className="euiText euiText--medium"
+                        />
+                      </EuiText>
                     </div>
-                  </EuiText>
-                  <EuiText
-                    size="m"
-                  >
-                    <div
-                      className="euiText euiText--medium"
-                    />
-                  </EuiText>
+                  </EuiFlexItem>
                 </div>
-              </EuiFlexItem>
+              </EuiFlexGroup>
             </div>
-          </EuiFlexGroup>
+          </EuiPanel>
           <EuiSpacer
             size="s"
           >
@@ -349,28 +382,20 @@ exports[`Added Integration View Test Renders added integration view using dummy 
             <div
               className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
             >
-              <PanelTitle
-                title="Assets List"
+              <EuiTitle
+                size="s"
               >
-                <EuiText
-                  size="m"
+                <h3
+                  className="euiTitle euiTitle--small"
                 >
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    <span
-                      className="panel-title"
-                    >
-                      Assets List
-                    </span>
-                  </div>
-                </EuiText>
-              </PanelTitle>
+                  Assets List
+                </h3>
+              </EuiTitle>
               <EuiSpacer
-                size="l"
+                size="s"
               >
                 <div
-                  className="euiSpacer euiSpacer--l"
+                  className="euiSpacer euiSpacer--s"
                 />
               </EuiSpacer>
               <EuiInMemoryTable

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration_table.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration_table.test.tsx.snap
@@ -92,15 +92,16 @@ exports[`Added Integration Table View Test Renders added integration table view 
 >
   <EuiPageContent
     data-test-subj="addedIntegrationsArea"
+    paddingSize="m"
   >
     <EuiPanel
       className="euiPageContent"
       data-test-subj="addedIntegrationsArea"
-      paddingSize="l"
+      paddingSize="m"
       role="main"
     >
       <div
-        className="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
         data-test-subj="addedIntegrationsArea"
         role="main"
       >
@@ -125,13 +126,6 @@ exports[`Added Integration Table View Test Renders added integration table view 
               Object {
                 "field": "dateAdded",
                 "name": "Date Added",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "field": "actions",
-                "name": "Actions",
                 "render": [Function],
                 "sortable": true,
                 "truncateText": true,
@@ -189,6 +183,12 @@ exports[`Added Integration Table View Test Renders added integration table view 
                   "type": "field_value_selection",
                 },
               ],
+              "toolsLeft": false,
+            }
+          }
+          selection={
+            Object {
+              "onSelectionChange": [Function],
             }
           }
           tableLayout="auto"
@@ -220,6 +220,7 @@ exports[`Added Integration Table View Test Renders added integration table view 
                 ]
               }
               onChange={[Function]}
+              toolsLeft={false}
             >
               <EuiFlexGroup
                 alignItems="center"
@@ -589,13 +590,6 @@ exports[`Added Integration Table View Test Renders added integration table view 
                     "sortable": true,
                     "truncateText": true,
                   },
-                  Object {
-                    "field": "actions",
-                    "name": "Actions",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                  },
                 ]
               }
               isSelectable={true}
@@ -632,6 +626,11 @@ exports[`Added Integration Table View Test Renders added integration table view 
                 }
               }
               responsive={true}
+              selection={
+                Object {
+                  "onSelectionChange": [Function],
+                }
+              }
               tableLayout="auto"
             >
               <div
@@ -655,7 +654,46 @@ exports[`Added Integration Table View Test Renders added integration table view 
                           >
                             <div
                               className="euiFlexItem euiFlexItem--flexGrowZero"
-                            />
+                            >
+                              <EuiI18n
+                                default="Select all rows"
+                                token="euiBasicTable.selectAllRows"
+                              >
+                                <EuiCheckbox
+                                  aria-label="Select all rows"
+                                  checked={false}
+                                  compressed={false}
+                                  disabled={false}
+                                  id="_selection_column-checkbox_random_html_id"
+                                  indeterminate={false}
+                                  label="Select all rows"
+                                  onChange={[Function]}
+                                >
+                                  <div
+                                    className="euiCheckbox"
+                                  >
+                                    <input
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      className="euiCheckbox__input"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      onChange={[Function]}
+                                      type="checkbox"
+                                    />
+                                    <div
+                                      className="euiCheckbox__square"
+                                    />
+                                    <label
+                                      className="euiCheckbox__label"
+                                      htmlFor="_selection_column-checkbox_random_html_id"
+                                    >
+                                      Select all rows
+                                    </label>
+                                  </div>
+                                </EuiCheckbox>
+                              </EuiI18n>
+                            </div>
                           </EuiFlexItem>
                           <EuiFlexItem
                             grow={false}
@@ -690,6 +728,59 @@ exports[`Added Integration Table View Test Renders added integration table view 
                       <EuiTableHeader>
                         <thead>
                           <tr>
+                            <EuiTableHeaderCellCheckbox
+                              key="_selection_column_h"
+                            >
+                              <th
+                                className="euiTableHeaderCellCheckbox"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiI18n
+                                    default="Select all rows"
+                                    token="euiBasicTable.selectAllRows"
+                                  >
+                                    <EuiCheckbox
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      compressed={false}
+                                      data-test-subj="checkboxSelectAll"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      indeterminate={false}
+                                      label={null}
+                                      onChange={[Function]}
+                                      type="inList"
+                                    >
+                                      <div
+                                        className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                      >
+                                        <input
+                                          aria-label="Select all rows"
+                                          checked={false}
+                                          className="euiCheckbox__input"
+                                          data-test-subj="checkboxSelectAll"
+                                          disabled={false}
+                                          id="_selection_column-checkbox_random_html_id"
+                                          onChange={[Function]}
+                                          type="checkbox"
+                                        />
+                                        <div
+                                          className="euiCheckbox__square"
+                                        />
+                                      </div>
+                                    </EuiCheckbox>
+                                  </EuiI18n>
+                                </div>
+                              </th>
+                            </EuiTableHeaderCellCheckbox>
                             <EuiTableHeaderCell
                               align="left"
                               data-test-subj="tableHeaderCell_name_0"
@@ -828,52 +919,6 @@ exports[`Added Integration Table View Test Renders added integration table view 
                                 </CellContents>
                               </th>
                             </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="left"
-                              data-test-subj="tableHeaderCell_actions_3"
-                              key="_data_h_actions_3"
-                            >
-                              <th
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_actions_3"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  showSortMsg={false}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Actions",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Actions"
-                                        >
-                                          Actions
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </th>
-                            </EuiTableHeaderCell>
                           </tr>
                         </thead>
                       </EuiTableHeader>
@@ -888,6 +933,54 @@ exports[`Added Integration Table View Test Renders added integration table view 
                             <tr
                               className="euiTableRow euiTableRow-isSelectable"
                             >
+                              <EuiTableRowCellCheckbox
+                                key="_selection_column_ad7e6e30-0b99-11ee-b27c-c9863222e9bf"
+                              >
+                                <td
+                                  className="euiTableRowCellCheckbox"
+                                >
+                                  <div
+                                    className="euiTableCellContent"
+                                  >
+                                    <EuiI18n
+                                      default="Select this row"
+                                      token="euiBasicTable.selectThisRow"
+                                    >
+                                      <EuiCheckbox
+                                        aria-label="Select this row"
+                                        checked={false}
+                                        compressed={false}
+                                        data-test-subj="checkboxSelectRow-ad7e6e30-0b99-11ee-b27c-c9863222e9bf"
+                                        disabled={false}
+                                        id="_selection_column_ad7e6e30-0b99-11ee-b27c-c9863222e9bf-checkbox"
+                                        indeterminate={false}
+                                        onChange={[Function]}
+                                        title="Select this row"
+                                        type="inList"
+                                      >
+                                        <div
+                                          className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                        >
+                                          <input
+                                            aria-label="Select this row"
+                                            checked={false}
+                                            className="euiCheckbox__input"
+                                            data-test-subj="checkboxSelectRow-ad7e6e30-0b99-11ee-b27c-c9863222e9bf"
+                                            disabled={false}
+                                            id="_selection_column_ad7e6e30-0b99-11ee-b27c-c9863222e9bf-checkbox"
+                                            onChange={[Function]}
+                                            title="Select this row"
+                                            type="checkbox"
+                                          />
+                                          <div
+                                            className="euiCheckbox__square"
+                                          />
+                                        </div>
+                                      </EuiCheckbox>
+                                    </EuiI18n>
+                                  </div>
+                                </td>
+                              </EuiTableRowCellCheckbox>
                               <EuiTableRowCell
                                 align="left"
                                 key="_data_column_name_ad7e6e30-0b99-11ee-b27c-c9863222e9bf_0"
@@ -1023,70 +1116,6 @@ exports[`Added Integration Table View Test Renders added integration table view 
                                         2023-06-15T16:28:36.370Z
                                       </div>
                                     </EuiText>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="left"
-                                key="_data_column_actions_ad7e6e30-0b99-11ee-b27c-c9863222e9bf_3"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Actions",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Actions
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiIcon
-                                      className=""
-                                      key=".0"
-                                      onClick={[Function]}
-                                      type="trash"
-                                    >
-                                      <EuiIconBeaker
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                        focusable="false"
-                                        onClick={[Function]}
-                                        role="img"
-                                        style={null}
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium euiIcon-isLoading"
-                                          focusable="false"
-                                          height={16}
-                                          onClick={[Function]}
-                                          role="img"
-                                          style={null}
-                                          viewBox="0 0 16 16"
-                                          width={16}
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                          />
-                                        </svg>
-                                      </EuiIconBeaker>
-                                    </EuiIcon>
                                   </div>
                                 </td>
                               </EuiTableRowCell>
@@ -1607,15 +1636,16 @@ exports[`Added Integration Table View Test Renders added integration table view 
 >
   <EuiPageContent
     data-test-subj="addedIntegrationsArea"
+    paddingSize="m"
   >
     <EuiPanel
       className="euiPageContent"
       data-test-subj="addedIntegrationsArea"
-      paddingSize="l"
+      paddingSize="m"
       role="main"
     >
       <div
-        className="euiPanel euiPanel--paddingLarge euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPageContent"
         data-test-subj="addedIntegrationsArea"
         role="main"
       >
@@ -1640,13 +1670,6 @@ exports[`Added Integration Table View Test Renders added integration table view 
               Object {
                 "field": "dateAdded",
                 "name": "Date Added",
-                "render": [Function],
-                "sortable": true,
-                "truncateText": true,
-              },
-              Object {
-                "field": "actions",
-                "name": "Actions",
                 "render": [Function],
                 "sortable": true,
                 "truncateText": true,
@@ -1704,6 +1727,12 @@ exports[`Added Integration Table View Test Renders added integration table view 
                   "type": "field_value_selection",
                 },
               ],
+              "toolsLeft": false,
+            }
+          }
+          selection={
+            Object {
+              "onSelectionChange": [Function],
             }
           }
           tableLayout="auto"
@@ -1735,6 +1764,7 @@ exports[`Added Integration Table View Test Renders added integration table view 
                 ]
               }
               onChange={[Function]}
+              toolsLeft={false}
             >
               <EuiFlexGroup
                 alignItems="center"
@@ -2105,13 +2135,6 @@ exports[`Added Integration Table View Test Renders added integration table view 
                     "sortable": true,
                     "truncateText": true,
                   },
-                  Object {
-                    "field": "actions",
-                    "name": "Actions",
-                    "render": [Function],
-                    "sortable": true,
-                    "truncateText": true,
-                  },
                 ]
               }
               isSelectable={true}
@@ -2148,6 +2171,11 @@ exports[`Added Integration Table View Test Renders added integration table view 
                 }
               }
               responsive={true}
+              selection={
+                Object {
+                  "onSelectionChange": [Function],
+                }
+              }
               tableLayout="auto"
             >
               <div
@@ -2171,7 +2199,46 @@ exports[`Added Integration Table View Test Renders added integration table view 
                           >
                             <div
                               className="euiFlexItem euiFlexItem--flexGrowZero"
-                            />
+                            >
+                              <EuiI18n
+                                default="Select all rows"
+                                token="euiBasicTable.selectAllRows"
+                              >
+                                <EuiCheckbox
+                                  aria-label="Select all rows"
+                                  checked={false}
+                                  compressed={false}
+                                  disabled={false}
+                                  id="_selection_column-checkbox_random_html_id"
+                                  indeterminate={false}
+                                  label="Select all rows"
+                                  onChange={[Function]}
+                                >
+                                  <div
+                                    className="euiCheckbox"
+                                  >
+                                    <input
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      className="euiCheckbox__input"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      onChange={[Function]}
+                                      type="checkbox"
+                                    />
+                                    <div
+                                      className="euiCheckbox__square"
+                                    />
+                                    <label
+                                      className="euiCheckbox__label"
+                                      htmlFor="_selection_column-checkbox_random_html_id"
+                                    >
+                                      Select all rows
+                                    </label>
+                                  </div>
+                                </EuiCheckbox>
+                              </EuiI18n>
+                            </div>
                           </EuiFlexItem>
                           <EuiFlexItem
                             grow={false}
@@ -2206,6 +2273,59 @@ exports[`Added Integration Table View Test Renders added integration table view 
                       <EuiTableHeader>
                         <thead>
                           <tr>
+                            <EuiTableHeaderCellCheckbox
+                              key="_selection_column_h"
+                            >
+                              <th
+                                className="euiTableHeaderCellCheckbox"
+                                scope="col"
+                                style={
+                                  Object {
+                                    "width": undefined,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="euiTableCellContent"
+                                >
+                                  <EuiI18n
+                                    default="Select all rows"
+                                    token="euiBasicTable.selectAllRows"
+                                  >
+                                    <EuiCheckbox
+                                      aria-label="Select all rows"
+                                      checked={false}
+                                      compressed={false}
+                                      data-test-subj="checkboxSelectAll"
+                                      disabled={false}
+                                      id="_selection_column-checkbox_random_html_id"
+                                      indeterminate={false}
+                                      label={null}
+                                      onChange={[Function]}
+                                      type="inList"
+                                    >
+                                      <div
+                                        className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                      >
+                                        <input
+                                          aria-label="Select all rows"
+                                          checked={false}
+                                          className="euiCheckbox__input"
+                                          data-test-subj="checkboxSelectAll"
+                                          disabled={false}
+                                          id="_selection_column-checkbox_random_html_id"
+                                          onChange={[Function]}
+                                          type="checkbox"
+                                        />
+                                        <div
+                                          className="euiCheckbox__square"
+                                        />
+                                      </div>
+                                    </EuiCheckbox>
+                                  </EuiI18n>
+                                </div>
+                              </th>
+                            </EuiTableHeaderCellCheckbox>
                             <EuiTableHeaderCell
                               align="left"
                               data-test-subj="tableHeaderCell_name_0"
@@ -2344,52 +2464,6 @@ exports[`Added Integration Table View Test Renders added integration table view 
                                 </CellContents>
                               </th>
                             </EuiTableHeaderCell>
-                            <EuiTableHeaderCell
-                              align="left"
-                              data-test-subj="tableHeaderCell_actions_3"
-                              key="_data_h_actions_3"
-                            >
-                              <th
-                                className="euiTableHeaderCell"
-                                data-test-subj="tableHeaderCell_actions_3"
-                                role="columnheader"
-                                scope="col"
-                                style={
-                                  Object {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <CellContents
-                                  className="euiTableCellContent"
-                                  showSortMsg={false}
-                                >
-                                  <span
-                                    className="euiTableCellContent"
-                                  >
-                                    <EuiInnerText>
-                                      <EuiI18n
-                                        default="{innerText}; {description}"
-                                        token="euiTableHeaderCell.titleTextWithDesc"
-                                        values={
-                                          Object {
-                                            "description": undefined,
-                                            "innerText": "Actions",
-                                          }
-                                        }
-                                      >
-                                        <span
-                                          className="euiTableCellContent__text"
-                                          title="Actions"
-                                        >
-                                          Actions
-                                        </span>
-                                      </EuiI18n>
-                                    </EuiInnerText>
-                                  </span>
-                                </CellContents>
-                              </th>
-                            </EuiTableHeaderCell>
                           </tr>
                         </thead>
                       </EuiTableHeader>
@@ -2404,6 +2478,54 @@ exports[`Added Integration Table View Test Renders added integration table view 
                             <tr
                               className="euiTableRow euiTableRow-isSelectable"
                             >
+                              <EuiTableRowCellCheckbox
+                                key="_selection_column_ad7e6e30-0b99-11ee-b27c-c9863222e9bf"
+                              >
+                                <td
+                                  className="euiTableRowCellCheckbox"
+                                >
+                                  <div
+                                    className="euiTableCellContent"
+                                  >
+                                    <EuiI18n
+                                      default="Select this row"
+                                      token="euiBasicTable.selectThisRow"
+                                    >
+                                      <EuiCheckbox
+                                        aria-label="Select this row"
+                                        checked={false}
+                                        compressed={false}
+                                        data-test-subj="checkboxSelectRow-ad7e6e30-0b99-11ee-b27c-c9863222e9bf"
+                                        disabled={false}
+                                        id="_selection_column_ad7e6e30-0b99-11ee-b27c-c9863222e9bf-checkbox"
+                                        indeterminate={false}
+                                        onChange={[Function]}
+                                        title="Select this row"
+                                        type="inList"
+                                      >
+                                        <div
+                                          className="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                                        >
+                                          <input
+                                            aria-label="Select this row"
+                                            checked={false}
+                                            className="euiCheckbox__input"
+                                            data-test-subj="checkboxSelectRow-ad7e6e30-0b99-11ee-b27c-c9863222e9bf"
+                                            disabled={false}
+                                            id="_selection_column_ad7e6e30-0b99-11ee-b27c-c9863222e9bf-checkbox"
+                                            onChange={[Function]}
+                                            title="Select this row"
+                                            type="checkbox"
+                                          />
+                                          <div
+                                            className="euiCheckbox__square"
+                                          />
+                                        </div>
+                                      </EuiCheckbox>
+                                    </EuiI18n>
+                                  </div>
+                                </td>
+                              </EuiTableRowCellCheckbox>
                               <EuiTableRowCell
                                 align="left"
                                 key="_data_column_name_ad7e6e30-0b99-11ee-b27c-c9863222e9bf_0"
@@ -2539,70 +2661,6 @@ exports[`Added Integration Table View Test Renders added integration table view 
                                         2023-06-15T16:28:36.370Z
                                       </div>
                                     </EuiText>
-                                  </div>
-                                </td>
-                              </EuiTableRowCell>
-                              <EuiTableRowCell
-                                align="left"
-                                key="_data_column_actions_ad7e6e30-0b99-11ee-b27c-c9863222e9bf_3"
-                                mobileOptions={
-                                  Object {
-                                    "header": "Actions",
-                                    "render": undefined,
-                                  }
-                                }
-                                setScopeRow={false}
-                                textOnly={false}
-                                truncateText={true}
-                              >
-                                <td
-                                  className="euiTableRowCell"
-                                  style={
-                                    Object {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    className="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                                  >
-                                    Actions
-                                  </div>
-                                  <div
-                                    className="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-                                  >
-                                    <EuiIcon
-                                      className=""
-                                      key=".0"
-                                      onClick={[Function]}
-                                      type="trash"
-                                    >
-                                      <EuiIconTrash
-                                        aria-hidden={true}
-                                        className="euiIcon euiIcon--medium"
-                                        focusable="false"
-                                        onClick={[Function]}
-                                        role="img"
-                                        style={null}
-                                      >
-                                        <svg
-                                          aria-hidden={true}
-                                          className="euiIcon euiIcon--medium"
-                                          focusable="false"
-                                          height={16}
-                                          onClick={[Function]}
-                                          role="img"
-                                          style={null}
-                                          viewBox="0 0 16 16"
-                                          width={16}
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M11 3h5v1H0V3h5V1a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2Zm-7.056 8H7v1H4.1l.392 2.519c.042.269.254.458.493.458h6.03c.239 0 .451-.189.493-.458l1.498-9.576H14l-1.504 9.73c-.116.747-.74 1.304-1.481 1.304h-6.03c-.741 0-1.365-.557-1.481-1.304l-1.511-9.73H9V5.95H3.157L3.476 8H8v1H3.632l.312 2ZM6 3h4V1H6v2Z"
-                                          />
-                                        </svg>
-                                      </EuiIconTrash>
-                                    </EuiIcon>
                                   </div>
                                 </td>
                               </EuiTableRowCell>

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
@@ -512,12 +512,6 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                     alt=""
                     className="synopsisIcon"
                     src="/api/integrations/repository/nginx/static/logo.svg"
-                    style={
-                      Object {
-                        "height": 60,
-                        "width": 60,
-                      }
-                    }
                   />
                 }
                 title="NginX Dashboard"
@@ -542,12 +536,6 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                         alt=""
                         className="synopsisIcon euiCard__icon"
                         src="/api/integrations/repository/nginx/static/logo.svg"
-                        style={
-                          Object {
-                            "height": 60,
-                            "width": 60,
-                          }
-                        }
                       />
                     </div>
                     <div

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
@@ -514,8 +514,8 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                     src="/api/integrations/repository/nginx/static/logo.svg"
                     style={
                       Object {
-                        "height": 100,
-                        "width": 100,
+                        "height": 60,
+                        "width": 60,
                       }
                     }
                   />
@@ -544,8 +544,8 @@ exports[`Available Integration Card View Test Renders nginx integration card vie
                         src="/api/integrations/repository/nginx/static/logo.svg"
                         style={
                           Object {
-                            "height": 100,
-                            "width": 100,
+                            "height": 60,
+                            "width": 60,
                           }
                         }
                       />

--- a/public/components/integrations/components/__tests__/__snapshots__/integration_details.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/integration_details.test.tsx.snap
@@ -8,13 +8,6 @@ exports[`Available Integration Table View Test Renders nginx integration table v
     className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     data-test-subj="nginx-details"
   >
-    <EuiTitle>
-      <h2
-        className="euiTitle euiTitle--medium"
-      >
-        Details
-      </h2>
-    </EuiTitle>
     <EuiSpacer
       size="s"
     >
@@ -30,20 +23,23 @@ exports[`Available Integration Table View Test Renders nginx integration table v
           <div
             className="euiFlexItem"
           >
-            <EuiText>
-              <div
-                className="euiText euiText--medium"
+            <EuiTitle
+              size="s"
+            >
+              <h3
+                className="euiTitle euiTitle--small"
               >
-                <h4>
-                  Version
-                </h4>
-              </div>
-            </EuiText>
+                Version
+              </h3>
+            </EuiTitle>
             <EuiFlexGroup
-              direction="column"
+              alignItems="center"
+              direction="row"
+              gutterSize="xs"
+              responsive={false}
             >
               <div
-                className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+                className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
               >
                 <EuiFlexItem
                   grow={false}
@@ -51,66 +47,43 @@ exports[`Available Integration Table View Test Renders nginx integration table v
                   <div
                     className="euiFlexItem euiFlexItem--flexGrowZero"
                   >
-                    <EuiFlexGroup
-                      alignItems="flexEnd"
-                      justifyContent="spaceBetween"
-                      responsive={false}
+                    <EuiText
+                      size="m"
                     >
                       <div
-                        className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsFlexEnd euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+                        className="euiText euiText--medium"
                       >
-                        <EuiFlexItem
-                          grow={false}
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          >
-                            <EuiText
-                              size="m"
-                            >
-                              <div
-                                className="euiText euiText--medium"
-                              >
-                                1.0.1
-                              </div>
-                            </EuiText>
-                          </div>
-                        </EuiFlexItem>
-                        <EuiFlexItem
-                          grow={false}
-                        >
-                          <div
-                            className="euiFlexItem euiFlexItem--flexGrowZero"
-                          >
-                            <EuiText
-                              size="xs"
-                            >
-                              <div
-                                className="euiText euiText--extraSmall"
-                              >
-                                <EuiLink
-                                  href="https://github.com/opensearch-project/opensearch-catalog/releases"
-                                >
-                                  <a
-                                    className="euiLink euiLink--primary"
-                                    href="https://github.com/opensearch-project/opensearch-catalog/releases"
-                                    rel="noreferrer"
-                                  >
-                                    Check for new versions
-                                  </a>
-                                </EuiLink>
-                              </div>
-                            </EuiText>
-                          </div>
-                        </EuiFlexItem>
+                        1.0.1
                       </div>
-                    </EuiFlexGroup>
+                    </EuiText>
                   </div>
                 </EuiFlexItem>
-                <EuiFlexItem>
+                <EuiFlexItem
+                  grow={false}
+                >
                   <div
-                    className="euiFlexItem"
-                  />
+                    className="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <EuiText
+                      size="xs"
+                    >
+                      <div
+                        className="euiText euiText--extraSmall"
+                      >
+                        <EuiLink
+                          href="https://github.com/opensearch-project/opensearch-catalog/releases"
+                        >
+                          <a
+                            className="euiLink euiLink--primary"
+                            href="https://github.com/opensearch-project/opensearch-catalog/releases"
+                            rel="noreferrer"
+                          >
+                            Check for new versions
+                          </a>
+                        </EuiLink>
+                      </div>
+                    </EuiText>
+                  </div>
                 </EuiFlexItem>
               </div>
             </EuiFlexGroup>
@@ -120,15 +93,15 @@ exports[`Available Integration Table View Test Renders nginx integration table v
           <div
             className="euiFlexItem"
           >
-            <EuiText>
-              <div
-                className="euiText euiText--medium"
+            <EuiTitle
+              size="s"
+            >
+              <h3
+                className="euiTitle euiTitle--small"
               >
-                <h4>
-                  Category
-                </h4>
-              </div>
-            </EuiText>
+                Category
+              </h3>
+            </EuiTitle>
             <EuiBadgeGroup>
               <div
                 className="euiBadgeGroup euiBadgeGroup--gutterExtraSmall"
@@ -140,15 +113,15 @@ exports[`Available Integration Table View Test Renders nginx integration table v
           <div
             className="euiFlexItem"
           >
-            <EuiText>
-              <div
-                className="euiText euiText--medium"
+            <EuiTitle
+              size="s"
+            >
+              <h3
+                className="euiTitle euiTitle--small"
               >
-                <h4>
-                  Contributer
-                </h4>
-              </div>
-            </EuiText>
+                Contributor
+              </h3>
+            </EuiTitle>
             <EuiText
               size="s"
             >
@@ -209,15 +182,15 @@ exports[`Available Integration Table View Test Renders nginx integration table v
           <div
             className="euiFlexItem"
           >
-            <EuiText>
-              <div
-                className="euiText euiText--medium"
+            <EuiTitle
+              size="s"
+            >
+              <h3
+                className="euiTitle euiTitle--small"
               >
-                <h4>
-                  License
-                </h4>
-              </div>
-            </EuiText>
+                License
+              </h3>
+            </EuiTitle>
             <EuiText
               size="s"
             >
@@ -235,15 +208,15 @@ exports[`Available Integration Table View Test Renders nginx integration table v
       <div
         className="euiFlexItem"
       >
-        <EuiText>
-          <div
-            className="euiText euiText--medium"
+        <EuiTitle
+          size="s"
+        >
+          <h3
+            className="euiTitle euiTitle--small"
           >
-            <h4>
-              Description
-            </h4>
-          </div>
-        </EuiText>
+            Description
+          </h3>
+        </EuiTitle>
         <EuiText
           size="s"
         >

--- a/public/components/integrations/components/__tests__/__snapshots__/integration_details.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/integration_details.test.tsx.snap
@@ -23,15 +23,17 @@ exports[`Available Integration Table View Test Renders nginx integration table v
           <div
             className="euiFlexItem"
           >
-            <EuiTitle
-              size="s"
+            <EuiText
+              size="m"
             >
-              <h3
-                className="euiTitle euiTitle--small"
+              <div
+                className="euiText euiText--medium"
               >
-                Version
-              </h3>
-            </EuiTitle>
+                <h4>
+                  Version
+                </h4>
+              </div>
+            </EuiText>
             <EuiFlexGroup
               alignItems="center"
               direction="row"
@@ -93,15 +95,17 @@ exports[`Available Integration Table View Test Renders nginx integration table v
           <div
             className="euiFlexItem"
           >
-            <EuiTitle
-              size="s"
+            <EuiText
+              size="m"
             >
-              <h3
-                className="euiTitle euiTitle--small"
+              <div
+                className="euiText euiText--medium"
               >
-                Category
-              </h3>
-            </EuiTitle>
+                <h4>
+                  Category
+                </h4>
+              </div>
+            </EuiText>
             <EuiBadgeGroup>
               <div
                 className="euiBadgeGroup euiBadgeGroup--gutterExtraSmall"
@@ -113,15 +117,17 @@ exports[`Available Integration Table View Test Renders nginx integration table v
           <div
             className="euiFlexItem"
           >
-            <EuiTitle
-              size="s"
+            <EuiText
+              size="m"
             >
-              <h3
-                className="euiTitle euiTitle--small"
+              <div
+                className="euiText euiText--medium"
               >
-                Contributor
-              </h3>
-            </EuiTitle>
+                <h4>
+                  Contributor
+                </h4>
+              </div>
+            </EuiText>
             <EuiText
               size="s"
             >
@@ -182,15 +188,17 @@ exports[`Available Integration Table View Test Renders nginx integration table v
           <div
             className="euiFlexItem"
           >
-            <EuiTitle
-              size="s"
+            <EuiText
+              size="m"
             >
-              <h3
-                className="euiTitle euiTitle--small"
+              <div
+                className="euiText euiText--medium"
               >
-                License
-              </h3>
-            </EuiTitle>
+                <h4>
+                  License
+                </h4>
+              </div>
+            </EuiText>
             <EuiText
               size="s"
             >
@@ -208,15 +216,17 @@ exports[`Available Integration Table View Test Renders nginx integration table v
       <div
         className="euiFlexItem"
       >
-        <EuiTitle
-          size="s"
+        <EuiText
+          size="m"
         >
-          <h3
-            className="euiTitle euiTitle--small"
+          <div
+            className="euiText euiText--medium"
           >
-            Description
-          </h3>
-        </EuiTitle>
+            <h4>
+              Description
+            </h4>
+          </div>
+        </EuiText>
         <EuiText
           size="s"
         >

--- a/public/components/integrations/components/__tests__/__snapshots__/integration_fields.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/integration_fields.test.tsx.snap
@@ -8,12 +8,14 @@ exports[`Available Integration Table View Test Renders nginx integration table v
     className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     data-test-subj="nginx-fields"
   >
-    <EuiTitle>
-      <h2
-        className="euiTitle euiTitle--medium"
+    <EuiTitle
+      size="s"
+    >
+      <h3
+        className="euiTitle euiTitle--small"
       >
         Fields
-      </h2>
+      </h3>
     </EuiTitle>
     <EuiSpacer
       size="s"

--- a/public/components/integrations/components/__tests__/__snapshots__/integration_header.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/integration_header.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Integration Header Test Renders integration header as expected 1`] = `
           <div
             className="euiPageHeaderSection"
           >
-            <IntegrationHeaderActions
+            <IntegrationHeaderActionsOldNav
               onShowUpload={[Function]}
             >
               <EuiFlexGroup
@@ -154,7 +154,7 @@ exports[`Integration Header Test Renders integration header as expected 1`] = `
                   </EuiFlexItem>
                 </div>
               </EuiFlexGroup>
-            </IntegrationHeaderActions>
+            </IntegrationHeaderActionsOldNav>
           </div>
         </EuiPageHeaderSection>
       </header>
@@ -233,11 +233,11 @@ exports[`Integration Header Test Renders integration header as expected 1`] = `
       />
     </EuiSpacer>
     <EuiTabs
-      display="condensed"
+      display="default"
       size="s"
     >
       <div
-        className="euiTabs euiTabs--condensed euiTabs--small"
+        className="euiTabs euiTabs--small"
         role="tablist"
       >
         <EuiTab

--- a/public/components/integrations/components/added_integration.tsx
+++ b/public/components/integrations/components/added_integration.tsx
@@ -177,15 +177,15 @@ export function AddedIntegration(props: AddedIntegrationProps) {
     const additionalInfo = (
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiTitle size="s">
-            <h3>Template</h3>
-          </EuiTitle>
+          <EuiText size="m">
+            <h4>Template</h4>
+          </EuiText>
           <EuiLink href={`#/available/${data?.templateName}`}>{data?.templateName}</EuiLink>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiTitle size="s">
-            <h3>Date Added</h3>
-          </EuiTitle>
+          <EuiText size="m">
+            <h4>Date Added</h4>
+          </EuiText>
           <EuiText size="m">{data?.creationDate?.split('T')[0]}</EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/public/components/integrations/components/added_integration.tsx
+++ b/public/components/integrations/components/added_integration.tsx
@@ -21,9 +21,12 @@ import {
   EuiSpacer,
   EuiTableFieldDataColumnType,
   EuiText,
+  EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import truncate from 'lodash/truncate';
 import React, { useEffect, useState } from 'react';
+import { FormattedMessage } from '@osd/i18n/react';
 import { DataSourceViewConfig } from '../../../../../../src/plugins/data_source_management/public';
 import { ASSET_FILTER_OPTIONS } from '../../../../common/constants/integrations';
 import { INTEGRATIONS_BASE } from '../../../../common/constants/shared';
@@ -32,7 +35,6 @@ import { useToast } from '../../../../public/components/common/toast';
 import { HeaderControlledComponentsWrapper } from '../../../../public/plugin_helpers/plugin_headerControl';
 import { coreRefs } from '../../../framework/core_refs';
 import { DeleteModal } from '../../common/helpers/delete_modal';
-import { PanelTitle } from '../../trace_analytics/components/common/helper_functions';
 import { AddedIntegrationProps } from './integration_types';
 
 const newNavigation = coreRefs.chrome?.navGroup.getNavGroupEnabled();
@@ -89,7 +91,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
 
   const DataSourceMenu = dataSourceManagement?.ui?.getDataSourceMenu<DataSourceViewConfig>();
 
-  const activateDeleteModal = (integrationName?: string) => {
+  const activateDeleteModal = () => {
     setModalLayout(
       <DeleteModal
         onConfirm={() => {
@@ -101,7 +103,6 @@ export function AddedIntegration(props: AddedIntegrationProps) {
         }}
         title={`Delete Integration`}
         message={`Are you sure you want to delete the selected Integration?`}
-        prompt={integrationName}
       />
     );
     setIsModalVisible(true);
@@ -134,15 +135,25 @@ export function AddedIntegration(props: AddedIntegrationProps) {
     const badgeContent = <IntegrationHealthBadge status={data?.status} />;
 
     const deleteButton = (
-      <EuiSmallButtonIcon
-        iconType="trash"
-        aria-label="Delete"
-        color="danger"
-        onClick={() => {
-          activateDeleteModal(data?.name);
-        }}
-        data-test-subj="deleteInstanceButton"
-      />
+      <EuiToolTip
+        content={
+          <FormattedMessage
+            id="integration.deleteButtonTooltip"
+            defaultMessage="Delete this instance"
+          />
+        }
+      >
+        <EuiSmallButtonIcon
+          display="base"
+          iconType="trash"
+          aria-label="Delete"
+          color="danger"
+          onClick={() => {
+            activateDeleteModal(data?.name);
+          }}
+          data-test-subj="deleteInstanceButton"
+        />
+      </EuiToolTip>
     );
 
     const headerContent = (
@@ -166,15 +177,15 @@ export function AddedIntegration(props: AddedIntegrationProps) {
     const additionalInfo = (
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiText>
-            <h4>Template</h4>
-          </EuiText>
+          <EuiTitle size="s">
+            <h3>Template</h3>
+          </EuiTitle>
           <EuiLink href={`#/available/${data?.templateName}`}>{data?.templateName}</EuiLink>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiText>
-            <h4>Date Added</h4>
-          </EuiText>
+          <EuiTitle size="s">
+            <h3>Date Added</h3>
+          </EuiTitle>
           <EuiText size="m">{data?.creationDate?.split('T')[0]}</EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -206,7 +217,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
             deleteButton,
           ]}
         />
-        {additionalInfo}
+        <EuiPanel>{additionalInfo}</EuiPanel>
       </>
     ) : (
       <>
@@ -231,7 +242,7 @@ export function AddedIntegration(props: AddedIntegrationProps) {
             {headerContent}
           </EuiPageHeaderSection>
         </EuiPageHeader>
-        {additionalInfo}
+        <EuiPanel>{additionalInfo}</EuiPanel>
       </>
     );
   }
@@ -356,8 +367,10 @@ export function AddedIntegration(props: AddedIntegrationProps) {
 
     return (
       <EuiPanel>
-        <PanelTitle title={'Assets List'} />
-        <EuiSpacer size="l" />
+        <EuiTitle size="s">
+          <h3>Assets List</h3>
+        </EuiTitle>
+        <EuiSpacer size="s" />
         <EuiInMemoryTable
           itemId="id"
           loading={false}

--- a/public/components/integrations/components/added_integration_table.tsx
+++ b/public/components/integrations/components/added_integration_table.tsx
@@ -94,7 +94,7 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
       }
     });
 
-    await Promise.all(deletePromises);
+    Promise.all(deletePromises);
 
     props.setData({
       hits: props.data.hits.filter(
@@ -226,7 +226,7 @@ export function AddedIntegrationsTable(props: AddedIntegrationsTableProps) {
           body={
             <p>
               There are currently no added integrations in this table. Add integrations from the{' '}
-              <EuiLink href={'#/available'}>Available list</EuiLink>.
+              <EuiLink href={'#/available'}>available list</EuiLink>.
             </p>
           }
         />

--- a/public/components/integrations/components/available_integration_card_view.tsx
+++ b/public/components/integrations/components/available_integration_card_view.tsx
@@ -27,9 +27,7 @@ export function AvailableIntegrationsCardView(props: AvailableIntegrationsCardVi
   const getImage = (url?: string) => {
     let optionalImg;
     if (url) {
-      optionalImg = (
-        <img style={{ height: 60, width: 60 }} alt="" className="synopsisIcon" src={url} />
-      );
+      optionalImg = <img alt="" className="synopsisIcon" src={url} />;
     }
     return optionalImg;
   };

--- a/public/components/integrations/components/available_integration_card_view.tsx
+++ b/public/components/integrations/components/available_integration_card_view.tsx
@@ -28,7 +28,7 @@ export function AvailableIntegrationsCardView(props: AvailableIntegrationsCardVi
     let optionalImg;
     if (url) {
       optionalImg = (
-        <img style={{ height: 100, width: 100 }} alt="" className="synopsisIcon" src={url} />
+        <img style={{ height: 60, width: 60 }} alt="" className="synopsisIcon" src={url} />
       );
     }
     return optionalImg;

--- a/public/components/integrations/components/integration.tsx
+++ b/public/components/integrations/components/integration.tsx
@@ -256,7 +256,7 @@ export function Integration(props: AvailableIntegrationProps) {
         <EuiSpacer size="s" />
         {IntegrationScreenshots({ integration, http })}
         <EuiSpacer size="s" />
-        <EuiTabs display="condensed" size="s">
+        <EuiTabs display="default" size="s">
           {renderTabs()}
         </EuiTabs>
         <EuiSpacer size="s" />

--- a/public/components/integrations/components/integration_assets_panel.tsx
+++ b/public/components/integrations/components/integration_assets_panel.tsx
@@ -85,8 +85,8 @@ export function IntegrationAssets(props: {
 
   return (
     <EuiPanel data-test-subj={`${config.name}-assets`}>
-      <EuiTitle>
-        <h2>Assets</h2>
+      <EuiTitle size="s">
+        <h3>Assets</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
       <EuiInMemoryTable

--- a/public/components/integrations/components/integration_details_panel.tsx
+++ b/public/components/integrations/components/integration_details_panel.tsx
@@ -12,7 +12,6 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
-  EuiTitle,
 } from '@elastic/eui';
 import React from 'react';
 import { OPENSEARCH_CATALOG_URL } from '../../../../common/constants/integrations';
@@ -25,9 +24,9 @@ export function IntegrationDetails(props: { integration: IntegrationConfig }) {
       <EuiSpacer size="s" />
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiTitle size="s">
-            <h3>Version</h3>
-          </EuiTitle>
+          <EuiText size="m">
+            <h4>Version</h4>
+          </EuiText>
           <EuiFlexGroup direction="row" alignItems="center" responsive={false} gutterSize="xs">
             <EuiFlexItem grow={false}>
               <EuiText size="m">{config.version}</EuiText>
@@ -40,9 +39,9 @@ export function IntegrationDetails(props: { integration: IntegrationConfig }) {
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiTitle size="s">
-            <h3>Category</h3>
-          </EuiTitle>
+          <EuiText size="m">
+            <h4>Category</h4>
+          </EuiText>
           <EuiBadgeGroup>
             {config.labels?.map((label: string) => {
               return <EuiBadge>{label}</EuiBadge>;
@@ -50,9 +49,9 @@ export function IntegrationDetails(props: { integration: IntegrationConfig }) {
           </EuiBadgeGroup>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiTitle size="s">
-            <h3>Contributor</h3>
-          </EuiTitle>
+          <EuiText size="m">
+            <h4>Contributor</h4>
+          </EuiText>
           <EuiText size="s">
             <EuiLink href={config.sourceUrl} external={true} target="blank">
               {config.author}
@@ -60,16 +59,16 @@ export function IntegrationDetails(props: { integration: IntegrationConfig }) {
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiTitle size="s">
-            <h3>License</h3>
-          </EuiTitle>
+          <EuiText size="m">
+            <h4>License</h4>
+          </EuiText>
           <EuiText size="s">{config.license}</EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiFlexItem>
-        <EuiTitle size="s">
-          <h3>Description</h3>
-        </EuiTitle>
+        <EuiText size="m">
+          <h4>Description</h4>
+        </EuiText>
         <EuiText size="s">{config.description}</EuiText>
       </EuiFlexItem>
     </EuiPanel>

--- a/public/components/integrations/components/integration_details_panel.tsx
+++ b/public/components/integrations/components/integration_details_panel.tsx
@@ -22,45 +22,27 @@ export function IntegrationDetails(props: { integration: IntegrationConfig }) {
 
   return (
     <EuiPanel data-test-subj={`${config.name}-details`}>
-      <EuiTitle>
-        <h2>Details</h2>
-      </EuiTitle>
       <EuiSpacer size="s" />
       <EuiFlexGroup>
         <EuiFlexItem>
-          <EuiText>
-            <h4>Version</h4>
-          </EuiText>
-          {/*
-          For the link, we have the slightly odd constraint to have it go to the end of the version
-          space while being horizontally next to the version (i.e. no direct EuiText). It should be
-          smaller, while aligning to the bottom of the line, but not the bottom of the entire flex
-          area, for a nice subscript effect.
-
-          The end result is a bit of flex magic: make two vertical boxes with the second one empty
-          and growing, then in the top one put two horizontal boxes with space-between, aligning to
-          the bottom.
-          */}
-          <EuiFlexGroup direction="column">
+          <EuiTitle size="s">
+            <h3>Version</h3>
+          </EuiTitle>
+          <EuiFlexGroup direction="row" alignItems="center" responsive={false} gutterSize="xs">
             <EuiFlexItem grow={false}>
-              <EuiFlexGroup justifyContent="spaceBetween" alignItems="flexEnd" responsive={false}>
-                <EuiFlexItem grow={false}>
-                  <EuiText size="m">{config.version}</EuiText>
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiText size="xs">
-                    <EuiLink href={OPENSEARCH_CATALOG_URL}>Check for new versions</EuiLink>
-                  </EuiText>
-                </EuiFlexItem>
-              </EuiFlexGroup>
+              <EuiText size="m">{config.version}</EuiText>
             </EuiFlexItem>
-            <EuiFlexItem />
+            <EuiFlexItem grow={false}>
+              <EuiText size="xs">
+                <EuiLink href={OPENSEARCH_CATALOG_URL}>Check for new versions</EuiLink>
+              </EuiText>
+            </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiText>
-            <h4>Category</h4>
-          </EuiText>
+          <EuiTitle size="s">
+            <h3>Category</h3>
+          </EuiTitle>
           <EuiBadgeGroup>
             {config.labels?.map((label: string) => {
               return <EuiBadge>{label}</EuiBadge>;
@@ -68,9 +50,9 @@ export function IntegrationDetails(props: { integration: IntegrationConfig }) {
           </EuiBadgeGroup>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiText>
-            <h4>Contributer</h4>
-          </EuiText>
+          <EuiTitle size="s">
+            <h3>Contributor</h3>
+          </EuiTitle>
           <EuiText size="s">
             <EuiLink href={config.sourceUrl} external={true} target="blank">
               {config.author}
@@ -78,16 +60,16 @@ export function IntegrationDetails(props: { integration: IntegrationConfig }) {
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiText>
-            <h4>License</h4>
-          </EuiText>
+          <EuiTitle size="s">
+            <h3>License</h3>
+          </EuiTitle>
           <EuiText size="s">{config.license}</EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiFlexItem>
-        <EuiText>
-          <h4>Description</h4>
-        </EuiText>
+        <EuiTitle size="s">
+          <h3>Description</h3>
+        </EuiTitle>
         <EuiText size="s">{config.description}</EuiText>
       </EuiFlexItem>
     </EuiPanel>

--- a/public/components/integrations/components/integration_fields_panel.tsx
+++ b/public/components/integrations/components/integration_fields_panel.tsx
@@ -94,8 +94,8 @@ export function IntegrationFields(props: any) {
 
   return (
     <EuiPanel data-test-subj={`${config.name}-fields`}>
-      <EuiTitle>
-        <h2>Fields</h2>
+      <EuiTitle size="s">
+        <h3>Fields</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
       <EuiInMemoryTable

--- a/public/components/integrations/components/integration_header.tsx
+++ b/public/components/integrations/components/integration_header.tsx
@@ -24,10 +24,35 @@ import {
 import { IntegrationUploadFlyout } from './upload_flyout';
 import { HeaderControlledComponentsWrapper } from '../../../../public/plugin_helpers/plugin_headerControl';
 import { coreRefs } from '../../../framework/core_refs';
+import {
+  TopNavControlButtonData,
+  TopNavControlLinkData,
+} from '../../../../../../src/plugins/navigation/public';
 
 const newNavigation = coreRefs.chrome?.navGroup.getNavGroupEnabled();
 
-export const IntegrationHeaderActions = ({ onShowUpload }: { onShowUpload: () => void }) => {
+export const IntegrationHeaderActions = ({
+  onShowUpload,
+}: {
+  onShowUpload: () => void;
+}): Array<TopNavControlButtonData | TopNavControlLinkData> => {
+  return [
+    {
+      label: 'View Catalog',
+      href: OPENSEARCH_CATALOG_URL,
+      target: '_blank',
+      controlType: 'link',
+    } as TopNavControlLinkData,
+    {
+      label: 'Upload Integration',
+      run: onShowUpload,
+      fill: true,
+      controlType: 'button',
+    } as TopNavControlButtonData,
+  ];
+};
+
+export const IntegrationHeaderActionsOldNav = ({ onShowUpload }: { onShowUpload: () => void }) => {
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center">
       <EuiFlexItem grow={false}>
@@ -85,15 +110,12 @@ export const IntegrationHeader = () => {
     <div>
       {newNavigation ? (
         <HeaderControlledComponentsWrapper
-          description={
-            <>
-              View integrations with preconfigured assets immediately within your OpenSearch setup.{' '}
-              <EuiLink external={true} href={OPENSEARCH_DOCUMENTATION_URL} target="_blank">
-                Learn more
-              </EuiLink>
-            </>
-          }
-          components={[<IntegrationHeaderActions onShowUpload={() => setShowUploadFlyout(true)} />]}
+          description={{
+            text:
+              'View integrations with preconfigured assets immediately within your OpenSearch setup.',
+            url: OPENSEARCH_DOCUMENTATION_URL,
+          }}
+          components={IntegrationHeaderActions({ onShowUpload: () => setShowUploadFlyout(true) })}
         />
       ) : (
         <>
@@ -104,7 +126,7 @@ export const IntegrationHeader = () => {
               </EuiTitle>
             </EuiPageHeaderSection>
             <EuiPageHeaderSection>
-              <IntegrationHeaderActions onShowUpload={() => setShowUploadFlyout(true)} />
+              <IntegrationHeaderActionsOldNav onShowUpload={() => setShowUploadFlyout(true)} />
             </EuiPageHeaderSection>
           </EuiPageHeader>
           <EuiText size="s" color="subdued">
@@ -116,7 +138,7 @@ export const IntegrationHeader = () => {
         </>
       )}
       {!newNavigation && <EuiSpacer size="s" />}
-      <EuiTabs display="condensed" size="s">
+      <EuiTabs display="default" size="s">
         {renderTabs()}
       </EuiTabs>
       <EuiSpacer size="s" />

--- a/public/components/integrations/components/integration_screenshots_panel.tsx
+++ b/public/components/integrations/components/integration_screenshots_panel.tsx
@@ -17,8 +17,8 @@ export function IntegrationScreenshots(props: any) {
 
   return (
     <EuiPanel data-test-subj={`${config.name}-screenshots`}>
-      <EuiTitle>
-        <h2>Screenshots</h2>
+      <EuiTitle size="s">
+        <h3>Screenshots</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
       <EuiFlexGroup gutterSize="l" alignItems="flexStart">

--- a/public/components/notebooks/components/note_table.tsx
+++ b/public/components/notebooks/components/note_table.tsx
@@ -241,17 +241,12 @@ export function NoteTable({
           <EuiPageContent id="notebookArea" paddingSize="m">
             {newNavigation ? (
               <HeaderControlledComponentsWrapper
-                description={
-                  <>
-                    Use Notebooks to interactively and collaboratively develop rich reports backed
-                    by live data. Common use cases for notebooks include creating postmortem
-                    reports, designing run books, building live infrastructure reports, or even
-                    documentation.{' '}
-                    <EuiLink external={true} href={NOTEBOOKS_DOCUMENTATION_URL} target="_blank">
-                      Learn more
-                    </EuiLink>
-                  </>
-                }
+                description={{
+                  text:
+                    'Use Notebooks to interactively and collaboratively develop rich reports backed by live data. Common use cases for notebooks include creating postmortem reports, designing run books, building live infrastructure reports, or even documentation.',
+                  url: NOTEBOOKS_DOCUMENTATION_URL,
+                  urlTitle: 'Learn more',
+                }}
                 components={[
                   <EuiFlexGroup gutterSize="s" key="controls">
                     <EuiFlexItem grow={false}>

--- a/public/index.scss
+++ b/public/index.scss
@@ -11,3 +11,8 @@
 
 // event analytics
 @import 'components/event_analytics/index';
+
+.synopsisIcon {
+    height: 40px;
+    width: 40px;
+  }

--- a/public/plugin_helpers/plugin_headerControl.tsx
+++ b/public/plugin_helpers/plugin_headerControl.tsx
@@ -22,6 +22,42 @@ interface HeaderControlledComponentsWrapperProps {
   description?: string | DescriptionWithOptionalLink;
 }
 
+const renderTheComponent = (
+  component: TopNavControlButtonData | TopNavControlLinkData | React.ReactElement
+) => {
+  if (React.isValidElement(component)) {
+    return {
+      renderComponent: component,
+    };
+  }
+
+  switch ((component as TopNavControlButtonData | TopNavControlLinkData).controlType) {
+    case 'button': {
+      const buttonData = component as TopNavControlButtonData;
+      return {
+        label: buttonData.label,
+        run: buttonData.run,
+        fill: buttonData.fill,
+        color: buttonData.color,
+        iconType: buttonData.iconType,
+        iconSide: buttonData.iconSide,
+        controlType: 'button',
+      };
+    }
+    case 'link': {
+      const linkData = component as TopNavControlLinkData;
+      return {
+        label: linkData.label,
+        href: linkData.href,
+        target: linkData.target,
+        controlType: 'link',
+      };
+    }
+    default:
+      return {};
+  }
+};
+
 export const HeaderControlledComponentsWrapper = ({
   components = [],
   badgeContent,
@@ -90,32 +126,7 @@ export const HeaderControlledComponentsWrapper = ({
           {showActionsInHeader && HeaderControl ? (
             <HeaderControl
               setMountPoint={coreRefs.application?.setAppRightControls}
-              controls={components.map((component) => {
-                if (React.isValidElement(component)) {
-                  return {
-                    renderComponent: component,
-                  };
-                } else if ((component as TopNavControlButtonData).controlType === 'button') {
-                  const buttonData = component as TopNavControlButtonData;
-                  return {
-                    label: buttonData.label,
-                    run: buttonData.run,
-                    fill: buttonData.fill,
-                    color: buttonData.color,
-                    iconType: buttonData.iconType,
-                    iconSide: buttonData.iconSide,
-                    controlType: 'button',
-                  };
-                } else if ((component as TopNavControlLinkData).controlType === 'link') {
-                  const linkData = component as TopNavControlLinkData;
-                  return {
-                    label: linkData.label,
-                    href: linkData.href,
-                    target: linkData.target,
-                    controlType: 'link',
-                  };
-                }
-              })}
+              controls={components.map((component) => renderTheComponent(component))}
             />
           ) : (
             <div>

--- a/public/plugin_helpers/plugin_headerControl.tsx
+++ b/public/plugin_helpers/plugin_headerControl.tsx
@@ -22,7 +22,7 @@ interface HeaderControlledComponentsWrapperProps {
   description?: string | DescriptionWithOptionalLink;
 }
 
-const renderTheComponent = (
+const renderHeaderComponent = (
   component: TopNavControlButtonData | TopNavControlLinkData | React.ReactElement
 ) => {
   if (React.isValidElement(component)) {
@@ -126,7 +126,7 @@ export const HeaderControlledComponentsWrapper = ({
           {showActionsInHeader && HeaderControl ? (
             <HeaderControl
               setMountPoint={coreRefs.application?.setAppRightControls}
-              controls={components.map((component) => renderTheComponent(component))}
+              controls={components.map((component) => renderHeaderComponent(component))}
             />
           ) : (
             <div>

--- a/public/plugin_helpers/plugin_headerControl.tsx
+++ b/public/plugin_helpers/plugin_headerControl.tsx
@@ -4,13 +4,22 @@
  */
 
 import React from 'react';
-import { EuiText } from '@elastic/eui';
 import { coreRefs } from '../framework/core_refs';
+import {
+  TopNavControlLinkData,
+  TopNavControlButtonData,
+} from '../../../../src/plugins/navigation/public';
+
+interface DescriptionWithOptionalLink {
+  text: string;
+  url?: string;
+  urlTitle?: string;
+}
 
 interface HeaderControlledComponentsWrapperProps {
-  components?: React.ReactElement[];
+  components?: Array<TopNavControlButtonData | TopNavControlLinkData | React.ReactElement>;
   badgeContent?: React.ReactElement | string | number;
-  description?: React.ReactNode;
+  description?: string | DescriptionWithOptionalLink;
 }
 
 export const HeaderControlledComponentsWrapper = ({
@@ -23,48 +32,104 @@ export const HeaderControlledComponentsWrapper = ({
 
   const isBadgeReactElement = React.isValidElement(badgeContent);
 
-  if (showActionsInHeader && HeaderControl) {
-    return (
-      <>
-        {badgeContent && (
-          <HeaderControl
-            setMountPoint={coreRefs.application?.setAppBadgeControls}
-            controls={[
-              {
-                key: 'header-badge-control-left',
-                renderComponent: isBadgeReactElement ? (
-                  <span key="badge">{badgeContent}</span>
-                ) : (
-                  <span key="badge">{`(${badgeContent})`}</span>
-                ), // Render based on type
-              },
-            ]}
-          />
-        )}
-        {description && (
-          <HeaderControl
-            setMountPoint={coreRefs.application?.setAppDescriptionControls}
-            controls={[
-              {
-                key: 'header-description-control',
-                renderComponent: <EuiText key="description">{description}</EuiText>,
-              },
-            ]}
-          />
-        )}
-        {components.length > 0 && (
-          <HeaderControl
-            setMountPoint={coreRefs.application?.setAppRightControls}
-            controls={components.map((component, index) => ({
-              key: `header-control-${index}`,
-              renderComponent: component,
-            }))}
-          />
-        )}
-      </>
-    );
-  }
+  return (
+    <>
+      {badgeContent && (
+        <>
+          {showActionsInHeader && HeaderControl ? (
+            <HeaderControl
+              setMountPoint={coreRefs.application?.setAppBadgeControls}
+              controls={[
+                {
+                  renderComponent: isBadgeReactElement ? (
+                    <span>{badgeContent}</span>
+                  ) : (
+                    <span>{`(${badgeContent})`}</span>
+                  ),
+                },
+              ]}
+            />
+          ) : (
+            <span>{isBadgeReactElement ? badgeContent : `(${badgeContent})`}</span>
+          )}
+        </>
+      )}
 
-  // Only render the components if the nav group is disabled
-  return <>{components}</>;
+      {description && (
+        <>
+          {showActionsInHeader && HeaderControl ? (
+            <HeaderControl
+              setMountPoint={coreRefs.application?.setAppDescriptionControls}
+              controls={[
+                {
+                  description: typeof description === 'string' ? description : description.text,
+                  ...(typeof description === 'object' && description.url
+                    ? {
+                        links: [
+                          ({
+                            label: description.urlTitle || 'Learn more',
+                            href: description.url || '#',
+                            target: '_blank',
+                            controlType: 'link',
+                            flush: true,
+                          } as unknown) as TopNavControlLinkData,
+                        ],
+                      }
+                    : {}),
+                },
+              ]}
+            />
+          ) : (
+            <p>{typeof description === 'string' ? description : description.text}</p>
+          )}
+        </>
+      )}
+
+      {components.length > 0 && (
+        <>
+          {showActionsInHeader && HeaderControl ? (
+            <HeaderControl
+              setMountPoint={coreRefs.application?.setAppRightControls}
+              controls={components.map((component) => {
+                if (React.isValidElement(component)) {
+                  return {
+                    renderComponent: component,
+                  };
+                } else if ((component as TopNavControlButtonData).controlType === 'button') {
+                  const buttonData = component as TopNavControlButtonData;
+                  return {
+                    label: buttonData.label,
+                    run: buttonData.run,
+                    fill: buttonData.fill,
+                    color: buttonData.color,
+                    iconType: buttonData.iconType,
+                    iconSide: buttonData.iconSide,
+                    controlType: 'button',
+                  };
+                } else if ((component as TopNavControlLinkData).controlType === 'link') {
+                  const linkData = component as TopNavControlLinkData;
+                  return {
+                    label: linkData.label,
+                    href: linkData.href,
+                    target: linkData.target,
+                    controlType: 'link',
+                  };
+                }
+              })}
+            />
+          ) : (
+            <div>
+              {components.map((component) =>
+                React.isValidElement(component) ? (
+                  <span>{component}</span>
+                ) : (
+                  <span>{(component as TopNavControlButtonData).label}</span>
+                )
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
 };


### PR DESCRIPTION
### Description
1. Update plugin header control to use functionality for styling from core.
2. Adjust the descriptions and links to use new header control functionality in notebooks and integrations.
3. Small adjustment to applications to move button to header for the old navigation.
4. Update integrations Cypress testing for new delete (just requires standard "delete" instead of application name following use pattern applied everywhere else).
5. Update Integrations UI

~2 New Header control change (Buttons and Description field)
| Before | After |
| ------ | ----- |
| ![NotebookBefore](https://github.com/user-attachments/assets/27793cc2-61d4-4e97-a7c5-edd834f7d0bb) | ![NotebookAfter](https://github.com/user-attachments/assets/a18b37c8-b0b3-4a43-917c-76622e67fa47) |
| ![IntegBefore](https://github.com/user-attachments/assets/64e1302b-fd9b-414d-b88d-821bea3a0d98) | ![IntegAfter](https://github.com/user-attachments/assets/e6668add-8f6f-4852-b295-cd71c35e949d) |

~4 Updated Cypress Testing
<img width="512" alt="IntegCypress" src="https://github.com/user-attachments/assets/97f9e478-9c38-4629-a1ec-47a2cb46e0d2">

~5 Integration Changes
a. Image on cards smaller
![5aCards](https://github.com/user-attachments/assets/2178c4eb-1450-41e4-9ad0-16c8a299cf3d)
b. Bulk delete
![5bBulkDelete](https://github.com/user-attachments/assets/9ab897e9-8b4c-4166-9252-b246c75bff0e)
c. Empty State
![5cEmptyState](https://github.com/user-attachments/assets/8e0e0873-6fe4-4706-af3c-36cef461dfe2)
d. Underline Tabs
![5dUnderlineTabs](https://github.com/user-attachments/assets/0c84c5d8-22eb-46d3-aa89-9b8875713a2f)
e. Padding to 16px
![5ePaddingAroundTable](https://github.com/user-attachments/assets/4424a7bc-8bf2-448d-8d59-380934f83871)
f. Delete button secondary /hover
![5fDeleteButtonSecondary:Hover](https://github.com/user-attachments/assets/76672545-9199-41e8-a2a6-72a792be23c5)
g. Panel added to Template text
![5gPanelAdded](https://github.com/user-attachments/assets/03be31da-6d39-4e54-81d5-d391c807ffcb)
h. Remove Details / space between check new version
![5hRemoveDetails:spaceOnNewVersions](https://github.com/user-attachments/assets/62c4ad0f-8106-43ad-870a-dae2e61ceaf3)
i. Fix spelling
![5iFixSpelling](https://github.com/user-attachments/assets/ff43e07d-56d2-48ba-9ec1-f4079565092c)
h. Headings all adjusted to H3
![5jH3HeadingsAllTitles](https://github.com/user-attachments/assets/c8eb678d-7ecd-40af-b8bf-766a4ad61b09)



Integrations Before:
![Screenshot 2024-09-17 at 11 47 21 AM](https://github.com/user-attachments/assets/212dd865-4089-42d2-b452-fc0a745880e9)
![Screenshot 2024-09-17 at 11 43 59 AM](https://github.com/user-attachments/assets/8de567e2-eebb-444a-9d44-907e3ce7039f)
![Screenshot 2024-09-17 at 11 44 09 AM](https://github.com/user-attachments/assets/b02360fd-ccb9-445e-8647-4950b34916b0)
![Screenshot 2024-09-17 at 11 44 24 AM](https://github.com/user-attachments/assets/bce43b33-33c5-464a-84bc-afbe853cfb9d)


### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
