### PR TITLE
Improve the test results for Integrations internals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,13 @@ module.exports = {
         ],
       },
     ],
+    'jest/expect-expect': [
+      'warn',
+      {
+        // Allow using custom expect test helpers as long as the name starts with `expect`.
+        assertFunctionNames: ["expect*"],
+      }
+    ]
   },
   overrides: [
     {

--- a/server/adaptors/integrations/__test__/custom_expects.ts
+++ b/server/adaptors/integrations/__test__/custom_expects.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Useful for asserting results are okay, while still having access to error information. A context
+ * object can be supplied to help provide context if the value of the result doesn't contain enough
+ * information to know what went wrong.
+ */
+export const expectOkResult = (result: Result<unknown>, context?: string | object) => {
+  const labeled = {
+    ...result,
+    context,
+  };
+  expect(labeled).toEqual({
+    ok: true,
+    context,
+    value: expect.anything(),
+  });
+};
+
+/**
+ * Validate an error result is correctly returned. A context object can be supplied to help provide
+ * context if the value of the result doesn't contain enough information to know what went wrong.
+ */
+export const expectErrorResult = (result: Result<unknown>, context?: string | object) => {
+  const labeled = {
+    ...result,
+    context,
+  };
+  expect(labeled).toEqual({
+    ok: false,
+    context,
+    error: expect.anything(),
+  });
+};

--- a/server/adaptors/integrations/__test__/json_repository.test.ts
+++ b/server/adaptors/integrations/__test__/json_repository.test.ts
@@ -32,7 +32,9 @@ const fetchSerializedIntegrations = async (): Promise<Result<SerializedIntegrati
   const serializedIntegrationResults = await Promise.all(
     (readers.filter((x) => x !== null) as IntegrationReader[]).map((r) => r.serialize())
   );
-  return foldResults(serializedIntegrationResults);
+  const folded = foldResults(serializedIntegrationResults);
+  expectOkResult(folded);
+  return folded;
 };
 
 describe('The Local Serialized Catalog', () => {
@@ -49,7 +51,7 @@ describe('The Local Serialized Catalog', () => {
 
     for (const integ of await repository.getIntegrationList()) {
       const validationResult = await deepCheck(integ);
-      await expect(validationResult).toHaveProperty('ok', true);
+      expectOkResult(validationResult);
     }
   });
 

--- a/server/adaptors/integrations/__test__/local_fs_repository.test.ts
+++ b/server/adaptors/integrations/__test__/local_fs_repository.test.ts
@@ -49,25 +49,40 @@ describe('The local repository', () => {
   });
 });
 
+// Nginx and VPC are specifically used in other tests, so we add dedicated checks for them.
+
 describe('Local Nginx Integration', () => {
   it('Should serialize without errors', async () => {
     const integration = await repository.getIntegration('nginx');
 
-    await expect(integration?.serialize()).resolves.toEqual({
-      ok: true,
-      value: expect.anything(),
-    });
+    expect(integration).not.toBeNull();
+    expectOkResult(await integration!.serialize());
   });
 
-  it('Should serialize to include the config', async () => {
+  it('Should contain its config in its serialized form', async () => {
     const integration = await repository.getIntegration('nginx');
     const config = await integration!.getConfig();
     const serialized = await integration!.serialize();
 
-    expect(serialized).toEqual({
-      ok: true,
-      value: expect.anything(),
-    });
+    expectOkResult(serialized);
+    expect(serialized.value).toMatchObject(config.value!);
+  });
+});
+
+describe('Local VPC Integration', () => {
+  it('Should serialize without errors', async () => {
+    const integration = await repository.getIntegration('amazon_vpc_flow');
+
+    expect(integration).not.toBeNull();
+    expectOkResult(await integration!.serialize());
+  });
+
+  it('Should contain its config in its serialized form', async () => {
+    const integration = await repository.getIntegration('amazon_vpc_flow');
+    const config = await integration!.getConfig();
+    const serialized = await integration!.serialize();
+
+    expectOkResult(serialized);
     expect(serialized.value).toMatchObject(config.value!);
   });
 });

--- a/server/adaptors/integrations/repository/__test__/integration_reader.test.ts
+++ b/server/adaptors/integrations/repository/__test__/integration_reader.test.ts
@@ -8,6 +8,7 @@ import { IntegrationReader } from '../integration_reader';
 import { Dirent, Stats } from 'fs';
 import * as path from 'path';
 import { TEST_INTEGRATION_CONFIG } from '../../../../../test/constants';
+import { expectOkResult } from '../../__test__/custom_expects';
 
 jest.mock('fs/promises');
 
@@ -75,7 +76,7 @@ describe('Integration', () => {
 
       const result = await integration.getConfig(TEST_INTEGRATION_CONFIG.version);
 
-      expect(result.error?.message).toBe('data/version must be string');
+      expect(result.error?.message).toContain('data/version must be string');
     });
 
     it('should return an error if the config file has syntax errors', async () => {
@@ -83,7 +84,7 @@ describe('Integration', () => {
 
       const result = await integration.getConfig(TEST_INTEGRATION_CONFIG.version);
 
-      expect(result.error?.message).toBe(
+      expect(result.error?.message).toContain(
         "Unable to parse file 'sample-2.0.0.json' as JSON or NDJson"
       );
     });
@@ -114,7 +115,7 @@ describe('Integration', () => {
 
       const result = await integration.getAssets(TEST_INTEGRATION_CONFIG.version);
 
-      expect(result.ok).toBe(true);
+      expectOkResult(result);
       expect((result as { value: Array<{ data: object[] }> }).value[0].data).toEqual([
         { name: 'asset1' },
         { name: 'asset2' },
@@ -136,7 +137,7 @@ describe('Integration', () => {
 
       const result = await integration.getAssets(TEST_INTEGRATION_CONFIG.version);
 
-      expect(result.error?.message).toBe(
+      expect(result.error?.message).toContain(
         "Unable to parse file 'sample-1.0.1.ndjson' as JSON or NDJson"
       );
     });
@@ -178,7 +179,7 @@ describe('Integration', () => {
       );
       const result = await integration.getSchemas();
 
-      expect(result.error?.message).toBe("data must have required property 'name'");
+      expect(result.error?.message).toContain("data must have required property 'name'");
     });
 
     it('should reject with an error if a mapping file is invalid', async () => {
@@ -188,7 +189,7 @@ describe('Integration', () => {
         .mockRejectedValueOnce(new Error('Could not load schema'));
 
       const result = await integration.getSchemas();
-      expect(result.error?.message).toBe('Could not load schema');
+      expect(result.error?.message).toContain('Could not load schema');
     });
   });
 
@@ -200,8 +201,8 @@ describe('Integration', () => {
 
       const result = await integration.getStatic('logo.png');
 
-      expect(result.ok).toBe(true);
-      expect((result as { value: unknown }).value).toStrictEqual(Buffer.from('logo data', 'ascii'));
+      expectOkResult(result);
+      expect(result.value).toStrictEqual(Buffer.from('logo data', 'ascii'));
       expect(readFileMock).toBeCalledWith(path.join('sample', 'static', 'logo.png'));
     });
 
@@ -247,7 +248,7 @@ describe('Integration', () => {
 
       const result = await integration.getSampleData();
 
-      expect(result.ok).toBe(true);
+      expectOkResult(result);
       expect((result as { value: { sampleData: unknown } }).value.sampleData).toBeNull();
     });
 
@@ -266,7 +267,9 @@ describe('Integration', () => {
 
       const result = await integration.getSampleData();
 
-      expect(result.error?.message).toBe("Unable to parse file 'sample.json' as JSON or NDJson");
+      expect(result.error?.message).toContain(
+        "Unable to parse file 'sample.json' as JSON or NDJson"
+      );
     });
   });
 });

--- a/server/adaptors/integrations/repository/integration_reader.ts
+++ b/server/adaptors/integrations/repository/integration_reader.ts
@@ -51,17 +51,17 @@ export class IntegrationReader {
    */
   private async fetchDataOrReadFile(
     item: { data?: string },
-    fileParams: { filename: string; type?: IntegrationPart },
+    fileParams: FileParams,
     format: 'json'
   ): Promise<Result<object | object[]>>;
   private async fetchDataOrReadFile(
     item: { data?: string },
-    fileParams: { filename: string; type?: IntegrationPart },
+    fileParams: FileParams,
     format: 'binary'
   ): Promise<Result<Buffer>>;
   private async fetchDataOrReadFile(
     item: { data?: string },
-    fileParams: { filename: string; type?: IntegrationPart },
+    fileParams: FileParams,
     format: 'json' | 'binary'
   ): Promise<Result<object | object[] | Buffer>> {
     if (this.reader.isConfigLocalized) {


### PR DESCRIPTION
### Description
I was debugging some tests locally and it stood out that the errors aren't that useful: most of them are `result.ok` assertions of the form "Expected true but got false." This is inactionable without custom debugging logic (usually well-placed `console.log`s). I've added some result helpers that can check results with context, and show the specific errors on failure. [Failures should be actionable.](https://testing.googleblog.com/2024/05/test-failures-should-be-actionable.html)

After implementing, I tried introducing some random errors in our integration configs and parsing logic, and verified that the failures made sense.

### Issues Resolved
N/A

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
