### PR TITLE
Remove PPL viz & create observability dashboards in MDS environment

### DIFF
--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -531,11 +531,11 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                   >
                     <EuiFlexGroup
                       alignItems="center"
-                      gutterSize="m"
+                      gutterSize="s"
                       wrap={true}
                     >
                       <div
-                        className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
                       >
                         <EuiFlexItem
                           className="euiSearchBar__searchHolder"

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -401,32 +401,33 @@ export class ObservabilityPlugin
     }));
     setupDeps.embeddable.registerEmbeddableFactory(OBSERVABILITY_EMBEDDABLE, embeddableFactory);
 
-    setupDeps.visualizations.registerAlias({
-      name: OBSERVABILITY_EMBEDDABLE_ID,
-      title: OBSERVABILITY_EMBEDDABLE_DISPLAY_NAME,
-      description: OBSERVABILITY_EMBEDDABLE_DESCRIPTION,
-      icon: OBSERVABILITY_EMBEDDABLE_ICON,
-      aliasApp: observabilityLogsID,
-      aliasPath: `#/explorer/?${CREATE_TAB_PARAM_KEY}=${CREATE_TAB_PARAM[TAB_CHART_ID]}`,
-      stage: 'production',
-      appExtensions: {
-        visualizations: {
-          docTypes: [VISUALIZATION_SAVED_OBJECT],
-          toListItem: ({ id, attributes, updated_at: updatedAt }) => ({
-            description: attributes?.description,
-            editApp: observabilityLogsID,
-            editUrl: `#/explorer/${VISUALIZATION_SAVED_OBJECT}:${id}`,
-            icon: OBSERVABILITY_EMBEDDABLE_ICON,
-            id,
-            savedObjectType: VISUALIZATION_SAVED_OBJECT,
-            title: attributes?.title,
-            typeTitle: OBSERVABILITY_EMBEDDABLE_DISPLAY_NAME,
-            stage: 'production',
-            updated_at: updatedAt,
-          }),
+    if (!setupDeps.dataSource)
+      setupDeps.visualizations.registerAlias({
+        name: OBSERVABILITY_EMBEDDABLE_ID,
+        title: OBSERVABILITY_EMBEDDABLE_DISPLAY_NAME,
+        description: OBSERVABILITY_EMBEDDABLE_DESCRIPTION,
+        icon: OBSERVABILITY_EMBEDDABLE_ICON,
+        aliasApp: observabilityLogsID,
+        aliasPath: `#/explorer/?${CREATE_TAB_PARAM_KEY}=${CREATE_TAB_PARAM[TAB_CHART_ID]}`,
+        stage: 'production',
+        appExtensions: {
+          visualizations: {
+            docTypes: [VISUALIZATION_SAVED_OBJECT],
+            toListItem: ({ id, attributes, updated_at: updatedAt }) => ({
+              description: attributes?.description,
+              editApp: observabilityLogsID,
+              editUrl: `#/explorer/${VISUALIZATION_SAVED_OBJECT}:${id}`,
+              icon: OBSERVABILITY_EMBEDDABLE_ICON,
+              id,
+              savedObjectType: VISUALIZATION_SAVED_OBJECT,
+              title: attributes?.title,
+              typeTitle: OBSERVABILITY_EMBEDDABLE_DISPLAY_NAME,
+              stage: 'production',
+              updated_at: updatedAt,
+            }),
+          },
         },
-      },
-    });
+      });
 
     registerAsssitantDependencies(setupDeps.assistantDashboards);
 

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -200,17 +200,47 @@ export class ObservabilityPlugin
       window.location.assign(convertLegacyTraceAnalyticsUrl(window.location));
     }
 
-    const BASE_URL = core.http.basePath.prepend('/app/observability-dashboards#');
-    setupDeps.dashboard.registerDashboardProvider({
-      appId: 'observability-panel',
-      savedObjectsType: 'observability-panel',
-      savedObjectsName: 'Observability',
-      editUrlPathFn: (obj: SavedObject) => `${BASE_URL}/${obj.id}/edit`,
-      viewUrlPathFn: (obj: SavedObject) => `${BASE_URL}/${obj.id}`,
-      createLinkText: 'Observability Dashboard',
-      createSortText: 'Observability Dashboard',
-      createUrl: `${BASE_URL}/create`,
-    });
+    // if MDS is not enabled register observability dashboards & PPL visualizations in core
+    if (!setupDeps.dataSource) {
+      const BASE_URL = core.http.basePath.prepend('/app/observability-dashboards#');
+      setupDeps.dashboard.registerDashboardProvider({
+        appId: 'observability-panel',
+        savedObjectsType: 'observability-panel',
+        savedObjectsName: 'Observability',
+        editUrlPathFn: (obj: SavedObject) => `${BASE_URL}/${obj.id}/edit`,
+        viewUrlPathFn: (obj: SavedObject) => `${BASE_URL}/${obj.id}`,
+        createLinkText: 'Observability Dashboard',
+        createSortText: 'Observability Dashboard',
+        createUrl: `${BASE_URL}/create`,
+      });
+
+      setupDeps.visualizations.registerAlias({
+        name: OBSERVABILITY_EMBEDDABLE_ID,
+        title: OBSERVABILITY_EMBEDDABLE_DISPLAY_NAME,
+        description: OBSERVABILITY_EMBEDDABLE_DESCRIPTION,
+        icon: OBSERVABILITY_EMBEDDABLE_ICON,
+        aliasApp: observabilityLogsID,
+        aliasPath: `#/explorer/?${CREATE_TAB_PARAM_KEY}=${CREATE_TAB_PARAM[TAB_CHART_ID]}`,
+        stage: 'production',
+        appExtensions: {
+          visualizations: {
+            docTypes: [VISUALIZATION_SAVED_OBJECT],
+            toListItem: ({ id, attributes, updated_at: updatedAt }) => ({
+              description: attributes?.description,
+              editApp: observabilityLogsID,
+              editUrl: `#/explorer/${VISUALIZATION_SAVED_OBJECT}:${id}`,
+              icon: OBSERVABILITY_EMBEDDABLE_ICON,
+              id,
+              savedObjectType: VISUALIZATION_SAVED_OBJECT,
+              title: attributes?.title,
+              typeTitle: OBSERVABILITY_EMBEDDABLE_DISPLAY_NAME,
+              stage: 'production',
+              updated_at: updatedAt,
+            }),
+          },
+        },
+      });
+    }
 
     const OBSERVABILITY_APP_CATEGORIES: Record<string, AppCategory> = Object.freeze({
       observability: {
@@ -400,34 +430,6 @@ export class ObservabilityPlugin
       overlays: (await core.getStartServices())[0].overlays,
     }));
     setupDeps.embeddable.registerEmbeddableFactory(OBSERVABILITY_EMBEDDABLE, embeddableFactory);
-
-    if (!setupDeps.dataSource)
-      setupDeps.visualizations.registerAlias({
-        name: OBSERVABILITY_EMBEDDABLE_ID,
-        title: OBSERVABILITY_EMBEDDABLE_DISPLAY_NAME,
-        description: OBSERVABILITY_EMBEDDABLE_DESCRIPTION,
-        icon: OBSERVABILITY_EMBEDDABLE_ICON,
-        aliasApp: observabilityLogsID,
-        aliasPath: `#/explorer/?${CREATE_TAB_PARAM_KEY}=${CREATE_TAB_PARAM[TAB_CHART_ID]}`,
-        stage: 'production',
-        appExtensions: {
-          visualizations: {
-            docTypes: [VISUALIZATION_SAVED_OBJECT],
-            toListItem: ({ id, attributes, updated_at: updatedAt }) => ({
-              description: attributes?.description,
-              editApp: observabilityLogsID,
-              editUrl: `#/explorer/${VISUALIZATION_SAVED_OBJECT}:${id}`,
-              icon: OBSERVABILITY_EMBEDDABLE_ICON,
-              id,
-              savedObjectType: VISUALIZATION_SAVED_OBJECT,
-              title: attributes?.title,
-              typeTitle: OBSERVABILITY_EMBEDDABLE_DISPLAY_NAME,
-              stage: 'production',
-              updated_at: updatedAt,
-            }),
-          },
-        },
-      });
 
     registerAsssitantDependencies(setupDeps.assistantDashboards);
 

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../src/core/server';
 import { DataSourcePluginSetup } from '../../../src/plugins/data_source/server/types';
 import { DataSourceManagementPlugin } from '../../../src/plugins/data_source_management/public/plugin';
+import { observabilityPanelsID } from '../common/constants/shared';
 import { migrateV1IntegrationToV2Integration } from './adaptors/integrations/migrations';
 import { OpenSearchObservabilityPlugin } from './adaptors/opensearch_observability_plugin';
 import { PPLPlugin } from './adaptors/ppl_plugin';
@@ -23,9 +24,9 @@ import { PPLParsers } from './parsers/ppl_parser';
 import { registerObservabilityUISettings } from './plugin_helper/register_settings';
 import { setupRoutes } from './routes/index';
 import {
+  getSearchSavedObject,
+  getVisualizationSavedObject,
   notebookSavedObject,
-  searchSavedObject,
-  visualizationSavedObject,
 } from './saved_objects/observability_saved_object';
 import { AssistantPluginSetup, ObservabilityPluginSetup, ObservabilityPluginStart } from './types';
 
@@ -89,9 +90,9 @@ export class ObservabilityPlugin
       },
       management: {
         importableAndExportable: true,
-        getInAppUrl() {
+        getInAppUrl(obj) {
           return {
-            path: `/app/management/observability/settings`,
+            path: dataSourceEnabled ? '' : `/app/${observabilityPanelsID}#/${obj.id}`,
             uiCapabilitiesPath: 'advancedSettings.show',
           };
         },
@@ -219,8 +220,8 @@ export class ObservabilityPlugin
     // Register server side APIs
     setupRoutes({ router, client: openSearchObservabilityClient, dataSourceEnabled });
 
-    core.savedObjects.registerType(visualizationSavedObject);
-    core.savedObjects.registerType(searchSavedObject);
+    core.savedObjects.registerType(getVisualizationSavedObject(dataSourceEnabled));
+    core.savedObjects.registerType(getSearchSavedObject(dataSourceEnabled));
     core.savedObjects.registerType(notebookSavedObject);
     core.capabilities.registerProvider(() => ({
       observability: {

--- a/server/saved_objects/observability_saved_object.ts
+++ b/server/saved_objects/observability_saved_object.ts
@@ -11,7 +11,7 @@ import {
   VISUALIZATION_SAVED_OBJECT,
 } from '../../common/types/observability_saved_object_attributes';
 
-export const visualizationSavedObject: SavedObjectsType = {
+export const getVisualizationSavedObject = (dataSourceEnabled: boolean): SavedObjectsType => ({
   name: VISUALIZATION_SAVED_OBJECT,
   hidden: false,
   namespaceType: 'single',
@@ -26,7 +26,7 @@ export const visualizationSavedObject: SavedObjectsType = {
       const editPath = `#/explorer/${VISUALIZATION_SAVED_OBJECT}:${obj.id}`;
       const editUrl = `/app/${observabilityLogsID}${editPath}`;
       return {
-        path: editUrl,
+        path: dataSourceEnabled ? '' : editUrl,
         uiCapabilitiesPath: 'observability.show',
       };
     },
@@ -44,9 +44,9 @@ export const visualizationSavedObject: SavedObjectsType = {
     },
   },
   migrations: {},
-};
+});
 
-export const searchSavedObject: SavedObjectsType = {
+export const getSearchSavedObject = (dataSourceEnabled: boolean): SavedObjectsType => ({
   name: SEARCH_SAVED_OBJECT,
   icon: 'editorCodeBlock',
   hidden: false,
@@ -61,7 +61,7 @@ export const searchSavedObject: SavedObjectsType = {
       const editPath = `#/explorer/${SEARCH_SAVED_OBJECT}:${obj.id}`;
       const editUrl = `/app/${observabilityLogsID}${editPath}`;
       return {
-        path: editUrl,
+        path: dataSourceEnabled ? '' : editUrl,
         uiCapabilitiesPath: 'observability.show',
       };
     },
@@ -79,7 +79,7 @@ export const searchSavedObject: SavedObjectsType = {
     },
   },
   migrations: {},
-};
+});
 
 export const notebookSavedObject: SavedObjectsType = {
   name: NOTEBOOK_SAVED_OBJECT,


### PR DESCRIPTION
### Description
Remove PPL viz & create observability dashboards in MDS environment

### Issues Resolved
PPL visualization option landed users on an empty page when MDS is enabled. We removed this option when MDS is enabled to sync with the log explorer behavior.

Create visualization flow without MDS enabled:
<img width="1792" alt="Screenshot 2024-10-09 at 7 15 31 AM" src="https://github.com/user-attachments/assets/cb53125d-df84-4aab-894b-40627292dbd1">

Create visualization flow with MDS enabled:
<img width="1792" alt="Screenshot 2024-10-09 at 7 14 43 AM" src="https://github.com/user-attachments/assets/0963f024-d05d-42ed-a367-aabf95e31a7e">

Create dashboards flow without MDS enabled:
<img width="1791" alt="Screenshot 2024-10-09 at 8 23 34 AM" src="https://github.com/user-attachments/assets/de641f45-a468-4bf7-af67-190db8d5b3b8">



Create dashboards flow with MDS enabled:
<img width="1792" alt="Screenshot 2024-10-09 at 8 26 44 AM" src="https://github.com/user-attachments/assets/c25b5242-2938-46cd-a04f-e17c8b870dfc">

Other issues resolved:
- Remove the redirection link for editing observability-search, observability-visualization and observability-panel based saved-objects with MDS is enabled.


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
