### PR TITLE
Switch integ test cache strategy

### DIFF
--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -141,7 +141,9 @@ jobs:
       - name: Yarn Cache
         uses: actions/cache@v4
         with:
-          path: ${{ steps.setup-yarn.outputs.yarn-cache-dir }}
+          path: |
+            OpenSearch-Dashboards/**/node_modules
+            OpenSearch-Dashboards/**/target
           key: ${{ runner.OS }}-yarn-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
           restore-keys: |
             ${{ runner.OS }}-yarn-


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/dashboards-observability/issues/2188#issuecomment-2387239181, let's see what happens if we cache `/target` directly

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
