### PR TITLE
Use savedObjects client to fetch notebook visualizations

### DIFF
--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -184,7 +184,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
           }));
         })
         .catch((error) => {
-          console.error('Issue is fetching visualizations', error);
+          console.error('Failed to fetch visualizations', error);
         });
 
       const allVisualizations = [{ label: 'Dashboards Visualizations', options: opts }];
@@ -194,7 +194,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
         key: para.visSavedObjId,
       });
       if (selectedObject.length > 0) {
-        setVisType(selectedObject.className);
+        setVisType(selectedObject[0].className ?? 'VISUALIZATION');
         setSelectedVisOption(selectedObject);
       }
     } else {
@@ -235,7 +235,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
         key: para.visSavedObjId,
       });
       if (selectedObject.length > 0) {
-        setVisType(selectedObject.className);
+        setVisType(selectedObject[0].className ?? 'VISUALIZATION');
         setSelectedVisOption(selectedObject);
       }
     }


### PR DESCRIPTION
### Description
Use savedObjects client to fetch notebook visualizations

### Issues Resolved
Notebooks visualizations API was calling the local cluster to fetch savedobjects with MDS enabled. But when the savedObjects are not stored in `.kibana` index, they routes lead to 404/400. Hence, updating the client to use the one provided by OSD core. This automatically takes care of switching between the saved object source. 


https://github.com/user-attachments/assets/5fc25524-8a5a-4886-b5db-f2d0f36553bc



### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
