### PR TITLE
Add MDS support for missing datasourceId in traceGroup requests

### DIFF
--- a/public/components/trace_analytics/components/traces/span_detail_table.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_table.tsx
@@ -172,7 +172,6 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
   const [items, setItems] = useState<Span[]>([]);
   const [total, setTotal] = useState(0);
   const [isSpansTableDataLoading, setIsSpansTableDataLoading] = useState(false);
-  const { mode } = props;
 
   const fetchData = async () => {
     setIsSpansTableDataLoading(true);

--- a/public/components/trace_analytics/requests/dashboard_request_handler.ts
+++ b/public/components/trace_analytics/requests/dashboard_request_handler.ts
@@ -62,17 +62,21 @@ export const handleDashboardRequest = async (
     latencyTrendDSL,
     getLatencyTrendQuery(),
     mode,
-    setShowTimeoutToast
+    setShowTimeoutToast,
+    dataSourceMDSId
   )
     .then((response) => {
       const map: any = {};
-      response.aggregations.trace_group_name.buckets.map((bucket) => {
-        const latencyTrend = bucket.group_by_hour.buckets
+      response.aggregations.trace_group_name.buckets.map((aggBucket) => {
+        const latencyTrend = aggBucket.group_by_hour.buckets
           .slice(-24)
-          .filter((bucket) => bucket.average_latency?.value || bucket.average_latency?.value === 0);
+          .filter(
+            (filterBucket) =>
+              filterBucket.average_latency?.value || filterBucket.average_latency?.value === 0
+          );
         const values = {
-          x: latencyTrend.map((bucket) => bucket.key),
-          y: latencyTrend.map((bucket) => bucket.average_latency?.value || 0),
+          x: latencyTrend.map((xBucket) => xBucket.key),
+          y: latencyTrend.map((yBucket) => yBucket.average_latency?.value || 0),
         };
         const latencyTrendData =
           values.x?.length > 0
@@ -115,7 +119,7 @@ export const handleDashboardRequest = async (
                 },
               }
             : {};
-        map[bucket.key] = latencyTrendData;
+        map[aggBucket.key] = latencyTrendData;
       });
       return map;
     })
@@ -152,8 +156,7 @@ export const handleJaegerDashboardRequest = async (
   setItems,
   mode,
   setShowTimeoutToast,
-  dataSourceMDSId?,
-  setPercentileMap?
+  dataSourceMDSId?
 ) => {
   const latencyTrends = await handleDslRequest(
     http,
@@ -165,13 +168,16 @@ export const handleJaegerDashboardRequest = async (
   )
     .then((response) => {
       const map: any = {};
-      response.aggregations.trace_group_name.buckets.map((bucket) => {
-        const latencyTrend = bucket.group_by_hour.buckets
+      response.aggregations.trace_group_name.buckets.map((aggBucket) => {
+        const latencyTrend = aggBucket.group_by_hour.buckets
           .slice(-24)
-          .filter((bucket) => bucket.average_latency?.value || bucket.average_latency?.value === 0);
+          .filter(
+            (filterBucket) =>
+              filterBucket.average_latency?.value || filterBucket.average_latency?.value === 0
+          );
         const values = {
-          x: latencyTrend.map((bucket) => bucket.key),
-          y: latencyTrend.map((bucket) => bucket.average_latency?.value || 0),
+          x: latencyTrend.map((xBucket) => xBucket.key),
+          y: latencyTrend.map((yBucket) => yBucket.average_latency?.value || 0),
         };
         const latencyTrendData =
           values.x?.length > 0
@@ -211,7 +217,7 @@ export const handleJaegerDashboardRequest = async (
                 },
               }
             : {};
-        map[bucket.key] = latencyTrendData;
+        map[aggBucket.key] = latencyTrendData;
       });
       return map;
     })
@@ -251,7 +257,7 @@ export const handleJaegerDashboardRequest = async (
           newItems.map((a) => a.dashboard_trace_group_name)
         ),
         mode,
-        true,
+        dataSourceMDSId,
         setShowTimeoutToast
       )
         .then((response) => {
@@ -281,8 +287,7 @@ export const handleJaegerErrorDashboardRequest = async (
   setItems,
   mode,
   setShowTimeoutToast,
-  dataSourceMDSId?,
-  setPercentileMap?
+  dataSourceMDSId?
 ) => {
   const errorTrends = await handleDslRequest(
     http,
@@ -294,13 +299,15 @@ export const handleJaegerErrorDashboardRequest = async (
   )
     .then((response) => {
       const map: any = {};
-      response.aggregations.trace_group_name.buckets.map((bucket) => {
-        const errorTrend = bucket.group_by_hour.buckets
+      response.aggregations.trace_group_name.buckets.map((aggBucket) => {
+        const errorTrend = aggBucket.group_by_hour.buckets
           .slice(-24)
-          .filter((bucket) => bucket.error_rate?.value || bucket.error_rate?.value === 0);
+          .filter(
+            (filterBucket) => filterBucket.error_rate?.value || filterBucket.error_rate?.value === 0
+          );
         const values = {
-          x: errorTrend.map((bucket) => bucket.key),
-          y: errorTrend.map((bucket) => bucket.error_rate?.value || 0),
+          x: errorTrend.map((xBucket) => xBucket.key),
+          y: errorTrend.map((yBucket) => yBucket.error_rate?.value || 0),
         };
         const errorTrendData =
           values.x?.length > 0
@@ -340,7 +347,7 @@ export const handleJaegerErrorDashboardRequest = async (
                 },
               }
             : {};
-        map[bucket.key] = errorTrendData;
+        map[aggBucket.key] = errorTrendData;
       });
       return map;
     })


### PR DESCRIPTION
### Description
Add MDS support for missing datasourceId in traceGroup requests. The missing pieces lead to 400 errors when MDS is enabled. This fix makes sure the requests are going to the right cluster as selected by the users. 

### Issues Resolved
![Screenshot 2025-02-03 at 12 17 16 PM](https://github.com/user-attachments/assets/78b80546-91a4-4152-b3ef-f0d304641bac)


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
