### PR TITLE
Increase dashboards timeout & store logs on failure

### DIFF
--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -150,13 +150,20 @@ jobs:
       - name: Check If OpenSearch Dashboards Is Ready
         if: ${{ runner.os == 'Linux' }}
         run: |
-          cd ./OpenSearch-Dashboards
-          if timeout 60 grep -q "http server running" <(tail -n +1 -f dashboard.log); then
-            echo "OpenSearch Dashboards started successfully."
+          if timeout 1200 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
+            echo "OpenSearch Dashboards compiled successfully."
           else
-            echo "Timeout of 60 seconds reached. OpenSearch Dashboards did not start successfully."
+            echo "Timeout for 1200 seconds reached. OpenSearch Dashboards did not finish compiling."
             exit 1
-          fi&
+          fi
+        working-directory: OpenSearch-Dashboards
+
+      - name: Upload Dashboards logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: dashboard.logs
+          path: OpenSearch-Dashboards/dashboard.log
 
       - name: Checkout Dashboards Functioanl Test Repo
         uses: actions/checkout@v2

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -163,13 +163,20 @@ jobs:
       - name: Check If OpenSearch Dashboards Is Ready
         if: ${{ runner.os == 'Linux' }}
         run: |
-          cd ./OpenSearch-Dashboards
-          if timeout 60 grep -q "http server running" <(tail -n +1 -f dashboard.log); then
-            echo "OpenSearch Dashboards started successfully."
+          if timeout 1200 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
+            echo "OpenSearch Dashboards compiled successfully."
           else
-            echo "Timeout of 60 seconds reached. OpenSearch Dashboards did not start successfully."
+            echo "Timeout for 1200 seconds reached. OpenSearch Dashboards did not finish compiling."
             exit 1
-          fi&
+          fi
+        working-directory: OpenSearch-Dashboards
+
+      - name: Upload Dashboards logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: dashboard.logs
+          path: OpenSearch-Dashboards/dashboard.log
 
       - name: Install Cypress
         run: |


### PR DESCRIPTION
### Description
Increase dashboards timeout & store logs on failure

### Issues Resolved
Adds dashboards on CI failure for OSD including bootstrap timeout

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
