### PR TITLE
[Bug] Remove `only` from traces cypress spec

### DIFF
--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -95,7 +95,7 @@ describe('Testing trace view', () => {
     cy.get('.euiTitle').contains('Logs').should('exist');
   });
 
-  it.only('Renders data grid, flyout and filters', () => {
+  it('Renders data grid, flyout and filters', () => {
     cy.get('.panel-title-count').contains('(11)').should('exist');
     cy.get('.euiButton__text[title="Span list"]').click({ force: true });
     cy.contains('2 columns hidden').should('exist');


### PR DESCRIPTION
### Description
[Bug] Remove only from traces cypress spec

### Issues Resolved
A bad commit was introduced in https://github.com/opensearch-project/dashboards-observability/commit/ca79a8f092301c7ae6cf36cd17dda2ca242a910d which led to test skipping and only running one test in the `trace_analytics_traces.spec.js` 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
