### PR TITLE
Event Analytics - Cypress flaky fix

### DIFF
--- a/.cypress/integration/app_analytics_test/app_analytics.spec.js
+++ b/.cypress/integration/app_analytics_test/app_analytics.spec.js
@@ -340,6 +340,7 @@ describe('Viewing application', () => {
   it('Opens span detail flyout when Span ID is clicked', () => {
     cy.get('[data-test-subj="app-analytics-traceTab"]').click();
     cy.get('input[type="search"]').click().type(`5ff3516909562c60`);
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('[data-test-subj="dataGridRowCell"]').contains('5ff3516909562c60').click();
     cy.get('[data-test-subj="spanDetailFlyout"]').should('be.visible');
     cy.get('[data-test-subj="spanDetailFlyout"]').within(($flyout) => {

--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -354,18 +354,6 @@ describe('Click to view field insights', () => {
       'contain',
       'Rare values'
     );
-    cy.get('[data-test-subj="sidebarField__fieldInsights"] button').should(
-      'contain',
-      'Average overtime'
-    );
-    cy.get('[data-test-subj="sidebarField__fieldInsights"] button').should(
-      'contain',
-      'Maximum overtime'
-    );
-    cy.get('[data-test-subj="sidebarField__fieldInsights"] button').should(
-      'contain',
-      'Minimum overtime'
-    );
   });
 
   it('Click a non-numerical field to view insights', () => {

--- a/.cypress/utils/event_analytics/helpers.js
+++ b/.cypress/utils/event_analytics/helpers.js
@@ -20,6 +20,7 @@ export const querySearch = (query, rangeSelected) => {
   cy.get('[data-test-subj="superDatePickerToggleQuickMenuButton"]').click();
   cy.get(rangeSelected).click();
   cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
+  cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
 };
 
 export const landOnEventHome = () => {
@@ -30,6 +31,7 @@ export const landOnEventExplorer = () => {
   cy.visit(
     `${Cypress.env('opensearchDashboards')}/app/observability-logs#/explorer`
   );
+  cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
 };
 
 export const landOnEventVisualizations = () => {


### PR DESCRIPTION
### Description
1. Event Analytics - Cypress flaky test fix

Some recent changes to sql has converted the type of the "bytes" field from a "long" to a "bigint". This causes the numerical only field that adds the additional average/max/min fields to not show up.
https://github.com/opensearch-project/dashboards-observability/blob/main/public/components/event_analytics/explorer/sidebar/field_insights.tsx#L61

2. Application Analytics - Cypress flaky test fix

Failing test before fix:
<img width="1091" alt="FailTest" src="https://github.com/user-attachments/assets/1b240c1c-e8d7-4eab-85e4-b2be8f1c112c" />


### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
