### PR TITLE
Add compile step before Cypress runs in CI

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -39,6 +39,23 @@ jobs:
         with:
           path: OpenSearch-Dashboards/plugins/dashboards-observability
 
+      - name: Get yarn cache dir
+        id: setup-yarn
+        shell: bash
+        run: |
+          cd ./OpenSearch-Dashboards
+          source $NVM_DIR/nvm.sh
+          nvm use
+          echo "yarn-cache-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Yarn Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.setup-yarn.outputs.yarn-cache-dir }}
+          key: ${{ runner.OS }}-yarn-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-yarn-
+
       - name: Plugin Bootstrap
         uses: nick-fields/retry@v2
         with:
@@ -117,6 +134,20 @@ jobs:
 
       - run: node -v
       - run: yarn -v
+
+      - name: Get yarn cache dir
+        id: setup-yarn
+        shell: bash
+        run: |
+          echo "yarn-cache-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - name: Yarn Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.setup-yarn.outputs.yarn-cache-dir }}
+          key: ${{ runner.OS }}-yarn-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-yarn-
 
       - name: Checkout Dashboards Observability
         uses: actions/checkout@v2

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -114,10 +114,15 @@ jobs:
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
 
-      - name: Bootstrap the plugin
+      - name: Bootstrap OpenSearch Dashboards
         run: |
-          cd OpenSearch-Dashboards/plugins/dashboards-observability
+          cd OpenSearch-Dashboards
           yarn osd bootstrap --single-version=loose
+
+      - name: Compile OpenSearch Dashboards
+        run: |
+          cd OpenSearch-Dashboards
+          node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10
 
       - name: Run OpenSearch Dashboards server
         run: |
@@ -128,10 +133,10 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           cd ./OpenSearch-Dashboards
-          if timeout 600 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
-            echo "OpenSearch Dashboards compiled successfully."
+          if timeout 60 grep -q "[OpenSearchDashboards][http] http server running at" <(tail -n0 -f dashboard.log); then
+            echo "OpenSearch Dashboards started successfully."
           else
-            echo "Timeout for 600 seconds reached. OpenSearch Dashboards did not finish compiling."
+            echo "Timeout of 60 seconds reached. OpenSearch Dashboards did not start successfully."
             exit 1
           fi
 

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -122,6 +122,18 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-node-
 
+      - name: Restore target caches
+        id: cache-target-folders-restore
+        shell: bash
+        run: |
+          echo "Restoring target folder caches..."
+          target_folders=("./OpenSearch-Dashboards/packages/*/target" "./OpenSearch-Dashboards/src/plugins/*/target" "./OpenSearch-Dashboards/src/core/target" "./plugins/dashboards-observability/target")
+          for target_folder in "${target_folders[@]}"; do
+            target_name = $(echo "$target_folder" | sed 's/\/target//g')
+            cache_key="${{ runner.OS }}-$target_name-${{ hashFiles("$target_folder/**/*", "!$target_folder/target/**") }}
+            restored_cache=$(actions/cache/restore@v4 -p "$target_folder/target" -k "$cache_key" -r "${{ runner.OS }}-$target_name-")
+          done
+
       - name: Bootstrap OpenSearch Dashboards
         run: |
           cd OpenSearch-Dashboards
@@ -130,7 +142,19 @@ jobs:
       - name: Compile OpenSearch Dashboards
         run: |
           cd OpenSearch-Dashboards
-          node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10
+          node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10 --verbose
+
+      - name: Save target caches
+        id: cache-target-folders-save
+        shell: bash
+        run: |
+          echo "Saving target folder caches..."
+          target_folders=("./OpenSearch-Dashboards/packages/*/target" "./OpenSearch-Dashboards/src/plugins/*/target" "./OpenSearch-Dashboards/src/core/target" "./plugins/dashboards-observability/target")
+          for target_folder in "${target_folders[@]}"; do
+            target_name = $(echo "$target_folder" | sed 's/\/target//g')
+            cache_key="${{ runner.OS }}-$target_name-${{ hashFiles("$target_folder/**/*", "!$target_folder/target/**") }}
+            actions/cache/save@v4 -p "$target_folder/target" -k "$cache_key" -r "${{ runner.OS }}-$target_name-"
+          done
 
       - name: Run OpenSearch Dashboards server
         run: |

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -127,18 +127,7 @@ jobs:
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          nohup yarn start --no-base-path --no-watch | tee dashboard.log &
-
-      - name: Check If OpenSearch Dashboards Is Ready
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          cd ./OpenSearch-Dashboards
-          if timeout 60 grep -q "[OpenSearchDashboards][http] http server running at" <(tail -n0 -f dashboard.log); then
-            echo "OpenSearch Dashboards started successfully."
-          else
-            echo "Timeout of 60 seconds reached. OpenSearch Dashboards did not start successfully."
-            exit 1
-          fi
+          nohup yarn start --no-base-path --no-watch &
 
       - name: Checkout Dashboards Functioanl Test Repo
         uses: actions/checkout@v2

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -114,6 +114,14 @@ jobs:
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
 
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: OpenSearch-Dashboards/**/node_modules
+          key: ${{ runner.OS }}-node-${{ hashFiles('OpenSearch-Dashboards/**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+
       - name: Bootstrap OpenSearch Dashboards
         run: |
           cd OpenSearch-Dashboards
@@ -127,7 +135,18 @@ jobs:
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          nohup yarn start --no-base-path --no-watch &
+          nohup yarn start --no-base-path --no-watch | tee dashboard.log &
+
+      - name: Check If OpenSearch Dashboards Is Ready
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          cd ./OpenSearch-Dashboards
+          if timeout 60 grep -q "http server running" <(tail -n +1 -f dashboard.log); then
+            echo "OpenSearch Dashboards started successfully."
+          else
+            echo "Timeout of 60 seconds reached. OpenSearch Dashboards did not start successfully."
+            exit 1
+          fi&
 
       - name: Checkout Dashboards Functioanl Test Repo
         uses: actions/checkout@v2

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -109,30 +109,20 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install correct yarn version for OpenSearch Dashboards
+        id: setup-yarn
         run: |
           npm uninstall -g yarn
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
+          echo "yarn-cache-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - name: Cache node modules
+      - name: Yarn Cache
         uses: actions/cache@v4
         with:
-          path: OpenSearch-Dashboards/**/node_modules
-          key: ${{ runner.OS }}-node-${{ hashFiles('OpenSearch-Dashboards/**/package-lock.json') }}
+          path: ${{ steps.setup-yarn.outputs.yarn-cache-dir }}
+          key: ${{ runner.OS }}-yarn-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-node-
-
-      - name: Restore target caches
-        id: cache-target-folders-restore
-        shell: bash
-        run: |
-          echo "Restoring target folder caches..."
-          target_folders=("./OpenSearch-Dashboards/packages/*/target" "./OpenSearch-Dashboards/src/plugins/*/target" "./OpenSearch-Dashboards/src/core/target" "./plugins/dashboards-observability/target")
-          for target_folder in "${target_folders[@]}"; do
-            target_name = $(echo "$target_folder" | sed 's/\/target//g')
-            cache_key="${{ runner.OS }}-$target_name-${{ hashFiles("$target_folder/**/*", "!$target_folder/target/**") }}
-            restored_cache=$(actions/cache/restore@v4 -p "$target_folder/target" -k "$cache_key" -r "${{ runner.OS }}-$target_name-")
-          done
+            ${{ runner.OS }}-yarn-
 
       - name: Bootstrap OpenSearch Dashboards
         run: |

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -134,18 +134,6 @@ jobs:
           cd OpenSearch-Dashboards
           node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10 --verbose
 
-      - name: Save target caches
-        id: cache-target-folders-save
-        shell: bash
-        run: |
-          echo "Saving target folder caches..."
-          target_folders=("./OpenSearch-Dashboards/packages/*/target" "./OpenSearch-Dashboards/src/plugins/*/target" "./OpenSearch-Dashboards/src/core/target" "./plugins/dashboards-observability/target")
-          for target_folder in "${target_folders[@]}"; do
-            target_name = $(echo "$target_folder" | sed 's/\/target//g')
-            cache_key="${{ runner.OS }}-$target_name-${{ hashFiles("$target_folder/**/*", "!$target_folder/target/**") }}
-            actions/cache/save@v4 -p "$target_folder/target" -k "$cache_key" -r "${{ runner.OS }}-$target_name-"
-          done
-
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -149,18 +149,7 @@ jobs:
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          nohup yarn start --no-base-path --no-watch | tee dashboard.log &
-
-      - name: Check If OpenSearch Dashboards Is Ready
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          cd ./OpenSearch-Dashboards
-          if timeout 60 grep -q "[OpenSearchDashboards][http] http server running at" <(tail -n0 -f dashboard.log); then
-            echo "OpenSearch Dashboards started successfully."
-          else
-            echo "Timeout of 60 seconds reached. OpenSearch Dashboards did not start successfully."
-            exit 1
-          fi
+          nohup yarn start --no-base-path --no-watch &
 
       - name: Install Cypress
         run: |

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: OpenSearch-Dashboards/**/node_modules
-          key: ${{ runner.OS }}-node-${{ hashFiles('OpenSearch-Dashboards/**/package-lock.json') }}
+          key: ${{ runner.OS }}-node-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
           restore-keys: |
             ${{ runner.OS }}-node-
 

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -136,10 +136,15 @@ jobs:
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
 
-      - name: Bootstrap the plugin
+      - name: Bootstrap OpenSearch Dashboards
         run: |
-          cd OpenSearch-Dashboards/plugins/dashboards-observability
+          cd OpenSearch-Dashboards
           yarn osd bootstrap --single-version=loose
+
+      - name: Compile OpenSearch Dashboards
+        run: |
+          cd OpenSearch-Dashboards
+          node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10
 
       - name: Run OpenSearch Dashboards server
         run: |
@@ -150,10 +155,10 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           cd ./OpenSearch-Dashboards
-          if timeout 600 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
-            echo "OpenSearch Dashboards compiled successfully."
+          if timeout 60 grep -q "[OpenSearchDashboards][http] http server running at" <(tail -n0 -f dashboard.log); then
+            echo "OpenSearch Dashboards started successfully."
           else
-            echo "Timeout for 600 seconds reached. OpenSearch Dashboards did not finish compiling."
+            echo "Timeout of 60 seconds reached. OpenSearch Dashboards did not start successfully."
             exit 1
           fi
 

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -131,30 +131,20 @@ jobs:
         working-directory: OpenSearch-Dashboards
 
       - name: Install correct yarn version for OpenSearch Dashboards
+        id: setup-yarn
         run: |
           npm uninstall -g yarn
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
+          echo "yarn-cache-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - name: Cache node modules
+      - name: Yarn Cache
         uses: actions/cache@v4
         with:
-          path: OpenSearch-Dashboards/**/node_modules
-          key: ${{ runner.OS }}-node-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
+          path: ${{ steps.setup-yarn.outputs.yarn-cache-dir }}
+          key: ${{ runner.OS }}-yarn-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-node-
-
-      - name: Restore core-targets caches
-        id: cache-target-folders
-        shell: bash
-        run: |
-          echo "Restoring target folder caches..."
-          target_folders=("./OpenSearch-Dashboards/packages/*/target" "./OpenSearch-Dashboards/src/plugins/*/target" "./OpenSearch-Dashboards/src/core/target" "./plugins/dashboards-observability/target")
-          for target_folder in "${target_folders[@]}"; do
-            target_name = $(echo "$target_folder" | sed 's/\/target//g')
-            cache_key="${{ runner.OS }}-$target_name-${{ hashFiles("$target_folder/**/*", "!$target_folder/target/**") }}
-            restored_cache=$(actions/cache/restore@v4 -p "$target_folder/target" -k "$cache_key" -r "${{ runner.OS }}-$target_name-")
-          done
+            ${{ runner.OS }}-yarn-
 
       - name: Bootstrap OpenSearch Dashboards
         run: |
@@ -165,18 +155,6 @@ jobs:
         run: |
           cd OpenSearch-Dashboards
           node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10 --verbose
-
-      - name: Stash core-targets caches
-        id: cache-target-folders
-        shell: bash
-        run: |
-          echo "Saving target folder caches..."
-          target_folders=("./OpenSearch-Dashboards/packages/*/target" "./OpenSearch-Dashboards/src/plugins/*/target" "./OpenSearch-Dashboards/src/core/target" "./plugins/dashboards-observability/target")
-          for target_folder in "${target_folders[@]}"; do
-            target_name = $(echo "$target_folder" | sed 's/\/target//g')
-            cache_key="${{ runner.OS }}-$target_name-${{ hashFiles("$target_folder/**/*", "!$target_folder/target/**") }}
-            actions/cache/save@v4 -p "$target_folder/target" -k "$cache_key" -r "${{ runner.OS }}-$target_name-"
-          done
 
       - name: Run OpenSearch Dashboards server
         run: |

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -144,6 +144,18 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-node-
 
+      - name: Restore core-targets caches
+        id: cache-target-folders
+        shell: bash
+        run: |
+          echo "Restoring target folder caches..."
+          target_folders=("./OpenSearch-Dashboards/packages/*/target" "./OpenSearch-Dashboards/src/plugins/*/target" "./OpenSearch-Dashboards/src/core/target" "./plugins/dashboards-observability/target")
+          for target_folder in "${target_folders[@]}"; do
+            target_name = $(echo "$target_folder" | sed 's/\/target//g')
+            cache_key="${{ runner.OS }}-$target_name-${{ hashFiles("$target_folder/**/*", "!$target_folder/target/**") }}
+            restored_cache=$(actions/cache/restore@v4 -p "$target_folder/target" -k "$cache_key" -r "${{ runner.OS }}-$target_name-")
+          done
+
       - name: Bootstrap OpenSearch Dashboards
         run: |
           cd OpenSearch-Dashboards
@@ -152,7 +164,19 @@ jobs:
       - name: Compile OpenSearch Dashboards
         run: |
           cd OpenSearch-Dashboards
-          node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10
+          node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10 --verbose
+
+      - name: Stash core-targets caches
+        id: cache-target-folders
+        shell: bash
+        run: |
+          echo "Saving target folder caches..."
+          target_folders=("./OpenSearch-Dashboards/packages/*/target" "./OpenSearch-Dashboards/src/plugins/*/target" "./OpenSearch-Dashboards/src/core/target" "./plugins/dashboards-observability/target")
+          for target_folder in "${target_folders[@]}"; do
+            target_name = $(echo "$target_folder" | sed 's/\/target//g')
+            cache_key="${{ runner.OS }}-$target_name-${{ hashFiles("$target_folder/**/*", "!$target_folder/target/**") }}
+            actions/cache/save@v4 -p "$target_folder/target" -k "$cache_key" -r "${{ runner.OS }}-$target_name-"
+          done
 
       - name: Run OpenSearch Dashboards server
         run: |

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -136,6 +136,14 @@ jobs:
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
 
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: OpenSearch-Dashboards/**/node_modules
+          key: ${{ runner.OS }}-node-${{ hashFiles('OpenSearch-Dashboards/**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+
       - name: Bootstrap OpenSearch Dashboards
         run: |
           cd OpenSearch-Dashboards
@@ -149,7 +157,18 @@ jobs:
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          nohup yarn start --no-base-path --no-watch &
+          nohup yarn start --no-base-path --no-watch | tee dashboard.log &
+
+      - name: Check If OpenSearch Dashboards Is Ready
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          cd ./OpenSearch-Dashboards
+          if timeout 60 grep -q "http server running" <(tail -n +1 -f dashboard.log); then
+            echo "OpenSearch Dashboards started successfully."
+          else
+            echo "Timeout of 60 seconds reached. OpenSearch Dashboards did not start successfully."
+            exit 1
+          fi&
 
       - name: Install Cypress
         run: |


### PR DESCRIPTION
### Description
The current cypress runs are failing with the error `Timeout for 600 seconds reached. OpenSearch Dashboards did not finish compiling.`. By far, the longest step of OSD startup is compilation. A little poking around upstream reveals that there's a script that can frontload this compilation, so we can separate the server startup from the compile step. This PR applies this, and lowers the timeout since it no longer needs to be so high. It also adds some caching to reduce build times, although there's a bit more that needs to happen to make build times fast (namely, caching all the /target folders, see #2188).

### Issues Resolved
See above

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
