### PR TITLE
[Workspace] Fix non-workspace admin update observability:defaultDashboard

### DIFF
--- a/public/components/overview/home.tsx
+++ b/public/components/overview/home.tsx
@@ -11,7 +11,7 @@ import {
   EuiButtonEmpty,
   EuiToolTip,
 } from '@elastic/eui';
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useMemo, useState } from 'react';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 import { useObservable } from 'react-use';
 import { EMPTY } from 'rxjs';
@@ -51,6 +51,14 @@ export const Home = () => {
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [showGetStarted, setShowGetStarted] = useState<boolean | null>(null); // Initial null state
+
+  // When workspace enabled, only workspace owner can update observability:defaultDashboard.
+  const isWorkspaceOwner = useMemo(() => {
+    const isCurrentWorkspaceOwner = coreRefs.workspaces?.currentWorkspace$.getValue()?.owner;
+    const isDashboardAdmin =
+      coreRefs.application?.capabilities?.dashboards?.isDashboardAdmin !== false;
+    return isCurrentWorkspaceOwner || isDashboardAdmin;
+  }, [coreRefs.workspaces, coreRefs.application?.capabilities]);
 
   ObsDashboardStateManager.showFlyout$.next(() => () => setIsFlyoutVisible(true));
 
@@ -95,14 +103,16 @@ export const Home = () => {
           });
           ObsDashboardStateManager.isDashboardSelected$.next(true);
         } else {
-          setObservabilityDashboardsId(null);
-          ObsDashboardStateManager.dashboardState$.next({
-            startDate: '',
-            endDate: '',
-            dashboardTitle: '',
-            dashboardId: '',
-          });
-          ObsDashboardStateManager.isDashboardSelected$.next(false);
+          if (isWorkspaceOwner) {
+            setObservabilityDashboardsId(null);
+            ObsDashboardStateManager.dashboardState$.next({
+              startDate: '',
+              endDate: '',
+              dashboardTitle: '',
+              dashboardId: '',
+            });
+            ObsDashboardStateManager.isDashboardSelected$.next(false);
+          }
         }
       })
       .catch((error) => {
@@ -316,14 +326,16 @@ export const Home = () => {
           });
           ObsDashboardStateManager.isDashboardSelected$.next(true);
         } else {
-          setObservabilityDashboardsId(null);
-          ObsDashboardStateManager.dashboardState$.next({
-            startDate: '',
-            endDate: '',
-            dashboardTitle: '',
-            dashboardId: '',
-          });
-          ObsDashboardStateManager.isDashboardSelected$.next(false);
+          if (isWorkspaceOwner) {
+            setObservabilityDashboardsId(null);
+            ObsDashboardStateManager.dashboardState$.next({
+              startDate: '',
+              endDate: '',
+              dashboardTitle: '',
+              dashboardId: '',
+            });
+            ObsDashboardStateManager.isDashboardSelected$.next(false);
+          }
         }
       })
       .catch((error) => {

--- a/public/framework/core_refs.ts
+++ b/public/framework/core_refs.ts
@@ -12,6 +12,7 @@ import {
   IToasts,
   OverlayStart,
   SavedObjectsClientContract,
+  WorkspacesStart,
 } from '../../../../src/core/public';
 import { DashboardStart } from '../../../../src/plugins/dashboard/public';
 import { DataSourcePluginStart } from '../../../../src/plugins/data_source/public';
@@ -38,6 +39,7 @@ class CoreRefs {
   public dataSource?: DataSourcePluginStart;
   public navigation?: NavigationPublicPluginStart;
   public contentManagement?: ContentManagementPluginStart;
+  public workspaces?: WorkspacesStart;
   private constructor() {
     // ...
   }

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -459,6 +459,7 @@ export class ObservabilityPlugin
     coreRefs.dataSource = startDeps.dataSource;
     coreRefs.navigation = startDeps.navigation;
     coreRefs.contentManagement = startDeps.contentManagement;
+    coreRefs.workspaces = core.workspaces;
 
     // redirect trace URL based on new navigation
     if (window.location.pathname.includes(observabilityTracesID)) {


### PR DESCRIPTION
### Description
Non-workspace admin navigate to observability overview page that will update observability:defaultDashboard and show error toast.
![image](https://github.com/user-attachments/assets/e6b43f3a-f1db-4cfc-bdb8-324c14962d40)

After fixing:  Only workspace owner / OSD admin can update `observability:defaultDashboard`

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
