### PR TITLE
Traces custom source - Bug Fixes

### DIFF
--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -140,6 +140,27 @@ export const getTimestampPrecision = (timestamp: number): 'millis' | 'micros' | 
   }
 };
 
+export const appendModeToTraceViewUri = (
+  traceId: string,
+  getTraceViewUri?: (traceId: string) => string,
+  traceMode?: string | null
+): string => {
+  const baseUri = getTraceViewUri ? getTraceViewUri(traceId) : '';
+  const isHashRouter = baseUri.includes('#');
+  const separator = isHashRouter
+    ? baseUri.includes('?')
+      ? '&'
+      : '?'
+    : baseUri.includes('?')
+    ? '&'
+    : '?';
+
+  if (traceMode) {
+    return `${baseUri}${separator}mode=${encodeURIComponent(traceMode)}`;
+  }
+  return baseUri;
+};
+
 export function microToMilliSec(micro: number) {
   if (typeof micro !== 'number') return 0;
   return micro / 1000;

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -122,7 +122,6 @@ export function nanoToMilliSec(nano: number) {
 export const getTimestampPrecision = (timestamp: number): 'millis' | 'micros' | 'nanos' => {
   if (!timestamp) return 'millis';
 
-  // Convert to string and get total length
   const digitCount = timestamp.toString().length;
 
   // For Unix timestamps:

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -146,14 +146,7 @@ export const appendModeToTraceViewUri = (
   traceMode?: string | null
 ): string => {
   const baseUri = getTraceViewUri ? getTraceViewUri(traceId) : '';
-  const isHashRouter = baseUri.includes('#');
-  const separator = isHashRouter
-    ? baseUri.includes('?')
-      ? '&'
-      : '?'
-    : baseUri.includes('?')
-    ? '&'
-    : '?';
+  const separator = baseUri.includes('?') ? '&' : '?';
 
   if (traceMode) {
     return `${baseUri}${separator}mode=${encodeURIComponent(traceMode)}`;

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -119,6 +119,28 @@ export function nanoToMilliSec(nano: number) {
   return nano / 1000000;
 }
 
+export const getTimestampPrecision = (timestamp: number): 'millis' | 'micros' | 'nanos' => {
+  if (!timestamp) return 'millis';
+
+  // Convert to string and get total length
+  const digitCount = timestamp.toString().length;
+
+  // For Unix timestamps:
+  // 13 digits = milliseconds (e.g., 1703599200000)
+  // 16 digits = microseconds (e.g., 1703599200000000)
+  // 19 digits = nanoseconds  (e.g., 1703599200000000000)
+  switch (digitCount) {
+    case 13:
+      return 'millis';
+    case 16:
+      return 'micros';
+    case 19:
+      return 'nanos';
+    default:
+      return 'millis';
+  }
+};
+
 export function microToMilliSec(micro: number) {
   if (typeof micro !== 'number') return 0;
   return micro / 1000;

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -149,7 +149,7 @@ export function ServiceMap({
         includeMetricsCallback();
       }
     }
-  }, [selectableValue, setIdSelected]);
+  }, []);
 
   const removeFilter = (field: string, value: string) => {
     if (!setFilters) return;

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -123,17 +123,6 @@ export function ServiceMap({
     );
   }, [filters, focusedService]);
 
-  const onChangeSelectable = (value: React.SetStateAction<Array<EuiSuperSelectOption<any>>>) => {
-    // if the change is changing for the first time then callback servicemap with metrics
-    if (selectableValue.length === 0 && value.length !== 0) {
-      if (includeMetricsCallback) {
-        includeMetricsCallback();
-      }
-    }
-    setIdSelected(value);
-    setSelectableValue(value);
-  };
-
   const metricOptions: Array<EuiSuperSelectOption<any>> = [
     {
       value: 'latency',
@@ -148,6 +137,19 @@ export function ServiceMap({
       inputDisplay: 'Request Rate',
     },
   ];
+
+  // For the traces custom page
+  useEffect(() => {
+    if (!selectableValue || selectableValue.length === 0) {
+      // Set to the first option ("latency") and trigger the onChange function
+      const defaultValue = metricOptions[0].value;
+      setSelectableValue(defaultValue); // Update the state
+      setIdSelected(defaultValue); // Propagate the default to parent
+      if (includeMetricsCallback) {
+        includeMetricsCallback();
+      }
+    }
+  }, [selectableValue, setIdSelected]);
 
   const removeFilter = (field: string, value: string) => {
     if (!setFilters) return;
@@ -504,7 +506,10 @@ export function ServiceMap({
                   compressed
                   options={metricOptions}
                   valueOfSelected={selectableValue}
-                  onChange={(value) => onChangeSelectable(value)}
+                  onChange={(value) => {
+                    setSelectableValue(value);
+                    setIdSelected(value);
+                  }}
                 />
               </EuiFlexItem>
             )}

--- a/public/components/trace_analytics/components/dashboard/mode_picker.tsx
+++ b/public/components/trace_analytics/components/dashboard/mode_picker.tsx
@@ -67,7 +67,7 @@ export function DataSourcePicker(props: {
     const hash = window.location.hash;
 
     if (hash) {
-      const [hashPath, hashQueryString] = hash.split('?');
+      const [hashPath, hashQueryString] = hash.substring(1).split('?');
       const queryParams = new URLSearchParams(hashQueryString || '');
       queryParams.set('mode', key);
 

--- a/public/components/trace_analytics/components/dashboard/mode_picker.tsx
+++ b/public/components/trace_analytics/components/dashboard/mode_picker.tsx
@@ -62,6 +62,17 @@ export function DataSourcePicker(props: {
     );
   };
 
+  const updateUrlWithMode = (key: TraceAnalyticsMode) => {
+    const currentUrl = window.location.href.split('?')[0];
+    const queryParams = new URLSearchParams(window.location.search);
+
+    // Update the mode parameter in the query string
+    queryParams.set('mode', key);
+
+    // Update the URL without reloading the page
+    window.history.replaceState(null, '', `${currentUrl}?${queryParams.toString()}`);
+  };
+
   return (
     <>
       <EuiPopover
@@ -94,6 +105,7 @@ export function DataSourcePicker(props: {
                 key: TraceAnalyticsMode;
               };
               setMode(choice.key);
+              updateUrlWithMode(choice.key);
               setPopoverIsOpen(false);
               sessionStorage.setItem('TraceAnalyticsMode', choice.key);
             }}

--- a/public/components/trace_analytics/components/dashboard/mode_picker.tsx
+++ b/public/components/trace_analytics/components/dashboard/mode_picker.tsx
@@ -63,14 +63,25 @@ export function DataSourcePicker(props: {
   };
 
   const updateUrlWithMode = (key: TraceAnalyticsMode) => {
-    const currentUrl = window.location.href.split('?')[0];
-    const queryParams = new URLSearchParams(window.location.search);
+    const currentUrl = window.location.href.split('#')[0];
+    const hash = window.location.hash;
 
-    // Update the mode parameter in the query string
-    queryParams.set('mode', key);
+    if (hash) {
+      const [hashPath, hashQueryString] = hash.split('?');
+      const queryParams = new URLSearchParams(hashQueryString || '');
+      queryParams.set('mode', key);
 
-    // Update the URL without reloading the page
-    window.history.replaceState(null, '', `${currentUrl}?${queryParams.toString()}`);
+      const newHash = `${hashPath}?${queryParams.toString()}`;
+      const newUrl = `${currentUrl}#${newHash}`;
+      window.history.replaceState(null, '', newUrl);
+    } else {
+      // Non-hash-based URL
+      const queryParams = new URLSearchParams(window.location.search);
+      queryParams.set('mode', key);
+
+      const newUrl = `${currentUrl}?${queryParams.toString()}`;
+      window.history.replaceState(null, '', newUrl);
+    }
   };
 
   return (

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -1474,6 +1474,7 @@ exports[`Traces component renders empty traces page 1`] = `
               items={Array []}
               loading={true}
               mode="data_prepper"
+              page="traces"
               refresh={[Function]}
             >
               <EuiPanel>
@@ -3930,6 +3931,7 @@ exports[`Traces component renders jaeger traces page 1`] = `
               jaegerIndicesExist={true}
               loading={true}
               mode="jaeger"
+              page="traces"
               refresh={[Function]}
             >
               <EuiPanel>
@@ -6217,6 +6219,7 @@ exports[`Traces component renders traces page 1`] = `
               items={Array []}
               loading={true}
               mode="data_prepper"
+              page="traces"
               refresh={[Function]}
             >
               <EuiPanel>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -1121,12 +1121,13 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                       >
                                         <EuiLink
                                           data-test-subj="trace-link"
+                                          href="#/trace_analytics/traces/00079a615e31e61766fcb20b557051c1"
                                         >
-                                          <button
+                                          <a
                                             className="euiLink euiLink--primary"
                                             data-test-subj="trace-link"
-                                            disabled={false}
-                                            type="button"
+                                            href="#/trace_analytics/traces/00079a615e31e61766fcb20b557051c1"
+                                            rel="noreferrer"
                                           >
                                             <EuiText
                                               className="traces-table traces-table-trace-id"
@@ -1140,7 +1141,7 @@ exports[`Traces table component renders jaeger traces table 1`] = `
                                                 00079a615e31e61766fcb20b557051c1
                                               </div>
                                             </EuiText>
-                                          </button>
+                                          </a>
                                         </EuiLink>
                                       </div>
                                     </EuiFlexItem>
@@ -2686,12 +2687,13 @@ exports[`Traces table component renders traces table 1`] = `
                                       >
                                         <EuiLink
                                           data-test-subj="trace-link"
+                                          href="#/trace_analytics/traces/00079a615e31e61766fcb20b557051c1"
                                         >
-                                          <button
+                                          <a
                                             className="euiLink euiLink--primary"
                                             data-test-subj="trace-link"
-                                            disabled={false}
-                                            type="button"
+                                            href="#/trace_analytics/traces/00079a615e31e61766fcb20b557051c1"
+                                            rel="noreferrer"
                                           >
                                             <EuiText
                                               className="traces-table traces-table-trace-id"
@@ -2705,7 +2707,7 @@ exports[`Traces table component renders traces table 1`] = `
                                                 00079a615e31e61766fcb20b557051c1
                                               </div>
                                             </EuiText>
-                                          </button>
+                                          </a>
                                         </EuiLink>
                                       </div>
                                     </EuiFlexItem>

--- a/public/components/trace_analytics/components/traces/__tests__/traces_table.test.tsx
+++ b/public/components/trace_analytics/components/traces/__tests__/traces_table.test.tsx
@@ -13,8 +13,7 @@ describe('Traces table component', () => {
 
   it('renders empty traces table message', () => {
     const refresh = jest.fn();
-    const getTraceViewUri = (item: any) =>
-      location.assign(`#/trace_analytics/traces/${encodeURIComponent(item)}`);
+    const getTraceViewUri = (item: any) => `#/trace_analytics/traces/${encodeURIComponent(item)}`;
     const noIndicesTable = mount(
       <TracesTable
         items={[]}
@@ -55,8 +54,7 @@ describe('Traces table component', () => {
         actions: '#',
       },
     ];
-    const getTraceViewUri = (item: any) =>
-      location.assign(`#/trace_analytics/traces/${encodeURIComponent(item)}`);
+    const getTraceViewUri = (item: any) => `#/trace_analytics/traces/${encodeURIComponent(item)}`;
     const refresh = jest.fn();
     const wrapper = mount(
       <TracesTable
@@ -86,8 +84,7 @@ describe('Traces table component', () => {
         actions: '#',
       },
     ];
-    const getTraceViewUri = (item: any) =>
-      location.assign(`#/trace_analytics/traces/${encodeURIComponent(item)}`);
+    const getTraceViewUri = (item: any) => `#/trace_analytics/traces/${encodeURIComponent(item)}`;
     const refresh = jest.fn();
     const wrapper = mount(
       <TracesTable

--- a/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
+++ b/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
@@ -73,28 +73,44 @@ export const getTableColumns = (
       '-'
     );
 
-  const renderTraceLinkField = (item: string) => (
-    <EuiFlexGroup gutterSize="s" alignItems="center">
-      <EuiFlexItem grow={false}>
-        <EuiLink
-          data-test-subj="trace-link"
-          {...(getTraceViewUri && { href: getTraceViewUri(item) })}
-          {...(openTraceFlyout && { onClick: () => openTraceFlyout(item) })}
-        >
-          <EuiText size="s" className="traces-table traces-table-trace-id" title={item}>
-            {item}
-          </EuiText>
-        </EuiLink>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiCopy textToCopy={item}>
-          {(copy) => (
-            <EuiButtonIcon aria-label="Copy trace id" iconType="copyClipboard" onClick={copy} />
-          )}
-        </EuiCopy>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
+  const renderTraceLinkField = (item: string) => {
+    // Extract the current mode from the URL or session storage
+    const queryParams = new URLSearchParams(window.location.search);
+    const traceMode = queryParams.get('mode') || sessionStorage.getItem('TraceAnalyticsMode');
+
+    // Update the href to include the mode if available
+    const updatedGetTraceViewUri = (traceId: string) => {
+      const baseUri = getTraceViewUri ? getTraceViewUri(traceId) : '';
+      if (traceMode) {
+        const separator = baseUri.includes('?') ? '&' : '?';
+        return `${baseUri}${separator}mode=${encodeURIComponent(traceMode)}`;
+      }
+      return baseUri;
+    };
+
+    return (
+      <EuiFlexGroup gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiLink
+            data-test-subj="trace-link"
+            {...(getTraceViewUri && { href: updatedGetTraceViewUri(item) })}
+            {...(openTraceFlyout && { onClick: () => openTraceFlyout(item) })}
+          >
+            <EuiText size="s" className="traces-table traces-table-trace-id" title={item}>
+              {item}
+            </EuiText>
+          </EuiLink>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiCopy textToCopy={item}>
+            {(copy) => (
+              <EuiButtonIcon aria-label="Copy trace id" iconType="copyClipboard" onClick={copy} />
+            )}
+          </EuiCopy>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  };
 
   const renderErrorsField = (item: number) =>
     item == null ? (

--- a/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
+++ b/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
@@ -18,7 +18,7 @@ import moment from 'moment';
 import React from 'react';
 import { TRACE_ANALYTICS_DATE_FORMAT } from '../../../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode, TraceQueryMode } from '../../../../../common/types/trace_analytics';
-import { nanoToMilliSec } from '../common/helper_functions';
+import { appendModeToTraceViewUri, nanoToMilliSec } from '../common/helper_functions';
 
 export const fetchDynamicColumns = (columnItems: string[]) => {
   return columnItems
@@ -75,25 +75,17 @@ export const getTableColumns = (
 
   const renderTraceLinkField = (item: string) => {
     // Extract the current mode from the URL or session storage
-    const queryParams = new URLSearchParams(window.location.search);
-    const traceMode = queryParams.get('mode') || sessionStorage.getItem('TraceAnalyticsMode');
-
-    // Update the href to include the mode if available
-    const updatedGetTraceViewUri = (traceId: string) => {
-      const baseUri = getTraceViewUri ? getTraceViewUri(traceId) : '';
-      if (traceMode) {
-        const separator = baseUri.includes('?') ? '&' : '?';
-        return `${baseUri}${separator}mode=${encodeURIComponent(traceMode)}`;
-      }
-      return baseUri;
-    };
+    const currentUrl = window.location.href;
+    const traceMode =
+      new URLSearchParams(currentUrl.split('?')[1]).get('mode') ||
+      sessionStorage.getItem('TraceAnalyticsMode');
 
     return (
       <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false}>
           <EuiLink
             data-test-subj="trace-link"
-            {...(getTraceViewUri && { href: updatedGetTraceViewUri(item) })}
+            href={appendModeToTraceViewUri(item, getTraceViewUri, traceMode)}
             {...(openTraceFlyout && { onClick: () => openTraceFlyout(item) })}
           >
             <EuiText size="s" className="traces-table traces-table-trace-id" title={item}>

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -301,6 +301,8 @@ export function TracesContent(props: TracesProps) {
                 <EuiFlexItem grow={2}>
                   <ServicesList
                     addFilter={addFilter}
+                    filters={filters}
+                    setFilters={setFilters}
                     serviceMap={serviceMap}
                     filteredService={filteredService}
                     setFilteredService={setFilteredService}
@@ -310,6 +312,8 @@ export function TracesContent(props: TracesProps) {
                 <EuiFlexItem grow={8}>
                   <ServiceMap
                     addFilter={addFilter}
+                    filters={filters}
+                    setFilters={setFilters}
                     serviceMap={serviceMap}
                     idSelected={serviceMapIdSelected}
                     setIdSelected={setServiceMapIdSelected}

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -290,6 +290,7 @@ export function TracesContent(props: TracesProps) {
               openTraceFlyout={openTraceFlyout}
               jaegerIndicesExist={jaegerIndicesExist}
               dataPrepperIndicesExist={dataPrepperIndicesExist}
+              page={page}
             />
           )}
 

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -54,6 +54,18 @@ export function TracesTable(props: TracesTableProps) {
   };
 
   const columns = useMemo(() => {
+    const queryParams = new URLSearchParams(window.location.search);
+    const traceMode = queryParams.get('mode') || sessionStorage.getItem('TraceAnalyticsMode');
+
+    const updatedGetTraceViewUri = (traceId: string) => {
+      const baseUri = getTraceViewUri ? getTraceViewUri(traceId) : '';
+      if (traceMode) {
+        const separator = baseUri.includes('?') ? '&' : '?';
+        return `${baseUri}${separator}mode=${encodeURIComponent(traceMode)}`;
+      }
+      return baseUri;
+    };
+
     if (mode === 'data_prepper' || mode === 'custom_data_prepper') {
       return [
         {
@@ -67,7 +79,7 @@ export function TracesTable(props: TracesTableProps) {
               <EuiFlexItem grow={false}>
                 <EuiLink
                   data-test-subj="trace-link"
-                  {...(getTraceViewUri && { href: getTraceViewUri(item) })}
+                  {...(getTraceViewUri && { href: updatedGetTraceViewUri(item) })}
                   {...(openTraceFlyout && { onClick: () => openTraceFlyout(item) })}
                 >
                   <EuiText size="s" className="traces-table traces-table-trace-id" title={item}>
@@ -158,7 +170,7 @@ export function TracesTable(props: TracesTableProps) {
               <EuiFlexItem grow={false}>
                 <EuiLink
                   data-test-subj="trace-link"
-                  {...(getTraceViewUri && { href: getTraceViewUri(item) })}
+                  {...(getTraceViewUri && { href: updatedGetTraceViewUri(item) })}
                   {...(openTraceFlyout && { onClick: () => openTraceFlyout(item) })}
                 >
                   <EuiText size="s" className="traces-table traces-table-trace-id" title={item}>

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -40,6 +40,7 @@ interface TracesTableProps {
   openTraceFlyout?: (traceId: string) => void;
   jaegerIndicesExist: boolean;
   dataPrepperIndicesExist: boolean;
+  page?: 'traces' | 'app';
 }
 
 export function TracesTable(props: TracesTableProps) {
@@ -74,7 +75,9 @@ export function TracesTable(props: TracesTableProps) {
               <EuiFlexItem grow={false}>
                 <EuiLink
                   data-test-subj="trace-link"
-                  href={appendModeToTraceViewUri(item, getTraceViewUri, traceMode)}
+                  {...(props.page !== 'app' && {
+                    href: appendModeToTraceViewUri(item, getTraceViewUri, traceMode),
+                  })}
                   {...(openTraceFlyout && { onClick: () => openTraceFlyout(item) })}
                 >
                   <EuiText size="s" className="traces-table traces-table-trace-id" title={item}>

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -25,6 +25,7 @@ import React, { useMemo, useState } from 'react';
 import { TRACES_MAX_NUM } from '../../../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode } from '../../../../../common/types/trace_analytics';
 import {
+  appendModeToTraceViewUri,
   MissingConfigurationMessage,
   NoMatchMessage,
   PanelTitle,
@@ -54,17 +55,11 @@ export function TracesTable(props: TracesTableProps) {
   };
 
   const columns = useMemo(() => {
-    const queryParams = new URLSearchParams(window.location.search);
-    const traceMode = queryParams.get('mode') || sessionStorage.getItem('TraceAnalyticsMode');
-
-    const updatedGetTraceViewUri = (traceId: string) => {
-      const baseUri = getTraceViewUri ? getTraceViewUri(traceId) : '';
-      if (traceMode) {
-        const separator = baseUri.includes('?') ? '&' : '?';
-        return `${baseUri}${separator}mode=${encodeURIComponent(traceMode)}`;
-      }
-      return baseUri;
-    };
+    // Extract the current mode from the URL or session storage
+    const currentUrl = window.location.href;
+    const traceMode =
+      new URLSearchParams(currentUrl.split('?')[1]).get('mode') ||
+      sessionStorage.getItem('TraceAnalyticsMode');
 
     if (mode === 'data_prepper' || mode === 'custom_data_prepper') {
       return [
@@ -79,7 +74,7 @@ export function TracesTable(props: TracesTableProps) {
               <EuiFlexItem grow={false}>
                 <EuiLink
                   data-test-subj="trace-link"
-                  {...(getTraceViewUri && { href: updatedGetTraceViewUri(item) })}
+                  href={appendModeToTraceViewUri(item, getTraceViewUri, traceMode)}
                   {...(openTraceFlyout && { onClick: () => openTraceFlyout(item) })}
                 >
                   <EuiText size="s" className="traces-table traces-table-trace-id" title={item}>
@@ -170,7 +165,7 @@ export function TracesTable(props: TracesTableProps) {
               <EuiFlexItem grow={false}>
                 <EuiLink
                   data-test-subj="trace-link"
-                  {...(getTraceViewUri && { href: updatedGetTraceViewUri(item) })}
+                  href={appendModeToTraceViewUri(item, getTraceViewUri, traceMode)}
                   {...(openTraceFlyout && { onClick: () => openTraceFlyout(item) })}
                 >
                   <EuiText size="s" className="traces-table traces-table-trace-id" title={item}>

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -87,7 +87,7 @@ export const Home = (props: HomeProps) => {
   const [jaegerIndicesExist, setJaegerIndicesExist] = useState(false);
   const [attributesFilterFields, setAttributesFilterFields] = useState<string[]>([]);
   const [mode, setMode] = useState<TraceAnalyticsMode>(
-    (sessionStorage.getItem('TraceAnalyticsMode') as TraceAnalyticsMode) || 'jaeger'
+    (sessionStorage.getItem('TraceAnalyticsMode') as TraceAnalyticsMode) || 'data_prepper'
   );
   const storedFilters = sessionStorage.getItem('TraceAnalyticsFilters');
   const [query, setQuery] = useState<string>(sessionStorage.getItem('TraceAnalyticsQuery') || '');

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -210,6 +210,10 @@ export const Home = (props: HomeProps) => {
     ]);
   };
 
+  const isValidTraceAnalyticsMode = (urlMode: string | null): urlMode is TraceAnalyticsMode => {
+    return ['jaeger', 'data_prepper', 'custom_data_prepper'].includes(urlMode || '');
+  };
+
   useEffect(() => {
     handleDataPrepperIndicesExistRequest(
       props.http,
@@ -406,7 +410,8 @@ export const Home = (props: HomeProps) => {
           render={(_routerProps) => {
             const queryParams = new URLSearchParams(window.location.href.split('?')[1]);
             const traceId = queryParams.get('traceId');
-            const traceMode = queryParams.get('mode');
+            const traceModeFromURL = queryParams.get('mode');
+            const traceMode = isValidTraceAnalyticsMode(traceModeFromURL) ? traceModeFromURL : mode;
 
             const SideBarComponent = !isNavGroupEnabled ? TraceSideBar : React.Fragment;
             if (!traceId) {
@@ -451,7 +456,10 @@ export const Home = (props: HomeProps) => {
           render={(_routerProps) => {
             const queryParams = new URLSearchParams(window.location.href.split('?')[1]);
             const serviceId = queryParams.get('serviceId');
-            const serviceMode = queryParams.get('mode');
+            const serviceModeFromURL = queryParams.get('mode');
+            const serviceMode = isValidTraceAnalyticsMode(serviceModeFromURL)
+              ? serviceModeFromURL
+              : mode;
 
             const SideBarComponent = !isNavGroupEnabled ? TraceSideBar : React.Fragment;
             if (!serviceId) {

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -422,6 +422,7 @@ export const Home = (props: HomeProps) => {
                     tracesTableMode={tracesTableMode}
                     setTracesTableMode={setTracesTableMode}
                     {...commonProps}
+                    mode={((traceMode as unknown) as TraceAnalyticsMode) || mode}
                   />
                 </SideBarComponent>
               );
@@ -450,6 +451,7 @@ export const Home = (props: HomeProps) => {
           render={(_routerProps) => {
             const queryParams = new URLSearchParams(window.location.href.split('?')[1]);
             const serviceId = queryParams.get('serviceId');
+            const serviceMode = queryParams.get('mode');
 
             const SideBarComponent = !isNavGroupEnabled ? TraceSideBar : React.Fragment;
             if (!serviceId) {
@@ -463,6 +465,7 @@ export const Home = (props: HomeProps) => {
                     toasts={toasts}
                     dataSourceMDSId={dataSourceMDSId}
                     {...commonProps}
+                    mode={((serviceMode as unknown) as TraceAnalyticsMode) || mode}
                   />
                 </SideBarComponent>
               );
@@ -471,6 +474,7 @@ export const Home = (props: HomeProps) => {
                 <ServiceView
                   serviceName={decodeURIComponent(serviceId)}
                   {...commonProps}
+                  mode={((serviceMode as unknown) as TraceAnalyticsMode) || mode}
                   addFilter={(filter: FilterType) => {
                     for (const addedFilter of filters) {
                       if (

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -406,6 +406,7 @@ export const Home = (props: HomeProps) => {
           render={(_routerProps) => {
             const queryParams = new URLSearchParams(window.location.href.split('?')[1]);
             const traceId = queryParams.get('traceId');
+            const traceMode = queryParams.get('mode');
 
             const SideBarComponent = !isNavGroupEnabled ? TraceSideBar : React.Fragment;
             if (!traceId) {
@@ -431,7 +432,7 @@ export const Home = (props: HomeProps) => {
                   chrome={props.chrome}
                   http={props.http}
                   traceId={decodeURIComponent(traceId)}
-                  mode={mode}
+                  mode={((traceMode as unknown) as TraceAnalyticsMode) || mode}
                   dataSourceMDSId={dataSourceMDSId}
                   dataSourceManagement={props.dataSourceManagement}
                   setActionMenu={props.setActionMenu}

--- a/public/components/trace_analytics/requests/services_request_handler.ts
+++ b/public/components/trace_analytics/requests/services_request_handler.ts
@@ -22,6 +22,7 @@ import {
   getServiceTrendsQuery,
 } from './queries/services_queries';
 import { handleDslRequest } from './request_handler';
+import { coreRefs } from '../../../../public/framework/core_refs';
 
 export const handleServicesRequest = async (
   http: HttpSetup,
@@ -71,7 +72,13 @@ export const handleServicesRequest = async (
     .then((newItems) => {
       setItems(newItems);
     })
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handleServicesRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: 'Failed to retrieve services',
+        toastLifeTimeMs: 10000,
+      });
+    });
 };
 
 export const handleServiceMapRequest = async (
@@ -92,8 +99,19 @@ export const handleServiceMapRequest = async (
   }
   const map: ServiceObject = {};
   let id = 1;
-  await handleDslRequest(http, null, getServiceNodesQuery(mode), mode, dataSourceMDSId)
-    .then((response) =>
+  const serviceNodesResponse = await handleDslRequest(
+    http,
+    null,
+    getServiceNodesQuery(mode),
+    mode,
+    dataSourceMDSId
+  )
+    .then((response) => {
+      // Check if the mode hasn't been set first
+      if (mode === 'jaeger' && !response?.aggregations?.service_type?.buckets) {
+        console.warn('No service nodes found in response.');
+        return false;
+      }
       response.aggregations.service_name.buckets.map(
         (bucket: any) =>
           (map[bucket.key] = {
@@ -106,9 +124,22 @@ export const handleServiceMapRequest = async (
             targetServices: [],
             destServices: [],
           })
-      )
-    )
-    .catch((error) => console.error(error));
+      );
+      return true;
+    })
+    .catch((error) => {
+      console.error('Error retrieving service nodes:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: 'Failed to retrieve service nodes',
+        toastLifeTimeMs: 10000,
+      });
+      return false;
+    });
+
+  // Early return if service node not found
+  if (!serviceNodesResponse) {
+    return map;
+  }
 
   const targets = {};
   await handleDslRequest(http, null, getServiceEdgesQuery('target', mode), mode, dataSourceMDSId)
@@ -121,7 +152,14 @@ export const handleServiceMapRequest = async (
         });
       })
     )
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error retrieving target edges:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: 'Failed to retrieve target edges',
+        toastLifeTimeMs: 10000,
+      });
+    });
+
   await handleDslRequest(
     http,
     null,
@@ -146,24 +184,37 @@ export const handleServiceMapRequest = async (
         })
       )
     )
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error retrieving destination edges:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: 'Failed to retrieve destination edges',
+        toastLifeTimeMs: 10000,
+      });
+    });
 
   if (includeMetrics) {
-    // service map handles DSL differently
-    const latencies = await handleDslRequest(
-      http,
-      DSL,
-      getServiceMetricsQuery(DSL, Object.keys(map), map, mode),
-      mode,
-      dataSourceMDSId
-    );
-    latencies.aggregations.service_name.buckets.map((bucket: any) => {
-      map[bucket.key].latency = bucket.average_latency.value;
-      map[bucket.key].error_rate = round(bucket.error_rate.value, 2) || 0;
-      map[bucket.key].throughput = bucket.doc_count;
-      if (minutesInDateRange != null)
-        map[bucket.key].throughputPerMinute = round(bucket.doc_count / minutesInDateRange, 2);
-    });
+    try {
+      const latencies = await handleDslRequest(
+        http,
+        DSL,
+        getServiceMetricsQuery(DSL, Object.keys(map), map, mode),
+        mode,
+        dataSourceMDSId
+      );
+      latencies.aggregations.service_name.buckets.map((bucket: any) => {
+        map[bucket.key].latency = bucket.average_latency.value;
+        map[bucket.key].error_rate = round(bucket.error_rate.value, 2) || 0;
+        map[bucket.key].throughput = bucket.doc_count;
+        if (minutesInDateRange != null)
+          map[bucket.key].throughputPerMinute = round(bucket.doc_count / minutesInDateRange, 2);
+      });
+    } catch (error) {
+      console.error('Error retrieving service metrics:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: 'Failed to retrieve service metrics',
+        toastLifeTimeMs: 10000,
+      });
+    }
   }
 
   if (currService) {
@@ -180,7 +231,13 @@ export const handleServiceMapRequest = async (
         }
         map[currService].relatedServices = [...relatedServices];
       })
-      .catch((error) => console.error(error));
+      .catch((error) => {
+        console.error('Error retrieving related services:', error);
+        coreRefs.core?.notifications.toasts.addError(error, {
+          title: 'Failed to retrieve related services',
+          toastLifeTimeMs: 10000,
+        });
+      });
   }
 
   if (setItems) setItems(map);
@@ -222,7 +279,13 @@ export const handleServiceViewRequest = (
     .then((newFields) => {
       setFields(newFields);
     })
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handleServiceViewRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: 'Failed to retrieve service view data',
+        toastLifeTimeMs: 10000,
+      });
+    });
 };
 
 export const handleServiceTrendsRequest = (
@@ -324,5 +387,11 @@ export const handleServiceTrendsRequest = (
       });
       setItems(parsedResult);
     })
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handleServiceTrendsRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: 'Failed to retrieve service trends',
+        toastLifeTimeMs: 10000,
+      });
+    });
 };

--- a/public/components/trace_analytics/requests/services_request_handler.ts
+++ b/public/components/trace_analytics/requests/services_request_handler.ts
@@ -107,11 +107,6 @@ export const handleServiceMapRequest = async (
     dataSourceMDSId
   )
     .then((response) => {
-      // Check if the mode hasn't been set first
-      if (mode === 'jaeger' && !response?.aggregations?.service_type?.buckets) {
-        console.warn('No service nodes found in response.');
-        return false;
-      }
       response.aggregations.service_name.buckets.map(
         (bucket: any) =>
           (map[bucket.key] = {

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -154,10 +154,10 @@ export const handleTracesRequest = async (
       const response = responseResult.value;
 
       // Check if the mode hasn't been set first
-      if (mode === 'jaeger' && !response?.aggregations?.service_type?.buckets) {
-        console.warn('No traces or aggregations found.');
-        return [];
-      }
+      // if (mode === 'jaeger' && !response?.aggregations?.service_type?.buckets) {
+      //   console.warn('No traces or aggregations found.');
+      //   return [];
+      // }
 
       return response.aggregations.traces.buckets.map((bucket: any) => {
         if (mode === 'data_prepper' || mode === 'custom_data_prepper') {

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -31,6 +31,7 @@ import {
   getTracesQuery,
 } from './queries/traces_queries';
 import { handleDslRequest } from './request_handler';
+import { coreRefs } from '../../../../public/framework/core_refs';
 
 export const handleCustomIndicesTracesRequest = async (
   http: HttpSetup,
@@ -84,7 +85,13 @@ export const handleCustomIndicesTracesRequest = async (
       setColumns([...newItems[0]]);
       setItems(newItems[1]);
     })
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handleCustomIndicesTracesRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: 'Failed to retrieve custom indices traces',
+        toastLifeTimeMs: 10000,
+      });
+    });
 };
 
 export const handleTracesRequest = async (
@@ -145,6 +152,13 @@ export const handleTracesRequest = async (
       const percentileRanges =
         percentileRangesResult.status === 'fulfilled' ? percentileRangesResult.value : {};
       const response = responseResult.value;
+
+      // Check if the mode hasn't been set first
+      if (mode === 'jaeger' && !response?.aggregations?.service_type?.buckets) {
+        console.warn('No traces or aggregations found.');
+        return [];
+      }
+
       return response.aggregations.traces.buckets.map((bucket: any) => {
         if (mode === 'data_prepper' || mode === 'custom_data_prepper') {
           return {
@@ -172,7 +186,13 @@ export const handleTracesRequest = async (
     .then((newItems) => {
       setItems(newItems);
     })
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handleTracesRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: 'Failed to retrieve traces',
+        toastLifeTimeMs: 10000,
+      });
+    });
 };
 
 export const handleTraceViewRequest = (
@@ -185,6 +205,11 @@ export const handleTraceViewRequest = (
 ) => {
   handleDslRequest(http, null, getTracesQuery(mode, traceId), mode, dataSourceMDSId)
     .then(async (response) => {
+      // Check if the mode hasn't been set first
+      if (mode === 'jaeger' && !response?.aggregations?.service_type?.buckets) {
+        console.warn('No traces or aggregations found.');
+        return [];
+      }
       const bucket = response.aggregations.traces.buckets[0];
       return {
         trace_id: bucket.key,
@@ -201,7 +226,13 @@ export const handleTraceViewRequest = (
     .then((newFields) => {
       setFields(newFields);
     })
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handleTraceViewRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: `Failed to retrieve trace view for trace ID: ${traceId}`,
+        toastLifeTimeMs: 10000,
+      });
+    });
 };
 
 // setColorMap sets serviceName to color mappings
@@ -230,8 +261,14 @@ export const handleServicesPieChartRequest = async (
   const colorMap: any = {};
   let index = 0;
   await handleDslRequest(http, null, getServiceBreakdownQuery(traceId, mode), mode, dataSourceMDSId)
-    .then((response) =>
-      Promise.all(
+    .then((response) => {
+      // Check if the mode hasn't been set first
+      if (mode === 'jaeger' && !response?.aggregations?.service_type?.buckets) {
+        console.warn(`No service breakdown found for trace ID: ${traceId}`);
+        return [];
+      }
+
+      return Promise.all(
         response.aggregations.service_type.buckets.map((bucket: any) => {
           colorMap[bucket.key] = colors[index++ % colors.length];
           return {
@@ -241,9 +278,10 @@ export const handleServicesPieChartRequest = async (
             benchmark: 0,
           };
         })
-      )
-    )
+      );
+    })
     .then((newItems) => {
+      if (!newItems.length) return; // No data to process
       const latencySum = newItems.map((item) => item.value).reduce((a, b) => a + b, 0);
       return [
         {
@@ -262,10 +300,18 @@ export const handleServicesPieChartRequest = async (
       ];
     })
     .then((newItems) => {
-      setServiceBreakdownData(newItems);
-      setColorMap(colorMap);
+      if (newItems) {
+        setServiceBreakdownData(newItems);
+        setColorMap(colorMap);
+      }
     })
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handleServicesPieChartRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: `Failed to retrieve service breakdown for trace ID: ${traceId}`,
+        toastLifeTimeMs: 10000,
+      });
+    });
 };
 
 export const handleSpansGanttRequest = (
@@ -280,7 +326,13 @@ export const handleSpansGanttRequest = (
   handleDslRequest(http, spanFiltersDSL, getSpanDetailQuery(mode, traceId), mode, dataSourceMDSId)
     .then((response) => hitsToSpanDetailData(response.hits.hits, colorMap, mode))
     .then((newItems) => setSpanDetailData(newItems))
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handleSpansGanttRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: `Failed to retrieve spans Gantt chart for trace ID: ${traceId}`,
+        toastLifeTimeMs: 10000,
+      });
+    });
 };
 
 export const handleSpansFlyoutRequest = (
@@ -294,7 +346,13 @@ export const handleSpansFlyoutRequest = (
     .then((response) => {
       setItems(response?.hits.hits?.[0]?._source);
     })
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handleSpansFlyoutRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: `Failed to retrieve span details for span ID: ${spanId}`,
+        toastLifeTimeMs: 10000,
+      });
+    });
 };
 
 const hitsToSpanDetailData = async (hits: any, colorMap: any, mode: TraceAnalyticsMode) => {
@@ -409,7 +467,13 @@ export const handlePayloadRequest = (
 ) => {
   handleDslRequest(http, null, getPayloadQuery(mode, traceId), mode, dataSourceMDSId)
     .then((response) => setPayloadData(JSON.stringify(response.hits.hits, null, 2)))
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handlePayloadRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: `Failed to retrieve payload for trace ID: ${traceId}`,
+        toastLifeTimeMs: 10000,
+      });
+    });
 };
 
 export const handleSpansRequest = (
@@ -426,5 +490,11 @@ export const handleSpansRequest = (
       setItems(response.hits.hits.map((hit: any) => hit._source));
       setTotal(response.hits.total?.value || 0);
     })
-    .catch((error) => console.error(error));
+    .catch((error) => {
+      console.error('Error in handleSpansRequest:', error);
+      coreRefs.core?.notifications.toasts.addError(error, {
+        title: 'Failed to retrieve spans',
+        toastLifeTimeMs: 10000,
+      });
+    });
 };

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -153,12 +153,6 @@ export const handleTracesRequest = async (
         percentileRangesResult.status === 'fulfilled' ? percentileRangesResult.value : {};
       const response = responseResult.value;
 
-      // Check if the mode hasn't been set first
-      // if (mode === 'jaeger' && !response?.aggregations?.service_type?.buckets) {
-      //   console.warn('No traces or aggregations found.');
-      //   return [];
-      // }
-
       return response.aggregations.traces.buckets.map((bucket: any) => {
         if (mode === 'data_prepper' || mode === 'custom_data_prepper') {
           return {


### PR DESCRIPTION
### Description
1. Handle a bug that was causing a page crash if the filter was selected twice.
2. Now removes the filter when clicking.
3. Set a default metric when page loading for custom source. (Was defaulting to no selection)
4. Handle detection of start time by distinguishing between mili and nano seconds based on the sort field length.
5. Added toast messages for 503 returns from traces and services request handlers so the UI reflects issues.
6. Added trace-mode to the url so that new tabs and re-directs/favorites will work. (Previously it defaulted to data_prepper causing jaeger and custom_data_prepper links to break as session storage was not available in the new tabs)

Before: (Bug crashing page when a selected filter was clicked again)

https://github.com/user-attachments/assets/807c112e-fc2e-4ee0-b8c0-bb96f4473bf0

After: (No longer crashes, now removes the filter when clicked again)

https://github.com/user-attachments/assets/91b9afd2-7ee0-4b76-8d44-bde8e101cb6a

Before: (When the custom traces sources used date for the start time mapping instead of date_nanos the times would all start at 0)
<img width="1597" alt="Before1" src="https://github.com/user-attachments/assets/633c43bc-4ef5-4a53-a36b-47819d96a51a" />

After: (Now the time conversion is determined by the length of the sort metric. This example uses the mapping of start time "date", the indexes themselves have some in mili seconds and some in nanos but because the mapping of "date" is used the nanosecond precision is lost.)
<img width="1601" alt="After1" src="https://github.com/user-attachments/assets/4e28d64b-a459-45d4-b394-e3c46330d095" />

Toast message example (manually setting buckets to 1 to cause failure)

https://github.com/user-attachments/assets/eceb6e4d-4a24-4530-a0b8-de3bbf1e246c

URL redirection working:

https://github.com/user-attachments/assets/e544e915-0135-4a4b-8b92-e06a381d8196


### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
