### PR TITLE
[Link Checker Fix] Update latest github links in maintainer doc

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,7 +15,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Lior Perry              | [YANG-DB](https://github.com/YANG-DB)           | Amazon      |
 | Simeon Widdis           | [swiddis](https://github.com/swiddis)           | Amazon      |
 | Chen Dai                | [dai-chen](https://github.com/dai-chen)         | Amazon      |
-| Vamsi Manohar           | [vamsi-amazon](https://github.com/vamsi-amazon) | Amazon      |
+| Vamsi Manohar           | [vamsi-amazon](https://github.com/vamsimanohar) | Amazon      |
 | Peng Huo                | [penghuo](https://github.com/penghuo)           | Amazon      |
 | Sean Kao                | [seankao-az](https://github.com/seankao-az)     | Amazon      |
 | Anirudha Jadhav         | [anirudha](https://github.com/anirudha)         | Amazon      |


### PR DESCRIPTION
### Description
Update latest github links in maintainer doc

### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/actions/runs/12637652053/job/35212282695?pr=2299
```
### Errors in MAINTAINERS.md

* [404] [https://github.com/vamsi-amazon](https://github.com/vamsi-amazon) | Network error: Not Found

Error: Process completed with exit code 2.
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
