### PR TITLE
Fix flaky cypress tests

### DIFF
--- a/.cypress/integration/app_analytics_test/app_analytics.spec.js
+++ b/.cypress/integration/app_analytics_test/app_analytics.spec.js
@@ -433,13 +433,13 @@ describe('Viewing application', () => {
 
 
   it('Changes availability visualization', () => {
+    cy.intercept('PUT', `**/api/observability/application`).as('selectUpdate');
+    cy.intercept('GET', `**/api/observability/operational_panels/panels/**`).as('loadingPanels')
     cy.get('[data-test-subj="app-analytics-configTab"]').click();
     cy.get('select').select(visOneName);
-    cy.intercept('PUT', `**/api/observability/application`).as('selectUpdate');
     cy.wait('@selectUpdate');
 
     moveToHomePage();
-    cy.intercept('GET', `**/api/observability/operational_panels/panels/**`).as('loadingPanels')
     cy.wait('@loadingPanels');
     cy.reload();
     cy.get('[data-test-subj="AvailableAvailabilityBadge"][style="background-color: rgb(84, 179, 153); color: rgb(0, 0, 0);"]').should('contain', 'Available');

--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -479,6 +479,7 @@ describe('Visualizing data', () => {
   });
 
   it('Visualize vertical bar chart', () => {
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('[data-test-subj="comboBoxInput"]').eq(1).click();
     cy.get('[data-test-subj="comboBoxOptionsList "] span').contains(VIS_TYPE_VBAR).click();
     cy.get('[data-test-subj="vizConfigSection-series"]')

--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -164,6 +164,7 @@ describe('Testing traces tree view', () => {
     cy.get("[data-test-subj='indexPattern-switch-link']").click();
     cy.get("[data-test-subj='data_prepper-mode']").click();
     setTimeFilter();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.contains('02feb3a4f611abd81f2a53244d1278ae').click();
     cy.get('h1.overview-content').contains('02feb3a4f611abd81f2a53244d1278ae').should('exist');
   });

--- a/.cypress/utils/app_constants.js
+++ b/.cypress/utils/app_constants.js
@@ -136,6 +136,7 @@ export const moveToEditPage = () => {
 
 export const changeTimeTo24 = (timeUnit) => {
   cy.get('[data-test-subj="superDatePickerToggleQuickMenuButton"]').trigger('mouseover').click({ force: true });
+  cy.get('[aria-label="Time value"]').type('{selectall}24');
   cy.get('[aria-label="Time unit"]').select(timeUnit);
   cy.get('.euiButton').contains('Apply').click();
   cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();


### PR DESCRIPTION
### Description
Fix flaky cypress tests for app analytics, event analytics, and traces
Change time value to 24 when setting time in applications tests and wait for queries/tables to load before clicking

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
