### PR TITLE
ServiceMap Query Optimizations

### DIFF
--- a/public/components/trace_analytics/requests/queries/services_queries.ts
+++ b/public/components/trace_analytics/requests/queries/services_queries.ts
@@ -90,46 +90,7 @@ export const getServicesQuery = (
   return query;
 };
 
-export const getRelatedServicesQuery = (serviceName: string) => {
-  const query = {
-    size: 0,
-    query: {
-      bool: {
-        must: [],
-        filter: [],
-        should: [],
-        must_not: [],
-      },
-    },
-    aggs: {
-      traces: {
-        terms: {
-          field: 'traceId',
-          size: 10000,
-        },
-        aggs: {
-          service: {
-            filter: {
-              bool: {
-                must: [
-                  {
-                    term: {
-                      serviceName,
-                    },
-                  },
-                ],
-                must_not: [],
-              },
-            },
-          },
-        },
-      },
-    },
-  };
-  return query;
-};
-
-export const getServiceNodesQuery = (mode: TraceAnalyticsMode) => {
+export const getServiceMapQuery = (mode: TraceAnalyticsMode) => {
   return {
     index: getServiceIndices(mode),
     size: 0,
@@ -154,43 +115,41 @@ export const getServiceNodesQuery = (mode: TraceAnalyticsMode) => {
               size: SERVICE_MAP_MAX_EDGES,
             },
           },
-        },
-      },
-    },
-  };
-};
-
-export const getServiceEdgesQuery = (
-  source: 'destination' | 'target',
-  mode: TraceAnalyticsMode
-) => {
-  return {
-    index: getServiceIndices(mode),
-    size: 0,
-    query: {
-      bool: {
-        must: [],
-        filter: [],
-        should: [],
-        must_not: [],
-      },
-    },
-    aggs: {
-      service_name: {
-        terms: {
-          field: 'serviceName',
-          size: SERVICE_MAP_MAX_EDGES,
-        },
-        aggs: {
-          resource: {
+          target_edges: {
             terms: {
-              field: `${source}.resource`,
+              field: 'target.resource',
               size: SERVICE_MAP_MAX_EDGES,
             },
             aggs: {
+              service: {
+                terms: {
+                  field: 'target.serviceName',
+                  size: SERVICE_MAP_MAX_EDGES,
+                },
+              },
               domain: {
                 terms: {
-                  field: `${source}.domain`,
+                  field: 'target.domain',
+                  size: SERVICE_MAP_MAX_EDGES,
+                },
+              },
+            },
+          },
+          destination_edges: {
+            terms: {
+              field: 'destination.resource',
+              size: SERVICE_MAP_MAX_EDGES,
+            },
+            aggs: {
+              service: {
+                terms: {
+                  field: 'destination.serviceName',
+                  size: SERVICE_MAP_MAX_EDGES,
+                },
+              },
+              domain: {
+                terms: {
+                  field: 'destination.domain',
                   size: SERVICE_MAP_MAX_EDGES,
                 },
               },


### PR DESCRIPTION
### Description
Optimize the Service Map queries by combining the current getServiceNodeQuery, getServicesEdgesQuery(target), and getServicesEdgesQuery(destination) into one query removing the awaits.

Screenshot of TraceView Before: (5 Queries and 230ms time)
<img width="1665" alt="BeforeOpt" src="https://github.com/user-attachments/assets/9e6be849-e82a-43ff-b1ab-210895ce88b5" />

Screenshot of TraceView After: (3 Queries and 40ms time)
<img width="1667" alt="AfterOpt" src="https://github.com/user-attachments/assets/0f23c0e8-a119-4518-8394-7f4fa0c4dd5e" />

### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/issues/2334 - Service Map Optimizations

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
