### PR TITLE
[Integration] Remove `maxFilesPerTrigger` from all the integrations queries

### DIFF
--- a/public/components/getting_started/getting_started_artifacts/nginx/assets/create_mv-1.0.0.sql
+++ b/public/components/getting_started/getting_started_artifacts/nginx/assets/create_mv-1.0.0.sql
@@ -12,6 +12,5 @@ WITH (
     auto_refresh = 'true',
     refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
-    watermark_delay = '1 Minute',
-    extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+    watermark_delay = '1 Minute'
 )

--- a/server/adaptors/integrations/__data__/repository/amazon_cloudfront/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/amazon_cloudfront/assets/create_mv-1.0.0.sql
@@ -38,6 +38,5 @@ WITH (
   auto_refresh = true,
   refresh_interval = '15 Minute',
   checkpoint_location = '{s3_checkpoint_location}',
-  watermark_delay = '1 Minute',
-  extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+  watermark_delay = '1 Minute'
 )

--- a/server/adaptors/integrations/__data__/repository/amazon_elb/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/amazon_elb/assets/create_mv-1.0.0.sql
@@ -55,6 +55,5 @@ WITH (
     auto_refresh = true,
     refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
-    watermark_delay = '1 Minute',
-    extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+    watermark_delay = '1 Minute'
 )

--- a/server/adaptors/integrations/__data__/repository/amazon_s3/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/amazon_s3/assets/create_mv-1.0.0.sql
@@ -31,6 +31,5 @@ WITH (
   auto_refresh = true,
   refresh_interval = '15 Minute',
   checkpoint_location = '{s3_checkpoint_location}',
-  watermark_delay = '1 Minute',
-  extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+  watermark_delay = '1 Minute'
 )

--- a/server/adaptors/integrations/__data__/repository/apache/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/apache/assets/create_mv-1.0.0.sql
@@ -12,6 +12,5 @@ WITH (
     auto_refresh = true,
     refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
-    watermark_delay = '1 Minute',
-    extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+    watermark_delay = '1 Minute'
 )

--- a/server/adaptors/integrations/__data__/repository/aws_cloudtrail/assets/create_mv_cloud-trail-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_cloudtrail/assets/create_mv_cloud-trail-1.0.0.sql
@@ -49,6 +49,5 @@ WITH (
     auto_refresh = true,
     refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
-    watermark_delay = '1 Minute',
-    extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+    watermark_delay = '1 Minute'
 )

--- a/server/adaptors/integrations/__data__/repository/aws_cloudtrail/assets/create_mv_cloud-trail-records-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_cloudtrail/assets/create_mv_cloud-trail-records-1.0.0.sql
@@ -50,6 +50,5 @@ WITH (
   auto_refresh = true,
   refresh_interval = '15 Minute',
   checkpoint_location = '{s3_checkpoint_location}',
-  watermark_delay = '1 Minute',
-  extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
-  )
+  watermark_delay = '1 Minute'
+)

--- a/server/adaptors/integrations/__data__/repository/aws_waf/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/aws_waf/assets/create_mv-1.0.0.sql
@@ -24,6 +24,5 @@ WITH (
   auto_refresh = true,
   refresh_interval = '15 Minute',
   checkpoint_location = '{s3_checkpoint_location}',
-  watermark_delay = '1 Minute',
-  extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+  watermark_delay = '1 Minute'
 )

--- a/server/adaptors/integrations/__data__/repository/haproxy/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/haproxy/assets/create_mv-1.0.0.sql
@@ -146,6 +146,5 @@ WITH (
     auto_refresh = true,
     refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
-    watermark_delay = '1 Minute',
-    extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+    watermark_delay = '1 Minute'
 )

--- a/server/adaptors/integrations/__data__/repository/nginx/assets/create_mv-1.0.0.sql
+++ b/server/adaptors/integrations/__data__/repository/nginx/assets/create_mv-1.0.0.sql
@@ -12,6 +12,5 @@ WITH (
     auto_refresh = 'true',
     refresh_interval = '15 Minute',
     checkpoint_location = '{s3_checkpoint_location}',
-    watermark_delay = '1 Minute',
-    extra_options = '{ "{table_name}": { "maxFilesPerTrigger": "10" }}'
+    watermark_delay = '1 Minute'
 )


### PR DESCRIPTION
### Description
Remove `maxFilesPerTrigger` from all the integrations queries

### Issues Resolved
* Relate: https://github.com/opensearch-project/dashboards-observability/issues/2314

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
