### PR TITLE
Bump dep serialize-javascript version to 6.0.2 and @babel/runtime to 7.26.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "braces": "^3.0.3",
     "ws": "^8.18.0",
     "**/eslint/cross-spawn": "^7.0.5",
-    "nanoid": "3.3.8"
+    "nanoid": "3.3.8",
+    "@babel/runtime": "^7.26.10"
   },
   "eslintIgnore": [
     "common/query_manager/antlr/output/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,10 +49,10 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.9.2":
-  version "7.22.15"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.15.tgz#38f46494ccf6cf020bd4eed7124b425e83e523b8"
-  integrity sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.26.10", "@babel/runtime@^7.3.1", "@babel/runtime@^7.9.2":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.10.tgz#a07b4d8fa27af131a633d7b3524db803eb4764c2"
+  integrity sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==
   dependencies:
     regenerator-runtime "^0.14.0"
 


### PR DESCRIPTION
### Description
Bump dep serialize-javascript version to 6.0.2 and @babel/runtime to 7.26.10.
Resolved CVE-2024-11831.
At the moment cypress-parallel maintainer just come back since 2023 and have not release any newer versions yet: https://github.com/tnicola/cypress-parallel/commits/master/

Also bump @babel/runtime to 7.26.10.
as https://www.npmjs.com/package/@nteract/presentational-components havent been updated for a long time.
Related to CVE-2025-27789.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747

### Check List
- ~~[ ] New functionality includes testing.~~
  - ~~[ ] All tests pass, including unit test, integration test and doctest~~
- ~~[ ] New functionality has been documented.~~
  - ~~[ ] New functionality has javadoc added~~
  - ~~[ ] New functionality has user manual doc added~~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
