### PR TITLE
[Backport 2.x] Update latest github links in maintainer doc

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,7 +16,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons) | Amazon      |
 | Simeon Widdis     | [swiddis](https://github.com/swiddis)             | Amazon      |
 | Chen Dai          | [dai-chen](https://github.com/dai-chen)           | Amazon      |
-| Vamsi Manohar     | [vamsi-amazon](https://github.com/vamsi-amazon)   | Amazon      |
+| Vamsi Manohar     | [vamsi-amazon](https://github.com/vamsimanohar)   | Amazon      |
 | Peng Huo          | [penghuo](https://github.com/penghuo)             | Amazon      |
 | Sean Kao          | [seankao-az](https://github.com/seankao-az)       | Amazon      |
 | Adam Tackett      | [TackAdam](https://github.com/TackAdam)           | Amazon      |


### PR DESCRIPTION
### Description
Manual backport of #2303

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
