### PR TITLE
Support custom logs correlation

### DIFF
--- a/common/constants/trace_analytics.ts
+++ b/common/constants/trace_analytics.ts
@@ -34,7 +34,8 @@ export const DEFAULT_SS4O_LOGS_INDEX = 'ss4o_logs-*';
 export const DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS = `
 {
   "serviceName": "serviceName",
-  "spanId": "spanId"
+  "spanId": "spanId",
+  "timestamp": "time"
 }`;
 
 export enum TRACE_TABLE_TITLES {

--- a/common/constants/trace_analytics.ts
+++ b/common/constants/trace_analytics.ts
@@ -25,6 +25,10 @@ export const TRACE_ANALYTICS_DSL_ROUTE = '/api/observability/trace_analytics/que
 export const TRACE_CUSTOM_SPAN_INDEX_SETTING = 'observability:traceAnalyticsSpanIndices';
 export const TRACE_CUSTOM_SERVICE_INDEX_SETTING = 'observability:traceAnalyticsServiceIndices';
 export const TRACE_CUSTOM_MODE_DEFAULT_SETTING = 'observability:traceAnalyticsCustomModeDefault';
+export const TRACE_CORRELATED_LOGS_INDEX_SETTING =
+  'observability:traceAnalyticsCorrelatedLogsIndices';
+
+export const DEFAULT_SS4O_LOGS_INDEX = 'ss4o_logs-*';
 
 export enum TRACE_TABLE_TITLES {
   all_spans = 'All Spans',

--- a/common/constants/trace_analytics.ts
+++ b/common/constants/trace_analytics.ts
@@ -27,8 +27,15 @@ export const TRACE_CUSTOM_SERVICE_INDEX_SETTING = 'observability:traceAnalyticsS
 export const TRACE_CUSTOM_MODE_DEFAULT_SETTING = 'observability:traceAnalyticsCustomModeDefault';
 export const TRACE_CORRELATED_LOGS_INDEX_SETTING =
   'observability:traceAnalyticsCorrelatedLogsIndices';
+export const TRACE_LOGS_FIELD_MAPPNIGS_SETTING =
+  'observability:traceAnalyticsCorrelatedLogsFieldMappings';
 
 export const DEFAULT_SS4O_LOGS_INDEX = 'ss4o_logs-*';
+export const DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS = `
+{
+  "serviceName": "serviceName",
+  "spanId": "spanId"
+}`;
 
 export enum TRACE_TABLE_TITLES {
   all_spans = 'All Spans',

--- a/common/types/trace_analytics.ts
+++ b/common/types/trace_analytics.ts
@@ -61,4 +61,5 @@ export type TraceQueryMode = keyof typeof TRACE_TABLE_TITLES;
 export interface CorrelatedLogsFieldMappings {
   serviceName: string;
   spanId: string;
+  timestamp: string;
 }

--- a/common/types/trace_analytics.ts
+++ b/common/types/trace_analytics.ts
@@ -57,3 +57,8 @@ export interface GraphVisEdge {
 
 export type TraceAnalyticsMode = 'jaeger' | 'data_prepper' | 'custom_data_prepper';
 export type TraceQueryMode = keyof typeof TRACE_TABLE_TITLES;
+
+export interface CorrelatedLogsFieldMappings {
+  serviceName: string;
+  spanId: string;
+}

--- a/public/components/event_analytics/explorer/explorer.tsx
+++ b/public/components/event_analytics/explorer/explorer.tsx
@@ -111,8 +111,8 @@ import {
 import { getVizContainerProps } from '../../visualizations/charts/helpers';
 import { TabContext, useFetchEvents, useFetchPatterns, useFetchVisualizations } from '../hooks';
 import {
-  render as updateCountDistribution,
   selectCountDistribution,
+  render as updateCountDistribution,
 } from '../redux/slices/count_distribution_slice';
 import { selectFields, updateFields } from '../redux/slices/field_slice';
 import { selectQueryResult } from '../redux/slices/query_result_slice';
@@ -122,8 +122,8 @@ import { selectExplorerVisualization } from '../redux/slices/visualization_slice
 import {
   change as changeVisualizationConfig,
   change as changeVizConfig,
-  change as updateVizConfig,
   selectVisualizationConfig,
+  change as updateVizConfig,
 } from '../redux/slices/viualization_config_slice';
 import { getDefaultVisConfig } from '../utils';
 import { formatError, getContentTabTitle } from '../utils/utils';
@@ -274,6 +274,7 @@ export const Explorer = ({
       datasourceName,
       datasourceType,
       queryToRun,
+      timestampField,
       startTimeRange,
       endTimeRange,
     }: any = historyFromRedirection.location.state;
@@ -292,6 +293,14 @@ export const Explorer = ({
                 },
               ],
             },
+          })
+        );
+      }
+      if (timestampField) {
+        dispatch(
+          changeQuery({
+            tabId,
+            query: { [SELECTED_TIMESTAMP]: timestampField },
           })
         );
       }

--- a/public/components/trace_analytics/components/common/__tests__/custom_index_flyout.test.tsx
+++ b/public/components/trace_analytics/components/common/__tests__/custom_index_flyout.test.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useToast } from '../../../../common/toast';
+import { CustomIndexFlyout } from '../custom_index_flyout';
+import { TraceSettings } from '../helper_functions';
+
+// Mock TraceSettings functions
+jest.mock('../helper_functions', () => ({
+  TraceSettings: {
+    getCustomSpanIndex: jest.fn(),
+    getCustomServiceIndex: jest.fn(),
+    getCorrelatedLogsIndex: jest.fn(),
+    getCorrelatedLogsFieldMappings: jest.fn(),
+    getCustomModeSetting: jest.fn(),
+    setCustomSpanIndex: jest.fn(),
+    setCustomServiceIndex: jest.fn(),
+    setCorrelatedLogsIndex: jest.fn(),
+    setCorrelatedLogsFieldMappings: jest.fn(),
+    setCustomModeSetting: jest.fn(),
+  },
+}));
+
+// Mock the toast hook
+jest.mock('../../../../common/toast', () => ({
+  useToast: jest.fn(),
+}));
+
+describe('CustomIndexFlyout test', () => {
+  let setIsFlyoutVisibleMock: jest.Mock;
+  let setToastMock: jest.Mock;
+
+  beforeEach(() => {
+    setIsFlyoutVisibleMock = jest.fn();
+    setToastMock = jest.fn();
+
+    (useToast as jest.Mock).mockReturnValue({ setToast: setToastMock });
+
+    (TraceSettings.getCustomSpanIndex as jest.Mock).mockReturnValue('span-index-1');
+    (TraceSettings.getCustomServiceIndex as jest.Mock).mockReturnValue('service-index-1');
+    (TraceSettings.getCorrelatedLogsIndex as jest.Mock).mockReturnValue('logs-index-1');
+    (TraceSettings.getCorrelatedLogsFieldMappings as jest.Mock).mockReturnValue({
+      serviceName: 'service_field',
+      spanId: 'span_field',
+      timestamp: 'timestamp_field',
+    });
+    (TraceSettings.getCustomModeSetting as jest.Mock).mockReturnValue(false);
+  });
+
+  it('renders flyout when isFlyoutVisible is true', () => {
+    render(
+      <CustomIndexFlyout isFlyoutVisible={true} setIsFlyoutVisible={setIsFlyoutVisibleMock} />
+    );
+
+    expect(screen.getByText('Manage custom source')).toBeInTheDocument();
+    expect(screen.getByLabelText('spanIndices')).toHaveValue('span-index-1');
+    expect(screen.getByLabelText('serviceIndices')).toHaveValue('service-index-1');
+    expect(screen.getByLabelText('logsIndices')).toHaveValue('logs-index-1');
+    expect(screen.getByLabelText('Enable custom source as default mode')).not.toBeChecked();
+  });
+
+  it('updates span indices when input changes', () => {
+    render(
+      <CustomIndexFlyout isFlyoutVisible={true} setIsFlyoutVisible={setIsFlyoutVisibleMock} />
+    );
+
+    const input = screen.getByLabelText('Custom span indices');
+    fireEvent.change(input, { target: { value: 'new-span-index' } });
+
+    expect(input).toHaveValue('new-span-index');
+  });
+
+  it('calls TraceSettings set functions when save button is clicked', async () => {
+    render(
+      <CustomIndexFlyout isFlyoutVisible={true} setIsFlyoutVisible={setIsFlyoutVisibleMock} />
+    );
+
+    const saveButton = screen.getByText('Save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(TraceSettings.setCustomSpanIndex).toHaveBeenCalledWith('span-index-1');
+      expect(TraceSettings.setCustomServiceIndex).toHaveBeenCalledWith('service-index-1');
+      expect(TraceSettings.setCorrelatedLogsIndex).toHaveBeenCalledWith('logs-index-1');
+      expect(TraceSettings.setCorrelatedLogsFieldMappings).toHaveBeenCalled();
+      expect(TraceSettings.setCustomModeSetting).toHaveBeenCalledWith(false);
+      expect(setToastMock).toHaveBeenCalledWith(
+        'Updated trace analytics settings successfully',
+        'success'
+      );
+    });
+  });
+
+  it('shows error toast if save settings fail', async () => {
+    (TraceSettings.setCustomSpanIndex as jest.Mock).mockRejectedValue(new Error('Save error'));
+
+    render(
+      <CustomIndexFlyout isFlyoutVisible={true} setIsFlyoutVisible={setIsFlyoutVisibleMock} />
+    );
+
+    const saveButton = screen.getByText('Save');
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(setToastMock).toHaveBeenCalledWith(
+        'Failed to update trace analytics settings',
+        'danger'
+      );
+    });
+  });
+
+  it('closes the flyout when Close button is clicked', () => {
+    render(
+      <CustomIndexFlyout isFlyoutVisible={true} setIsFlyoutVisible={setIsFlyoutVisibleMock} />
+    );
+
+    const closeButton = screen.getByText('Close');
+    fireEvent.click(closeButton);
+
+    expect(setIsFlyoutVisibleMock).toHaveBeenCalledWith(false);
+  });
+});

--- a/public/components/trace_analytics/components/common/custom_index_flyout.tsx
+++ b/public/components/trace_analytics/components/common/custom_index_flyout.tsx
@@ -21,13 +21,9 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import React, { Fragment, useEffect, useState } from 'react';
-import {
-  TRACE_CUSTOM_SERVICE_INDEX_SETTING,
-  TRACE_CUSTOM_SPAN_INDEX_SETTING,
-  TRACE_CUSTOM_MODE_DEFAULT_SETTING,
-} from '../../../../../common/constants/trace_analytics';
 import { uiSettingsService } from '../../../../../common/utils';
 import { useToast } from '../../../common/toast';
+import { TraceSettings } from './helper_functions';
 
 interface CustomIndexFlyoutProps {
   isFlyoutVisible: boolean;
@@ -42,6 +38,7 @@ export const CustomIndexFlyout = ({
   const [spanIndices, setSpanIndices] = useState('');
   const [serviceIndices, setServiceIndices] = useState('');
   const [customModeDefault, setCustomModeDefault] = useState(false);
+  const [correlatedLogsIndices, setCorrelatedLogsIndices] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
   const onChangeSpanIndices = (e: { target: { value: React.SetStateAction<string> } }) => {
@@ -52,22 +49,30 @@ export const CustomIndexFlyout = ({
     setServiceIndices(e.target.value);
   };
 
+  const onChangeCorrelatedLogsIndices = (e: {
+    target: { value: React.SetStateAction<string> };
+  }) => {
+    setCorrelatedLogsIndices(e.target.value);
+  };
+
   const onToggleCustomModeDefault = (e: { target: { checked: boolean } }) => {
     setCustomModeDefault(e.target.checked);
   };
 
   useEffect(() => {
-    setSpanIndices(uiSettingsService.get(TRACE_CUSTOM_SPAN_INDEX_SETTING));
-    setServiceIndices(uiSettingsService.get(TRACE_CUSTOM_SERVICE_INDEX_SETTING));
-    setCustomModeDefault(uiSettingsService.get(TRACE_CUSTOM_MODE_DEFAULT_SETTING) || false);
+    setSpanIndices(TraceSettings.getCustomSpanIndex());
+    setServiceIndices(TraceSettings.getCustomServiceIndex());
+    setCorrelatedLogsIndices(TraceSettings.getCorrelatedLogsIndex());
+    setCustomModeDefault(TraceSettings.getCustomModeSetting());
   }, [uiSettingsService]);
 
   const onSaveSettings = async () => {
     try {
       setIsLoading(true);
-      await uiSettingsService.set(TRACE_CUSTOM_SPAN_INDEX_SETTING, spanIndices);
-      await uiSettingsService.set(TRACE_CUSTOM_SERVICE_INDEX_SETTING, serviceIndices);
-      await uiSettingsService.set(TRACE_CUSTOM_MODE_DEFAULT_SETTING, customModeDefault);
+      await TraceSettings.setCustomSpanIndex(spanIndices);
+      await TraceSettings.setCustomServiceIndex(serviceIndices);
+      await TraceSettings.setCorrelatedLogsIndex(correlatedLogsIndices);
+      await TraceSettings.setCustomModeSetting(customModeDefault);
       setIsLoading(false);
       setToast('Updated trace analytics settings successfully', 'success');
     } catch (error) {
@@ -140,6 +145,25 @@ export const CustomIndexFlyout = ({
                 placeholder="index1,cluster1:index2,cluster:index3"
                 value={serviceIndices}
                 onChange={onChangeServiceIndices}
+              />
+            </EuiFormRow>
+          </EuiDescribedFormGroup>
+          <EuiDescribedFormGroup
+            title={<h3>Correlated logs indices</h3>}
+            description={
+              <Fragment>
+                Configure custom logs indices to be used by the trace analytics plugin to correlate
+                spans and services
+              </Fragment>
+            }
+          >
+            <EuiFormRow label="Correlated logs indices">
+              <EuiCompressedFieldText
+                name="logsIndices"
+                aria-label="logsIndices"
+                placeholder="index1"
+                value={correlatedLogsIndices}
+                onChange={onChangeCorrelatedLogsIndices}
               />
             </EuiFormRow>
           </EuiDescribedFormGroup>

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import {
   DATA_PREPPER_INDEX_NAME,
   DATA_PREPPER_SERVICE_INDEX_NAME,
+  DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS,
   JAEGER_INDEX_NAME,
   JAEGER_SERVICE_INDEX_NAME,
   TRACE_ANALYTICS_DOCUMENTATION_LINK,
@@ -19,8 +20,10 @@ import {
   TRACE_CUSTOM_MODE_DEFAULT_SETTING,
   TRACE_CUSTOM_SERVICE_INDEX_SETTING,
   TRACE_CUSTOM_SPAN_INDEX_SETTING,
+  TRACE_LOGS_FIELD_MAPPNIGS_SETTING,
 } from '../../../../../common/constants/trace_analytics';
 import {
+  CorrelatedLogsFieldMappings,
   GraphVisEdge,
   GraphVisNode,
   TraceAnalyticsMode,
@@ -566,9 +569,19 @@ export const TraceSettings = {
 
   getCustomServiceIndex: () => uiSettingsService.get(TRACE_CUSTOM_SERVICE_INDEX_SETTING),
 
-  getCustomModeSetting: () => uiSettingsService.get(TRACE_CUSTOM_MODE_DEFAULT_SETTING) || false,
-
   getCorrelatedLogsIndex: () => uiSettingsService.get(TRACE_CORRELATED_LOGS_INDEX_SETTING),
+
+  getCorrelatedLogsFieldMappings: () => {
+    try {
+      const storedValue = uiSettingsService.get(TRACE_LOGS_FIELD_MAPPNIGS_SETTING);
+      return storedValue ? JSON.parse(storedValue) : DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS;
+    } catch (error) {
+      console.error('Error parsing TRACE_LOGS_FIELD_MAPPNIGS_SETTING:', error);
+      return DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS;
+    }
+  },
+
+  getCustomModeSetting: () => uiSettingsService.get(TRACE_CUSTOM_MODE_DEFAULT_SETTING) || false,
 
   setCustomSpanIndex: (value: string) =>
     uiSettingsService.set(TRACE_CUSTOM_SPAN_INDEX_SETTING, value),
@@ -576,11 +589,14 @@ export const TraceSettings = {
   setCustomServiceIndex: (value: string) =>
     uiSettingsService.set(TRACE_CUSTOM_SERVICE_INDEX_SETTING, value),
 
-  setCustomModeSetting: (value: boolean) =>
-    uiSettingsService.set(TRACE_CUSTOM_MODE_DEFAULT_SETTING, value),
-
   setCorrelatedLogsIndex: (value: string) =>
     uiSettingsService.set(TRACE_CORRELATED_LOGS_INDEX_SETTING, value),
+
+  setCorrelatedLogsFieldMappings: (value: CorrelatedLogsFieldMappings) =>
+    uiSettingsService.set(TRACE_LOGS_FIELD_MAPPNIGS_SETTING, JSON.stringify(value)),
+
+  setCustomModeSetting: (value: boolean) =>
+    uiSettingsService.set(TRACE_CUSTOM_MODE_DEFAULT_SETTING, value),
 };
 
 export const getSpanIndices = (mode: TraceAnalyticsMode) => {

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -15,6 +15,8 @@ import {
   JAEGER_INDEX_NAME,
   JAEGER_SERVICE_INDEX_NAME,
   TRACE_ANALYTICS_DOCUMENTATION_LINK,
+  TRACE_CORRELATED_LOGS_INDEX_SETTING,
+  TRACE_CUSTOM_MODE_DEFAULT_SETTING,
   TRACE_CUSTOM_SERVICE_INDEX_SETTING,
   TRACE_CUSTOM_SPAN_INDEX_SETTING,
 } from '../../../../../common/constants/trace_analytics';
@@ -26,9 +28,9 @@ import {
 import { uiSettingsService } from '../../../../../common/utils';
 import { FieldCapResponse } from '../../../common/types';
 import { serviceMapColorPalette } from './color_palette';
+import { NANOS_TO_MS, ParsedHit } from './constants';
 import { FilterType } from './filters/filters';
 import { ServiceObject } from './plots/service_map';
-import { NANOS_TO_MS, ParsedHit } from './constants';
 
 const missingJaegerTracesConfigurationMessage = `The indices required for trace analytics (${JAEGER_INDEX_NAME} and ${JAEGER_SERVICE_INDEX_NAME}) do not exist or you do not have permission to access them.`;
 
@@ -559,26 +561,32 @@ export const getAttributeFieldNames = (response: FieldCapResponse): string[] => 
   );
 };
 
-export const getTraceCustomSpanIndex = () => {
-  return uiSettingsService.get(TRACE_CUSTOM_SPAN_INDEX_SETTING);
-};
+export const TraceSettings = {
+  getCustomSpanIndex: () => uiSettingsService.get(TRACE_CUSTOM_SPAN_INDEX_SETTING),
 
-export const getTraceCustomServiceIndex = () => {
-  return uiSettingsService.get(TRACE_CUSTOM_SERVICE_INDEX_SETTING);
-};
+  getCustomServiceIndex: () => uiSettingsService.get(TRACE_CUSTOM_SERVICE_INDEX_SETTING),
 
-export const setTraceCustomSpanIndex = (value: string) => {
-  return uiSettingsService.set(TRACE_CUSTOM_SPAN_INDEX_SETTING, value);
-};
+  getCustomModeSetting: () => uiSettingsService.get(TRACE_CUSTOM_MODE_DEFAULT_SETTING) || false,
 
-export const setTraceCustomServiceIndex = (value: string) => {
-  return uiSettingsService.set(TRACE_CUSTOM_SERVICE_INDEX_SETTING, value);
+  getCorrelatedLogsIndex: () => uiSettingsService.get(TRACE_CORRELATED_LOGS_INDEX_SETTING),
+
+  setCustomSpanIndex: (value: string) =>
+    uiSettingsService.set(TRACE_CUSTOM_SPAN_INDEX_SETTING, value),
+
+  setCustomServiceIndex: (value: string) =>
+    uiSettingsService.set(TRACE_CUSTOM_SERVICE_INDEX_SETTING, value),
+
+  setCustomModeSetting: (value: boolean) =>
+    uiSettingsService.set(TRACE_CUSTOM_MODE_DEFAULT_SETTING, value),
+
+  setCorrelatedLogsIndex: (value: string) =>
+    uiSettingsService.set(TRACE_CORRELATED_LOGS_INDEX_SETTING, value),
 };
 
 export const getSpanIndices = (mode: TraceAnalyticsMode) => {
   switch (mode) {
     case 'custom_data_prepper':
-      return getTraceCustomSpanIndex();
+      return TraceSettings.getCustomSpanIndex();
     case 'data_prepper':
       return DATA_PREPPER_INDEX_NAME;
     case 'jaeger':
@@ -590,7 +598,7 @@ export const getSpanIndices = (mode: TraceAnalyticsMode) => {
 export const getServiceIndices = (mode: TraceAnalyticsMode) => {
   switch (mode) {
     case 'custom_data_prepper':
-      return getTraceCustomServiceIndex();
+      return TraceSettings.getCustomServiceIndex();
     case 'data_prepper':
       return DATA_PREPPER_SERVICE_INDEX_NAME;
     case 'jaeger':

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -571,13 +571,14 @@ export const TraceSettings = {
 
   getCorrelatedLogsIndex: () => uiSettingsService.get(TRACE_CORRELATED_LOGS_INDEX_SETTING),
 
-  getCorrelatedLogsFieldMappings: () => {
+  getCorrelatedLogsFieldMappings: (): CorrelatedLogsFieldMappings => {
+    const defaultMappings = JSON.parse(DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS);
     try {
       const storedValue = uiSettingsService.get(TRACE_LOGS_FIELD_MAPPNIGS_SETTING);
-      return storedValue ? JSON.parse(storedValue) : DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS;
+      return storedValue ? JSON.parse(storedValue) : defaultMappings;
     } catch (error) {
       console.error('Error parsing TRACE_LOGS_FIELD_MAPPNIGS_SETTING:', error);
-      return DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS;
+      return defaultMappings;
     }
   },
 

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -49,6 +49,7 @@ import { TraceFilter } from '../common/constants';
 import { FilterType } from '../common/filters/filters';
 import {
   PanelTitle,
+  TraceSettings,
   filtersToDsl,
   generateServiceUrl,
   processTimeStamp,
@@ -201,6 +202,7 @@ export function ServiceView(props: ServiceViewProps) {
                 name: 'View logs',
                 'data-test-subj': 'viewLogsButton',
                 onClick: () => {
+                  const correlatedLogsIndex = TraceSettings.getCorrelatedLogsIndex();
                   // NOTE: Discover has issue with PPL Time filter, hence adding +3/-3 days to actual timestamp
                   const startTime =
                     dateMath
@@ -218,7 +220,7 @@ export function ServiceView(props: ServiceViewProps) {
                         props.dataSourceMDSId[0].id ?? ''
                       }',title:'${props.dataSourceMDSId[0].label}',type:DATA_SOURCE),id:'${
                         props.dataSourceMDSId[0].id ?? ''
-                      }::ss4o_logs-*',timeFieldName:'time',title:'ss4o_logs-*',type:INDEXES),language:PPL,query:'source%20%3D%20ss4o_logs-%2A%20%7C%20where%20serviceName%20%3D%20%22${
+                      }::${correlatedLogsIndex}',timeFieldName:'time',title:'${correlatedLogsIndex}',type:INDEXES),language:PPL,query:'source%20%3D%20${correlatedLogsIndex}%20%7C%20where%20serviceName%20%3D%20%22${
                         props.serviceName
                       }%22'))`,
                     });
@@ -228,7 +230,7 @@ export function ServiceView(props: ServiceViewProps) {
                       state: {
                         DEFAULT_DATA_SOURCE_NAME,
                         DEFAULT_DATA_SOURCE_TYPE,
-                        queryToRun: `source = ss4o_logs-* | where serviceName='${props.serviceName}'`,
+                        queryToRun: `source = ${correlatedLogsIndex} | where serviceName='${props.serviceName}'`,
                         startTimeRange: props.startTime,
                         endTimeRange: props.endTime,
                       },

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -203,6 +203,8 @@ export function ServiceView(props: ServiceViewProps) {
                 'data-test-subj': 'viewLogsButton',
                 onClick: () => {
                   const correlatedLogsIndex = TraceSettings.getCorrelatedLogsIndex();
+                  const correlatedServiceNameField = TraceSettings.getCorrelatedLogsFieldMappings()
+                    .serviceName;
                   // NOTE: Discover has issue with PPL Time filter, hence adding +3/-3 days to actual timestamp
                   const startTime =
                     dateMath
@@ -220,7 +222,7 @@ export function ServiceView(props: ServiceViewProps) {
                         props.dataSourceMDSId[0].id ?? ''
                       }',title:'${props.dataSourceMDSId[0].label}',type:DATA_SOURCE),id:'${
                         props.dataSourceMDSId[0].id ?? ''
-                      }::${correlatedLogsIndex}',timeFieldName:'time',title:'${correlatedLogsIndex}',type:INDEXES),language:PPL,query:'source%20%3D%20${correlatedLogsIndex}%20%7C%20where%20serviceName%20%3D%20%22${
+                      }::${correlatedLogsIndex}',timeFieldName:'time',title:'${correlatedLogsIndex}',type:INDEXES),language:PPL,query:'source%20%3D%20${correlatedLogsIndex}%20%7C%20where%20${correlatedServiceNameField}%20%3D%20%22${
                         props.serviceName
                       }%22'))`,
                     });

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -232,7 +232,7 @@ export function ServiceView(props: ServiceViewProps) {
                       state: {
                         DEFAULT_DATA_SOURCE_NAME,
                         DEFAULT_DATA_SOURCE_TYPE,
-                        queryToRun: `source = ${correlatedLogsIndex} | where serviceName='${props.serviceName}'`,
+                        queryToRun: `source = ${correlatedLogsIndex} | where ${correlatedServiceNameField}='${props.serviceName}'`,
                         startTimeRange: props.startTime,
                         endTimeRange: props.endTime,
                       },

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -205,6 +205,8 @@ export function ServiceView(props: ServiceViewProps) {
                   const correlatedLogsIndex = TraceSettings.getCorrelatedLogsIndex();
                   const correlatedServiceNameField = TraceSettings.getCorrelatedLogsFieldMappings()
                     .serviceName;
+                  const correlatedTimestampField = TraceSettings.getCorrelatedLogsFieldMappings()
+                    .timestamp;
                   // NOTE: Discover has issue with PPL Time filter, hence adding +3/-3 days to actual timestamp
                   const startTime =
                     dateMath
@@ -222,7 +224,7 @@ export function ServiceView(props: ServiceViewProps) {
                         props.dataSourceMDSId[0].id ?? ''
                       }',title:'${props.dataSourceMDSId[0].label}',type:DATA_SOURCE),id:'${
                         props.dataSourceMDSId[0].id ?? ''
-                      }::${correlatedLogsIndex}',timeFieldName:'time',title:'${correlatedLogsIndex}',type:INDEXES),language:PPL,query:'source%20%3D%20${correlatedLogsIndex}%20%7C%20where%20${correlatedServiceNameField}%20%3D%20%22${
+                      }::${correlatedLogsIndex}',timeFieldName:'${correlatedTimestampField}',title:'${correlatedLogsIndex}',type:INDEXES),language:PPL,query:'source%20%3D%20${correlatedLogsIndex}%20%7C%20where%20${correlatedServiceNameField}%20%3D%20%22${
                         props.serviceName
                       }%22'))`,
                     });
@@ -233,6 +235,7 @@ export function ServiceView(props: ServiceViewProps) {
                         DEFAULT_DATA_SOURCE_NAME,
                         DEFAULT_DATA_SOURCE_TYPE,
                         queryToRun: `source = ${correlatedLogsIndex} | where ${correlatedServiceNameField}='${props.serviceName}'`,
+                        timestampField: correlatedTimestampField,
                         startTimeRange: props.startTime,
                         endTimeRange: props.endTime,
                       },

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -325,13 +325,13 @@ export function SpanDetailFlyout(props: {
 
   const redirectToExplorer = () => {
     const correlatedLogsIndex = TraceSettings.getCorrelatedLogsIndex();
+    const correlatedSpanField = TraceSettings.getCorrelatedLogsFieldMappings().spanId;
     // NOTE: Discover has issue with PPL Time filter, hence adding +3/-3 days to actual timestamp
     const startTime =
       moment(span.startTime).subtract(3, 'days').format(TRACE_ANALYTICS_DATE_FORMAT) ?? 'now-3y';
     const endTime =
       moment(span.endTime).add(3, 'days').format(TRACE_ANALYTICS_DATE_FORMAT) ?? 'now';
     const spanId = getSpanValue(span, mode, 'SPAN_ID');
-    const spanField = getSpanFieldKey(mode, 'SPAN_ID');
 
     if (coreRefs?.dataSource?.dataSourceEnabled) {
       coreRefs?.application!.navigateToApp('data-explorer', {
@@ -339,7 +339,7 @@ export function SpanDetailFlyout(props: {
           props.dataSourceMDSId ?? ''
         }',title:${props.dataSourceMDSLabel},type:DATA_SOURCE),id:'${
           props.dataSourceMDSId ?? ''
-        }::${correlatedLogsIndex}',timeFieldName:'time',title:'${correlatedLogsIndex}',type:INDEXES),language:PPL,query:'source%20%3D%20${correlatedLogsIndex}%20%7C%20where%20${spanField}%20%3D%20!'${spanId}!''))`,
+        }::${correlatedLogsIndex}',timeFieldName:'time',title:'${correlatedLogsIndex}',type:INDEXES),language:PPL,query:'source%20%3D%20${correlatedLogsIndex}%20%7C%20where%20${correlatedSpanField}%20%3D%20!'${spanId}!''))`,
       });
     } else {
       coreRefs?.application!.navigateToApp(observabilityLogsID, {

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -326,6 +326,7 @@ export function SpanDetailFlyout(props: {
   const redirectToExplorer = () => {
     const correlatedLogsIndex = TraceSettings.getCorrelatedLogsIndex();
     const correlatedSpanField = TraceSettings.getCorrelatedLogsFieldMappings().spanId;
+    const correlatedTimestampField = TraceSettings.getCorrelatedLogsFieldMappings().timestamp;
     // NOTE: Discover has issue with PPL Time filter, hence adding +3/-3 days to actual timestamp
     const startTime =
       moment(span.startTime).subtract(3, 'days').format(TRACE_ANALYTICS_DATE_FORMAT) ?? 'now-3y';
@@ -339,7 +340,7 @@ export function SpanDetailFlyout(props: {
           props.dataSourceMDSId ?? ''
         }',title:${props.dataSourceMDSLabel},type:DATA_SOURCE),id:'${
           props.dataSourceMDSId ?? ''
-        }::${correlatedLogsIndex}',timeFieldName:'time',title:'${correlatedLogsIndex}',type:INDEXES),language:PPL,query:'source%20%3D%20${correlatedLogsIndex}%20%7C%20where%20${correlatedSpanField}%20%3D%20!'${spanId}!''))`,
+        }::${correlatedLogsIndex}',timeFieldName:'${correlatedTimestampField}',title:'${correlatedLogsIndex}',type:INDEXES),language:PPL,query:'source%20%3D%20${correlatedLogsIndex}%20%7C%20where%20${correlatedSpanField}%20%3D%20!'${spanId}!''))`,
       });
     } else {
       coreRefs?.application!.navigateToApp(observabilityLogsID, {
@@ -348,6 +349,7 @@ export function SpanDetailFlyout(props: {
           DEFAULT_DATA_SOURCE_NAME,
           DEFAULT_DATA_SOURCE_TYPE,
           queryToRun: `source = ${correlatedLogsIndex} | where ${correlatedSpanField}='${spanId}'`,
+          timestampField: correlatedTimestampField,
           startTimeRange: startTime,
           endTimeRange: endTime,
         },

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -347,7 +347,7 @@ export function SpanDetailFlyout(props: {
         state: {
           DEFAULT_DATA_SOURCE_NAME,
           DEFAULT_DATA_SOURCE_TYPE,
-          queryToRun: `source = ${correlatedLogsIndex} | where ${spanField}='${spanId}'`,
+          queryToRun: `source = ${correlatedLogsIndex} | where ${correlatedSpanField}='${spanId}'`,
           startTimeRange: startTime,
           endTimeRange: endTime,
         },

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -33,7 +33,7 @@ import { TRACE_ANALYTICS_DATE_FORMAT } from '../../../../../common/constants/tra
 import { SpanField, TraceAnalyticsMode } from '../../../../../common/types/trace_analytics';
 import { coreRefs } from '../../../../framework/core_refs';
 import { handleSpansFlyoutRequest } from '../../requests/traces_request_handler';
-import { microToMilliSec, nanoToMilliSec } from '../common/helper_functions';
+import { microToMilliSec, nanoToMilliSec, TraceSettings } from '../common/helper_functions';
 import { FlyoutListItem } from './flyout_list_item';
 
 const MODE_TO_FIELDS: Record<TraceAnalyticsMode, Record<SpanField, string | undefined>> = {
@@ -324,6 +324,7 @@ export function SpanDetailFlyout(props: {
   };
 
   const redirectToExplorer = () => {
+    const correlatedLogsIndex = TraceSettings.getCorrelatedLogsIndex();
     // NOTE: Discover has issue with PPL Time filter, hence adding +3/-3 days to actual timestamp
     const startTime =
       moment(span.startTime).subtract(3, 'days').format(TRACE_ANALYTICS_DATE_FORMAT) ?? 'now-3y';
@@ -338,7 +339,7 @@ export function SpanDetailFlyout(props: {
           props.dataSourceMDSId ?? ''
         }',title:${props.dataSourceMDSLabel},type:DATA_SOURCE),id:'${
           props.dataSourceMDSId ?? ''
-        }::ss4o_logs-*',timeFieldName:'time',title:'ss4o_logs-*',type:INDEXES),language:PPL,query:'source%20%3D%20ss4o_logs-*%20%7C%20where%20${spanField}%20%3D%20!'${spanId}!''))`,
+        }::${correlatedLogsIndex}',timeFieldName:'time',title:'${correlatedLogsIndex}',type:INDEXES),language:PPL,query:'source%20%3D%20${correlatedLogsIndex}%20%7C%20where%20${spanField}%20%3D%20!'${spanId}!''))`,
       });
     } else {
       coreRefs?.application!.navigateToApp(observabilityLogsID, {
@@ -346,7 +347,7 @@ export function SpanDetailFlyout(props: {
         state: {
           DEFAULT_DATA_SOURCE_NAME,
           DEFAULT_DATA_SOURCE_TYPE,
-          queryToRun: `source = ss4o_logs-* | where ${spanField}='${spanId}'`,
+          queryToRun: `source = ${correlatedLogsIndex} | where ${spanField}='${spanId}'`,
           startTimeRange: startTime,
           endTimeRange: endTime,
         },

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -23,14 +23,15 @@ import {
 } from '../../../../../src/plugins/data_source_management/public';
 import { DataSourceAttributes } from '../../../../../src/plugins/data_source_management/public/types';
 import { observabilityTracesNewNavID } from '../../../common/constants/shared';
-import {
-  TRACE_CUSTOM_MODE_DEFAULT_SETTING,
-  TRACE_TABLE_TYPE_KEY,
-} from '../../../common/constants/trace_analytics';
+import { TRACE_TABLE_TYPE_KEY } from '../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode, TraceQueryMode } from '../../../common/types/trace_analytics';
 import { coreRefs } from '../../framework/core_refs';
 import { FilterType } from './components/common/filters/filters';
-import { getAttributeFieldNames, getSpanIndices } from './components/common/helper_functions';
+import {
+  TraceSettings,
+  getAttributeFieldNames,
+  getSpanIndices,
+} from './components/common/helper_functions';
 import { SearchBarProps } from './components/common/search_bar';
 import { ServiceView, Services } from './components/services';
 import { ServiceFlyout } from './components/services/service_flyout';
@@ -41,7 +42,6 @@ import {
   handleJaegerIndicesExistRequest,
 } from './requests/request_handler';
 import { TraceSideBar } from './trace_side_nav';
-import { uiSettingsService } from '../../../common/utils';
 
 const newNavigation = coreRefs.chrome?.navGroup.getNavGroupEnabled();
 
@@ -278,7 +278,7 @@ export const Home = (props: HomeProps) => {
       urlParts.length > 1 ? new URLSearchParams(urlParts[1].split('#')[0]) : new URLSearchParams();
 
     const urlMode = queryParams.get('mode');
-    const isCustomModeEnabled = uiSettingsService.get(TRACE_CUSTOM_MODE_DEFAULT_SETTING) || false;
+    const isCustomModeEnabled = TraceSettings.getCustomModeSetting();
 
     if (!urlMode && isCustomModeEnabled) {
       const newUrl = updateUrlWithMode('custom_data_prepper');

--- a/server/plugin_helper/register_settings.ts
+++ b/server/plugin_helper/register_settings.ts
@@ -94,6 +94,7 @@ export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSet
       schema: schema.object({
         serviceName: schema.string(),
         spanId: schema.string(),
+        timestamp: schema.string(),
       }),
     },
   });

--- a/server/plugin_helper/register_settings.ts
+++ b/server/plugin_helper/register_settings.ts
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { i18n } from '@osd/i18n';
 import { schema } from '@osd/config-schema';
+import { i18n } from '@osd/i18n';
 import { UiSettingsServiceSetup } from '../../../../src/core/server/ui_settings';
 import {
+  DEFAULT_SS4O_LOGS_INDEX,
+  TRACE_CORRELATED_LOGS_INDEX_SETTING,
   TRACE_CUSTOM_MODE_DEFAULT_SETTING,
   TRACE_CUSTOM_SERVICE_INDEX_SETTING,
   TRACE_CUSTOM_SPAN_INDEX_SETTING,
@@ -55,6 +57,21 @@ export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSet
           '<strong>Experimental feature:</strong> Enable this to default to "custom_data_prepper" mode in the trace analytics plugin',
       }),
       schema: schema.boolean(),
+    },
+  });
+
+  uiSettings.register({
+    [TRACE_CORRELATED_LOGS_INDEX_SETTING]: {
+      name: i18n.translate('observability.traceAnalyticsCorrelatedLogsIndices.name', {
+        defaultMessage: 'Trace analytics correlated logs indices',
+      }),
+      value: DEFAULT_SS4O_LOGS_INDEX,
+      category: ['Observability'],
+      description: i18n.translate('observability.traceAnalyticsCorrelatedLogsIndices.description', {
+        defaultMessage:
+          '<strong>Experimental feature:</strong> Configure correlated logs indices, to be used by the trace analytics plugin for correlated spans and services to logs',
+      }),
+      schema: schema.string(),
     },
   });
 };

--- a/server/plugin_helper/register_settings.ts
+++ b/server/plugin_helper/register_settings.ts
@@ -7,11 +7,13 @@ import { schema } from '@osd/config-schema';
 import { i18n } from '@osd/i18n';
 import { UiSettingsServiceSetup } from '../../../../src/core/server/ui_settings';
 import {
+  DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS,
   DEFAULT_SS4O_LOGS_INDEX,
   TRACE_CORRELATED_LOGS_INDEX_SETTING,
   TRACE_CUSTOM_MODE_DEFAULT_SETTING,
   TRACE_CUSTOM_SERVICE_INDEX_SETTING,
   TRACE_CUSTOM_SPAN_INDEX_SETTING,
+  TRACE_LOGS_FIELD_MAPPNIGS_SETTING,
 } from '../../common/constants/trace_analytics';
 
 export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSetup) => {
@@ -69,9 +71,30 @@ export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSet
       category: ['Observability'],
       description: i18n.translate('observability.traceAnalyticsCorrelatedLogsIndices.description', {
         defaultMessage:
-          '<strong>Experimental feature:</strong> Configure correlated logs indices, to be used by the trace analytics plugin for correlated spans and services to logs',
+          '<strong>Experimental feature:</strong> Configure correlated logs indices, to be used by the trace analytics plugin to correlate spans and services to logs',
       }),
       schema: schema.string(),
+    },
+  });
+
+  uiSettings.register({
+    [TRACE_LOGS_FIELD_MAPPNIGS_SETTING]: {
+      name: i18n.translate('observability.traceAnalyticsCorrelatedLogsFieldMappings.name', {
+        defaultMessage: 'Trace analytics correlated logs fields',
+      }),
+      value: DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS,
+      category: ['Observability'],
+      description: i18n.translate(
+        'observability.traceAnalyticsCorrelatedLogsFieldMappings.description',
+        {
+          defaultMessage:
+            '<strong>Experimental feature:</strong> Configure correlated logs fields, to be used by the trace analytics plugin for correlate spans and services to logs',
+        }
+      ),
+      schema: schema.object({
+        serviceName: schema.string(),
+        spanId: schema.string(),
+      }),
     },
   });
 };


### PR DESCRIPTION
### Description
Many users of trace analytics have different ways of defining their logs index. Many of them do not want set an alias on their existing indices and fields. Hence, we are adding this experimental feature to enable them to add custom log source used for correlation of spans & services to logs.  

Redirection to Explorer:

https://github.com/user-attachments/assets/2387592b-22a5-4a9b-9c69-81bd9110fa29



Redirection to Discover:
NOTE: We see an error in discover to load data from specific indexes using PPL. This looks to be a discover only issue.


https://github.com/user-attachments/assets/8a17e3d0-a137-4dd9-bd6a-74b4c1095d08





### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/issues/2141

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
