### PR TITLE
Traces/Services - Query optimization / UI setting / Bugfix

### DIFF
--- a/.cypress/utils/constants.js
+++ b/.cypress/utils/constants.js
@@ -87,6 +87,7 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
 };
 
 export const expandServiceView = (rowIndex = 0) => {
+  cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');//Replaces wait
   cy.get('*[data-test-subj^="service-flyout-action-btntrace_service"]').eq(rowIndex).click();
   cy.get('[data-test-subj="ActionContextMenu"]').click();
   cy.get('[data-test-subj="viewServiceButton"]').click();

--- a/common/constants/trace_analytics.ts
+++ b/common/constants/trace_analytics.ts
@@ -24,6 +24,7 @@ export const TRACE_ANALYTICS_DSL_ROUTE = '/api/observability/trace_analytics/que
 
 export const TRACE_CUSTOM_SPAN_INDEX_SETTING = 'observability:traceAnalyticsSpanIndices';
 export const TRACE_CUSTOM_SERVICE_INDEX_SETTING = 'observability:traceAnalyticsServiceIndices';
+export const TRACE_CUSTOM_MODE_DEFAULT_SETTING = 'observability:traceAnalyticsCustomModeDefault';
 
 export enum TRACE_TABLE_TITLES {
   all_spans = 'All Spans',

--- a/public/components/trace_analytics/components/common/__tests__/__snapshots__/helper_functions.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/__tests__/__snapshots__/helper_functions.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Helper functions renders benchmark 1`] = `
+exports[`Trace analytics helper functions renders benchmark 1`] = `
 <EuiText
   size="s"
   style={
@@ -22,7 +22,7 @@ exports[`Helper functions renders benchmark 1`] = `
 </EuiText>
 `;
 
-exports[`Helper functions renders benchmark 2`] = `
+exports[`Trace analytics helper functions renders benchmark 2`] = `
 <EuiText
   size="s"
   style={
@@ -44,7 +44,7 @@ exports[`Helper functions renders benchmark 2`] = `
 </EuiText>
 `;
 
-exports[`Helper functions renders benchmark 3`] = `
+exports[`Trace analytics helper functions renders benchmark 3`] = `
 <EuiText
   size="s"
   style={
@@ -66,7 +66,7 @@ exports[`Helper functions renders benchmark 3`] = `
 </EuiText>
 `;
 
-exports[`Helper functions renders no match and missing configuration messages 1`] = `
+exports[`Trace analytics helper functions renders no match and missing configuration messages 1`] = `
 <Fragment>
   <EuiSpacer
     size="s"
@@ -91,7 +91,7 @@ exports[`Helper functions renders no match and missing configuration messages 1`
 </Fragment>
 `;
 
-exports[`Helper functions renders no match and missing configuration messages 2`] = `
+exports[`Trace analytics helper functions renders no match and missing configuration messages 2`] = `
 <Fragment>
   <EuiEmptyPrompt
     actions={
@@ -120,7 +120,7 @@ exports[`Helper functions renders no match and missing configuration messages 2`
 </Fragment>
 `;
 
-exports[`Helper functions renders panel title 1`] = `
+exports[`Trace analytics helper functions renders panel title 1`] = `
 <EuiText
   size="m"
 >
@@ -137,7 +137,7 @@ exports[`Helper functions renders panel title 1`] = `
 </EuiText>
 `;
 
-exports[`Helper functions renders panel title 2`] = `
+exports[`Trace analytics helper functions renders panel title 2`] = `
 <EuiText
   size="m"
 >

--- a/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
+++ b/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
@@ -93,17 +93,6 @@ describe('Trace analytics helper functions', () => {
     expect(serviceMapGraph).toEqual(TEST_SERVICE_MAP_GRAPH);
   });
 
-  it('extracts correct target resources for a given service from its traceGroups', () => {
-    const traceGroups = TEST_SERVICE_MAP.order.traceGroups;
-
-    // Extract all target resources from the traceGroups
-    const targetResources = [].concat(...traceGroups.map((group) => group.targetResource));
-
-    // Verify the extracted resources match the expected list
-    const expectedResources = ['clear_order', 'update_order', 'get_order', 'pay_order'];
-    expect(targetResources).toEqual(expectedResources);
-  });
-
   it('calculates ticks', () => {
     const ticks = calculateTicks(500, 200);
     const ticks2 = calculateTicks(0, 200, 10);

--- a/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
+++ b/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
@@ -82,14 +82,11 @@ describe('Trace analytics helper functions', () => {
   });
 
   it('returns service map graph', () => {
-    const serviceMapGraph = getServiceMapGraph(TEST_SERVICE_MAP, 'latency', [
-      0,
-      50,
-      100,
-      150,
-      200,
-      250,
-    ]);
+    const serviceMapGraph = getServiceMapGraph({
+      map: TEST_SERVICE_MAP,
+      idSelected: 'latency',
+      ticks: [0, 50, 100, 150, 200, 250],
+    });
     expect(serviceMapGraph).toEqual(TEST_SERVICE_MAP_GRAPH);
   });
 

--- a/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
+++ b/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
@@ -32,7 +32,7 @@ import {
   renderBenchmark,
 } from '../helper_functions';
 
-describe('Helper functions', () => {
+describe('Trace analytics helper functions', () => {
   configure({ adapter: new Adapter() });
 
   it('renders panel title', () => {
@@ -93,10 +93,15 @@ describe('Helper functions', () => {
     expect(serviceMapGraph).toEqual(TEST_SERVICE_MAP_GRAPH);
   });
 
-  it('returns target resources for a service from the traceGroups', () => {
+  it('extracts correct target resources for a given service from its traceGroups', () => {
     const traceGroups = TEST_SERVICE_MAP.order.traceGroups;
+
+    // Extract all target resources from the traceGroups
     const targetResources = [].concat(...traceGroups.map((group) => group.targetResource));
-    expect(targetResources).toEqual(['clear_order', 'update_order', 'get_order', 'pay_order']);
+
+    // Verify the extracted resources match the expected list
+    const expectedResources = ['clear_order', 'update_order', 'get_order', 'pay_order'];
+    expect(targetResources).toEqual(expectedResources);
   });
 
   it('calculates ticks', () => {

--- a/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
+++ b/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
@@ -22,7 +22,6 @@ import {
   getPercentileFilter,
   getServiceMapGraph,
   getServiceMapScaleColor,
-  getServiceMapTargetResources,
   getTimestampPrecision,
   milliToNanoSec,
   minFixedInterval,
@@ -94,8 +93,9 @@ describe('Helper functions', () => {
     expect(serviceMapGraph).toEqual(TEST_SERVICE_MAP_GRAPH);
   });
 
-  it('returns target resources by service name', () => {
-    const targetResources = getServiceMapTargetResources(TEST_SERVICE_MAP, 'order');
+  it('returns target resources for a service from the traceGroups', () => {
+    const traceGroups = TEST_SERVICE_MAP.order.traceGroups;
+    const targetResources = [].concat(...traceGroups.map((group) => group.targetResource));
     expect(targetResources).toEqual(['clear_order', 'update_order', 'get_order', 'pay_order']);
   });
 

--- a/public/components/trace_analytics/components/common/custom_index_flyout.tsx
+++ b/public/components/trace_analytics/components/common/custom_index_flyout.tsx
@@ -5,6 +5,7 @@
 
 import {
   EuiCallOut,
+  EuiCheckbox,
   EuiCompressedFieldText,
   EuiDescribedFormGroup,
   EuiFlexGroup,
@@ -23,6 +24,7 @@ import React, { Fragment, useEffect, useState } from 'react';
 import {
   TRACE_CUSTOM_SERVICE_INDEX_SETTING,
   TRACE_CUSTOM_SPAN_INDEX_SETTING,
+  TRACE_CUSTOM_MODE_DEFAULT_SETTING,
 } from '../../../../../common/constants/trace_analytics';
 import { uiSettingsService } from '../../../../../common/utils';
 import { useToast } from '../../../common/toast';
@@ -39,6 +41,7 @@ export const CustomIndexFlyout = ({
   const { setToast } = useToast();
   const [spanIndices, setSpanIndices] = useState('');
   const [serviceIndices, setServiceIndices] = useState('');
+  const [customModeDefault, setCustomModeDefault] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   const onChangeSpanIndices = (e: { target: { value: React.SetStateAction<string> } }) => {
@@ -49,21 +52,27 @@ export const CustomIndexFlyout = ({
     setServiceIndices(e.target.value);
   };
 
+  const onToggleCustomModeDefault = (e: { target: { checked: boolean } }) => {
+    setCustomModeDefault(e.target.checked);
+  };
+
   useEffect(() => {
     setSpanIndices(uiSettingsService.get(TRACE_CUSTOM_SPAN_INDEX_SETTING));
     setServiceIndices(uiSettingsService.get(TRACE_CUSTOM_SERVICE_INDEX_SETTING));
+    setCustomModeDefault(uiSettingsService.get(TRACE_CUSTOM_MODE_DEFAULT_SETTING) || false);
   }, [uiSettingsService]);
 
-  const onSaveIndices = async () => {
+  const onSaveSettings = async () => {
     try {
       setIsLoading(true);
       await uiSettingsService.set(TRACE_CUSTOM_SPAN_INDEX_SETTING, spanIndices);
       await uiSettingsService.set(TRACE_CUSTOM_SERVICE_INDEX_SETTING, serviceIndices);
+      await uiSettingsService.set(TRACE_CUSTOM_MODE_DEFAULT_SETTING, customModeDefault);
       setIsLoading(false);
-      setToast('Updated trace analytics sources successfully', 'success');
+      setToast('Updated trace analytics settings successfully', 'success');
     } catch (error) {
       console.error(error);
-      setToast('Failed to update trace analytics sources', 'danger');
+      setToast('Failed to update trace analytics settings', 'danger');
     }
     setIsLoading(false);
   };
@@ -134,6 +143,23 @@ export const CustomIndexFlyout = ({
               />
             </EuiFormRow>
           </EuiDescribedFormGroup>
+          <EuiDescribedFormGroup
+            title={<h3>Set default mode</h3>}
+            description={
+              <Fragment>
+                Enable this to set &quot;Custom source&quot; as the default mode for trace analytics
+              </Fragment>
+            }
+          >
+            <EuiFormRow>
+              <EuiCheckbox
+                id="customModeDefault"
+                label="Enable custom source as default mode"
+                checked={customModeDefault}
+                onChange={onToggleCustomModeDefault}
+              />
+            </EuiFormRow>
+          </EuiDescribedFormGroup>
         </EuiFlyoutBody>
         <EuiFlyoutFooter>
           <EuiFlexGroup justifyContent="spaceBetween">
@@ -149,7 +175,7 @@ export const CustomIndexFlyout = ({
             <EuiFlexItem grow={false}>
               <EuiSmallButton
                 onClick={async () => {
-                  await onSaveIndices();
+                  await onSaveSettings();
                   setIsFlyoutVisible(false);
                 }}
                 fill

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -605,15 +605,12 @@ export const generateServiceUrl = (
   dataSourceId: string,
   mode?: TraceAnalyticsMode
 ): string => {
-  // Construct the base URL with the serviceId
   let url = `#/services?serviceId=${encodeURIComponent(service)}`;
 
-  // Append the datasourceId if provided
   if (dataSourceId && dataSourceId !== '') {
     url += `&datasourceId=${encodeURIComponent(dataSourceId)}`;
   }
 
-  // Append the mode parameter
   if (mode) {
     url += `&mode=${encodeURIComponent(mode)}`;
   }

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -292,14 +292,6 @@ export function getServiceMapGraph(
   return { graph: { nodes, edges } };
 }
 
-// returns flattened targetResource as an array for all traceGroups
-export function getServiceMapTargetResources(map: ServiceObject, serviceName: string) {
-  return ([] as string[]).concat.apply(
-    [],
-    [...map[serviceName].traceGroups.map((traceGroup) => [...traceGroup.targetResource])]
-  );
-}
-
 export function calculateTicks(min: number, max: number, numTicks = 5): number[] {
   if (min >= max) return calculateTicks(0, Math.max(1, max), numTicks);
   min = Math.floor(min);
@@ -608,14 +600,25 @@ export const getServiceIndices = (mode: TraceAnalyticsMode) => {
   }
 };
 
-export const generateServiceUrl = (service: string, dataSourceId: string) => {
-  const url = `#/services?serviceId=${encodeURIComponent(service)}`;
+export const generateServiceUrl = (
+  service: string,
+  dataSourceId: string,
+  mode?: TraceAnalyticsMode
+): string => {
+  // Construct the base URL with the serviceId
+  let url = `#/services?serviceId=${encodeURIComponent(service)}`;
 
+  // Append the datasourceId if provided
   if (dataSourceId && dataSourceId !== '') {
-    return `${url}&datasourceId=${encodeURIComponent(dataSourceId)}`;
+    url += `&datasourceId=${encodeURIComponent(dataSourceId)}`;
   }
 
-  return `${url}&datasourceId=`;
+  // Append the mode parameter
+  if (mode) {
+    url += `&mode=${encodeURIComponent(mode)}`;
+  }
+
+  return url;
 };
 
 interface FullScreenWrapperProps {

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -214,11 +214,8 @@ export function getServiceMapGraph(
   idSelected: 'latency' | 'error_rate' | 'throughput',
   ticks: number[],
   currService?: string,
-  relatedServices?: string[],
   filterByCurrService?: boolean
 ) {
-  if (!relatedServices) relatedServices = Object.keys(map);
-
   const nodes = Object.keys(map).map((service) => {
     const value = map[service][idSelected];
     let styleOptions;

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -229,14 +229,10 @@ export function getServiceMapGraph(
         borderWidth: 3,
         color: {
           border: '#4A4A4A',
-          background:
-            relatedServices!.indexOf(service) >= 0 ? `rgba(${color}, 1)` : `rgba(${color}, 0.2)`,
+          background: `rgba(${color}, 1)`,
         },
         font: {
-          color:
-            relatedServices!.indexOf(service) >= 0
-              ? `rgba(72, 122, 180, 1)`
-              : `rgba(72, 122, 180, 0.2)`,
+          color: `rgba(72, 122, 180, 1)`,
         },
       };
     } else {
@@ -285,10 +281,7 @@ export function getServiceMapGraph(
         edges.push({
           from: map[service].id,
           to: map[target].id,
-          color:
-            relatedServices!.indexOf(service) >= 0 && relatedServices!.indexOf(target) >= 0
-              ? `rgba(${edgeColor}, 1)`
-              : `rgba(${edgeColor}, 0.2)`,
+          color: `rgba(${edgeColor}, 1)`,
         });
       });
   });

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -214,8 +214,11 @@ export function getServiceMapGraph(
   idSelected: 'latency' | 'error_rate' | 'throughput',
   ticks: number[],
   currService?: string,
+  relatedServices?: string[],
   filterByCurrService?: boolean
 ) {
+  if (!relatedServices) relatedServices = Object.keys(map);
+
   const nodes = Object.keys(map).map((service) => {
     const value = map[service][idSelected];
     let styleOptions;

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -208,17 +208,22 @@ function filterGraphBySelectedNode(
   return { graph: { nodes: connectedNodes, edges: connectedEdges } };
 }
 
-// construct vis-js graph from ServiceObject
-export function getServiceMapGraph(
-  map: ServiceObject,
-  idSelected: 'latency' | 'error_rate' | 'throughput',
-  ticks: number[],
-  currService?: string,
-  relatedServices?: string[],
-  filterByCurrService?: boolean
-) {
-  if (!relatedServices) relatedServices = Object.keys(map);
+interface ServiceMapParams {
+  map: ServiceObject;
+  idSelected: 'latency' | 'error_rate' | 'throughput';
+  ticks: number[];
+  currService?: string;
+  filterByCurrService?: boolean;
+}
 
+// construct vis-js graph from ServiceObject
+export function getServiceMapGraph({
+  map,
+  idSelected,
+  ticks,
+  currService,
+  filterByCurrService,
+}: ServiceMapParams) {
   const nodes = Object.keys(map).map((service) => {
     const value = map[service][idSelected];
     let styleOptions;

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -301,7 +301,6 @@ export function ServiceMap({
             idSelected,
             ticks,
             undefined,
-            undefined,
             false // Show the entire graph without filtering
           )
         );
@@ -315,7 +314,6 @@ export function ServiceMap({
           idSelected,
           ticks,
           service,
-          serviceMap[service]?.relatedServices,
           true // Enable filtering to focus on connected nodes
         );
         setItems(filteredGraph);

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -301,6 +301,7 @@ export function ServiceMap({
             idSelected,
             ticks,
             undefined,
+            undefined,
             false // Show the entire graph without filtering
           )
         );
@@ -314,6 +315,7 @@ export function ServiceMap({
           idSelected,
           ticks,
           service,
+          serviceMap[service]?.relatedServices,
           true // Enable filtering to focus on connected nodes
         );
         setItems(filteredGraph);

--- a/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -296,28 +296,25 @@ export function ServiceMap({
       if (focusedService !== null) {
         removeFilter('serviceName', focusedService);
         setItems(
-          getServiceMapGraph(
-            serviceMap,
+          getServiceMapGraph({
+            map: serviceMap,
             idSelected,
             ticks,
-            undefined,
-            undefined,
-            false // Show the entire graph without filtering
-          )
+            filterByCurrService: false,
+          })
         );
         setFocusedService(null);
         setInvalid(false);
       }
     } else if (serviceMap[service]) {
       if (focusedService !== service) {
-        const filteredGraph = getServiceMapGraph(
-          serviceMap,
+        const filteredGraph = getServiceMapGraph({
+          map: serviceMap,
           idSelected,
           ticks,
-          service,
-          serviceMap[service]?.relatedServices,
-          true // Enable filtering to focus on connected nodes
-        );
+          currService: service,
+          filterByCurrService: true,
+        });
         setItems(filteredGraph);
         setFocusedService(service);
       }
@@ -369,14 +366,13 @@ export function ServiceMap({
     // Adjust graph rendering logic to ensure related services are visible
     const showRelatedServices = focusedService ? true : filterByCurrService;
     setItems(
-      getServiceMapGraph(
-        serviceMap,
+      getServiceMapGraph({
+        map: serviceMap,
         idSelected,
-        calculatedTicks,
-        focusedService ?? currService,
-        serviceMap[currService!]?.relatedServices,
-        showRelatedServices
-      )
+        ticks: calculatedTicks,
+        currService: focusedService ?? currService,
+        filterByCurrService: showRelatedServices,
+      })
     );
   }, [serviceMap, idSelected, focusedService, filterByCurrService]);
 

--- a/public/components/trace_analytics/components/services/__tests__/services_table.test.tsx
+++ b/public/components/trace_analytics/components/services/__tests__/services_table.test.tsx
@@ -118,6 +118,7 @@ describe('Services table component', () => {
 
   it('redirects to the correct URL when the service link is clicked', () => {
     const mockDataSourceId = 'mock-data-source-id';
+    const mockMode = 'data_prepper';
     const tableItems = [
       {
         name: 'checkoutservice',
@@ -161,7 +162,7 @@ describe('Services table component', () => {
 
     serviceLink.simulate('click');
 
-    const expectedUrl = generateServiceUrl('checkoutservice', mockDataSourceId);
+    const expectedUrl = generateServiceUrl('checkoutservice', mockDataSourceId, mockMode);
     expect(window.location.href).toBe(expectedUrl);
 
     window.location = originalLocation;

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -144,7 +144,7 @@ export function ServiceView(props: ServiceViewProps) {
   }, [props.serviceName, props.setDataSourceMenuSelectable]);
 
   const redirectToServicePage = (service: string) => {
-    window.location.href = generateServiceUrl(service, props.dataSourceMDSId[0].id);
+    window.location.href = generateServiceUrl(service, props.dataSourceMDSId[0].id, mode);
   };
 
   const onClickConnectedService = (service: string) => {

--- a/public/components/trace_analytics/components/services/services_table.tsx
+++ b/public/components/trace_analytics/components/services/services_table.tsx
@@ -81,7 +81,7 @@ export function ServicesTable(props: ServicesTableProps) {
     if (page === 'app') {
       setCurrentSelectedService(serviceName);
     } else {
-      window.location.href = generateServiceUrl(serviceName, dataSourceMDSId[0].id);
+      window.location.href = generateServiceUrl(serviceName, dataSourceMDSId[0].id, props.mode);
     }
   };
 

--- a/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
+++ b/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
@@ -119,6 +119,7 @@ export const getTableColumns = (
     item === undefined || item === null ? (
       '-'
     ) : item === 2 ? (
+      // 2 means Error, 1 means OK, 0 means Unset
       <EuiText color="danger" size="s">
         Yes
       </EuiText>

--- a/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
+++ b/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
@@ -118,7 +118,7 @@ export const getTableColumns = (
   const renderStatusCodeErrorsField = (item: number) =>
     item === undefined || item === null ? (
       '-'
-    ) : item === 2 ? ( // Error status code is 2
+    ) : item === 2 ? (
       <EuiText color="danger" size="s">
         Yes
       </EuiText>

--- a/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
+++ b/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
@@ -115,6 +115,17 @@ export const getTableColumns = (
       'No'
     );
 
+  const renderStatusCodeErrorsField = (item: number) =>
+    item === undefined || item === null ? (
+      '-'
+    ) : item === 2 ? ( // Error status code is 2
+      <EuiText color="danger" size="s">
+        Yes
+      </EuiText>
+    ) : (
+      'No'
+    );
+
   const renderDurationField = (item: number) =>
     item ? <EuiText size="s">{round(nanoToMilliSec(Math.max(0, item)), 2)}</EuiText> : '-';
 
@@ -166,7 +177,7 @@ export const getTableColumns = (
         name: 'Errors',
         align: 'right',
         sortable: true,
-        render: renderErrorsField,
+        render: renderStatusCodeErrorsField,
       },
       {
         field: 'endTime',

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -326,13 +326,20 @@ export const Home = (props: HomeProps) => {
   const traceColumnAction = () => {
     const tracesPath = '#/traces';
     const dataSourceId = dataSourceMDSId[0]?.id || ''; // Default to empty string if undefined
+    const urlParts = window.location.href.split('?');
+    const queryParams =
+      urlParts.length > 1 ? new URLSearchParams(urlParts[1]) : new URLSearchParams();
+
+    // Retain existing `mode` parameter if it exists
+    const modeParam = queryParams.get('mode') || '';
+    const modeQuery = modeParam ? `&mode=${encodeURIComponent(modeParam)}` : '';
 
     if (newNavigation) {
       coreRefs.application?.navigateToApp(observabilityTracesNewNavID, {
-        path: `${tracesPath}?datasourceId=${encodeURIComponent(dataSourceId)}`,
+        path: `${tracesPath}?datasourceId=${encodeURIComponent(dataSourceId)}${modeQuery}`,
       });
     } else {
-      location.assign(`${tracesPath}?datasourceId=${encodeURIComponent(dataSourceId)}`);
+      location.assign(`${tracesPath}?datasourceId=${encodeURIComponent(dataSourceId)}${modeQuery}`);
     }
 
     setTracesTableMode('traces');

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -325,12 +325,14 @@ export const Home = (props: HomeProps) => {
 
   const traceColumnAction = () => {
     const tracesPath = '#/traces';
+    const dataSourceId = dataSourceMDSId[0]?.id || ''; // Default to empty string if undefined
+
     if (newNavigation) {
       coreRefs.application?.navigateToApp(observabilityTracesNewNavID, {
-        path: tracesPath + '?datasourceId=' + dataSourceMDSId[0].id,
+        path: `${tracesPath}?datasourceId=${encodeURIComponent(dataSourceId)}`,
       });
     } else {
-      location.assign(tracesPath + '?datasourceId=' + dataSourceMDSId[0].id);
+      location.assign(`${tracesPath}?datasourceId=${encodeURIComponent(dataSourceId)}`);
     }
 
     setTracesTableMode('traces');

--- a/public/components/trace_analytics/requests/services_request_handler.ts
+++ b/public/components/trace_analytics/requests/services_request_handler.ts
@@ -146,10 +146,6 @@ export const handleServiceMapRequest = async (
     )
     .catch((error) => {
       console.error('Error retrieving target edges:', error);
-      coreRefs.core?.notifications.toasts.addError(error, {
-        title: 'Failed to retrieve target edges',
-        toastLifeTimeMs: 10000,
-      });
     });
 
   await handleDslRequest(
@@ -178,10 +174,6 @@ export const handleServiceMapRequest = async (
     )
     .catch((error) => {
       console.error('Error retrieving destination edges:', error);
-      coreRefs.core?.notifications.toasts.addError(error, {
-        title: 'Failed to retrieve destination edges',
-        toastLifeTimeMs: 10000,
-      });
     });
 
   if (includeMetrics) {
@@ -202,10 +194,6 @@ export const handleServiceMapRequest = async (
       });
     } catch (error) {
       console.error('Error retrieving service metrics:', error);
-      coreRefs.core?.notifications.toasts.addError(error, {
-        title: 'Failed to retrieve service metrics',
-        toastLifeTimeMs: 10000,
-      });
     }
   }
 
@@ -230,10 +218,6 @@ export const handleServiceMapRequest = async (
       })
       .catch((error) => {
         console.error('Error retrieving related services:', error);
-        coreRefs.core?.notifications.toasts.addError(error, {
-          title: 'Failed to retrieve related services',
-          toastLifeTimeMs: 10000,
-        });
       });
   }
 

--- a/server/plugin_helper/register_settings.ts
+++ b/server/plugin_helper/register_settings.ts
@@ -6,6 +6,7 @@
 import { schema } from '@osd/config-schema';
 import { UiSettingsServiceSetup } from '../../../../src/core/server/ui_settings';
 import {
+  TRACE_CUSTOM_MODE_DEFAULT_SETTING,
   TRACE_CUSTOM_SERVICE_INDEX_SETTING,
   TRACE_CUSTOM_SPAN_INDEX_SETTING,
 } from '../../common/constants/trace_analytics';
@@ -30,6 +31,17 @@ export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSet
       description:
         '<strong>Experimental feature:</strong> Configure custom service indices that adhere to data prepper schema, to be used by the trace analytics plugin',
       schema: schema.string(),
+    },
+  });
+
+  uiSettings.register({
+    [TRACE_CUSTOM_MODE_DEFAULT_SETTING]: {
+      name: 'Trace analytics custom mode default',
+      value: false,
+      category: ['Observability'],
+      description:
+        '<strong>Experimental feature:</strong> Enable this to default to "custom_data_prepper" mode in the trace analytics plugin',
+      schema: schema.boolean(),
     },
   });
 };

--- a/server/plugin_helper/register_settings.ts
+++ b/server/plugin_helper/register_settings.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { i18n } from '@osd/i18n';
 import { schema } from '@osd/config-schema';
 import { UiSettingsServiceSetup } from '../../../../src/core/server/ui_settings';
 import {
@@ -14,33 +15,45 @@ import {
 export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSetup) => {
   uiSettings.register({
     [TRACE_CUSTOM_SPAN_INDEX_SETTING]: {
-      name: 'Trace analytics custom span indices',
+      name: i18n.translate('observability.traceAnalyticsCustomSpanIndices.name', {
+        defaultMessage: 'Trace analytics custom span indices',
+      }),
       value: '',
       category: ['Observability'],
-      description:
-        '<strong>Experimental feature:</strong> Configure custom span indices that adhere to data prepper schema, to be used by the trace analytics plugin',
+      description: i18n.translate('observability.traceAnalyticsCustomSpanIndices.description', {
+        defaultMessage:
+          '<strong>Experimental feature:</strong> Configure custom span indices that adhere to data prepper schema, to be used by the trace analytics plugin',
+      }),
       schema: schema.string(),
     },
   });
 
   uiSettings.register({
     [TRACE_CUSTOM_SERVICE_INDEX_SETTING]: {
-      name: 'Trace analytics custom service indices',
+      name: i18n.translate('observability.traceAnalyticsCustomServiceIndices.name', {
+        defaultMessage: 'Trace analytics custom service indices',
+      }),
       value: '',
       category: ['Observability'],
-      description:
-        '<strong>Experimental feature:</strong> Configure custom service indices that adhere to data prepper schema, to be used by the trace analytics plugin',
+      description: i18n.translate('observability.traceAnalyticsCustomServiceIndices.description', {
+        defaultMessage:
+          '<strong>Experimental feature:</strong> Configure custom service indices that adhere to data prepper schema, to be used by the trace analytics plugin',
+      }),
       schema: schema.string(),
     },
   });
 
   uiSettings.register({
     [TRACE_CUSTOM_MODE_DEFAULT_SETTING]: {
-      name: 'Trace analytics custom mode default',
+      name: i18n.translate('observability.traceAnalyticsCustomModeDefault.name', {
+        defaultMessage: 'Trace analytics custom mode default',
+      }),
       value: false,
       category: ['Observability'],
-      description:
-        '<strong>Experimental feature:</strong> Enable this to default to "custom_data_prepper" mode in the trace analytics plugin',
+      description: i18n.translate('observability.traceAnalyticsCustomModeDefault.description', {
+        defaultMessage:
+          '<strong>Experimental feature:</strong> Enable this to default to "custom_data_prepper" mode in the trace analytics plugin',
+      }),
       schema: schema.boolean(),
     },
   });


### PR DESCRIPTION
### Description
1. Remove the all_services aggregation field from getRelatedServiceQuery. The only purpose seemed to be in displaying the “greyed-out” connection in service map. Earlier code changes removed the full map being displayed with this grey-out functionality in preference of the “Focus on” search box being implemented. This field being presented seemed to require a 4x increase in the number of buckets.
* Removed the shading logic from getServiceMapGraph as we no longer enter that state based on related services.
2. Remove the traceGroupName aggregation field from getServiceNodesQuery. This appeared to be an old artifact and was not used in any visualizations.
3. Remove the toast messages after the first check of handleServiceMapRequest as they were indicating false positives as the map took time to render.
4. Add "TRACE_CUSTOM_MODE_DEFAULT_SETTING" option for users to enable it as the default landing page. Update the fly-out for custom source to include the option to enable this. When the mode is not presented and this setting is enabled it will direct the user to correct mode.
5. Update the error field for custom spans under the non "traces" field. It was originally using the >0 check used for error_count but this field uses status.code which is only an error when it is equal to 2. https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
* Added renderStatusCodeErrorsField() as it's behavior is different for custom traces checking the spans and needs to do the ===2 check similiar to https://github.com/opensearch-project/dashboards-observability/blob/main/public/components/trace_analytics/requests/traces_request_handler.ts#L403
6. Update the Services table link, and Expand view buttons to append the trace mode to allow it to be used as a favorite or shared link.
7. Fix a bug that was causing infinite refreshes if MDS was disabled and the service page - traces link was clicked as the datasource was appended as undefined.
8. Fix flaky cypress test in services by adding wait condition.

Before: (with all_services) 
```
PUT _cluster/settings
{ "persistent": { "search.max_buckets": 450 } }
```

https://github.com/user-attachments/assets/da44ef8d-0bcb-49c8-bdf7-7038118ccbdb


Required 460 buckets to avoid errors.
After: (removed all_services)

https://github.com/user-attachments/assets/c6596f12-4a96-410d-8d15-cd8059cc07c1

Required just 110 buckets to avoid errors.

TRACE_CUSTOM_MODE_DEFAULT_SETTING:
<img width="802" alt="Screenshot 2025-01-14 at 2 00 22 PM" src="https://github.com/user-attachments/assets/b6bfb113-d23a-40b8-bdfb-37fa986a838b" />
<img width="1603" alt="Screenshot 2025-01-14 at 2 00 47 PM" src="https://github.com/user-attachments/assets/bde642f7-d300-4a8e-8fe2-7f3cc4ff339a" />
Example usage:

https://github.com/user-attachments/assets/c2fef915-3498-4fcf-9996-7ff7e68299e6

Service page infinite refresh while MDS disabled bug Before:

https://github.com/user-attachments/assets/2f30a84f-71f0-42d2-b8bb-b9263789c089

After (fixed):

https://github.com/user-attachments/assets/5a91fc38-26cf-4fbf-8d9a-db6e97544c39



### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
