### PR TITLE
[Bug] Fix notebook routes for savedNotebook endpoints

### DIFF
--- a/public/components/notebooks/components/main.tsx
+++ b/public/components/notebooks/components/main.tsx
@@ -98,7 +98,7 @@ export class Main extends React.Component<MainProps, MainState> {
     if (this.props.dataSourceEnabled) {
       // If `MDS` is enabled, only fetch from the first endpoint.
       return this.props.http
-        .get(`${NOTEBOOKS_API_PREFIX}/savedNotebook/`)
+        .get(`${NOTEBOOKS_API_PREFIX}/savedNotebook`)
         .then((savedNotebooksResponse) => {
           this.setState({ data: savedNotebooksResponse.data });
         })
@@ -106,9 +106,11 @@ export class Main extends React.Component<MainProps, MainState> {
           console.error('Issue in fetching the notebooks', err.body.message);
         });
     }
-    // If `MDS` is not enabled /savedNotebook/ API returns notebooks stored as saved objects, and the other one returns notebooks stored as observability objects.
+    // If `MDS` is not enabled /savedNotebook API returns notebooks stored as saved objects, and the other one returns notebooks stored as observability objects.
+    // ${NOTEBOOKS_API_PREFIX}/savedNotebook: this point to new notebooks saved in saved objects
+    // ${NOTEBOOKS_API_PREFIX}/: this point to old notebooks saved in observability index
     return Promise.all([
-      this.props.http.get(`${NOTEBOOKS_API_PREFIX}/savedNotebook/`),
+      this.props.http.get(`${NOTEBOOKS_API_PREFIX}/savedNotebook`),
       this.props.http.get(`${NOTEBOOKS_API_PREFIX}/`),
     ])
       .then(([savedNotebooksResponse, secondResponse]) => {

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -4,9 +4,9 @@
  */
 
 import {
-  EuiSmallButton,
   EuiButtonGroup,
   EuiButtonGroupOptionProps,
+  EuiButtonIcon,
   EuiCallOut,
   EuiCard,
   EuiContextMenu,
@@ -19,18 +19,18 @@ import {
   EuiPageBody,
   EuiPanel,
   EuiPopover,
+  EuiSmallButton,
   EuiSpacer,
   EuiText,
-  EuiButtonIcon,
   EuiTitle,
   EuiToolTip,
 } from '@elastic/eui';
+import { FormattedMessage } from '@osd/i18n/react';
 import CSS from 'csstype';
 import moment from 'moment';
 import queryString from 'query-string';
 import React, { Component } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { FormattedMessage } from '@osd/i18n/react';
 import {
   ChromeBreadcrumb,
   CoreStart,
@@ -43,6 +43,8 @@ import { CREATE_NOTE_MESSAGE, NOTEBOOKS_API_PREFIX } from '../../../../common/co
 import { UI_DATE_FORMAT } from '../../../../common/constants/shared';
 import { ParaType } from '../../../../common/types/notebooks';
 import { setNavBreadCrumbs } from '../../../../common/utils/set_nav_bread_crumbs';
+import { HeaderControlledComponentsWrapper } from '../../../../public/plugin_helpers/plugin_headerControl';
+import { coreRefs } from '../../../framework/core_refs';
 import PPLService from '../../../services/requests/ppl';
 import { GenerateReportLoadingModal } from './helpers/custom_modals/reporting_loading_modal';
 import { defaultParagraphParser } from './helpers/default_parser';
@@ -54,8 +56,6 @@ import {
   generateInContextReport,
 } from './helpers/reporting_context_menu_helper';
 import { Paragraphs } from './paragraph_components/paragraphs';
-import { HeaderControlledComponentsWrapper } from '../../../../public/plugin_helpers/plugin_headerControl';
-import { coreRefs } from '../../../framework/core_refs';
 
 const newNavigation = coreRefs.chrome?.navGroup.getNavGroupEnabled();
 
@@ -416,7 +416,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     };
 
     return this.props.http
-      .post(`${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/`, {
+      .post(`${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph`, {
         body: JSON.stringify(addParaObj),
       })
       .then((res) => {
@@ -468,7 +468,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     };
 
     return this.props.http
-      .post(`${NOTEBOOKS_API_PREFIX}/savedNotebook/set_paragraphs/`, {
+      .post(`${NOTEBOOKS_API_PREFIX}/savedNotebook/set_paragraphs`, {
         body: JSON.stringify(moveParaObj),
       })
       .then((_res) => this.setState({ paragraphs, parsedPara }))
@@ -499,7 +499,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
       noteId: this.props.openedNoteId,
     };
     this.props.http
-      .put(`${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/clearall/`, {
+      .put(`${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/clearall`, {
         body: JSON.stringify(clearParaObj),
       })
       .then((res) => {
@@ -537,8 +537,8 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     };
     const isValid = isValidUUID(this.props.openedNoteId);
     const route = isValid
-      ? `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/update/run/`
-      : `${NOTEBOOKS_API_PREFIX}/paragraph/update/run/`;
+      ? `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/update/run`
+      : `${NOTEBOOKS_API_PREFIX}/paragraph/update/run`;
     return this.props.http
       .post(route, {
         body: JSON.stringify(paraUpdateObject),

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -538,7 +538,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     const isValid = isValidUUID(this.props.openedNoteId);
     const route = isValid
       ? `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/update/run`
-      : `${NOTEBOOKS_API_PREFIX}/paragraph/update/run`;
+      : `${NOTEBOOKS_API_PREFIX}/paragraph/update/run/`;
     return this.props.http
       .post(route, {
         body: JSON.stringify(paraUpdateObject),

--- a/server/routes/notebooks/paraRouter.ts
+++ b/server/routes/notebooks/paraRouter.ts
@@ -284,7 +284,7 @@ export function registerParaRoute(router: IRouter) {
 
   router.post(
     {
-      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/`,
+      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph`,
       validate: {
         body: schema.object({
           noteId: schema.string(),
@@ -314,7 +314,7 @@ export function registerParaRoute(router: IRouter) {
   );
   router.put(
     {
-      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/clearall/`,
+      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/clearall`,
       validate: {
         body: schema.object({
           noteId: schema.string(),
@@ -377,7 +377,7 @@ export function registerParaRoute(router: IRouter) {
 
   router.post(
     {
-      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/update/run/`,
+      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/update/run`,
       validate: {
         body: schema.object({
           noteId: schema.string(),
@@ -413,7 +413,7 @@ export function registerParaRoute(router: IRouter) {
 
   router.put(
     {
-      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph/`,
+      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/paragraph`,
       validate: {
         body: schema.object({
           noteId: schema.string(),
@@ -445,7 +445,7 @@ export function registerParaRoute(router: IRouter) {
   );
   router.post(
     {
-      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/set_paragraphs/`,
+      path: `${NOTEBOOKS_API_PREFIX}/savedNotebook/set_paragraphs`,
       validate: {
         body: schema.object({
           noteId: schema.string(),


### PR DESCRIPTION
### Description
Fix notebook routes by removing extra slash. This is only done for new endpoints which use savedObjects API, workspaces and MDS.

### Issues Resolved
* Removes extra slashes from the notebooks saved object routes
* Doesn't need extra tests cypress would validate all the new endpoints automatically
https://github.com/opensearch-project/dashboards-observability/issues/2267 
https://github.com/opensearch-project/dashboards-observability/issues/2262

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
