### PR TITLE
Update custom traces table with filters

### DIFF
--- a/common/constants/trace_analytics.ts
+++ b/common/constants/trace_analytics.ts
@@ -26,33 +26,26 @@ export const TRACE_CUSTOM_SPAN_INDEX_SETTING = 'observability:traceAnalyticsSpan
 export const TRACE_CUSTOM_SERVICE_INDEX_SETTING = 'observability:traceAnalyticsServiceIndices';
 
 export enum TRACE_TABLE_TITLES {
-  all_spans = 'Spans',
-  trace_root_spans = 'Trace root spans',
-  service_entry_spans = 'Service entry spans',
+  all_spans = 'All Spans',
+  root_spans = 'Root Spans',
+  entry_spans = 'Service Entry Spans',
   traces = 'Traces',
 }
 
-export const TRACE_TABLE_OPTIONS = [
-  {
-    label: TRACE_TABLE_TITLES.all_spans,
-    key: 'all_spans',
-    'aria-describedby': 'All spans from all traces',
-  },
-  {
-    label: TRACE_TABLE_TITLES.trace_root_spans,
-    key: 'trace_root_spans',
-    'aria-describedby': 'The root spans which represent the starting point of a trace',
-  },
-  {
-    label: TRACE_TABLE_TITLES.service_entry_spans,
-    key: 'service_entry_spans',
-    'aria-describedby': 'The spans that mark start of server-side processing (SPAN_KIND_SERVER)',
-  },
-  {
-    label: TRACE_TABLE_TITLES.traces,
-    key: 'traces',
-    'aria-describedby': 'Aggregates all spans by traceId to show all traces',
-  },
-];
+const getDescription = (key: keyof typeof TRACE_TABLE_TITLES): string => {
+  const descriptions: Record<keyof typeof TRACE_TABLE_TITLES, string> = {
+    all_spans: 'Spans representing all activities in all traces across the system',
+    root_spans: 'Spans marking the root or starting point of each trace',
+    entry_spans: 'Spans that indicate the entry point of service-side processing',
+    traces: 'Spans grouped by traceId to show a complete trace lifecycle',
+  };
+  return descriptions[key];
+};
+
+export const TRACE_TABLE_OPTIONS = Object.entries(TRACE_TABLE_TITLES).map(([key, label]) => ({
+  label,
+  key,
+  'aria-describedby': getDescription(key as keyof typeof TRACE_TABLE_TITLES),
+}));
 
 export const TRACE_TABLE_TYPE_KEY = 'TraceAnalyticsTraceTableType';

--- a/common/constants/trace_analytics.ts
+++ b/common/constants/trace_analytics.ts
@@ -24,3 +24,35 @@ export const TRACE_ANALYTICS_DSL_ROUTE = '/api/observability/trace_analytics/que
 
 export const TRACE_CUSTOM_SPAN_INDEX_SETTING = 'observability:traceAnalyticsSpanIndices';
 export const TRACE_CUSTOM_SERVICE_INDEX_SETTING = 'observability:traceAnalyticsServiceIndices';
+
+export enum TRACE_TABLE_TITLES {
+  all_spans = 'Spans',
+  trace_root_spans = 'Trace root spans',
+  service_entry_spans = 'Service entry spans',
+  traces = 'Traces',
+}
+
+export const TRACE_TABLE_OPTIONS = [
+  {
+    label: TRACE_TABLE_TITLES.all_spans,
+    key: 'all_spans',
+    'aria-describedby': 'All spans from all traces',
+  },
+  {
+    label: TRACE_TABLE_TITLES.trace_root_spans,
+    key: 'trace_root_spans',
+    'aria-describedby': 'The root spans which represent the starting point of a trace',
+  },
+  {
+    label: TRACE_TABLE_TITLES.service_entry_spans,
+    key: 'service_entry_spans',
+    'aria-describedby': 'The spans that mark start of server-side processing (SPAN_KIND_SERVER)',
+  },
+  {
+    label: TRACE_TABLE_TITLES.traces,
+    key: 'traces',
+    'aria-describedby': 'Aggregates all spans by traceId to show all traces',
+  },
+];
+
+export const TRACE_TABLE_TYPE_KEY = 'TraceAnalyticsTraceTableType';

--- a/common/types/trace_analytics.ts
+++ b/common/types/trace_analytics.ts
@@ -54,3 +54,4 @@ export interface GraphVisEdge {
 }
 
 export type TraceAnalyticsMode = 'jaeger' | 'data_prepper' | 'custom_data_prepper';
+export type TraceQueryMode = 'trace_root_spans' | 'all_spans' | 'traces' | 'service_entry_spans';

--- a/common/types/trace_analytics.ts
+++ b/common/types/trace_analytics.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { TRACE_TABLE_TITLES } from '../constants/trace_analytics';
+
 export type SpanField =
   | 'SPAN_ID'
   | 'PARENT_SPAN_ID'
@@ -54,4 +56,4 @@ export interface GraphVisEdge {
 }
 
 export type TraceAnalyticsMode = 'jaeger' | 'data_prepper' | 'custom_data_prepper';
-export type TraceQueryMode = 'trace_root_spans' | 'all_spans' | 'traces' | 'service_entry_spans';
+export type TraceQueryMode = keyof typeof TRACE_TABLE_TITLES;

--- a/public/components/application_analytics/components/application.tsx
+++ b/public/components/application_analytics/components/application.tsx
@@ -326,6 +326,9 @@ export function Application(props: AppDetailProps) {
           setStartTime={setStartTimeForApp}
           setEndTime={setEndTimeForApp}
           dataSourceMDSId={[{ id: '', label: '' }]}
+          setCurrentSelectedService={() => {}}
+          tracesTableMode="traces"
+          setTracesTableMode={() => {}}
         />
         <EuiPanel>
           <PanelTitle title="Spans" totalItems={totalSpans} />

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -907,10 +907,10 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                     </EuiFlexGroup>
                   </EuiSearchBar>
                   <EuiSpacer
-                    size="l"
+                    size="m"
                   >
                     <div
-                      className="euiSpacer euiSpacer--l"
+                      className="euiSpacer euiSpacer--m"
                     />
                   </EuiSpacer>
                   <EuiBasicTable

--- a/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
+++ b/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
@@ -13,7 +13,7 @@ import {
   EuiText,
   EuiToolTip,
 } from '@elastic/eui';
-import { round, truncate } from 'lodash';
+import { round } from 'lodash';
 import moment from 'moment';
 import React from 'react';
 import { TRACE_ANALYTICS_DATE_FORMAT } from '../../../../../common/constants/trace_analytics';
@@ -40,8 +40,8 @@ export const fetchDynamicColumns = (columnItems: string[]) => {
         item ? (
           <EuiText>
             <EuiToolTip content={item}>
-              <EuiText size="s">
-                {item.length < 36 ? item : <div title={item}>{truncate(item, { length: 36 })}</div>}
+              <EuiText size="s" className="attributes-column" title={item}>
+                {item}
               </EuiText>
             </EuiToolTip>
           </EuiText>
@@ -64,8 +64,8 @@ export const getTableColumns = (
     item ? (
       <EuiText>
         <EuiToolTip content={item}>
-          <EuiText size="s">
-            {item.length < 36 ? item : <div title={item}>{truncate(item, { length: 36 })}</div>}
+          <EuiText size="s" className="traces-table traces-table-trace-id" title={item}>
+            {item}
           </EuiText>
         </EuiToolTip>
       </EuiText>
@@ -166,6 +166,7 @@ export const getTableColumns = (
         align: 'right',
         sortable: true,
         render: renderDateField,
+        className: 'span-group-column',
       },
       ...(showAttributes ? fetchDynamicColumns(columnItems) : []),
     ] as Array<EuiTableFieldDataColumnType<any>>;
@@ -209,7 +210,13 @@ export const getTableColumns = (
         sortable: true,
         render: renderErrorsField,
       },
-      { field: 'last_updated', name: 'Last updated', align: 'left', sortable: true },
+      {
+        field: 'last_updated',
+        name: 'Last updated',
+        align: 'left',
+        sortable: true,
+        className: 'span-group-column',
+      },
     ] as Array<EuiTableFieldDataColumnType<any>>;
   }
 
@@ -230,6 +237,12 @@ export const getTableColumns = (
       sortable: true,
       render: renderErrorsField,
     },
-    { field: 'last_updated', name: 'Last updated', align: 'left', sortable: true },
+    {
+      field: 'last_updated',
+      name: 'Last updated',
+      align: 'left',
+      sortable: true,
+      className: 'span-group-column',
+    },
   ] as Array<EuiTableFieldDataColumnType<any>>;
 };

--- a/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
+++ b/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
@@ -1,0 +1,235 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButtonIcon,
+  EuiCopy,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiTableFieldDataColumnType,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
+import { round, truncate } from 'lodash';
+import moment from 'moment';
+import React from 'react';
+import { TRACE_ANALYTICS_DATE_FORMAT } from '../../../../../common/constants/trace_analytics';
+import { TraceAnalyticsMode, TraceQueryMode } from '../../../../../common/types/trace_analytics';
+import { nanoToMilliSec } from '../common/helper_functions';
+
+export const fetchDynamicColumns = (columnItems: string[]) => {
+  return columnItems
+    .filter((col) => col.includes('attributes') || col.includes('instrumentation'))
+    .map((col) => ({
+      className: 'attributes-column',
+      field: col,
+      name: (
+        <EuiText className="euiTableCellContent">
+          <EuiToolTip content={col}>
+            <p className="euiTableCellContent__text attributes-column-header">{col}</p>
+          </EuiToolTip>
+        </EuiText>
+      ),
+      align: 'right',
+      sortable: true,
+      truncateText: true,
+      render: (item) =>
+        item ? (
+          <EuiText>
+            <EuiToolTip content={item}>
+              <EuiText size="s">
+                {item.length < 36 ? item : <div title={item}>{truncate(item, { length: 36 })}</div>}
+              </EuiText>
+            </EuiToolTip>
+          </EuiText>
+        ) : (
+          '-'
+        ),
+    }));
+};
+
+export const getTableColumns = (
+  showAttributes: boolean,
+  columnItems: string[],
+  mode: TraceAnalyticsMode,
+  tracesTableMode: TraceQueryMode,
+  getTraceViewUri?: (traceId: string) => string,
+  openTraceFlyout?: (traceId: string) => void
+): Array<EuiTableFieldDataColumnType<any>> => {
+  // Helper functions for rendering table fields
+  const renderIdField = (item: string) =>
+    item ? (
+      <EuiText>
+        <EuiToolTip content={item}>
+          <EuiText size="s">
+            {item.length < 36 ? item : <div title={item}>{truncate(item, { length: 36 })}</div>}
+          </EuiText>
+        </EuiToolTip>
+      </EuiText>
+    ) : (
+      '-'
+    );
+
+  const renderTraceLinkField = (item: string) => (
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiLink
+          data-test-subj="trace-link"
+          {...(getTraceViewUri && { href: getTraceViewUri(item) })}
+          {...(openTraceFlyout && { onClick: () => openTraceFlyout(item) })}
+        >
+          <EuiText size="s" className="traces-table traces-table-trace-id" title={item}>
+            {item}
+          </EuiText>
+        </EuiLink>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiCopy textToCopy={item}>
+          {(copy) => (
+            <EuiButtonIcon aria-label="Copy trace id" iconType="copyClipboard" onClick={copy} />
+          )}
+        </EuiCopy>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+
+  const renderErrorsField = (item: number) =>
+    item == null ? (
+      '-'
+    ) : +item > 0 ? (
+      <EuiText color="danger" size="s">
+        Yes
+      </EuiText>
+    ) : (
+      'No'
+    );
+
+  const renderDurationField = (item: number) =>
+    item ? <EuiText size="s">{round(nanoToMilliSec(Math.max(0, item)), 2)}</EuiText> : '-';
+
+  const renderDateField = (item: number) =>
+    item === 0 || item ? moment(item).format(TRACE_ANALYTICS_DATE_FORMAT) : '-';
+
+  // Columns for custom_data_prepper mode
+  if (mode === 'custom_data_prepper' && tracesTableMode !== 'traces') {
+    return [
+      {
+        field: 'spanId',
+        name: 'Span Id',
+        align: 'left',
+        sortable: true,
+        render: renderIdField,
+        className: 'span-group-column',
+      },
+      {
+        field: 'traceId',
+        name: 'Trace Id',
+        align: 'left',
+        sortable: true,
+        render: renderTraceLinkField,
+      },
+      {
+        field: 'parentSpanId',
+        name: 'Parent Span Id',
+        align: 'left',
+        sortable: true,
+        render: renderIdField,
+        className: 'span-group-column',
+      },
+      {
+        field: 'traceGroup',
+        name: 'Trace group',
+        align: 'left',
+        sortable: true,
+        truncateText: true,
+      },
+      {
+        field: 'durationInNanos',
+        name: 'Duration (ms)',
+        align: 'right',
+        sortable: true,
+        render: renderDurationField,
+      },
+      {
+        field: 'status.code',
+        name: 'Errors',
+        align: 'right',
+        sortable: true,
+        render: renderErrorsField,
+      },
+      {
+        field: 'endTime',
+        name: 'Last updated',
+        align: 'right',
+        sortable: true,
+        render: renderDateField,
+      },
+      ...(showAttributes ? fetchDynamicColumns(columnItems) : []),
+    ] as Array<EuiTableFieldDataColumnType<any>>;
+  }
+
+  // Columns for non-jaeger traces mode
+  if (mode !== 'jaeger' && tracesTableMode === 'traces') {
+    return [
+      {
+        field: 'trace_id',
+        name: 'Trace ID',
+        align: 'left',
+        sortable: true,
+        render: renderTraceLinkField,
+      },
+      {
+        field: 'trace_group',
+        name: 'Trace group',
+        align: 'left',
+        sortable: true,
+        truncateText: true,
+      },
+      {
+        field: 'latency',
+        name: 'Duration (ms)',
+        align: 'right',
+        sortable: true,
+        truncateText: true,
+      },
+      {
+        field: 'percentile_in_trace_group',
+        name: 'Percentile in trace group',
+        align: 'right',
+        sortable: true,
+        render: (item) => (item ? `${round(item, 2)}th` : '-'),
+      },
+      {
+        field: 'error_count',
+        name: 'Errors',
+        align: 'right',
+        sortable: true,
+        render: renderErrorsField,
+      },
+      { field: 'last_updated', name: 'Last updated', align: 'left', sortable: true },
+    ] as Array<EuiTableFieldDataColumnType<any>>;
+  }
+
+  // Default columns for other modes
+  return [
+    {
+      field: 'trace_id',
+      name: 'Trace ID',
+      align: 'left',
+      sortable: true,
+      render: renderTraceLinkField,
+    },
+    { field: 'latency', name: 'Latency (ms)', align: 'right', sortable: true },
+    {
+      field: 'error_count',
+      name: 'Errors',
+      align: 'right',
+      sortable: true,
+      render: renderErrorsField,
+    },
+    { field: 'last_updated', name: 'Last updated', align: 'left', sortable: true },
+  ] as Array<EuiTableFieldDataColumnType<any>>;
+};

--- a/public/components/trace_analytics/components/traces/traces.tsx
+++ b/public/components/trace_analytics/components/traces/traces.tsx
@@ -7,6 +7,7 @@ import { EuiBreadcrumb } from '@elastic/eui';
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import React from 'react';
 import { DataSourceOption } from '../../../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
+import { TraceQueryMode } from '../../../../../common/types/trace_analytics';
 import { TraceAnalyticsComponentDeps } from '../../home';
 import { TracesContent } from './traces_content';
 
@@ -18,6 +19,8 @@ export interface TracesProps extends TraceAnalyticsComponentDeps {
   openTraceFlyout?: (traceId: string) => void;
   toasts: Toast[];
   dataSourceMDSId: DataSourceOption[];
+  tracesTableMode: TraceQueryMode;
+  setTracesTableMode: React.Dispatch<React.SetStateAction<TraceQueryMode>>;
 }
 
 export function Traces(props: TracesProps) {

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -4,6 +4,7 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
+import datemath from '@elastic/datemath';
 import {
   EuiAccordion,
   EuiFlexGroup,
@@ -154,6 +155,7 @@ export function TracesContent(props: TracesProps) {
       processTimeStamp(endTime, mode),
       page
     );
+    const isUnderOneHour = datemath.parse(endTime)?.diff(datemath.parse(startTime), 'hours')! < 1;
 
     if (mode === 'custom_data_prepper') {
       // service map should not be filtered by service name
@@ -172,7 +174,8 @@ export function TracesContent(props: TracesProps) {
           mode,
           props.dataSourceMDSId[0].id,
           sort,
-          tracesTableMode
+          tracesTableMode,
+          isUnderOneHour
         );
       else {
         await handleTracesRequest(
@@ -183,7 +186,8 @@ export function TracesContent(props: TracesProps) {
           setTableItems,
           mode,
           props.dataSourceMDSId[0].id,
-          sort
+          sort,
+          isUnderOneHour
         );
       }
       await handleServiceMapRequest(
@@ -204,7 +208,8 @@ export function TracesContent(props: TracesProps) {
         setTableItems,
         mode,
         props.dataSourceMDSId[0].id,
-        sort
+        sort,
+        isUnderOneHour
       );
     }
 

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -16,8 +16,6 @@ import {
 } from '@elastic/eui';
 import cloneDeep from 'lodash/cloneDeep';
 import React, { useEffect, useState } from 'react';
-import { TRACE_TABLE_TYPE_KEY } from '../../../../../common/constants/trace_analytics';
-import { TraceQueryMode } from '../../../../../common/types/trace_analytics';
 import { coreRefs } from '../../../../framework/core_refs';
 import { handleServiceMapRequest } from '../../requests/services_request_handler';
 import {
@@ -58,6 +56,8 @@ export function TracesContent(props: TracesProps) {
     jaegerIndicesExist,
     attributesFilterFields,
     setCurrentSelectedService,
+    tracesTableMode,
+    setTracesTableMode,
   } = props;
   const [tableItems, setTableItems] = useState([]);
   const [columns, setColumns] = useState([]);
@@ -70,9 +70,6 @@ export function TracesContent(props: TracesProps) {
     'latency' | 'error_rate' | 'throughput'
   >('');
   const [includeMetrics, setIncludeMetrics] = useState(false);
-  const [tracesTableMode, setTracesTableMode] = useState<TraceQueryMode>(
-    (sessionStorage.getItem(TRACE_TABLE_TYPE_KEY) as TraceQueryMode) || 'all_spans'
-  );
   const isNavGroupEnabled = coreRefs?.chrome?.navGroup.getNavGroupEnabled();
 
   useEffect(() => {

--- a/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
@@ -101,7 +101,7 @@ export function TracesCustomIndicesTable(props: TracesLandingTableProps) {
                 'data-test-subj': 'traceTableMode',
               }}
               renderOption={renderTableOptions}
-              listProps={{ rowHeight: 75 }}
+              listProps={{ rowHeight: 80 }}
               options={tableOptions}
               onChange={(newOptions) => {
                 setTableOptions(newOptions);

--- a/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
@@ -53,7 +53,7 @@ export function TracesCustomIndicesTable(props: TracesLandingTableProps) {
   const { columnItems, items, refresh, mode, loading, getTraceViewUri, openTraceFlyout } = props;
   const [showAttributes, setShowAttributes] = useState(false);
   const [isTitlePopoverOpen, setIsTitlePopoverOpen] = useState(false);
-  const [tableOptions, setTableOptions] = useState<EuiSelectableOption[]>(
+  const [tableOptions, setTableOptions] = useState<EuiSelectableOption[]>(() =>
     TRACE_TABLE_OPTIONS.map((obj) =>
       obj.key === props.tracesTableMode ? { ...obj, checked: 'on' } : obj
     )

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -5,7 +5,7 @@
 
 import { EuiGlobalToastList } from '@elastic/eui';
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
-import React, { ReactChild, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { HashRouter, Redirect, Route, RouteComponentProps } from 'react-router-dom';
 import {
   ChromeBreadcrumb,
@@ -19,7 +19,8 @@ import {
   DataSourceManagementPluginSetup,
   DataSourceSelectableConfig,
 } from '../../../../../src/plugins/data_source_management/public';
-import { TraceAnalyticsMode } from '../../../common/types/trace_analytics';
+import { TRACE_TABLE_TYPE_KEY } from '../../../common/constants/trace_analytics';
+import { TraceAnalyticsMode, TraceQueryMode } from '../../../common/types/trace_analytics';
 import { dataSourceFilterFn } from '../../../common/utils/shared';
 import { coreRefs } from '../../framework/core_refs';
 import { FilterType } from './components/common/filters/filters';
@@ -111,11 +112,9 @@ export const Home = (props: HomeProps) => {
   };
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const _setToast = (title: string, color = 'success', text?: ReactChild, _side?: string) => {
-    if (!text) text = '';
-    setToasts([...toasts, { id: new Date().toISOString(), title, text, color } as Toast]);
-  };
-
+  const [tracesTableMode, setTracesTableMode] = useState<TraceQueryMode>(
+    (sessionStorage.getItem(TRACE_TABLE_TYPE_KEY) as TraceQueryMode) || 'all_spans'
+  );
   const [dataSourceMDSId, setDataSourceMDSId] = useState([{ id: '', label: '' }]);
   const [currentSelectedService, setCurrentSelectedService] = useState('');
 
@@ -230,7 +229,11 @@ export const Home = (props: HomeProps) => {
     },
   ];
 
-  const traceColumnAction = () => location.assign('#/traces');
+  const traceColumnAction = () => {
+    location.assign('#/traces');
+    setTracesTableMode('traces');
+    sessionStorage.setItem(TRACE_TABLE_TYPE_KEY, 'traces');
+  };
 
   const getTraceViewUri = (traceId: string) => `#/traces/${encodeURIComponent(traceId)}`;
 
@@ -329,6 +332,8 @@ export const Home = (props: HomeProps) => {
                   setCurrentSelectedService={setCurrentSelectedService}
                   toasts={toasts}
                   dataSourceMDSId={dataSourceMDSId}
+                  tracesTableMode={tracesTableMode}
+                  setTracesTableMode={setTracesTableMode}
                   {...commonProps}
                 />
               </TraceSideBar>
@@ -343,6 +348,8 @@ export const Home = (props: HomeProps) => {
                   setCurrentSelectedService={setCurrentSelectedService}
                   toasts={toasts}
                   dataSourceMDSId={dataSourceMDSId}
+                  tracesTableMode={tracesTableMode}
+                  setTracesTableMode={setTracesTableMode}
                   {...commonProps}
                 />
               </>

--- a/public/components/trace_analytics/index.scss
+++ b/public/components/trace_analytics/index.scss
@@ -97,6 +97,10 @@ th[data-test-subj^='tableHeaderCell_dashboard_latency_variance'] {
 .attributes-column-header,
 .attributes-column {
   max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-left: 8px;
 }
 
 .trace-group-column {

--- a/public/components/trace_analytics/index.scss
+++ b/public/components/trace_analytics/index.scss
@@ -103,6 +103,18 @@ th[data-test-subj^='tableHeaderCell_dashboard_latency_variance'] {
   min-width: 200px;
 }
 
+.span-group-column {
+  min-width: 150px;
+}
+
 .attributes-column-header {
   display: table-cell;
+}
+
+.tableModePopover {
+  width: 300px;
+}
+
+.popOverSelectableItem {
+  white-space: initial !important;
 }

--- a/public/components/trace_analytics/requests/queries/traces_queries.ts
+++ b/public/components/trace_analytics/requests/queries/traces_queries.ts
@@ -571,13 +571,13 @@ export const getCustomIndicesTracesQuery = (
     track_total_hits: false,
   };
 
-  if (queryMode === 'trace_root_spans') {
+  if (queryMode === 'root_spans') {
     dataPrepperQuery.query.bool.filter.push({
       term: {
         parentSpanId: '', // Data prepper root span doesn't have any parent.
       },
     });
-  } else if (queryMode === 'service_entry_spans') {
+  } else if (queryMode === 'entry_spans') {
     dataPrepperQuery.query.bool.filter.push({
       term: {
         kind: 'SPAN_KIND_SERVER',

--- a/public/components/trace_analytics/requests/queries/traces_queries.ts
+++ b/public/components/trace_analytics/requests/queries/traces_queries.ts
@@ -50,7 +50,8 @@ export const getTraceGroupPercentilesQuery = () => {
 export const getTracesQuery = (
   mode: TraceAnalyticsMode,
   traceId: string = '',
-  sort?: PropertySort
+  sort?: PropertySort,
+  isUnderOneHour?: boolean
 ) => {
   const field = sort?.field || '_key';
   const direction = sort?.direction || 'asc';
@@ -72,7 +73,7 @@ export const getTracesQuery = (
           order: {
             [field]: direction,
           },
-          execution_hint: 'map',
+          ...(isUnderOneHour && { execution_hint: 'map' }),
         },
         aggs: {
           latency: {
@@ -139,7 +140,7 @@ export const getTracesQuery = (
           order: {
             [field]: direction,
           },
-          execution_hint: 'map',
+          ...(isUnderOneHour && { execution_hint: 'map' }),
         },
         aggs: {
           latency: {
@@ -472,7 +473,8 @@ export const getCustomIndicesTracesQuery = (
   mode: TraceAnalyticsMode,
   traceId: string = '',
   sort?: PropertySort,
-  queryMode?: TraceQueryMode
+  queryMode?: TraceQueryMode,
+  isUnderOneHour?: boolean
 ) => {
   const jaegerQuery: any = {
     size: 0,
@@ -492,7 +494,7 @@ export const getCustomIndicesTracesQuery = (
           order: {
             [sort?.field || '_key']: sort?.direction || 'asc',
           },
-          execution_hint: 'map',
+          ...(isUnderOneHour && { execution_hint: 'map' }),
         },
         aggs: {
           latency: {

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -13,7 +13,7 @@ import { v1 as uuid } from 'uuid';
 import { HttpSetup } from '../../../../../../src/core/public';
 import { BarOrientation } from '../../../../common/constants/shared';
 import { TRACE_ANALYTICS_DATE_FORMAT } from '../../../../common/constants/trace_analytics';
-import { TraceAnalyticsMode } from '../../../../common/types/trace_analytics';
+import { TraceAnalyticsMode, TraceQueryMode } from '../../../../common/types/trace_analytics';
 import { microToMilliSec, nanoToMilliSec } from '../components/common/helper_functions';
 import { SpanSearchParams } from '../components/traces/span_detail_table';
 import {
@@ -36,12 +36,13 @@ export const handleCustomIndicesTracesRequest = async (
   setColumns: (items: any) => void,
   mode: TraceAnalyticsMode,
   dataSourceMDSId?: string,
-  sort?: PropertySort
+  sort?: PropertySort,
+  queryMode?: TraceQueryMode
 ) => {
   const responsePromise = handleDslRequest(
     http,
     DSL,
-    getCustomIndicesTracesQuery(mode, undefined, sort),
+    getCustomIndicesTracesQuery(mode, undefined, sort, queryMode),
     mode,
     dataSourceMDSId
   );

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -37,12 +37,13 @@ export const handleCustomIndicesTracesRequest = async (
   mode: TraceAnalyticsMode,
   dataSourceMDSId?: string,
   sort?: PropertySort,
-  queryMode?: TraceQueryMode
+  queryMode?: TraceQueryMode,
+  isUnderOneHour?: boolean
 ) => {
   const responsePromise = handleDslRequest(
     http,
     DSL,
-    getCustomIndicesTracesQuery(mode, undefined, sort, queryMode),
+    getCustomIndicesTracesQuery(mode, undefined, sort, queryMode, isUnderOneHour),
     mode,
     dataSourceMDSId
   );
@@ -90,7 +91,8 @@ export const handleTracesRequest = async (
   setItems: (items: any) => void,
   mode: TraceAnalyticsMode,
   dataSourceMDSId?: string,
-  sort?: PropertySort
+  sort?: PropertySort,
+  isUnderOneHour?: boolean
 ) => {
   const binarySearch = (arr: number[], target: number) => {
     if (!arr) return Number.NaN;
@@ -108,7 +110,7 @@ export const handleTracesRequest = async (
   const responsePromise = handleDslRequest(
     http,
     DSL,
-    getTracesQuery(mode, undefined, sort),
+    getTracesQuery(mode, undefined, sort, isUnderOneHour),
     mode,
     dataSourceMDSId
   );


### PR DESCRIPTION
### Description

* The issue with original custom source table was that it says traces on top but shows data only from trace root spans. This is a problem cause it breaks users expectation of filtering traces across various fields like services and resource attributes. 

Sorting and Pagination push down won’t be part of this PR. 

Update custom traces table with filters added below:

* All Spans - All spans from all traces
* Traces - Aggregates all spans by traceId to show all traces
* Service Entry Spans - The spans that mark start of server-side processing (SPAN_KIND_SERVER)
* Trace Root Spans - The root spans which represent the starting point of a trace

Functional updates: 
* The trace table in custom source defaults to all spans
* The trace table mode is stored in session storage, to persist across tab refreshes and page changes

### Issues Resolved

* Default table view 
![Screenshot 2024-09-20 at 9 26 28 AM](https://github.com/user-attachments/assets/f1ffd944-5baf-48b4-bcfc-51440a8e63f2)

* Table filter options 
![Screenshot 2024-09-20 at 9 26 38 AM](https://github.com/user-attachments/assets/3ed878b3-6250-4f88-b09f-058b1277a947)

* Table showing trace root spans
![Screenshot 2024-09-20 at 9 26 50 AM](https://github.com/user-attachments/assets/9f5ed60e-376d-4f2d-823e-0600488be57d)

* Table showing attributes
![Screenshot 2024-09-20 at 9 27 00 AM](https://github.com/user-attachments/assets/165085c1-341f-4b53-93d5-729096ff2d0c)

Demo Video

https://github.com/user-attachments/assets/6cc5060e-14a6-4ab6-9a2c-b31c16b86bd3



### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
