### PR TITLE
Configure OpenSearch Dashboards before running in CI

### DIFF
--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -108,6 +108,15 @@ jobs:
           node-version: ${{ steps.versions_step.outputs.node_version }}
           registry-url: "https://registry.npmjs.org"
 
+      - name: Configure OpenSearch Dashboards
+        run: |
+          rm -rf ./config/opensearch_dashboards.yml
+          cat << 'EOT' > ./config/opensearch_dashboards.yml
+          server.host: "0.0.0.0"
+          home.disableWelcomeScreen: true
+          EOT
+        working-directory: OpenSearch-Dashboards
+
       - name: Install correct yarn version for OpenSearch Dashboards
         id: setup-yarn
         run: |


### PR DESCRIPTION
### Description
Add step to configure OpenSearch Dashboards before running FTR Cypress tests so that Cypress can connect to server
This will allow the FTR tests to run

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
