### PR TITLE
Traces - Filter Adjustment and DataGrid abstraction

### DIFF
--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -284,7 +284,9 @@ describe('Override timestamp for an index', () => {
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.tab-title').contains('Events').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.get('[data-test-subj="eventExplorer__overrideDefaultTimestamp"]').click({ force: true });
+    cy.get('[data-test-subj="eventExplorer__overrideDefaultTimestamp"]')
+      .should('have.length', 1)
+      .click({ force: true });
 
     cy.get('[data-attr-field="utc_time"] [data-test-subj="eventFields__default-timestamp-mark"')
       .contains('Default Timestamp')

--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -25,7 +25,7 @@ import {
   FIELD_HOST,
   FIELD_AGENT
 } from '../../utils/event_analytics/constants';
-import { suppressResizeObserverIssue, COMMAND_TIMEOUT_LONG } from '../../utils/constants';
+import { COMMAND_TIMEOUT_LONG } from '../../utils/constants';
 
 import {
   querySearch,
@@ -281,6 +281,7 @@ describe('Override timestamp for an index', () => {
     clearQuerySearchBoxText('searchAutocompleteTextArea');
     cy.get('[data-test-subj="searchAutocompleteTextArea"]').type(TEST_QUERIES[2].query);
     cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.tab-title').contains('Events').click();
     cy.get('[data-test-subj="eventExplorer__overrideDefaultTimestamp"]').click({ force: true });
 

--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -283,6 +283,7 @@ describe('Override timestamp for an index', () => {
     cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.tab-title').contains('Events').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('[data-test-subj="eventExplorer__overrideDefaultTimestamp"]').click({ force: true });
 
     cy.get('[data-attr-field="utc_time"] [data-test-subj="eventFields__default-timestamp-mark"')

--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -284,6 +284,14 @@ describe('Override timestamp for an index', () => {
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.tab-title').contains('Events').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+
+    // handle redux state not setting default timestamp
+    cy.get('[data-test-subj="eventExplorer__overrideDefaultTimestamp"]').then(($buttons) => {
+      if ($buttons.length > 1) {
+        cy.wrap($buttons.first()).click({ force: true });
+      }
+    });
+
     cy.get('[data-test-subj="eventExplorer__overrideDefaultTimestamp"]')
       .should('have.length', 1)
       .click({ force: true });

--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -25,7 +25,7 @@ import {
   FIELD_HOST,
   FIELD_AGENT
 } from '../../utils/event_analytics/constants';
-import { COMMAND_TIMEOUT_LONG } from '../../utils/constants';
+import { suppressResizeObserverIssue, COMMAND_TIMEOUT_LONG } from '../../utils/constants';
 
 import {
   querySearch,
@@ -281,20 +281,8 @@ describe('Override timestamp for an index', () => {
     clearQuerySearchBoxText('searchAutocompleteTextArea');
     cy.get('[data-test-subj="searchAutocompleteTextArea"]').type(TEST_QUERIES[2].query);
     cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.tab-title').contains('Events').click();
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-
-    // handle redux state not setting default timestamp
-    cy.get('[data-test-subj="eventExplorer__overrideDefaultTimestamp"]').then(($buttons) => {
-      if ($buttons.length > 1) {
-        cy.wrap($buttons.first()).click({ force: true });
-      }
-    });
-
-    cy.get('[data-test-subj="eventExplorer__overrideDefaultTimestamp"]')
-      .should('have.length', 1)
-      .click({ force: true });
+    cy.get('[data-test-subj="eventExplorer__overrideDefaultTimestamp"]').click({ force: true });
 
     cy.get('[data-attr-field="utc_time"] [data-test-subj="eventFields__default-timestamp-mark"')
       .contains('Default Timestamp')

--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -179,7 +179,7 @@ describe('Testing traces tree view', () => {
     cy.get("[data-test-subj='treeExpandAll']").click();
     cy.get("[data-test-subj='treeCollapseAll']").click();
 
-    cy.get("[data-test-subj='spanId-link']")
+    cy.get("[data-test-subj='spanId-flyout-button']")
       .should('have.length', 6)
       .then((initialSpanIds) => {
         const initialCount = initialSpanIds.length;
@@ -187,14 +187,14 @@ describe('Testing traces tree view', () => {
 
         cy.get("[data-test-subj='treeExpandAll']").click();
 
-        cy.get("[data-test-subj='spanId-link']").then((expandedSpanIds) => {
+        cy.get("[data-test-subj='spanId-flyout-button']").then((expandedSpanIds) => {
           const expandedCount = expandedSpanIds.length;
           expect(expandedCount).to.equal(10);
         });
 
         cy.get("[data-test-subj='treeCollapseAll']").click();
 
-        cy.get("[data-test-subj='spanId-link']").then((collapsedSpanIds) => {
+        cy.get("[data-test-subj='spanId-flyout-button']").then((collapsedSpanIds) => {
           const collapsedCount = collapsedSpanIds.length;
           expect(collapsedCount).to.equal(6); // Collapsed rows should match the initial count
         });
@@ -209,7 +209,7 @@ describe('Testing traces tree view', () => {
     cy.get("[data-test-subj='treeExpandAll']").click();
     cy.get("[data-test-subj='treeCollapseAll']").click();
 
-    cy.get("[data-test-subj='spanId-link']").then((initialSpanIds) => {
+    cy.get("[data-test-subj='spanId-flyout-button']").then((initialSpanIds) => {
       const initialCount = initialSpanIds.length;
       expect(initialCount).to.equal(6);
 
@@ -217,7 +217,7 @@ describe('Testing traces tree view', () => {
       cy.get("[data-test-subj='treeViewExpandArrow']").first().click();
 
       // Check the number of Span IDs after expanding the arrow (should be 7)
-      cy.get("[data-test-subj='spanId-link']").then((expandedSpanIds) => {
+      cy.get("[data-test-subj='spanId-flyout-button']").then((expandedSpanIds) => {
         const expandedCount = expandedSpanIds.length;
         expect(expandedCount).to.equal(7);
       });
@@ -233,7 +233,7 @@ describe('Testing traces tree view', () => {
     cy.get("[data-test-subj='treeCollapseAll']").click();
 
     // Open flyout for a span
-    cy.get("[data-test-subj='spanId-link']")
+    cy.get("[data-test-subj='spanId-flyout-button']")
       .contains(SPAN_ID_TREE_VIEW)
       .click()
     cy.contains('Span detail').should('exist');

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Filter popover component renders filter popover 1`] = `
   <div
     style={
       Object {
-        "width": 500,
+        "width": 600,
       }
     }
   >
@@ -44,28 +44,29 @@ exports[`Filter popover component renders filter popover 1`] = `
       }
     />
     <EuiFlexGroup
-      gutterSize="s"
+      direction="column"
+      gutterSize="m"
     >
       <div
-        className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+        className="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionColumn euiFlexGroup--responsive"
       >
         <EuiFlexItem
-          grow={6}
+          grow={true}
         >
           <div
-            className="euiFlexItem euiFlexItem--flexGrow6"
+            className="euiFlexItem"
           >
             <EuiCompressedFormRow
               describedByIds={Array []}
               display="rowCompressed"
-              fullWidth={false}
+              fullWidth={true}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
               label="Field"
               labelType="label"
             >
               <div
-                className="euiFormRow euiFormRow--compressed"
+                className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="random_html_id-row"
               >
                 <div
@@ -92,7 +93,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                     async={false}
                     compressed={true}
                     data-test-subj="field-selector-filter-panel"
-                    fullWidth={false}
+                    fullWidth={true}
                     id="random_html_id"
                     isClearable={false}
                     onBlur={[Function]}
@@ -129,7 +130,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                     <div
                       aria-expanded={false}
                       aria-haspopup="listbox"
-                      className="euiComboBox euiComboBox--compressed"
+                      className="euiComboBox euiComboBox--compressed euiComboBox--fullWidth"
                       data-test-subj="field-selector-filter-panel"
                       onKeyDown={[Function]}
                       role="combobox"
@@ -137,7 +138,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                       <EuiComboBoxInput
                         autoSizeInputRef={[Function]}
                         compressed={true}
-                        fullWidth={false}
+                        fullWidth={true}
                         hasSelectedOptions={false}
                         id="random_html_id"
                         inputRef={[Function]}
@@ -164,7 +165,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                       >
                         <EuiFormControlLayout
                           compressed={true}
-                          fullWidth={false}
+                          fullWidth={true}
                           icon={
                             Object {
                               "aria-label": "Open list of options",
@@ -178,13 +179,13 @@ exports[`Filter popover component renders filter popover 1`] = `
                           }
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--compressed"
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                           >
                             <div
                               className="euiFormControlLayout__childrenWrapper"
                             >
                               <div
-                                className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
+                                className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap--noWrap"
                                 data-test-subj="comboBoxInput"
                                 onClick={[Function]}
                                 tabIndex={-1}
@@ -332,22 +333,22 @@ exports[`Filter popover component renders filter popover 1`] = `
           </div>
         </EuiFlexItem>
         <EuiFlexItem
-          grow={5}
+          grow={true}
         >
           <div
-            className="euiFlexItem euiFlexItem--flexGrow5"
+            className="euiFlexItem"
           >
             <EuiCompressedFormRow
               describedByIds={Array []}
               display="rowCompressed"
-              fullWidth={false}
+              fullWidth={true}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
               label="Operator"
               labelType="label"
             >
               <div
-                className="euiFormRow euiFormRow--compressed"
+                className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 id="random_html_id-row"
               >
                 <div
@@ -374,7 +375,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                     async={false}
                     compressed={true}
                     data-test-subj="operator-selector-filter-panel"
-                    fullWidth={false}
+                    fullWidth={true}
                     id="random_html_id"
                     isClearable={false}
                     isDisabled={true}
@@ -394,7 +395,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                     <div
                       aria-expanded={false}
                       aria-haspopup="listbox"
-                      className="euiComboBox euiComboBox--compressed euiComboBox-isDisabled"
+                      className="euiComboBox euiComboBox--compressed euiComboBox--fullWidth euiComboBox-isDisabled"
                       data-test-subj="operator-selector-filter-panel"
                       onKeyDown={[Function]}
                       role="combobox"
@@ -402,7 +403,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                       <EuiComboBoxInput
                         autoSizeInputRef={[Function]}
                         compressed={true}
-                        fullWidth={false}
+                        fullWidth={true}
                         hasSelectedOptions={false}
                         id="random_html_id"
                         inputRef={[Function]}
@@ -430,7 +431,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                       >
                         <EuiFormControlLayout
                           compressed={true}
-                          fullWidth={false}
+                          fullWidth={true}
                           icon={
                             Object {
                               "aria-label": "Open list of options",
@@ -444,13 +445,13 @@ exports[`Filter popover component renders filter popover 1`] = `
                           }
                         >
                           <div
-                            className="euiFormControlLayout euiFormControlLayout--compressed"
+                            className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
                           >
                             <div
                               className="euiFormControlLayout__childrenWrapper"
                             >
                               <div
-                                className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
+                                className="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap--noWrap"
                                 data-test-subj="comboBoxInput"
                                 onClick={[Function]}
                                 tabIndex={-1}

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_helpers.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_helpers.test.tsx.snap
@@ -134,89 +134,99 @@ Array [
       className="euiSpacer euiSpacer--s"
     />
   </EuiSpacer>,
-  <EuiCompressedFormRow
-    describedByIds={Array []}
-    display="rowCompressed"
-    fullWidth={false}
-    hasChildLabel={true}
-    hasEmptyLabelSpace={false}
-    label="Value"
-    labelType="label"
+  <EuiFlexItem
+    grow={true}
   >
     <div
-      className="euiFormRow euiFormRow--compressed"
-      id="random_html_id-row"
+      className="euiFlexItem"
     >
-      <div
-        className="euiFormRow__labelWrapper"
+      <EuiCompressedFormRow
+        describedByIds={Array []}
+        display="rowCompressed"
+        fullWidth={true}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        label="Value"
+        labelType="label"
       >
-        <EuiFormLabel
-          className="euiFormRow__label"
-          htmlFor="random_html_id"
-          isFocused={false}
-          type="label"
+        <div
+          className="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+          id="random_html_id-row"
         >
-          <label
-            className="euiFormLabel euiFormRow__label"
-            htmlFor="random_html_id"
+          <div
+            className="euiFormRow__labelWrapper"
           >
-            Value
-          </label>
-        </EuiFormLabel>
-      </div>
-      <div
-        className="euiFormRow__fieldWrapper"
-      >
-        <EuiCompressedFieldText
-          id="random_html_id"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Enter a value"
-          value={0}
-        >
-          <EuiFieldText
-            compressed={true}
-            id="random_html_id"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder="Enter a value"
-            value={0}
-          >
-            <EuiFormControlLayout
-              compressed={true}
-              fullWidth={false}
-              inputId="random_html_id"
+            <EuiFormLabel
+              className="euiFormRow__label"
+              htmlFor="random_html_id"
+              isFocused={false}
+              type="label"
             >
-              <div
-                className="euiFormControlLayout euiFormControlLayout--compressed"
+              <label
+                className="euiFormLabel euiFormRow__label"
+                htmlFor="random_html_id"
               >
-                <div
-                  className="euiFormControlLayout__childrenWrapper"
+                Value
+              </label>
+            </EuiFormLabel>
+          </div>
+          <div
+            className="euiFormRow__fieldWrapper"
+          >
+            <EuiCompressedFieldText
+              fullWidth={true}
+              id="random_html_id"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              placeholder="Enter a value"
+              value={0}
+            >
+              <EuiFieldText
+                compressed={true}
+                fullWidth={true}
+                id="random_html_id"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder="Enter a value"
+                value={0}
+              >
+                <EuiFormControlLayout
+                  compressed={true}
+                  fullWidth={true}
+                  inputId="random_html_id"
                 >
-                  <EuiValidatableControl>
-                    <input
-                      className="euiFieldText euiFieldText--compressed"
-                      id="random_html_id"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Enter a value"
-                      type="text"
-                      value={0}
-                    />
-                  </EuiValidatableControl>
-                  <EuiFormControlLayoutIcons
-                    compressed={true}
-                  />
-                </div>
-              </div>
-            </EuiFormControlLayout>
-          </EuiFieldText>
-        </EuiCompressedFieldText>
-      </div>
+                  <div
+                    className="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+                  >
+                    <div
+                      className="euiFormControlLayout__childrenWrapper"
+                    >
+                      <EuiValidatableControl>
+                        <input
+                          className="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
+                          id="random_html_id"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder="Enter a value"
+                          type="text"
+                          value={0}
+                        />
+                      </EuiValidatableControl>
+                      <EuiFormControlLayoutIcons
+                        compressed={true}
+                      />
+                    </div>
+                  </div>
+                </EuiFormControlLayout>
+              </EuiFieldText>
+            </EuiCompressedFieldText>
+          </div>
+        </div>
+      </EuiCompressedFormRow>
     </div>
-  </EuiCompressedFormRow>,
+  </EuiFlexItem>,
 ]
 `;

--- a/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
@@ -14,6 +14,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import React, { useState } from 'react';
+import { i18n } from '@osd/i18n';
 import { getInvertedOperator, getOperatorOptions, getValueComponent } from './filter_helpers';
 import { FilterType } from './filters';
 
@@ -44,7 +45,9 @@ export function FilterEditPopover(props: {
         <EuiFlexItem grow={true}>
           <EuiCompressedFormRow label={'Field'} fullWidth>
             <EuiCompressedComboBox
-              placeholder="Select a field first"
+              placeholder={i18n.translate('addFilter.selectFieldPlaceholder', {
+                defaultMessage: 'Select a field first',
+              })}
               data-test-subj="field-selector-filter-panel"
               isClearable={false}
               options={props.filterFieldOptions}
@@ -62,7 +65,15 @@ export function FilterEditPopover(props: {
         <EuiFlexItem grow={true}>
           <EuiCompressedFormRow label={'Operator'} fullWidth>
             <EuiCompressedComboBox
-              placeholder={selectedFieldOptions.length === 0 ? 'Waiting' : 'Select'}
+              placeholder={
+                selectedFieldOptions.length === 0
+                  ? i18n.translate('addFilter.waitingPlaceholder', {
+                      defaultMessage: 'Waiting',
+                    })
+                  : i18n.translate('addFilter.selectPlaceholder', {
+                      defaultMessage: 'Select',
+                    })
+              }
               data-test-subj="operator-selector-filter-panel"
               isClearable={false}
               isDisabled={selectedFieldOptions.length === 0}

--- a/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_edit_popover.tsx
@@ -37,12 +37,12 @@ export function FilterEditPopover(props: {
   const [filterValue, setFilterValue] = useState(props.filter?.value || '');
 
   return (
-    <div style={{ width: 500 }}>
+    <div style={{ width: 600 }}>
       {/* invisible button workaround to prevent auto focus on context menu panel switch */}
       <button style={{ width: 0, height: 0, position: 'fixed', marginLeft: -1000, bottom: 0 }} />
-      <EuiFlexGroup gutterSize="s">
-        <EuiFlexItem grow={6}>
-          <EuiCompressedFormRow label={'Field'}>
+      <EuiFlexGroup gutterSize="m" direction="column">
+        <EuiFlexItem grow={true}>
+          <EuiCompressedFormRow label={'Field'} fullWidth>
             <EuiCompressedComboBox
               placeholder="Select a field first"
               data-test-subj="field-selector-filter-panel"
@@ -55,11 +55,12 @@ export function FilterEditPopover(props: {
                 setFilterValue('');
               }}
               singleSelection={{ asPlainText: true }}
+              fullWidth
             />
           </EuiCompressedFormRow>
         </EuiFlexItem>
-        <EuiFlexItem grow={5}>
-          <EuiCompressedFormRow label={'Operator'}>
+        <EuiFlexItem grow={true}>
+          <EuiCompressedFormRow label={'Operator'} fullWidth>
             <EuiCompressedComboBox
               placeholder={selectedFieldOptions.length === 0 ? 'Waiting' : 'Select'}
               data-test-subj="operator-selector-filter-panel"
@@ -76,6 +77,7 @@ export function FilterEditPopover(props: {
                 setFilterValue('');
               }}
               singleSelection={{ asPlainText: true }}
+              fullWidth
             />
           </EuiCompressedFormRow>
         </EuiFlexItem>

--- a/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
@@ -7,6 +7,7 @@ import {
   EuiCompressedComboBox,
   EuiCompressedFieldText,
   EuiCompressedFormRow,
+  EuiFlexItem,
   EuiFormControlLayoutDelimited,
   EuiSpacer,
 } from '@elastic/eui';
@@ -157,13 +158,16 @@ export const getValueComponent = (
   const textField = (
     <>
       <EuiSpacer size="s" />
-      <EuiCompressedFormRow label={'Value'}>
-        <EuiCompressedFieldText
-          placeholder="Enter a value"
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-        />
-      </EuiCompressedFormRow>
+      <EuiFlexItem grow={true}>
+        <EuiCompressedFormRow label={'Value'} fullWidth>
+          <EuiCompressedFieldText
+            placeholder="Enter a value"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            fullWidth
+          />
+        </EuiCompressedFormRow>
+      </EuiFlexItem>
     </>
   );
 

--- a/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
+++ b/public/components/trace_analytics/components/common/filters/filter_helpers.tsx
@@ -13,6 +13,7 @@ import {
 } from '@elastic/eui';
 import get from 'lodash/get';
 import React from 'react';
+import { i18n } from '@osd/i18n';
 import { TraceAnalyticsMode } from '../../../../../../common/types/trace_analytics';
 
 const getFields = (
@@ -161,7 +162,9 @@ export const getValueComponent = (
       <EuiFlexItem grow={true}>
         <EuiCompressedFormRow label={'Value'} fullWidth>
           <EuiCompressedFieldText
-            placeholder="Enter a value"
+            placeholder={i18n.translate('filterValue.placeholderText', {
+              defaultMessage: 'Enter a value',
+            })}
             value={value}
             onChange={(e) => setValue(e.target.value)}
             fullWidth
@@ -198,7 +201,9 @@ export const getValueComponent = (
             startControl={
               <input
                 type="string"
-                placeholder="Start of range"
+                placeholder={i18n.translate('rangeField.startOfRangePlaceholder', {
+                  defaultMessage: 'Start of range',
+                })}
                 className="euiFieldText"
                 value={getFromValue()}
                 onChange={(e) => setFromValue(e.target.value)}
@@ -207,7 +212,9 @@ export const getValueComponent = (
             endControl={
               <input
                 type="string"
-                placeholder="End of range"
+                placeholder={i18n.translate('rangeField.endOfRangePlaceholder', {
+                  defaultMessage: 'End of range',
+                })}
                 className="euiFieldText"
                 value={getToValue()}
                 onChange={(e) => setToValue(e.target.value)}
@@ -225,7 +232,9 @@ export const getValueComponent = (
         <EuiSpacer size="s" />
         <EuiCompressedFormRow label={'Value'}>
           <EuiCompressedComboBox
-            placeholder="Select a value"
+            placeholder={i18n.translate('comboBox.selectValuePlaceholder', {
+              defaultMessage: 'Select a value',
+            })}
             options={[
               {
                 label: 'true',

--- a/public/components/trace_analytics/components/common/filters/filters.tsx
+++ b/public/components/trace_analytics/components/common/filters/filters.tsx
@@ -106,7 +106,7 @@ export function Filters(props: FiltersOwnProps) {
     },
     {
       id: 1,
-      width: 530,
+      width: 630,
       title: 'Edit filter',
       content: (
         <div style={{ margin: 15 }}>
@@ -228,7 +228,7 @@ export function Filters(props: FiltersOwnProps) {
   return props.filters.length > 0 ? (
     <>
       <EuiSpacer size="s" />
-      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
         {filterComponents}
         <EuiFlexItem grow={false}>
           <AddFilterButton />
@@ -353,7 +353,7 @@ export const GlobalFilterButton = ({
     {
       id: 1,
       title: 'Add filter',
-      width: 530,
+      width: 630,
       content: (
         <div style={{ margin: 15 }}>
           <FilterEditPopover

--- a/public/components/trace_analytics/components/common/filters/filters.tsx
+++ b/public/components/trace_analytics/components/common/filters/filters.tsx
@@ -258,6 +258,7 @@ export const GlobalFilterButton = ({
       getFilterFields(mode, page, attributesFilterFields).map((field) => ({
         label: field,
         'data-test-subj': `filterFieldOptions-${field}`,
+        className: 'ellipsis-left',
       })),
     [mode, page, attributesFilterFields]
   );

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -5,14 +5,7 @@
 /* eslint-disable radix */
 
 import dateMath from '@elastic/datemath';
-import {
-  EuiButtonIcon,
-  EuiEmptyPrompt,
-  EuiOverlayMask,
-  EuiSmallButtonEmpty,
-  EuiSpacer,
-  EuiText,
-} from '@elastic/eui';
+import { EuiEmptyPrompt, EuiSmallButtonEmpty, EuiSpacer, EuiText } from '@elastic/eui';
 import { SpacerSize } from '@elastic/eui/src/components/spacer/spacer';
 import { isEmpty, round } from 'lodash';
 import React from 'react';
@@ -621,34 +614,4 @@ export const generateServiceUrl = (
   }
 
   return url;
-};
-
-interface FullScreenWrapperProps {
-  children: React.ReactNode;
-  onClose: () => void;
-  isFullScreen: boolean;
-}
-
-// EUI Data grid full screen button is currently broken, this is a workaround
-export const FullScreenWrapper: React.FC<FullScreenWrapperProps> = ({
-  children,
-  onClose,
-  isFullScreen,
-}) => {
-  if (!isFullScreen) return <>{children}</>;
-
-  return (
-    <EuiOverlayMask>
-      <div className="full-screen-wrapper">
-        <EuiButtonIcon
-          iconType="cross"
-          aria-label="Close full screen"
-          onClick={onClose}
-          display="empty"
-          className="full-screen-close-icon"
-        />
-        <div className="full-screen-content">{children}</div>
-      </div>
-    </EuiOverlayMask>
-  );
 };

--- a/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
@@ -92,6 +92,7 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
         key="fullScreen"
         color="text"
         iconType={isFullScreen ? 'cross' : 'fullScreen'}
+        data-test-subj="fullScreenButton"
       >
         {isFullScreen ? 'Exit full screen' : 'Full screen'}
       </EuiButtonEmpty>,

--- a/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useMemo } from 'react';
+import {
+  EuiDataGrid,
+  EuiButtonEmpty,
+  EuiDataGridColumn,
+  EuiDataGridSorting,
+  EuiOverlayMask,
+  EuiButtonIcon,
+} from '@elastic/eui';
+import { NoMatchMessage } from '../helper_functions';
+
+interface FullScreenWrapperProps {
+  children: React.ReactNode;
+  onClose: () => void;
+  isFullScreen: boolean;
+}
+
+// EUI Data grid full screen button is currently broken, this is a workaround
+const FullScreenWrapper: React.FC<FullScreenWrapperProps> = ({
+  children,
+  onClose,
+  isFullScreen,
+}) => {
+  if (!isFullScreen) return <>{children}</>;
+
+  return (
+    <EuiOverlayMask>
+      <div className="full-screen-wrapper">
+        <EuiButtonIcon
+          iconType="cross"
+          aria-label="Close full screen"
+          onClick={onClose}
+          display="empty"
+          className="full-screen-close-icon"
+        />
+        <div className="full-screen-content">{children}</div>
+      </div>
+    </EuiOverlayMask>
+  );
+};
+
+interface PaginationParams {
+  pageIndex: number;
+  pageSize: number;
+  pageSizeOptions?: number[];
+  onChangePage: (page: number) => void;
+  onChangeItemsPerPage: (size: number) => void;
+}
+
+interface RenderCustomDataGridParams {
+  columns: EuiDataGridColumn[];
+  renderCellValue: (props: any) => React.ReactNode;
+  rowCount: number;
+  sorting?: EuiDataGridSorting;
+  pagination?: PaginationParams;
+  toolbarButtons?: React.ReactNode[];
+  fullScreen?: boolean;
+  availableWidth?: number;
+  noMatchMessageSize?: string;
+  defaultHeight?: string;
+  visibleColumns?: string[];
+}
+
+export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
+  columns,
+  renderCellValue,
+  rowCount,
+  sorting,
+  pagination,
+  toolbarButtons = [],
+  fullScreen = false,
+  availableWidth,
+  noMatchMessageSize = 'xl',
+  defaultHeight = '500px',
+  visibleColumns,
+}) => {
+  const [localVisibleColumns, setLocalVisibleColumns] = useState(
+    visibleColumns ?? columns.map((col) => col.id)
+  );
+  const [isFullScreen, setIsFullScreen] = useState(fullScreen);
+
+  const toolbarControls = useMemo(
+    () => [
+      <EuiButtonEmpty
+        size="xs"
+        onClick={() => setIsFullScreen((prev) => !prev)}
+        key="fullScreen"
+        color="text"
+        iconType={isFullScreen ? 'cross' : 'fullScreen'}
+      >
+        {isFullScreen ? 'Exit full screen' : 'Full screen'}
+      </EuiButtonEmpty>,
+      ...toolbarButtons,
+    ],
+    [isFullScreen, toolbarButtons]
+  );
+
+  const gridStyle = useMemo(
+    () => ({
+      stripes: true,
+    }),
+    []
+  );
+
+  return (
+    <>
+      <FullScreenWrapper isFullScreen={isFullScreen} onClose={() => setIsFullScreen(false)}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: isFullScreen ? '100vh' : 'auto',
+          }}
+        >
+          <EuiDataGrid
+            aria-labelledby="custom-data-grid"
+            columns={columns}
+            columnVisibility={{
+              visibleColumns: localVisibleColumns,
+              setVisibleColumns: setLocalVisibleColumns,
+            }}
+            rowCount={rowCount}
+            renderCellValue={renderCellValue}
+            sorting={sorting}
+            toolbarVisibility={{
+              showColumnSelector: true,
+              showSortSelector: !!sorting,
+              showFullScreenSelector: false,
+              additionalControls: toolbarControls,
+            }}
+            pagination={pagination}
+            gridStyle={gridStyle}
+            style={{
+              width: isFullScreen ? '100%' : availableWidth ? `${availableWidth}px` : '100%',
+              height: isFullScreen ? '100%' : pagination ? 'auto' : defaultHeight,
+            }}
+          />
+        </div>
+      </FullScreenWrapper>
+      {rowCount === 0 && <NoMatchMessage size={noMatchMessageSize} />}
+    </>
+  );
+};

--- a/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
@@ -84,6 +84,8 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
   );
   const [isFullScreen, setIsFullScreen] = useState(fullScreen);
 
+  const disableInteractions = useMemo(() => isFullScreen, [isFullScreen]);
+
   const toolbarControls = useMemo(
     () => [
       <EuiButtonEmpty
@@ -132,7 +134,12 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
               setVisibleColumns: setLocalVisibleColumns,
             }}
             rowCount={rowCount}
-            renderCellValue={renderCellValue}
+            renderCellValue={(props) =>
+              renderCellValue({
+                ...props,
+                disableInteractions,
+              })
+            }
             sorting={sorting}
             toolbarVisibility={{
               showColumnSelector: true,

--- a/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
@@ -12,6 +12,7 @@ import {
   EuiOverlayMask,
   EuiButtonIcon,
 } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
 import { NoMatchMessage } from '../helper_functions';
 
 interface FullScreenWrapperProps {
@@ -102,7 +103,13 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
         iconType={isFullScreen ? 'cross' : 'fullScreen'}
         data-test-subj="fullScreenButton"
       >
-        {isFullScreen ? 'Exit full screen' : 'Full screen'}
+        {isFullScreen
+          ? i18n.translate('toolbarControls.exitFullScreen', {
+              defaultMessage: 'Exit full screen',
+            })
+          : i18n.translate('toolbarControls.fullScreen', {
+              defaultMessage: 'Full screen',
+            })}
       </EuiButtonEmpty>,
       ...toolbarButtons,
     ],

--- a/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
@@ -52,9 +52,15 @@ interface PaginationParams {
   onChangeItemsPerPage: (size: number) => void;
 }
 
+interface RenderCellValueProps {
+  rowIndex: number;
+  columnId: string;
+  disableInteractions: boolean;
+}
+
 interface RenderCustomDataGridParams {
   columns: EuiDataGridColumn[];
-  renderCellValue: (props: any) => React.ReactNode;
+  renderCellValue: (props: RenderCellValueProps) => React.ReactNode;
   rowCount: number;
   sorting?: EuiDataGridSorting;
   pagination?: PaginationParams;
@@ -119,13 +125,7 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
   return (
     <>
       <FullScreenWrapper isFullScreen={isFullScreen} onClose={() => setIsFullScreen(false)}>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            height: isFullScreen ? '100vh' : 'auto',
-          }}
-        >
+        <div className={isFullScreen ? 'full-wrapper' : 'normal-wrapper'}>
           <EuiDataGrid
             aria-labelledby="custom-data-grid"
             columns={columns}

--- a/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
@@ -102,7 +102,13 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
 
   const gridStyle = useMemo(
     () => ({
-      stripes: true,
+      border: 'horizontal',
+      stripes: false,
+      rowHover: 'highlight',
+      header: 'underline',
+      fontSize: 's',
+      cellPadding: 's',
+      footer: 'overline',
     }),
     []
   );

--- a/public/components/trace_analytics/components/common/shared_components/sharedComponents.scss
+++ b/public/components/trace_analytics/components/common/shared_components/sharedComponents.scss
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
+.ellipsis-left {
+    direction: rtl; 
+    unicode-bidi: plaintext;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  
+  .full-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+  }
+  
+  .normal-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: auto;
+  }

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_table.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SpanDetailTable renders the component with data 1`] = `
 <div>
   <div
-    style="display: flex; flex-direction: column; height: auto;"
+    class="normal-wrapper"
   >
     <div
       data-focus-guard="true"
@@ -69,13 +69,7 @@ exports[`SpanDetailTable renders the empty component 1`] = `
     onClose={[Function]}
   >
     <div
-      style={
-        Object {
-          "display": "flex",
-          "flexDirection": "column",
-          "height": "auto",
-        }
-      }
+      className="normal-wrapper"
     >
       <EuiDataGrid
         aria-labelledby="custom-data-grid"
@@ -409,7 +403,7 @@ exports[`SpanDetailTable renders the empty component 1`] = `
 exports[`SpanDetailTable renders the jaeger component with data 1`] = `
 <div>
   <div
-    style="display: flex; flex-direction: column; height: auto;"
+    class="normal-wrapper"
   >
     <div
       data-focus-guard="true"
@@ -468,7 +462,7 @@ exports[`SpanDetailTable renders the jaeger component with data 1`] = `
 exports[`SpanDetailTableHierarchy renders the component with data 1`] = `
 <div>
   <div
-    style="display: flex; flex-direction: column; height: auto;"
+    class="normal-wrapper"
   >
     <div
       data-focus-guard="true"
@@ -565,13 +559,7 @@ exports[`SpanDetailTableHierarchy renders the empty component 1`] = `
     onClose={[Function]}
   >
     <div
-      style={
-        Object {
-          "display": "flex",
-          "flexDirection": "column",
-          "height": "auto",
-        }
-      }
+      className="normal-wrapper"
     >
       <EuiDataGrid
         aria-labelledby="custom-data-grid"
@@ -904,7 +892,7 @@ exports[`SpanDetailTableHierarchy renders the empty component 1`] = `
 exports[`SpanDetailTableHierarchy renders the jaeger component with data 1`] = `
 <div>
   <div
-    style="display: flex; flex-direction: column; height: auto;"
+    class="normal-wrapper"
   >
     <div
       data-focus-guard="true"

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_table.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`SpanDetailTable renders the component with data 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+        class="euiDataGrid euiDataGrid--fontSizeSmall euiDataGrid--bordersHorizontal euiDataGrid--headerUnderline euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--paddingSmall euiDataGrid--stickyFooter"
         style="width: 100%; height: auto;"
       />
     </div>
@@ -142,7 +142,13 @@ exports[`SpanDetailTable renders the empty component 1`] = `
         }
         gridStyle={
           Object {
-            "stripes": true,
+            "border": "horizontal",
+            "cellPadding": "s",
+            "fontSize": "s",
+            "footer": "overline",
+            "header": "underline",
+            "rowHover": "highlight",
+            "stripes": false,
           }
         }
         pagination={
@@ -177,6 +183,7 @@ exports[`SpanDetailTable renders the empty component 1`] = `
             "additionalControls": Array [
               <EuiButtonEmpty
                 color="text"
+                data-test-subj="fullScreenButton"
                 iconType="fullScreen"
                 onClick={[Function]}
                 size="xs"
@@ -287,7 +294,7 @@ exports[`SpanDetailTable renders the empty component 1`] = `
                     onWheelCapture={[Function]}
                   >
                     <div
-                      className="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+                      className="euiDataGrid euiDataGrid--fontSizeSmall euiDataGrid--bordersHorizontal euiDataGrid--headerUnderline euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--paddingSmall euiDataGrid--stickyFooter"
                       onKeyDown={[Function]}
                       style={
                         Object {
@@ -414,7 +421,7 @@ exports[`SpanDetailTable renders the jaeger component with data 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+        class="euiDataGrid euiDataGrid--fontSizeSmall euiDataGrid--bordersHorizontal euiDataGrid--headerUnderline euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--paddingSmall euiDataGrid--stickyFooter"
         style="width: 100%; height: auto;"
       />
     </div>
@@ -473,7 +480,7 @@ exports[`SpanDetailTableHierarchy renders the component with data 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+        class="euiDataGrid euiDataGrid--fontSizeSmall euiDataGrid--bordersHorizontal euiDataGrid--headerUnderline euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--paddingSmall euiDataGrid--stickyFooter"
         style="width: 100%; height: 500px;"
       />
     </div>
@@ -631,7 +638,13 @@ exports[`SpanDetailTableHierarchy renders the empty component 1`] = `
         }
         gridStyle={
           Object {
-            "stripes": true,
+            "border": "horizontal",
+            "cellPadding": "s",
+            "fontSize": "s",
+            "footer": "overline",
+            "header": "underline",
+            "rowHover": "highlight",
+            "stripes": false,
           }
         }
         renderCellValue={[Function]}
@@ -647,6 +660,7 @@ exports[`SpanDetailTableHierarchy renders the empty component 1`] = `
             "additionalControls": Array [
               <EuiButtonEmpty
                 color="text"
+                data-test-subj="fullScreenButton"
                 iconType="fullScreen"
                 onClick={[Function]}
                 size="xs"
@@ -775,7 +789,7 @@ exports[`SpanDetailTableHierarchy renders the empty component 1`] = `
                     onWheelCapture={[Function]}
                   >
                     <div
-                      className="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+                      className="euiDataGrid euiDataGrid--fontSizeSmall euiDataGrid--bordersHorizontal euiDataGrid--headerUnderline euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--paddingSmall euiDataGrid--stickyFooter"
                       onKeyDown={[Function]}
                       style={
                         Object {
@@ -902,7 +916,7 @@ exports[`SpanDetailTableHierarchy renders the jaeger component with data 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+        class="euiDataGrid euiDataGrid--fontSizeSmall euiDataGrid--bordersHorizontal euiDataGrid--headerUnderline euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--paddingSmall euiDataGrid--stickyFooter"
         style="width: 100%; height: 500px;"
       />
     </div>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_table.test.tsx.snap
@@ -3,24 +3,28 @@
 exports[`SpanDetailTable renders the component with data 1`] = `
 <div>
   <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-  <div
-    class="euiDataGrid__focusWrap"
-    data-focus-lock-disabled="disabled"
+    style="display: flex; flex-direction: column; height: auto;"
   >
     <div
-      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter"
-      style="width: 100%; height: auto;"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      class="euiDataGrid__focusWrap"
+      data-focus-lock-disabled="disabled"
+    >
+      <div
+        class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+        style="width: 100%; height: auto;"
+      />
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
     />
   </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
 </div>
 `;
 
@@ -64,128 +68,133 @@ exports[`SpanDetailTable renders the empty component 1`] = `
     isFullScreen={false}
     onClose={[Function]}
   >
-    <EuiDataGrid
-      aria-labelledby="span-detail-data-grid"
-      columnVisibility={
-        Object {
-          "setVisibleColumns": [Function],
-          "visibleColumns": Array [
-            "spanId",
-            "parentSpanId",
-            "serviceName",
-            "name",
-            "durationInNanos",
-            "status.code",
-            "startTime",
-            "endTime",
-          ],
-        }
-      }
-      columns={
-        Array [
-          Object {
-            "display": "Span ID",
-            "id": "spanId",
-          },
-          Object {
-            "display": "Parent span ID",
-            "id": "parentSpanId",
-          },
-          Object {
-            "display": "Trace ID",
-            "id": "traceId",
-          },
-          Object {
-            "display": "Trace group",
-            "id": "traceGroup",
-          },
-          Object {
-            "display": "Service",
-            "id": "serviceName",
-          },
-          Object {
-            "display": "Operation",
-            "id": "name",
-          },
-          Object {
-            "display": "Duration",
-            "id": "durationInNanos",
-            "initialWidth": 100,
-          },
-          Object {
-            "display": "Errors",
-            "id": "status.code",
-            "initialWidth": 100,
-          },
-          Object {
-            "display": "Start time",
-            "id": "startTime",
-          },
-          Object {
-            "display": "End time",
-            "id": "endTime",
-          },
-        ]
-      }
-      pagination={
-        Object {
-          "onChangeItemsPerPage": [Function],
-          "onChangePage": [Function],
-          "pageIndex": 0,
-          "pageSize": 10,
-          "pageSizeOptions": Array [
-            10,
-            50,
-            100,
-          ],
-        }
-      }
-      renderCellValue={[Function]}
-      rowCount={0}
-      sorting={
-        Object {
-          "columns": Array [],
-          "onSort": [Function],
-        }
-      }
+    <div
       style={
         Object {
+          "display": "flex",
+          "flexDirection": "column",
           "height": "auto",
-          "width": "100%",
-        }
-      }
-      toolbarVisibility={
-        Object {
-          "additionalControls": Array [
-            <EuiButtonEmpty
-              color="text"
-              data-test-subj="fullScreenButton"
-              iconType="fullScreen"
-              onClick={[Function]}
-              size="xs"
-            >
-              Full screen
-            </EuiButtonEmpty>,
-          ],
-          "showColumnSelector": true,
-          "showFullScreenSelector": false,
-          "showSortSelector": true,
         }
       }
     >
-      <EuiFocusTrap
-        className="euiDataGrid__focusWrap"
-        clickOutsideDisables={false}
-        disabled={true}
-        noIsolation={true}
-        returnFocus={true}
-        scrollLock={false}
+      <EuiDataGrid
+        aria-labelledby="custom-data-grid"
+        columnVisibility={
+          Object {
+            "setVisibleColumns": [Function],
+            "visibleColumns": Array [
+              "spanId",
+              "parentSpanId",
+              "serviceName",
+              "name",
+              "durationInNanos",
+              "status.code",
+              "startTime",
+              "endTime",
+            ],
+          }
+        }
+        columns={
+          Array [
+            Object {
+              "display": "Span ID",
+              "id": "spanId",
+            },
+            Object {
+              "display": "Parent span ID",
+              "id": "parentSpanId",
+            },
+            Object {
+              "display": "Trace ID",
+              "id": "traceId",
+            },
+            Object {
+              "display": "Trace group",
+              "id": "traceGroup",
+            },
+            Object {
+              "display": "Service",
+              "id": "serviceName",
+            },
+            Object {
+              "display": "Operation",
+              "id": "name",
+            },
+            Object {
+              "display": "Duration",
+              "id": "durationInNanos",
+              "initialWidth": 100,
+            },
+            Object {
+              "display": "Errors",
+              "id": "status.code",
+              "initialWidth": 100,
+            },
+            Object {
+              "display": "Start time",
+              "id": "startTime",
+            },
+            Object {
+              "display": "End time",
+              "id": "endTime",
+            },
+          ]
+        }
+        gridStyle={
+          Object {
+            "stripes": true,
+          }
+        }
+        pagination={
+          Object {
+            "onChangeItemsPerPage": [Function],
+            "onChangePage": [Function],
+            "pageIndex": 0,
+            "pageSize": 10,
+            "pageSizeOptions": Array [
+              10,
+              50,
+              100,
+            ],
+          }
+        }
+        renderCellValue={[Function]}
+        rowCount={0}
+        sorting={
+          Object {
+            "columns": Array [],
+            "onSort": [Function],
+          }
+        }
+        style={
+          Object {
+            "height": "auto",
+            "width": "100%",
+          }
+        }
+        toolbarVisibility={
+          Object {
+            "additionalControls": Array [
+              <EuiButtonEmpty
+                color="text"
+                iconType="fullScreen"
+                onClick={[Function]}
+                size="xs"
+              >
+                Full screen
+              </EuiButtonEmpty>,
+            ],
+            "showColumnSelector": true,
+            "showFullScreenSelector": false,
+            "showSortSelector": true,
+          }
+        }
       >
-        <ForwardRef
+        <EuiFocusTrap
           className="euiDataGrid__focusWrap"
-          enabled={false}
+          clickOutsideDisables={false}
+          disabled={true}
           noIsolation={true}
-          onClickOutside={[Function]}
           returnFocus={true}
           scrollLock={false}
         >
@@ -196,111 +205,120 @@ exports[`SpanDetailTable renders the empty component 1`] = `
             onClickOutside={[Function]}
             returnFocus={true}
             scrollLock={false}
-            sideCar={[Function]}
           >
-            <ForwardRef(FocusLockUI)
-              as={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "classNames": Object {
-                    "fullWidth": "width-before-scroll-bar",
-                    "zeroRight": "right-scroll-bar-position",
-                  },
-                  "defaultProps": Object {
-                    "enabled": true,
-                    "inert": false,
-                    "removeScrollBar": true,
-                  },
-                  "render": [Function],
-                }
-              }
-              autoFocus={true}
+            <ForwardRef
               className="euiDataGrid__focusWrap"
-              crossFrame={true}
-              disabled={true}
-              lockProps={
-                Object {
-                  "allowPinchZoom": undefined,
-                  "as": undefined,
-                  "enabled": false,
-                  "inert": undefined,
-                  "shards": undefined,
-                  "sideCar": [Function],
-                  "style": undefined,
-                }
-              }
-              noFocusGuards={false}
-              persistentFocus={false}
+              enabled={false}
+              noIsolation={true}
+              onClickOutside={[Function]}
               returnFocus={true}
+              scrollLock={false}
               sideCar={[Function]}
             >
-              <div
-                data-focus-guard={true}
-                key="guard-first"
-                style={
+              <ForwardRef(FocusLockUI)
+                as={
                   Object {
-                    "height": "0px",
-                    "left": "1px",
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "fixed",
-                    "top": "1px",
-                    "width": "1px",
+                    "$$typeof": Symbol(react.forward_ref),
+                    "classNames": Object {
+                      "fullWidth": "width-before-scroll-bar",
+                      "zeroRight": "right-scroll-bar-position",
+                    },
+                    "defaultProps": Object {
+                      "enabled": true,
+                      "inert": false,
+                      "removeScrollBar": true,
+                    },
+                    "render": [Function],
                   }
                 }
-                tabIndex={-1}
-              />
-              <ForwardRef
+                autoFocus={true}
                 className="euiDataGrid__focusWrap"
-                data-focus-lock-disabled="disabled"
-                enabled={false}
-                inert={false}
-                onBlur={[Function]}
-                onFocus={[Function]}
-                removeScrollBar={true}
+                crossFrame={true}
+                disabled={true}
+                lockProps={
+                  Object {
+                    "allowPinchZoom": undefined,
+                    "as": undefined,
+                    "enabled": false,
+                    "inert": undefined,
+                    "shards": undefined,
+                    "sideCar": [Function],
+                    "style": undefined,
+                  }
+                }
+                noFocusGuards={false}
+                persistentFocus={false}
+                returnFocus={true}
                 sideCar={[Function]}
               >
                 <div
+                  data-focus-guard={true}
+                  key="guard-first"
+                  style={
+                    Object {
+                      "height": "0px",
+                      "left": "1px",
+                      "overflow": "hidden",
+                      "padding": 0,
+                      "position": "fixed",
+                      "top": "1px",
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex={-1}
+                />
+                <ForwardRef
                   className="euiDataGrid__focusWrap"
                   data-focus-lock-disabled="disabled"
+                  enabled={false}
+                  inert={false}
                   onBlur={[Function]}
                   onFocus={[Function]}
-                  onScrollCapture={[Function]}
-                  onTouchMoveCapture={[Function]}
-                  onWheelCapture={[Function]}
+                  removeScrollBar={true}
+                  sideCar={[Function]}
                 >
                   <div
-                    className="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter"
-                    onKeyDown={[Function]}
-                    style={
-                      Object {
-                        "height": "auto",
-                        "width": "100%",
+                    className="euiDataGrid__focusWrap"
+                    data-focus-lock-disabled="disabled"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onScrollCapture={[Function]}
+                    onTouchMoveCapture={[Function]}
+                    onWheelCapture={[Function]}
+                  >
+                    <div
+                      className="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+                      onKeyDown={[Function]}
+                      style={
+                        Object {
+                          "height": "auto",
+                          "width": "100%",
+                        }
                       }
+                    />
+                  </div>
+                </ForwardRef>
+                <div
+                  data-focus-guard={true}
+                  style={
+                    Object {
+                      "height": "0px",
+                      "left": "1px",
+                      "overflow": "hidden",
+                      "padding": 0,
+                      "position": "fixed",
+                      "top": "1px",
+                      "width": "1px",
                     }
-                  />
-                </div>
-              </ForwardRef>
-              <div
-                data-focus-guard={true}
-                style={
-                  Object {
-                    "height": "0px",
-                    "left": "1px",
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "fixed",
-                    "top": "1px",
-                    "width": "1px",
                   }
-                }
-                tabIndex={-1}
-              />
-            </ForwardRef(FocusLockUI)>
+                  tabIndex={-1}
+                />
+              </ForwardRef(FocusLockUI)>
+            </ForwardRef>
           </ForwardRef>
-        </ForwardRef>
-      </EuiFocusTrap>
-    </EuiDataGrid>
+        </EuiFocusTrap>
+      </EuiDataGrid>
+    </div>
   </FullScreenWrapper>
   <NoMatchMessage
     size="xl"
@@ -384,24 +402,28 @@ exports[`SpanDetailTable renders the empty component 1`] = `
 exports[`SpanDetailTable renders the jaeger component with data 1`] = `
 <div>
   <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-  <div
-    class="euiDataGrid__focusWrap"
-    data-focus-lock-disabled="disabled"
+    style="display: flex; flex-direction: column; height: auto;"
   >
     <div
-      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter"
-      style="width: 100%; height: auto;"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      class="euiDataGrid__focusWrap"
+      data-focus-lock-disabled="disabled"
+    >
+      <div
+        class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+        style="width: 100%; height: auto;"
+      />
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
     />
   </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
   <div
     class="euiSpacer euiSpacer--xl"
   />
@@ -439,24 +461,28 @@ exports[`SpanDetailTable renders the jaeger component with data 1`] = `
 exports[`SpanDetailTableHierarchy renders the component with data 1`] = `
 <div>
   <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-  <div
-    class="euiDataGrid__focusWrap"
-    data-focus-lock-disabled="disabled"
+    style="display: flex; flex-direction: column; height: auto;"
   >
     <div
-      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter"
-      style="width: 100%; height: 500px; overflow-y: auto;"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      class="euiDataGrid__focusWrap"
+      data-focus-lock-disabled="disabled"
+    >
+      <div
+        class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+        style="width: 100%; height: 500px;"
+      />
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
     />
   </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
   <div
     class="euiSpacer euiSpacer--xl"
   />
@@ -531,128 +557,132 @@ exports[`SpanDetailTableHierarchy renders the empty component 1`] = `
     isFullScreen={false}
     onClose={[Function]}
   >
-    <EuiDataGrid
-      aria-labelledby="span-detail-data-grid"
-      columnVisibility={
-        Object {
-          "setVisibleColumns": [Function],
-          "visibleColumns": Array [
-            "spanId",
-            "parentSpanId",
-            "serviceName",
-            "name",
-            "durationInNanos",
-            "status.code",
-            "startTime",
-            "endTime",
-          ],
-        }
-      }
-      columns={
-        Array [
-          Object {
-            "display": "Span ID",
-            "id": "spanId",
-          },
-          Object {
-            "display": "Parent span ID",
-            "id": "parentSpanId",
-          },
-          Object {
-            "display": "Trace ID",
-            "id": "traceId",
-          },
-          Object {
-            "display": "Trace group",
-            "id": "traceGroup",
-          },
-          Object {
-            "display": "Service",
-            "id": "serviceName",
-          },
-          Object {
-            "display": "Operation",
-            "id": "name",
-          },
-          Object {
-            "display": "Duration",
-            "id": "durationInNanos",
-            "initialWidth": 100,
-          },
-          Object {
-            "display": "Errors",
-            "id": "status.code",
-            "initialWidth": 100,
-          },
-          Object {
-            "display": "Start time",
-            "id": "startTime",
-          },
-          Object {
-            "display": "End time",
-            "id": "endTime",
-          },
-        ]
-      }
-      renderCellValue={[Function]}
-      rowCount={0}
+    <div
       style={
         Object {
-          "height": "500px",
-          "overflowY": "auto",
-          "width": "100%",
-        }
-      }
-      toolbarVisibility={
-        Object {
-          "additionalControls": Array [
-            <EuiButtonEmpty
-              color="text"
-              data-test-subj="fullScreenButton"
-              iconType="fullScreen"
-              onClick={[Function]}
-              size="xs"
-            >
-              Full screen
-            </EuiButtonEmpty>,
-            <EuiButtonEmpty
-              color="text"
-              data-test-subj="treeExpandAll"
-              iconType="expand"
-              onClick={[Function]}
-              size="xs"
-            >
-              Expand all
-            </EuiButtonEmpty>,
-            <EuiButtonEmpty
-              color="text"
-              data-test-subj="treeCollapseAll"
-              iconType="minimize"
-              onClick={[Function]}
-              size="xs"
-            >
-              Collapse all
-            </EuiButtonEmpty>,
-          ],
-          "showColumnSelector": true,
-          "showFullScreenSelector": false,
-          "showSortSelector": true,
+          "display": "flex",
+          "flexDirection": "column",
+          "height": "auto",
         }
       }
     >
-      <EuiFocusTrap
-        className="euiDataGrid__focusWrap"
-        clickOutsideDisables={false}
-        disabled={true}
-        noIsolation={true}
-        returnFocus={true}
-        scrollLock={false}
+      <EuiDataGrid
+        aria-labelledby="custom-data-grid"
+        columnVisibility={
+          Object {
+            "setVisibleColumns": [Function],
+            "visibleColumns": Array [
+              "spanId",
+              "parentSpanId",
+              "serviceName",
+              "name",
+              "durationInNanos",
+              "status.code",
+              "startTime",
+              "endTime",
+            ],
+          }
+        }
+        columns={
+          Array [
+            Object {
+              "display": "Span ID",
+              "id": "spanId",
+            },
+            Object {
+              "display": "Parent span ID",
+              "id": "parentSpanId",
+            },
+            Object {
+              "display": "Trace ID",
+              "id": "traceId",
+            },
+            Object {
+              "display": "Trace group",
+              "id": "traceGroup",
+            },
+            Object {
+              "display": "Service",
+              "id": "serviceName",
+            },
+            Object {
+              "display": "Operation",
+              "id": "name",
+            },
+            Object {
+              "display": "Duration",
+              "id": "durationInNanos",
+              "initialWidth": 100,
+            },
+            Object {
+              "display": "Errors",
+              "id": "status.code",
+              "initialWidth": 100,
+            },
+            Object {
+              "display": "Start time",
+              "id": "startTime",
+            },
+            Object {
+              "display": "End time",
+              "id": "endTime",
+            },
+          ]
+        }
+        gridStyle={
+          Object {
+            "stripes": true,
+          }
+        }
+        renderCellValue={[Function]}
+        rowCount={0}
+        style={
+          Object {
+            "height": "500px",
+            "width": "100%",
+          }
+        }
+        toolbarVisibility={
+          Object {
+            "additionalControls": Array [
+              <EuiButtonEmpty
+                color="text"
+                iconType="fullScreen"
+                onClick={[Function]}
+                size="xs"
+              >
+                Full screen
+              </EuiButtonEmpty>,
+              <EuiButtonEmpty
+                color="text"
+                data-test-subj="treeExpandAll"
+                iconType="expand"
+                onClick={[Function]}
+                size="xs"
+              >
+                Expand all
+              </EuiButtonEmpty>,
+              <EuiButtonEmpty
+                color="text"
+                data-test-subj="treeCollapseAll"
+                iconType="minimize"
+                onClick={[Function]}
+                size="xs"
+              >
+                Collapse all
+              </EuiButtonEmpty>,
+            ],
+            "showColumnSelector": true,
+            "showFullScreenSelector": false,
+            "showSortSelector": false,
+          }
+        }
       >
-        <ForwardRef
+        <EuiFocusTrap
           className="euiDataGrid__focusWrap"
-          enabled={false}
+          clickOutsideDisables={false}
+          disabled={true}
           noIsolation={true}
-          onClickOutside={[Function]}
           returnFocus={true}
           scrollLock={false}
         >
@@ -663,112 +693,120 @@ exports[`SpanDetailTableHierarchy renders the empty component 1`] = `
             onClickOutside={[Function]}
             returnFocus={true}
             scrollLock={false}
-            sideCar={[Function]}
           >
-            <ForwardRef(FocusLockUI)
-              as={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "classNames": Object {
-                    "fullWidth": "width-before-scroll-bar",
-                    "zeroRight": "right-scroll-bar-position",
-                  },
-                  "defaultProps": Object {
-                    "enabled": true,
-                    "inert": false,
-                    "removeScrollBar": true,
-                  },
-                  "render": [Function],
-                }
-              }
-              autoFocus={true}
+            <ForwardRef
               className="euiDataGrid__focusWrap"
-              crossFrame={true}
-              disabled={true}
-              lockProps={
-                Object {
-                  "allowPinchZoom": undefined,
-                  "as": undefined,
-                  "enabled": false,
-                  "inert": undefined,
-                  "shards": undefined,
-                  "sideCar": [Function],
-                  "style": undefined,
-                }
-              }
-              noFocusGuards={false}
-              persistentFocus={false}
+              enabled={false}
+              noIsolation={true}
+              onClickOutside={[Function]}
               returnFocus={true}
+              scrollLock={false}
               sideCar={[Function]}
             >
-              <div
-                data-focus-guard={true}
-                key="guard-first"
-                style={
+              <ForwardRef(FocusLockUI)
+                as={
                   Object {
-                    "height": "0px",
-                    "left": "1px",
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "fixed",
-                    "top": "1px",
-                    "width": "1px",
+                    "$$typeof": Symbol(react.forward_ref),
+                    "classNames": Object {
+                      "fullWidth": "width-before-scroll-bar",
+                      "zeroRight": "right-scroll-bar-position",
+                    },
+                    "defaultProps": Object {
+                      "enabled": true,
+                      "inert": false,
+                      "removeScrollBar": true,
+                    },
+                    "render": [Function],
                   }
                 }
-                tabIndex={-1}
-              />
-              <ForwardRef
+                autoFocus={true}
                 className="euiDataGrid__focusWrap"
-                data-focus-lock-disabled="disabled"
-                enabled={false}
-                inert={false}
-                onBlur={[Function]}
-                onFocus={[Function]}
-                removeScrollBar={true}
+                crossFrame={true}
+                disabled={true}
+                lockProps={
+                  Object {
+                    "allowPinchZoom": undefined,
+                    "as": undefined,
+                    "enabled": false,
+                    "inert": undefined,
+                    "shards": undefined,
+                    "sideCar": [Function],
+                    "style": undefined,
+                  }
+                }
+                noFocusGuards={false}
+                persistentFocus={false}
+                returnFocus={true}
                 sideCar={[Function]}
               >
                 <div
+                  data-focus-guard={true}
+                  key="guard-first"
+                  style={
+                    Object {
+                      "height": "0px",
+                      "left": "1px",
+                      "overflow": "hidden",
+                      "padding": 0,
+                      "position": "fixed",
+                      "top": "1px",
+                      "width": "1px",
+                    }
+                  }
+                  tabIndex={-1}
+                />
+                <ForwardRef
                   className="euiDataGrid__focusWrap"
                   data-focus-lock-disabled="disabled"
+                  enabled={false}
+                  inert={false}
                   onBlur={[Function]}
                   onFocus={[Function]}
-                  onScrollCapture={[Function]}
-                  onTouchMoveCapture={[Function]}
-                  onWheelCapture={[Function]}
+                  removeScrollBar={true}
+                  sideCar={[Function]}
                 >
                   <div
-                    className="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter"
-                    onKeyDown={[Function]}
-                    style={
-                      Object {
-                        "height": "500px",
-                        "overflowY": "auto",
-                        "width": "100%",
+                    className="euiDataGrid__focusWrap"
+                    data-focus-lock-disabled="disabled"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onScrollCapture={[Function]}
+                    onTouchMoveCapture={[Function]}
+                    onWheelCapture={[Function]}
+                  >
+                    <div
+                      className="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+                      onKeyDown={[Function]}
+                      style={
+                        Object {
+                          "height": "500px",
+                          "width": "100%",
+                        }
                       }
+                    />
+                  </div>
+                </ForwardRef>
+                <div
+                  data-focus-guard={true}
+                  style={
+                    Object {
+                      "height": "0px",
+                      "left": "1px",
+                      "overflow": "hidden",
+                      "padding": 0,
+                      "position": "fixed",
+                      "top": "1px",
+                      "width": "1px",
                     }
-                  />
-                </div>
-              </ForwardRef>
-              <div
-                data-focus-guard={true}
-                style={
-                  Object {
-                    "height": "0px",
-                    "left": "1px",
-                    "overflow": "hidden",
-                    "padding": 0,
-                    "position": "fixed",
-                    "top": "1px",
-                    "width": "1px",
                   }
-                }
-                tabIndex={-1}
-              />
-            </ForwardRef(FocusLockUI)>
+                  tabIndex={-1}
+                />
+              </ForwardRef(FocusLockUI)>
+            </ForwardRef>
           </ForwardRef>
-        </ForwardRef>
-      </EuiFocusTrap>
-    </EuiDataGrid>
+        </EuiFocusTrap>
+      </EuiDataGrid>
+    </div>
   </FullScreenWrapper>
   <NoMatchMessage
     size="xl"
@@ -852,24 +890,28 @@ exports[`SpanDetailTableHierarchy renders the empty component 1`] = `
 exports[`SpanDetailTableHierarchy renders the jaeger component with data 1`] = `
 <div>
   <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-  <div
-    class="euiDataGrid__focusWrap"
-    data-focus-lock-disabled="disabled"
+    style="display: flex; flex-direction: column; height: auto;"
   >
     <div
-      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter"
-      style="width: 100%; height: 500px; overflow-y: auto;"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      class="euiDataGrid__focusWrap"
+      data-focus-lock-disabled="disabled"
+    >
+      <div
+        class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stripes euiDataGrid--stickyFooter"
+        style="width: 100%; height: 500px;"
+      />
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
     />
   </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
   <div
     class="euiSpacer euiSpacer--xl"
   />

--- a/public/components/trace_analytics/components/traces/span_detail_table.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_table.tsx
@@ -216,14 +216,12 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
     setTableParams((prev) => ({ ...prev, size, page: 0 }));
   };
 
-  const hiddenColumns = props.hiddenColumns ?? ['traceId', 'traceGroup'];
-
   const visibleColumns = useMemo(
     () =>
       getColumns(props.mode)
-        .filter(({ id }) => !hiddenColumns.includes(id))
+        .filter(({ id }) => !props.hiddenColumns.includes(id))
         .map(({ id }) => id),
-    [props.mode, hiddenColumns]
+    [props.mode]
   );
 
   return RenderCustomDataGrid({

--- a/public/components/trace_analytics/components/traces/span_detail_table.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_table.tsx
@@ -89,12 +89,14 @@ const renderCommonCellValue = ({
   items,
   tableParams,
   props,
+  disableInteractions,
 }: {
   rowIndex: number;
   columnId: string;
   items: any[];
   tableParams: any;
   props: SpanDetailTableProps;
+  disableInteractions: boolean;
 }) => {
   const adjustedRowIndex = rowIndex - tableParams.page * tableParams.size;
   const item = items[adjustedRowIndex];
@@ -117,7 +119,9 @@ const renderCommonCellValue = ({
       return value?.serviceName;
     case 'spanId':
     case 'spanID':
-      return (
+      return disableInteractions ? (
+        <span>{value}</span>
+      ) : (
         <EuiLink data-test-subj="spanId-link" onClick={() => props.openFlyout(value)}>
           {value}
         </EuiLink>
@@ -193,13 +197,14 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
   }, [total]);
   const columns = useMemo(() => getColumns(props.mode), [props.mode]);
   const renderCellValue = useCallback(
-    ({ rowIndex, columnId }) =>
+    ({ rowIndex, columnId, disableInteractions }) =>
       renderCommonCellValue({
         rowIndex,
         columnId,
         items,
         tableParams,
         props,
+        disableInteractions,
       }),
     [items, tableParams, props]
   );
@@ -331,7 +336,7 @@ export function SpanDetailTableHierarchy(props: SpanDetailTableProps) {
   };
 
   const renderCellValue = useCallback(
-    ({ rowIndex, columnId }) => {
+    ({ rowIndex, columnId, disableInteractions }) => {
       const item = flattenedItems[rowIndex];
       const value = item[columnId];
 
@@ -360,14 +365,17 @@ export function SpanDetailTableHierarchy(props: SpanDetailTableProps) {
             ) : (
               <EuiIcon type="empty" style={{ visibility: 'hidden', marginRight: 5 }} />
             )}
-            <EuiButtonEmpty
-              size="xs"
-              onClick={() => openFlyout(value)}
-              color="primary"
-              data-test-subj="spanId-flyout-button"
-            >
-              {value}
-            </EuiButtonEmpty>
+            {disableInteractions ? (
+              <span>{value}</span>
+            ) : (
+              <EuiLink
+                onClick={() => openFlyout(value)}
+                color="primary"
+                data-test-subj="spanId-flyout-button"
+              >
+                {value}
+              </EuiLink>
+            )}
           </div>
         );
       }

--- a/public/components/trace_analytics/index.scss
+++ b/public/components/trace_analytics/index.scss
@@ -148,8 +148,8 @@ th[data-test-subj^='tableHeaderCell_dashboard_latency_variance'] {
 }
 
 .ellipsis-left {
-  direction: rtl;
-  unicode-bidi: bidi-override;
+  direction: rtl; 
+  unicode-bidi: plaintext;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/public/components/trace_analytics/index.scss
+++ b/public/components/trace_analytics/index.scss
@@ -146,3 +146,11 @@ th[data-test-subj^='tableHeaderCell_dashboard_latency_variance'] {
   flex: 1 1 auto;
   overflow: auto;
 }
+
+.ellipsis-left {
+  direction: rtl;
+  unicode-bidi: bidi-override;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/public/components/trace_analytics/index.scss
+++ b/public/components/trace_analytics/index.scss
@@ -4,6 +4,7 @@
  */
 
 @import '../../../node_modules/vis-network/dist/dist/vis-network.min.css';
+@import './components/common/shared_components/sharedComponents.scss';
 
 .overview-title {
   color: '#333333';
@@ -145,24 +146,4 @@ th[data-test-subj^='tableHeaderCell_dashboard_latency_variance'] {
 .full-screen-content {
   flex: 1 1 auto;
   overflow: auto;
-}
-
-.ellipsis-left {
-  direction: rtl; 
-  unicode-bidi: plaintext;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.full-wrapper {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-}
-
-.normal-wrapper {
-  display: flex;
-  flex-direction: column;
-  height: auto;
 }

--- a/public/components/trace_analytics/index.scss
+++ b/public/components/trace_analytics/index.scss
@@ -154,3 +154,15 @@ th[data-test-subj^='tableHeaderCell_dashboard_latency_variance'] {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.full-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.normal-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: auto;
+}


### PR DESCRIPTION
### Description
1. Updated the attribute filters to show the ending instead of the start to provide the useful information before hovering.
2. Abstracted the EUI Datagrid componenet to have uniform styling.
3. Update cypress test

Old filter:
<img width="953" alt="OldFilter" src="https://github.com/user-attachments/assets/4df6a289-9948-47c8-bd87-2a90d3a70611" />

New filter:
<img width="1195" alt="Screenshot 2025-01-30 at 2 02 54 PM" src="https://github.com/user-attachments/assets/6ca03462-2dfd-4801-8735-fc8544ed4cbc" />

<img width="752" alt="Screenshot 2025-01-30 at 2 03 08 PM" src="https://github.com/user-attachments/assets/4fe2b9a2-26c9-418e-853f-0c85f74516db" />

Example of left ellipsis (text window made smaller to show)
<img width="738" alt="Screenshot 2025-01-30 at 2 04 20 PM" src="https://github.com/user-attachments/assets/874e81c8-4ccd-4361-8388-50b54c41d400" />


Old DataGrid:
<img width="1291" alt="OldDataGrid" src="https://github.com/user-attachments/assets/20985f0d-0586-4878-b9bd-5deb3e8e3f07" />

New DataGrid
<img width="1287" alt="NewDataGrid" src="https://github.com/user-attachments/assets/a5c79ffe-38f3-482e-b3e1-fad926e52051" />


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
