### PR TITLE
[Cypress Updates] App analytics updates

### DIFF
--- a/.cypress/integration/app_analytics_test/app_analytics.spec.js
+++ b/.cypress/integration/app_analytics_test/app_analytics.spec.js
@@ -254,6 +254,7 @@ describe('Viewing application', () => {
 
   it('Shows latency variance in dashboards table', () => {
     changeTimeTo24('years');
+    cy.get('[data-test-subj="app-analytics-traceTab"]').click();
     cy.get('[data-test-subj="trace-groups-service-operation-accordian"]').click();
     cy.get('[data-test-subj="dashboardTable"]').first().within(($table) => {
       cy.get('.plot-container').should('have.length.at.least', 1);
@@ -261,6 +262,7 @@ describe('Viewing application', () => {
   });
 
   it('Adds filter when Trace group name is clicked', () => {
+    cy.get('[data-test-subj="app-analytics-traceTab"]').click();
     cy.get('[data-test-subj="trace-groups-service-operation-accordian"]').click();
     cy.get('[data-test-subj="dashboard-table-trace-group-name-button"]').contains('client_create_order').click();
     cy.get('[data-test-subj="client_create_orderFilterBadge"]').should('exist');
@@ -271,7 +273,7 @@ describe('Viewing application', () => {
 
   it('Opens service detail flyout when Service Name is clicked', () => {
     cy.get('[data-test-subj="app-analytics-serviceTab"]').click();
-    cy.get('.euiLink').contains('authentication').click();
+    cy.get('*[data-test-subj^="service-flyout-action-btntrace"]').eq(0).click();
     cy.get('[data-test-subj="serviceDetailFlyoutTitle"]').should('be.visible');
     cy.get('[data-test-subj="Number of connected servicesDescriptionList"]').should('contain', '3');
     cy.get('[data-text="Errors"]').eq(1).click(); // Selecting errors tab within flyout
@@ -433,7 +435,6 @@ describe('Viewing application', () => {
     cy.get('select').select(visOneName);
     cy.intercept('PUT', `**/api/observability/application`).as('selectUpdate');
     cy.wait('@selectUpdate')
-    cy.wait(2000); // despite the previous wait grabbing the call that updates the panel select, it doesn't appear without this
     moveToHomePage();
     cy.intercept('GET', `**/api/observability/operational_panels/panels/**`).as('loadingPanels')
     cy.wait('@loadingPanels');
@@ -479,8 +480,7 @@ describe('Separate from other plugins', () => {
     cy.visit(
       `${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/`
     );
-    cy.get('[data-test-subj="operationalPanelsActionsButton"]', { timeout: timeoutDelay }).click();
-    cy.get('[data-test-subj="addSampleContextMenuItem"]', { timeout: timeoutDelay }).click();
+    cy.get('.euiButtonContent').contains('Add samples').click();
     cy.get('[data-test-subj="confirmModalConfirmButton"]', { timeout: timeoutDelay }).click();
     cy.get('.euiLink').contains('[Logs] Web traffic Panel').first().click();
     cy.get('[data-test-subj="addVisualizationButton"]').click();
@@ -547,15 +547,9 @@ describe('Application Analytics home page', () => {
   });
 
   it('Renames application', () => {
-    cy.get('[data-test-subj="appAnalyticsActionsButton"]').click();
-    cy.get('[data-test-subj="renameApplicationContextMenuItem"]').should('be.disabled');
-    cy.get('[data-test-subj="appAnalyticsActionsButton"]').click();
-    cy.get('.euiTableRow').first().find('.euiCheckbox').click();
-    cy.wait(2000); // checkbox being clicked has a small delay before enabling action button
-    cy.get('[data-test-subj="appAnalyticsActionsButton"]').click();
-    cy.get('[data-test-subj="renameApplicationContextMenuItem"]').click();
-    cy.get('[data-test-subj="customModalFieldText"]').clear().click().type(newName);
-    cy.get('[data-test-subj="runModalButton"]').click();
+    cy.get('[data-test-subj="renameApplication"]').eq(0).click();
+    cy.get('input[type="text"]').clear().click().type(newName);
+    cy.get('.euiButton__text').contains('Rename').click();
     cy.get('.euiToast').contains(`Application successfully renamed to "${newName}"`);
     cy.get('.euiTableRow').first().within(($row) => {
       cy.get('.euiLink').contains(newName).should('exist');
@@ -563,23 +557,16 @@ describe('Application Analytics home page', () => {
   });
 
   it('Deletes application', () => {
-    cy.get('[data-test-subj="appAnalyticsActionsButton"]').click();
-    cy.get('[data-test-subj="deleteApplicationContextMenuItem"]').should('exist');
-    cy.get('[data-test-subj="appAnalyticsActionsButton"]').click();
-    cy.get('.euiTableRow').first().within(($row) => {
-      cy.get('.euiCheckbox').click();
-    });
-    cy.get('.euiTableRow').eq(1).within(($row) => {
-      cy.get('.euiCheckbox').click();
-    });
-    cy.get('.euiTableRow').eq(2).within(($row) => {
-      cy.get('.euiCheckbox').click();
-    });
-    cy.get('[data-test-subj="appAnalyticsActionsButton"]').click();
-    cy.get('[data-test-subj="deleteApplicationContextMenuItem"]').click();
+    cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
     cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
     cy.get('[data-test-subj="popoverModal__deleteButton"').click();
     cy.get('.euiToast').contains(`Applications successfully deleted!`);
+    cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
+    cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
+    cy.get('[data-test-subj="popoverModal__deleteButton"').click();
+    cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
+    cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
+    cy.get('[data-test-subj="popoverModal__deleteButton"').click();
     cy.get(`[data-test-subj="${newName}ApplicationLink"]`).should('not.exist');
   });
 });

--- a/.cypress/integration/app_analytics_test/app_analytics.spec.js
+++ b/.cypress/integration/app_analytics_test/app_analytics.spec.js
@@ -206,6 +206,7 @@ describe('Setting availability', () => {
     cy.get('.euiTableRow').should('have.length.lessThan', 1);
     cy.get('[data-test-subj="applicationTitle"]').should('contain', nameThree);
     cy.get('.euiBreadcrumb[href="#/"]').click();
+    cy.reload();
     cy.get(`[data-test-subj="${nameThree}ApplicationLink"]`);
     cy.get('[data-test-subj="setAvailabilityHomePageLink"]').first().click();
     cy.get('[data-test-subj="applicationTitle"]').should('contain', nameThree);
@@ -431,15 +432,15 @@ describe('Viewing application', () => {
 
 
   it('Changes availability visualization', () => {
-    cy.intercept('PUT', `**/api/observability/application`).as('selectUpdate');
-    cy.intercept('GET', `**/api/observability/operational_panels/panels/**`).as('loadingPanels')
     cy.get('[data-test-subj="app-analytics-configTab"]').click();
     cy.get('select').select(visOneName);
+    cy.intercept('PUT', `**/api/observability/application`).as('selectUpdate');
     cy.wait('@selectUpdate');
-    cy.get('select').find('option:selected').should('have.text', visOneName);
 
     moveToHomePage();
+    cy.intercept('GET', `**/api/observability/operational_panels/panels/**`).as('loadingPanels')
     cy.wait('@loadingPanels');
+    cy.reload();
     cy.get('[data-test-subj="AvailableAvailabilityBadge"][style="background-color: rgb(84, 179, 153); color: rgb(0, 0, 0);"]').should('contain', 'Available');
     moveToApplication(nameOne);
     cy.get('[data-test-subj="app-analytics-configTab"]').click();
@@ -561,18 +562,20 @@ describe('Application Analytics home page', () => {
   });
 
   it('Deletes application', () => {
-    cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
+    cy.get('.euiFieldSearch').clear().type(nameTwo);
+    cy.get('[data-test-subj="deleteApplication"]').click();
     cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
     cy.get('[data-test-subj="popoverModal__deleteButton"').click();
-    cy.get('[data-test-subj="applicationHomePageTitle"]').contains(`(2)`);
-    cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
+    cy.get('.euiToast').contains(`Applications successfully deleted!`);
+    cy.get('.euiFieldSearch').clear().type(nameThree);
+    cy.get('[data-test-subj="deleteApplication"]').click();
     cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
     cy.get('[data-test-subj="popoverModal__deleteButton"').click();
-    cy.get('[data-test-subj="applicationHomePageTitle"]').contains(`(1)`);
-    cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
+    cy.get('.euiFieldSearch').clear().type(newName);
+    cy.get('[data-test-subj="deleteApplication"]').click();
     cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
     cy.get('[data-test-subj="popoverModal__deleteButton"').click();
-    cy.get('[data-test-subj="applicationHomePageTitle"]').contains(`(0)`);
-    cy.get(`[data-test-subj="${newName}ApplicationLink"]`).should('not.exist');
+    cy.get('.euiFieldSearch').clear()
+    cy.get('[data-test-subj="applicationHomePageTitle"]').contains('(0)');
   });
 });

--- a/.cypress/integration/app_analytics_test/app_analytics.spec.js
+++ b/.cypress/integration/app_analytics_test/app_analytics.spec.js
@@ -571,6 +571,7 @@ describe('Application Analytics home page', () => {
     cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
     cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
     cy.get('[data-test-subj="popoverModal__deleteButton"').click();
+    cy.reload();
     cy.get(`[data-test-subj="${newName}ApplicationLink"]`).should('not.exist');
   });
 });

--- a/.cypress/integration/app_analytics_test/app_analytics.spec.js
+++ b/.cypress/integration/app_analytics_test/app_analytics.spec.js
@@ -438,7 +438,6 @@ describe('Viewing application', () => {
     cy.wait('@selectUpdate');
 
     moveToHomePage();
-    cy.reload()
     cy.wait('@loadingPanels');
     cy.get('[data-test-subj="AvailableAvailabilityBadge"][style="background-color: rgb(84, 179, 153); color: rgb(0, 0, 0);"]').should('contain', 'Available');
     moveToApplication(nameOne);
@@ -571,7 +570,6 @@ describe('Application Analytics home page', () => {
     cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
     cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
     cy.get('[data-test-subj="popoverModal__deleteButton"').click();
-    cy.reload();
     cy.get(`[data-test-subj="${newName}ApplicationLink"]`).should('not.exist');
   });
 });

--- a/.cypress/integration/app_analytics_test/app_analytics.spec.js
+++ b/.cypress/integration/app_analytics_test/app_analytics.spec.js
@@ -431,12 +431,14 @@ describe('Viewing application', () => {
 
 
   it('Changes availability visualization', () => {
+    cy.intercept('PUT', `**/api/observability/application`).as('selectUpdate');
+    cy.intercept('GET', `**/api/observability/operational_panels/panels/**`).as('loadingPanels')
     cy.get('[data-test-subj="app-analytics-configTab"]').click();
     cy.get('select').select(visOneName);
-    cy.intercept('PUT', `**/api/observability/application`).as('selectUpdate');
-    cy.wait('@selectUpdate')
+    cy.wait('@selectUpdate');
+
     moveToHomePage();
-    cy.intercept('GET', `**/api/observability/operational_panels/panels/**`).as('loadingPanels')
+    cy.reload()
     cy.wait('@loadingPanels');
     cy.get('[data-test-subj="AvailableAvailabilityBadge"][style="background-color: rgb(84, 179, 153); color: rgb(0, 0, 0);"]').should('contain', 'Available');
     moveToApplication(nameOne);

--- a/.cypress/integration/app_analytics_test/app_analytics.spec.js
+++ b/.cypress/integration/app_analytics_test/app_analytics.spec.js
@@ -519,10 +519,12 @@ describe('Editing application', () => {
     cy.get('[data-test-subj="logSourceAccordion"]').trigger('mouseover').click();
     cy.get('[data-test-subj="searchAutocompleteTextArea"]').should('be.disabled');
     cy.get('[data-test-subj="servicesEntitiesAccordion"]').trigger('mouseover').click();
+    cy.get('[data-test-subj="servicesEntitiesCountBadge"]').should('contain', '1');
     cy.get('[data-test-subj="servicesEntitiesComboBox"]').click();
     cy.get('.euiFilterSelectItem').contains(service_two).click();
     cy.get('[data-test-subj="servicesEntitiesCountBadge"]').should('contain', '2');
     cy.get('[data-test-subj="traceGroupsAccordion"]').trigger('mouseover').click();
+    cy.get('[data-test-subj="traceGroupsCountBadge"]').should('contain', '2');
     cy.get('[data-test-subj="comboBoxToggleListButton"]').eq(1).click();
     cy.get('.euiFilterSelectItem').contains(trace_three).trigger('click');
     cy.get('[data-test-subj="traceGroupsCountBadge"]').should('contain', '3');

--- a/.cypress/integration/app_analytics_test/app_analytics.spec.js
+++ b/.cypress/integration/app_analytics_test/app_analytics.spec.js
@@ -436,6 +436,7 @@ describe('Viewing application', () => {
     cy.get('[data-test-subj="app-analytics-configTab"]').click();
     cy.get('select').select(visOneName);
     cy.wait('@selectUpdate');
+    cy.get('select').find('option:selected').should('have.text', visOneName);
 
     moveToHomePage();
     cy.wait('@loadingPanels');
@@ -563,13 +564,15 @@ describe('Application Analytics home page', () => {
     cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
     cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
     cy.get('[data-test-subj="popoverModal__deleteButton"').click();
-    cy.get('.euiToast').contains(`Applications successfully deleted!`);
+    cy.get('[data-test-subj="applicationHomePageTitle"]').contains(`(2)`);
     cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
     cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
     cy.get('[data-test-subj="popoverModal__deleteButton"').click();
+    cy.get('[data-test-subj="applicationHomePageTitle"]').contains(`(1)`);
     cy.get('[data-test-subj="deleteApplication"]').eq(0).click();
     cy.get('[data-test-subj="popoverModal__deleteTextInput"]').type('delete');
     cy.get('[data-test-subj="popoverModal__deleteButton"').click();
+    cy.get('[data-test-subj="applicationHomePageTitle"]').contains(`(0)`);
     cy.get(`[data-test-subj="${newName}ApplicationLink"]`).should('not.exist');
   });
 });

--- a/public/components/application_analytics/components/app_table.tsx
+++ b/public/components/application_analytics/components/app_table.tsx
@@ -227,8 +227,6 @@ export function AppTable(props: AppTableProps) {
     app.name.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
-  console.log('Applications', applications);
-
   return (
     <>
       <EuiPage>

--- a/public/components/application_analytics/components/app_table.tsx
+++ b/public/components/application_analytics/components/app_table.tsx
@@ -86,7 +86,7 @@ export function AppTable(props: AppTableProps) {
     );
     clear();
     fetchApplications();
-  }, [applications.length]);
+  }, []);
 
   const clear = () => {
     setFilters([]);
@@ -226,6 +226,8 @@ export function AppTable(props: AppTableProps) {
   const filteredApplications = applications.filter((app) =>
     app.name.toLowerCase().includes(searchQuery.toLowerCase())
   );
+
+  console.log('Applications', applications);
 
   return (
     <>

--- a/public/components/application_analytics/components/app_table.tsx
+++ b/public/components/application_analytics/components/app_table.tsx
@@ -138,6 +138,7 @@ export function AppTable(props: AppTableProps) {
       description: 'Rename this application',
       icon: 'pencil',
       type: 'icon',
+      'data-test-subj': 'renameApplication',
       onClick: (app: ApplicationType) => renameApp(app),
     },
     {
@@ -146,6 +147,7 @@ export function AppTable(props: AppTableProps) {
       icon: 'trash',
       type: 'icon',
       color: 'danger',
+      'data-test-subj': 'deleteApplication',
       onClick: (app: ApplicationType) => deleteApp(app),
     },
   ];
@@ -231,7 +233,7 @@ export function AppTable(props: AppTableProps) {
         <EuiPageBody component="div">
           <EuiPageHeader>
             {!newNavigation && (
-              <EuiTitle size="l">
+              <EuiTitle data-test-subj="applicationHomePageTitle" size="l">
                 <h3>Applications {` (${applications.length})`}</h3>
               </EuiTitle>
             )}

--- a/public/components/application_analytics/components/application.tsx
+++ b/public/components/application_analytics/components/application.tsx
@@ -294,7 +294,7 @@ export function Application(props: AppDetailProps) {
         <ServicesContent
           {...props}
           page="app"
-          nameColumnAction={nameColumnAction}
+          setCurrentSelectedService={nameColumnAction}
           traceColumnAction={traceColumnAction}
           parentBreadcrumb={parentBreadcrumbs[0]}
           childBreadcrumbs={childBreadcrumbs}

--- a/public/components/application_analytics/home.tsx
+++ b/public/components/application_analytics/home.tsx
@@ -38,6 +38,7 @@ import {
   isNameValid,
   removeTabData,
 } from './helpers/utils';
+import { SavedObjectsActions } from '../../services/saved_objects/saved_object_client/saved_objects_actions';
 
 export type AppAnalyticsCoreDeps = TraceAnalyticsCoreDeps;
 
@@ -201,8 +202,7 @@ export const Home = (props: HomeProps) => {
   const deleteSavedVisualizationsForPanel = async (appPanelId: string) => {
     const savedVizIdsToDelete = await fetchPanelsVizIdList(http, appPanelId);
     if (!isEmpty(savedVizIdsToDelete)) {
-      savedObjects
-        .deleteSavedObjectsList({ objectIdList: savedVizIdsToDelete })
+      await SavedObjectsActions.deleteBulk({ objectIdList: savedVizIdsToDelete })
         .then((_res) => {
           deletePanelForApp(appPanelId);
         })
@@ -350,14 +350,10 @@ export const Home = (props: HomeProps) => {
   };
 
   // Delete existing applications
-  const deleteApp = (appList: string[], panelList: string[], toastMessage?: string) => {
+  const deleteApp = async (appList: string[], panelList: string[], toastMessage?: string) => {
     return http
-      .delete(`${APP_ANALYTICS_API_PREFIX}/${appList.join(',')}`)
-      .then((res) => {
-        setApplicationList((prevApplicationList) => {
-          return prevApplicationList.filter((app) => !appList.includes(app.id));
-        });
-
+      .delete(`${APP_ANALYTICS_API_PREFIX}/${[...appList].join(',')}`)
+      .then(async (res) => {
         for (let i = 0; i < appList.length; i++) {
           removeTabData(dispatch, appList[i], '');
         }
@@ -366,6 +362,9 @@ export const Home = (props: HomeProps) => {
           deleteSavedVisualizationsForPanel(panelList[i]);
         }
 
+        setApplicationList((prevApplicationList) => {
+          return prevApplicationList.filter((app) => !appList.includes(app.id));
+        });
         const message =
           toastMessage || `Application${appList.length > 1 ? 's' : ''} successfully deleted!`;
         setToast(message);

--- a/public/components/custom_panels/panel_modules/visualization_container/__tests__/__snapshots__/visualization_container.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_container/__tests__/__snapshots__/visualization_container.test.tsx.snap
@@ -94,6 +94,48 @@ exports[`Visualization Container Component renders add visualization container 1
                   </EuiText>
                 </div>
               </EuiFlexItem>
+              <EuiFlexItem
+                className="visualization-action-button"
+                grow={false}
+              >
+                <div
+                  className="euiFlexItem euiFlexItem--flexGrowZero visualization-action-button"
+                >
+                  <EuiIcon
+                    data-test-subj="removeVisualizationButton"
+                    onClick={[Function]}
+                    type="crossInACircleFilled"
+                  >
+                    <EuiIconBeaker
+                      aria-hidden={true}
+                      className="euiIcon euiIcon--medium euiIcon-isLoading"
+                      data-test-subj="removeVisualizationButton"
+                      focusable="false"
+                      onClick={[Function]}
+                      role="img"
+                      style={null}
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="euiIcon euiIcon--medium euiIcon-isLoading"
+                        data-test-subj="removeVisualizationButton"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        role="img"
+                        style={null}
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                        />
+                      </svg>
+                    </EuiIconBeaker>
+                  </EuiIcon>
+                </div>
+              </EuiFlexItem>
             </div>
           </EuiFlexGroup>
         </div>

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -5,8 +5,10 @@
 
 import {
   EuiSmallButton,
+  EuiSmallButtonIcon,
   EuiCodeBlock,
   EuiContextMenuItem,
+  EuiContextMenuPanel,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
@@ -17,6 +19,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiPanel,
+  EuiPopover,
   EuiSpacer,
   EuiText,
   EuiToolTip,
@@ -100,6 +103,7 @@ export const VisualizationContainer = ({
   onEditClick,
   cloneVisualization,
   showFlyout,
+  removeVisualization,
   catalogVisualization,
   inlineEditor,
   actionMenuType,
@@ -112,6 +116,7 @@ export const VisualizationContainer = ({
   const [visualizationData, setVisualizationData] = useState<Plotly.Data[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState({} as VizContainerError);
+  const onActionsMenuClick = () => setIsPopoverOpen((currPopoverOpen) => !currPopoverOpen);
   const closeActionsMenu = () => setIsPopoverOpen(false);
   const { http, pplService } = coreRefs;
   const { setToast } = useToast();
@@ -367,6 +372,37 @@ export const VisualizationContainer = ({
                   <h5 data-test-subj="visualizationHeader">{visualizationTitle}</h5>
                 </EuiToolTip>
               </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false} className="visualization-action-button">
+              {editMode ? (
+                <EuiIcon
+                  data-test-subj="removeVisualizationButton"
+                  type="crossInACircleFilled"
+                  onClick={() => {
+                    removeVisualization(visualizationId);
+                  }}
+                />
+              ) : (
+                <EuiPopover
+                  button={
+                    <EuiSmallButtonIcon
+                      aria-label="actionMenuButton"
+                      iconType="boxesHorizontal"
+                      onClick={onActionsMenuClick}
+                    />
+                  }
+                  isOpen={isPopoverOpen}
+                  closePopover={closeActionsMenu}
+                  anchorPosition="downLeft"
+                  panelPaddingSize="none"
+                >
+                  <EuiContextMenuPanel
+                    items={popoverPanel}
+                    data-test-subj="panelViz__popoverPanel"
+                    size="s"
+                  />
+                </EuiPopover>
+              )}
             </EuiFlexItem>
           </EuiFlexGroup>
           {inlineEditor}

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -238,10 +238,7 @@ export const VisualizationContainer = ({
     </EuiContextMenuItem>,
   ];
 
-  if (
-    visualizationMetaData?.metricType === PROMQL_METRIC_SUBTYPE &&
-    actionMenuType === 'metricsGrid'
-  ) {
+  if (actionMenuType === 'metricsGrid') {
     popoverPanel = [showPPLQueryPanel];
   } else if (usedInNotebooks) {
     popoverPanel = [popoverPanel[0]];


### PR DESCRIPTION
### Description
1. Update cypress tests for app analytics 
2. Update to use savedObjects client to delete saved visualizations in applications
3. Add back visualization action menu

<img width="400" alt="Screenshot 2024-11-21 at 4 50 00 PM" src="https://github.com/user-attachments/assets/517bdc3f-f5a4-4d63-858d-86dd9431f6e0">

Visualization action menu:
![Screenshot 2024-12-04 at 3 01 06 PM](https://github.com/user-attachments/assets/b027f93a-82cf-4096-9970-5570b96a1658)




### Issues Resolved
#1886 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
