### PR TITLE
[Bug] Traces redirection while QA enabled

### DIFF
--- a/public/components/common/search/query_area.tsx
+++ b/public/components/common/search/query_area.tsx
@@ -38,7 +38,6 @@ export function QueryArea({
   const memoizedHandleQueryChange = useMemo(() => handleQueryChange, []);
   useEffect(() => {
     const indexQuery = `source = ${selectedIndex[0]?.label || ''}`;
-    memoizedHandleQueryChange(indexQuery);
     memoizedGetAvailableFields(indexQuery);
   }, [selectedIndex, memoizedGetAvailableFields, memoizedHandleQueryChange]);
   const [lastFocusedInput, setLastFocusedInput] = useState<'query_area' | 'nlq_input'>('nlq_input');

--- a/public/components/common/search/search.tsx
+++ b/public/components/common/search/search.tsx
@@ -259,7 +259,6 @@ export const Search = (props: any) => {
       setSelectedIndex(reduxIndex);
       // sets the editor text and populates sidebar field for a particular index upon initialization
       const indexQuery = `source = ${reduxIndex[0].label}`;
-      handleQueryChange(indexQuery);
       getAvailableFields(indexQuery);
     }
     if (queryRedux.ollyQueryAssistant.length > 0) {


### PR DESCRIPTION
### Description
Re-direction from Traces to Explorer to view logs is being over written when QA is enabled. 

Before:

https://github.com/user-attachments/assets/56f094ea-ad4a-4794-9e61-376ae3cee33a


After:

https://github.com/user-attachments/assets/ec6a3c34-c3e4-4b1e-8b33-4c4d7ca92338


### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
