### PR TITLE
Update workflows to use real build cache

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -39,23 +39,6 @@ jobs:
         with:
           path: OpenSearch-Dashboards/plugins/dashboards-observability
 
-      - name: Get yarn cache dir
-        id: setup-yarn
-        shell: bash
-        run: |
-          cd ./OpenSearch-Dashboards
-          source $NVM_DIR/nvm.sh
-          nvm use
-          echo "yarn-cache-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Yarn Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.setup-yarn.outputs.yarn-cache-dir }}
-          key: ${{ runner.OS }}-yarn-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-yarn-
-
       - name: Plugin Bootstrap
         uses: nick-fields/retry@v2
         with:
@@ -134,20 +117,6 @@ jobs:
 
       - run: node -v
       - run: yarn -v
-
-      - name: Get yarn cache dir
-        id: setup-yarn
-        shell: bash
-        run: |
-          echo "yarn-cache-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Yarn Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.setup-yarn.outputs.yarn-cache-dir }}
-          key: ${{ runner.OS }}-yarn-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-yarn-
 
       - name: Checkout Dashboards Observability
         uses: actions/checkout@v2

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -114,15 +114,16 @@ jobs:
           npm uninstall -g yarn
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
-          echo "yarn-cache-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Yarn Cache
         uses: actions/cache@v4
         with:
-          path: ${{ steps.setup-yarn.outputs.yarn-cache-dir }}
-          key: ${{ runner.OS }}-yarn-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
+          path: |
+            OpenSearch-Dashboards/**/target
+            OpenSearch-Dashboards/**/node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-yarn-
+            ${{ runner.OS }}-build-
 
       - name: Bootstrap OpenSearch Dashboards
         run: |

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -136,15 +136,16 @@ jobs:
           npm uninstall -g yarn
           echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
-          echo "yarn-cache-dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Yarn Cache
         uses: actions/cache@v4
         with:
-          path: ${{ steps.setup-yarn.outputs.yarn-cache-dir }}
-          key: ${{ runner.OS }}-yarn-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
+          path: |
+            OpenSearch-Dashboards/**/target
+            OpenSearch-Dashboards/**/node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('OpenSearch-Dashboards/**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-yarn-
+            ${{ runner.OS }}-build-
 
       - name: Bootstrap OpenSearch Dashboards
         run: |

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -535,7 +535,7 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                       wrap={true}
                     >
                       <div
-                        className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+                        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
                       >
                         <EuiFlexItem
                           className="euiSearchBar__searchHolder"

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -531,7 +531,7 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                   >
                     <EuiFlexGroup
                       alignItems="center"
-                      gutterSize="m"
+                      gutterSize="s"
                       wrap={true}
                     >
                       <div
@@ -907,10 +907,10 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                     </EuiFlexGroup>
                   </EuiSearchBar>
                   <EuiSpacer
-                    size="l"
+                    size="m"
                   >
                     <div
-                      className="euiSpacer euiSpacer--l"
+                      className="euiSpacer euiSpacer--m"
                     />
                   </EuiSpacer>
                   <EuiBasicTable

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -907,10 +907,10 @@ exports[`Added Integration View Test Renders added integration view using dummy 
                     </EuiFlexGroup>
                   </EuiSearchBar>
                   <EuiSpacer
-                    size="m"
+                    size="l"
                   >
                     <div
-                      className="euiSpacer euiSpacer--m"
+                      className="euiSpacer euiSpacer--l"
                     />
                   </EuiSpacer>
                   <EuiBasicTable


### PR DESCRIPTION
### Description
Following https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8472 and #2188, this PR switches the cache to the actual build target directories to speed up caching dramatically.

### Issues Resolved
Resolves #2188 
Avenges #925 

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
