### PR TITLE
[Bug fix] Metrics datasource

### DIFF
--- a/public/components/metrics/index.tsx
+++ b/public/components/metrics/index.tsx
@@ -55,7 +55,7 @@ export const Home = ({
   // Side bar constants
   const [selectedDataSource, setSelectedDataSource] = useState<OptionType[]>([]);
   const [selectedOTIndex, setSelectedOTIndex] = useState([]);
-  const [dataSourceMDSId, setDataSourceMDSId] = useState<string>('');
+  const [dataSourceMDSId, setDataSourceMDSId] = useState<string | null>(null);
   const [reloadSidebar, setReloadSidebar] = useState<boolean>(false);
 
   useEffect(() => {
@@ -77,7 +77,7 @@ export const Home = ({
   const dispatch = useDispatch();
 
   const onSelectedDataSource = async (dataSources: DataSourceOption[]) => {
-    const id = dataSources[0] ? dataSources[0].id : '';
+    const id = dataSources[0] ? dataSources[0].id : null;
     setDataSourceMDSId(id);
     debounce(() => {
       dispatch(setSelectedDataSourceMDSId(id));
@@ -111,7 +111,7 @@ export const Home = ({
           path={['/:id', '/']}
           render={(routerProps) => (
             <div>
-              {reloadSidebar && (
+              {(dataSourceEnabled ? dataSourceMDSId !== null : true) && reloadSidebar && (
                 <EuiPage>
                   <EuiPageBody component="div">
                     <TopMenu />

--- a/public/components/metrics/index.tsx
+++ b/public/components/metrics/index.tsx
@@ -133,6 +133,7 @@ export const Home = ({
                                 selectedOTIndex={selectedOTIndex}
                                 setSelectedOTIndex={setSelectedOTIndex}
                                 dataSourceMDSId={dataSourceMDSId}
+                                dataSourceEnabled={dataSourceEnabled}
                               />
                             </EuiResizablePanel>
 

--- a/public/components/metrics/sidebar/sidebar.tsx
+++ b/public/components/metrics/sidebar/sidebar.tsx
@@ -40,7 +40,8 @@ interface SideBarMenuProps {
   selectedOTIndex: React.SetStateAction<Array<{}>>;
   setSelectedOTIndex: React.Dispatch<React.SetStateAction<unknown>>;
   additionalSelectedMetricId?: string;
-  dataSourceMDSId: string;
+  dataSourceMDSId: string | null;
+  dataSourceEnabled: boolean;
 }
 export const Sidebar = ({
   selectedDataSource,
@@ -49,6 +50,7 @@ export const Sidebar = ({
   setSelectedOTIndex,
   additionalSelectedMetricId,
   dataSourceMDSId,
+  dataSourceEnabled,
 }: SideBarMenuProps) => {
   const dispatch = useDispatch();
   const [availableOTDocuments, setAvailableOTDocuments] = useState([]);
@@ -95,6 +97,11 @@ export const Sidebar = ({
   }, [selectedMetrics, selectedMetricsIds, dataSourceMDSId]);
 
   useEffect(() => {
+    // If data source is enabled but is still null prevent the invalid call
+    if (dataSourceEnabled && dataSourceMDSId === null) {
+      return;
+    }
+
     if (selectedOTIndex.length > 0 && selectedDataSource[0]?.label === 'OpenTelemetry') {
       const fetchOtelDocuments = async () => {
         try {


### PR DESCRIPTION
### Description
While datasource is enabled, set initial condition to null and wait to render page until the selection/default is registered.

Currently if a localhost is not defined the call will trigger the search on a non valid datasource.
<img width="1754" alt="NoLocalHost" src="https://github.com/user-attachments/assets/ac4f5ea7-b70b-40fc-a8bf-a8581aa735f5">

This change prevents the search call from being triggered until the datasource has been read.

https://github.com/user-attachments/assets/75e8559e-07dc-46d3-b9bf-fe127f83ee65


### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
