### PR TITLE
Separate uploaded cypress artifacts for actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -199,12 +199,12 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots-${{ matrix.os }}
+          name: cypress-screenshots-${{ matrix.os }}-${{ matrix.testgroups }}
           path: OpenSearch-Dashboards/plugins/dashboards-observability/.cypress/screenshots
 
       - name: Capture test video
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-videos-${{ matrix.os }}
+          name: cypress-videos-${{ matrix.os }}-${{ matrix.testgroups }}
           path: OpenSearch-Dashboards/plugins/dashboards-observability/.cypress/videos


### PR DESCRIPTION
### Description
Separate uploaded cypress artifacts for actions/upload-artifact@v4

### Issues Resolved
Previously the behavior allowed for the artifact names to be the same which resulted in unexpected mutations and accidental corruption. Artifacts created by upload-artifact@v4 are immutable.

This leads to cypress tests failing as artifact upload fails with multiple test groups using the same name to upload. More details can be found here: [uploadArtifactv4/docs](https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact), [Bug report](https://github.com/actions/upload-artifact/issues/478)

Failing PR workflows: https://github.com/opensearch-project/dashboards-observability/actions/runs/11903948018/job/33171873868?pr=2258

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
