### PR TITLE
[Traces] Return 503 if opensearch calls failed

### DIFF
--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -219,7 +219,12 @@ export class ObservabilityPlugin
     core.savedObjects.registerType(integrationTemplateType);
 
     // Register server side APIs
-    setupRoutes({ router, client: openSearchObservabilityClient, dataSourceEnabled });
+    setupRoutes({
+      router,
+      client: openSearchObservabilityClient,
+      dataSourceEnabled,
+      logger: this.logger,
+    });
 
     core.savedObjects.registerType(getVisualizationSavedObject(dataSourceEnabled));
     core.savedObjects.registerType(getSearchSavedObject(dataSourceEnabled));

--- a/server/routes/dsl.ts
+++ b/server/routes/dsl.ts
@@ -42,7 +42,7 @@ export function registerDslRoute(
       } catch (error) {
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
-          statusCode: error.statusCode || 500,
+          statusCode: error.statusCode === 500 ? 503 : error.statusCode || 503,
           body: error.message,
         });
       }
@@ -71,7 +71,7 @@ export function registerDslRoute(
       } catch (error) {
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
-          statusCode: error.statusCode || 500,
+          statusCode: error.statusCode === 500 ? 503 : error.statusCode || 503,
           body: error.message,
         });
       }
@@ -95,7 +95,7 @@ export function registerDslRoute(
       } catch (error) {
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
-          statusCode: error.statusCode || 500,
+          statusCode: error.statusCode === 500 ? 503 : error.statusCode || 503,
           body: error.message,
         });
       }
@@ -119,7 +119,7 @@ export function registerDslRoute(
       } catch (error) {
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
-          statusCode: error.statusCode || 500,
+          statusCode: error.statusCode === 500 ? 503 : error.statusCode || 503,
           body: error.message,
         });
       }
@@ -158,7 +158,7 @@ export function registerDslRoute(
       } catch (error) {
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
-          statusCode: error.statusCode || 500,
+          statusCode: error.statusCode === 500 ? 503 : error.statusCode || 503,
           body: error.message,
         });
       }
@@ -194,7 +194,7 @@ export function registerDslRoute(
       } catch (error) {
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
-          statusCode: error.statusCode || 500,
+          statusCode: error.statusCode === 500 ? 503 : error.statusCode || 503,
           body: error.message,
         });
       }
@@ -230,7 +230,7 @@ export function registerDslRoute(
       } catch (error) {
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
-          statusCode: error.statusCode || 500,
+          statusCode: error.statusCode === 500 ? 503 : error.statusCode || 503,
           body: error.message,
         });
       }
@@ -263,7 +263,7 @@ export function registerDslRoute(
       } catch (error) {
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
-          statusCode: error.statusCode || 500,
+          statusCode: error.statusCode === 500 ? 503 : error.statusCode || 503,
           body: error.message,
         });
       }
@@ -298,7 +298,7 @@ export function registerDslRoute(
       } catch (error) {
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
-          statusCode: error.statusCode || 500,
+          statusCode: error.statusCode === 500 ? 503 : error.statusCode || 503,
           body: error.message,
         });
       }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ILegacyClusterClient, IRouter } from '../../../../src/core/server';
+import { ILegacyClusterClient, IRouter, Logger } from '../../../../src/core/server';
 import { DSLFacet } from '../services/facets/dsl_facet';
 import { PPLFacet } from '../services/facets/ppl_facet';
 import SavedObjectFacet from '../services/facets/saved_objects';
@@ -30,10 +30,12 @@ export function setupRoutes({
   router,
   client,
   dataSourceEnabled,
+  logger,
 }: {
   router: IRouter;
   client: ILegacyClusterClient;
   dataSourceEnabled: boolean;
+  logger: Logger;
 }) {
   PanelsRouter(router);
   VisualizationsRouter(router);
@@ -49,7 +51,7 @@ export function setupRoutes({
   registerParaRoute(router);
   registerNoteRoute(router);
   registerVizRoute(router, dataSourceEnabled);
-  const queryService = new QueryService(client);
+  const queryService = new QueryService(client, logger);
   registerSqlRoute(router, queryService, dataSourceEnabled);
 
   registerMetricsRoute(router, dataSourceEnabled);

--- a/server/services/queryService.ts
+++ b/server/services/queryService.ts
@@ -6,10 +6,11 @@
 import 'core-js/stable';
 import _ from 'lodash';
 import 'regenerator-runtime/runtime';
+import { Logger } from '../../../../src/core/server';
 
 export class QueryService {
   private client: any;
-  constructor(client: any) {
+  constructor(client: any, private readonly logger: Logger) {
     this.client = client;
   }
 


### PR DESCRIPTION
### Description
- Return 503 if opensearch calls failed
- logger usage is added by https://github.com/opensearch-project/dashboards-observability/commit/2ab83698235f958aa28d51465111e3cb996cf4a3#diff-0106d9bfdc6fc208bd6c5ae2c242dd8f479d18dcc51d706df628d973e35fd221R47-R48 but not passed in to QueryService, this PR passes it in

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
