### PR TITLE
[Backport 2.x]  Restore spans limit to 3000 in trace view

### DIFF
--- a/public/components/application_analytics/__tests__/__snapshots__/flyout.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/flyout.test.tsx.snap
@@ -751,6 +751,8 @@ exports[`Trace Detail Render Flyout component render trace detail 1`] = `
     openSpanFlyout={[Function]}
     page="app"
     payloadData=""
+    setSpanFiltersWithStorage={[Function]}
+    spanFilters={Array []}
     traceId="mockTrace"
   >
     <EuiPanel

--- a/public/components/application_analytics/components/flyout_components/trace_detail_render.tsx
+++ b/public/components/application_analytics/components/flyout_components/trace_detail_render.tsx
@@ -7,14 +7,15 @@ import { EuiCodeBlock, EuiHorizontalRule, EuiSpacer, EuiText } from '@elastic/eu
 import React, { useEffect, useMemo, useState } from 'react';
 import { HttpStart } from '../../../../../../../src/core/public';
 import { TraceAnalyticsMode } from '../../../../../common/types/trace_analytics';
+import { TraceFilter } from '../../../trace_analytics/components/common/constants';
 import { ServiceBreakdownPanel } from '../../../trace_analytics/components/traces/service_breakdown_panel';
 import { SpanDetailPanel } from '../../../trace_analytics/components/traces/span_detail_panel';
-import { handlePayloadRequest } from '../../../trace_analytics/requests/traces_request_handler';
-import { getListItem } from '../../helpers/utils';
 import {
   getOverviewFields,
   getServiceBreakdownData,
 } from '../../../trace_analytics/components/traces/trace_view_helpers';
+import { handlePayloadRequest } from '../../../trace_analytics/requests/traces_request_handler';
+import { getListItem } from '../../helpers/utils';
 
 interface TraceDetailRenderProps {
   traceId: string;
@@ -35,6 +36,17 @@ export const TraceDetailRender = ({
   const [serviceBreakdownData, setServiceBreakdownData] = useState([]);
   const [payloadData, setPayloadData] = useState('');
   const [colorMap, setColorMap] = useState({});
+
+  const storedFilters = sessionStorage.getItem('TraceAnalyticsSpanFilters');
+  const [spanFilters, setSpanFilters] = useState<TraceFilter[]>(() =>
+    storedFilters ? JSON.parse(storedFilters) : []
+  );
+
+  const setSpanFiltersWithStorage = (newFilters: TraceFilter[]) => {
+    handlePayloadRequest(traceId, http, payloadData, setPayloadData, mode);
+    setSpanFilters(newFilters);
+    sessionStorage.setItem('TraceAnalyticsSpanFilters', JSON.stringify(newFilters));
+  };
 
   const renderContent = useMemo(() => {
     if (!traceId) return <></>;
@@ -79,6 +91,8 @@ export const TraceDetailRender = ({
           dataSourceMDSId={dataSourceMDSId}
           isApplicationFlyout={true}
           payloadData={payloadData}
+          spanFilters={spanFilters}
+          setSpanFiltersWithStorage={setSpanFiltersWithStorage}
         />
         <EuiSpacer size="xs" />
         <EuiHorizontalRule margin="s" />

--- a/public/components/trace_analytics/components/common/constants.tsx
+++ b/public/components/trace_analytics/components/common/constants.tsx
@@ -59,3 +59,8 @@ export interface ParsedHit {
   _source: Span;
   sort?: any[];
 }
+
+export interface TraceFilter {
+  field: string;
+  value: any;
+}

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -45,6 +45,7 @@ import {
   handleServiceMapRequest,
   handleServiceViewRequest,
 } from '../../requests/services_request_handler';
+import { TraceFilter } from '../common/constants';
 import { FilterType } from '../common/filters/filters';
 import {
   PanelTitle,
@@ -442,12 +443,12 @@ export function ServiceView(props: ServiceViewProps) {
 
   const [currentSpan, setCurrentSpan] = useState('');
   const storedFilters = sessionStorage.getItem('TraceAnalyticsSpanFilters');
-  const [spanFilters, setSpanFilters] = useState<Array<{ field: string; value: any }>>(
+  const [spanFilters, setSpanFilters] = useState<TraceFilter[]>(
     storedFilters ? JSON.parse(storedFilters) : []
   );
   const [DSL, setDSL] = useState<any>({});
 
-  const setSpanFiltersWithStorage = (newFilters: Array<{ field: string; value: any }>) => {
+  const setSpanFiltersWithStorage = (newFilters: TraceFilter[]) => {
     setSpanFilters(newFilters);
     sessionStorage.setItem('TraceAnalyticsSpanFilters', JSON.stringify(newFilters));
   };

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/trace_view.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/trace_view.test.tsx.snap
@@ -147,6 +147,8 @@ exports[`Trace view component renders trace view 1`] = `
             payloadData=""
             setGanttChartLoading={[Function]}
             setGanttData={[Function]}
+            setSpanFiltersWithStorage={[Function]}
+            spanFilters={Array []}
             traceId="test"
           />
         </EuiFlexItem>

--- a/public/components/trace_analytics/components/traces/__tests__/span_detail_panel.test.tsx
+++ b/public/components/trace_analytics/components/traces/__tests__/span_detail_panel.test.tsx
@@ -79,6 +79,8 @@ const mockProps = {
   setData: mockSetData,
   addSpanFilter: mockAddSpanFilter,
   removeSpanFilter: jest.fn(),
+  spanFilters: [],
+  setSpanFiltersWithStorage: jest.fn(),
 };
 
 describe('SpanDetailPanel component', () => {

--- a/public/components/trace_analytics/components/traces/span_detail_table.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_table.tsx
@@ -11,9 +11,9 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { HttpSetup } from '../../../../../../../src/core/public';
 import { TRACE_ANALYTICS_DATE_FORMAT } from '../../../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode } from '../../../../../common/types/trace_analytics';
+import { handleSpansRequest } from '../../requests/traces_request_handler';
 import { microToMilliSec, nanoToMilliSec, parseHits } from '../common/helper_functions';
 import { RenderCustomDataGrid } from '../common/shared_components/custom_datagrid';
-import { handleSpansRequest } from '../../requests/traces_request_handler';
 
 interface SpanDetailTableProps {
   http: HttpSetup;
@@ -25,7 +25,7 @@ interface SpanDetailTableProps {
   dataSourceMDSId: string;
   availableWidth?: number;
   payloadData: string;
-  filters: Array<{ field: string; value: any }>;
+  filters: TraceFilter[];
 }
 
 interface Span {

--- a/public/components/trace_analytics/components/traces/trace_view.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view.tsx
@@ -19,9 +19,9 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
-import _ from 'lodash';
-import React, { useEffect, useState } from 'react';
 import { i18n } from '@osd/i18n';
+import round from 'lodash/round';
+import React, { useEffect, useState } from 'react';
 import { MountPoint } from '../../../../../../../src/core/public';
 import { DataSourceManagementPluginSetup } from '../../../../../../../src/plugins/data_source_management/public';
 import { DataSourceOption } from '../../../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
@@ -31,11 +31,12 @@ import { coreRefs } from '../../../../framework/core_refs';
 import { TraceAnalyticsCoreDeps } from '../../home';
 import { handleServiceMapRequest } from '../../requests/services_request_handler';
 import { handlePayloadRequest } from '../../requests/traces_request_handler';
+import { TraceFilter } from '../common/constants';
 import { PanelTitle, filtersToDsl, processTimeStamp } from '../common/helper_functions';
 import { ServiceMap, ServiceObject } from '../common/plots/service_map';
 import { ServiceBreakdownPanel } from './service_breakdown_panel';
 import { SpanDetailPanel } from './span_detail_panel';
-import { getOverviewFields, getServiceBreakdownData } from './trace_view_helpers';
+import { getOverviewFields, getServiceBreakdownData, spanFiltersToDSL } from './trace_view_helpers';
 
 const newNavigation = coreRefs.chrome?.navGroup.getNavGroupEnabled();
 
@@ -84,6 +85,12 @@ export function TraceView(props: TraceViewProps) {
   const [isTracePayloadLoading, setTracePayloadLoading] = useState(false);
   const [isServicesPieChartLoading, setIsServicesPieChartLoading] = useState(false);
   const [isGanttChartLoading, setIsGanttChartLoading] = useState(false);
+
+  const storedFilters = sessionStorage.getItem('TraceAnalyticsSpanFilters');
+  const [spanFilters, setSpanFilters] = useState<TraceFilter[]>(() =>
+    storedFilters ? JSON.parse(storedFilters) : []
+  );
+  const [filteredPayload, setFilteredPayload] = useState('');
 
   const renderOverview = (overviewFields: any) => {
     return (
@@ -224,10 +231,36 @@ export function TraceView(props: TraceViewProps) {
     ).finally(() => setIsServicesDataLoading(false));
   };
 
+  const setSpanFiltersWithStorage = (newFilters: TraceFilter[]) => {
+    refreshFilteredPayload(newFilters);
+    setSpanFilters(newFilters);
+    sessionStorage.setItem('TraceAnalyticsSpanFilters', JSON.stringify(newFilters));
+  };
+
+  const refreshFilteredPayload = async (newFilters: TraceFilter[]) => {
+    const spanDSL = spanFiltersToDSL(newFilters);
+    setIsGanttChartLoading(true);
+    handlePayloadRequest(
+      props.traceId,
+      props.http,
+      spanDSL,
+      setFilteredPayload,
+      mode,
+      props.dataSourceMDSId[0].id
+    );
+  };
+
   useEffect(() => {
     if (!payloadData) return;
 
     try {
+      if (spanFilters.length > 0) {
+        refreshFilteredPayload(spanFilters);
+      } else {
+        setFilteredPayload(payloadData);
+      }
+
+      setFilteredPayload(payloadData);
       const parsedPayload = JSON.parse(payloadData);
       const overview = getOverviewFields(parsedPayload, mode);
       if (overview) {
@@ -267,8 +300,8 @@ export function TraceView(props: TraceViewProps) {
     Object.entries(services).forEach(([serviceName, service]: [string, any]) => {
       if (!serviceMap[serviceName]) return;
       filteredServiceMap[serviceName] = serviceMap[serviceName];
-      filteredServiceMap[serviceName].latency = _.round(service.latency / service.throughput, 2);
-      filteredServiceMap[serviceName].error_rate = _.round(
+      filteredServiceMap[serviceName].latency = round(service.latency / service.throughput, 2);
+      filteredServiceMap[serviceName].error_rate = round(
         (service.errors / service.throughput) * 100,
         2
       );
@@ -330,9 +363,11 @@ export function TraceView(props: TraceViewProps) {
                 setGanttData={setGanttData}
                 dataSourceMDSId={props.dataSourceMDSId[0].id}
                 dataSourceMDSLabel={props.dataSourceMDSId[0].label}
-                payloadData={payloadData}
+                payloadData={filteredPayload}
                 isGanttChartLoading={isGanttChartLoading}
                 setGanttChartLoading={setIsGanttChartLoading}
+                spanFilters={spanFilters}
+                setSpanFiltersWithStorage={setSpanFiltersWithStorage}
               />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/components/trace_analytics/components/traces/trace_view_helpers.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view_helpers.tsx
@@ -4,7 +4,7 @@
  */
 
 import moment from 'moment';
-import { MILI_TO_SEC, NANOS_TO_MS, pieChartColors } from '../common/constants';
+import { MILI_TO_SEC, NANOS_TO_MS, pieChartColors, TraceFilter } from '../common/constants';
 
 export function getOverviewFields(parsed: any, mode: string) {
   if (parsed.length === 0) return null;
@@ -121,3 +121,26 @@ export function getServiceBreakdownData(parsed: any, mode: string) {
 
   return { serviceBreakdownData, colorMap };
 }
+
+export const spanFiltersToDSL = (spanFilters: TraceFilter[]) => {
+  const spanDSL: any = {
+    query: {
+      bool: {
+        must: [],
+        filter: [],
+        should: [],
+        must_not: [],
+      },
+    },
+  };
+  spanFilters.map(({ field, value }) => {
+    if (value != null) {
+      spanDSL.query.bool.must.push({
+        term: {
+          [field]: value,
+        },
+      });
+    }
+  });
+  return spanDSL;
+};

--- a/public/components/trace_analytics/requests/queries/traces_queries.ts
+++ b/public/components/trace_analytics/requests/queries/traces_queries.ts
@@ -194,7 +194,7 @@ export const getTracesQuery = (
   return mode === 'jaeger' ? jaegerQuery : dataPrepperQuery;
 };
 
-export const getPayloadQuery = (mode: TraceAnalyticsMode, traceId: string, size = 1000) => {
+export const getPayloadQuery = (mode: TraceAnalyticsMode, traceId: string, size = 3000) => {
   if (mode === 'jaeger') {
     return {
       size,

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -15,6 +15,7 @@ import { BarOrientation } from '../../../../common/constants/shared';
 import { TRACE_ANALYTICS_DATE_FORMAT } from '../../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode, TraceQueryMode } from '../../../../common/types/trace_analytics';
 import { coreRefs } from '../../../../public/framework/core_refs';
+import { MILI_TO_SEC } from '../components/common/constants';
 import {
   getTimestampPrecision,
   microToMilliSec,
@@ -31,7 +32,6 @@ import {
   getTracesQuery,
 } from './queries/traces_queries';
 import { handleDslRequest } from './request_handler';
-import { MILI_TO_SEC } from '../components/common/constants';
 
 export const handleCustomIndicesTracesRequest = async (
   http: HttpSetup,
@@ -351,12 +351,12 @@ export function normalizePayload(parsed: ParsedResponse): Hit[] {
 export const handlePayloadRequest = (
   traceId: string,
   http: HttpSetup,
-  payloadData: any,
+  spanDSL: any,
   setPayloadData: (payloadData: any) => void,
   mode: TraceAnalyticsMode,
   dataSourceMDSId?: string
 ) => {
-  return handleDslRequest(http, null, getPayloadQuery(mode, traceId), mode, dataSourceMDSId)
+  return handleDslRequest(http, spanDSL, getPayloadQuery(mode, traceId), mode, dataSourceMDSId)
     .then((response) => {
       const normalizedData = normalizePayload(response);
       const sortedData = normalizedData


### PR DESCRIPTION
* restore spans max value to 3000 in trace view

Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

* update filtering mechanism for span payloads

Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

* avoid parsing again on re-render in trace view

Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

---------

Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>
(cherry picked from commit 84fbc2fe1a6809e7f95b4e8d58c32026e8ef4ec8)
PR to main : https://github.com/opensearch-project/dashboards-observability/pull/2353


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
