### PR TITLE
Custom Traces- Sorting/Toast

### DIFF
--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -325,7 +325,7 @@ describe('Testing traces Custom source', () => {
 
     cy.get('a.euiLink.euiLink--primary').first().click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.get('.overview-content').should('contain.text', '4fa04f117be100f476b175e41096e736');
+    cy.get('.overview-content').should('contain.text', 'd5bc99166e521eec173bcb7f9b0d3c43');
   });
 
   it('Renders all spans column attributes as hidden, shows column when added', () => {
@@ -366,6 +366,6 @@ describe('Testing traces Custom source', () => {
 
     cy.get('a.euiLink.euiLink--primary').first().click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.get('.overview-content').should('contain.text', '02feb3a4f611abd81f2a53244d1278ae');
+    cy.get('.overview-content').should('contain.text', 'be0a3dceda2ecf601fd2e476fef3ee07');
   });
 });

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -675,3 +675,12 @@ export const parseHits = (payloadData: string): ParsedHit[] => {
     return [];
   }
 };
+
+export const isUnderOneHourRange = (startTime: string, endTime: string): boolean => {
+  const start = dateMath.parse(startTime);
+  const end = dateMath.parse(endTime);
+
+  if (!start || !end) return false;
+
+  return end.diff(start, 'hours')! < 1;
+};

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -4,7 +4,6 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import datemath from '@elastic/datemath';
 import {
   EuiAccordion,
   EuiFlexGroup,
@@ -25,7 +24,7 @@ import {
 } from '../../requests/traces_request_handler';
 import { getValidFilterFields } from '../common/filters/filter_helpers';
 import { Filters, FilterType } from '../common/filters/filters';
-import { filtersToDsl, processTimeStamp } from '../common/helper_functions';
+import { filtersToDsl, isUnderOneHourRange, processTimeStamp } from '../common/helper_functions';
 import { ServiceMap, ServiceObject } from '../common/plots/service_map';
 import { SearchBar } from '../common/search_bar';
 import { DashboardContent } from '../dashboard/dashboard_content';
@@ -101,10 +100,11 @@ export function TracesContent(props: TracesProps) {
 
     setSortingColumns(sortColumns);
 
+    // The columns that can not be used in a query, only rendered on page
     const localOnlyFields = ['trace_group', 'percentile_in_trace_group', 'trace_id'];
 
     if (tracesTableMode === 'traces') {
-      //  Client-side sort if field is local-only
+      // Client-side sort if field is local-only
       if (localOnlyFields.includes(sortField)) {
         const sorted = [...tableItems].sort((a, b) => {
           let valueA = a[sortField];
@@ -154,7 +154,7 @@ export function TracesContent(props: TracesProps) {
         page,
         appConfigs
       ),
-      isUnderOneHour: datemath.parse(endTime)?.diff(datemath.parse(startTime), 'hours')! < 1,
+      isUnderOneHour: isUnderOneHourRange(startTime, endTime),
     };
   };
 
@@ -312,7 +312,7 @@ export function TracesContent(props: TracesProps) {
       page
     );
 
-    const isUnderOneHour = datemath.parse(endTime)?.diff(datemath.parse(startTime), 'hours')! < 1;
+    const isUnderOneHour = isUnderOneHourRange(startTime, endTime);
 
     await handleTracesRequest(
       http,
@@ -352,7 +352,7 @@ export function TracesContent(props: TracesProps) {
       processTimeStamp(endTime, mode),
       page
     );
-    const isUnderOneHour = datemath.parse(endTime)?.diff(datemath.parse(startTime), 'hours')! < 1;
+    const isUnderOneHour = isUnderOneHourRange(startTime, endTime);
     const newSort = sort ?? getDefaultSort();
 
     setIsTraceTableLoading(true);

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -413,7 +413,7 @@ export function TracesContent(props: TracesProps) {
         mode,
         maxTraces,
         props.dataSourceMDSId[0].id,
-        newSort,
+        sort,
         isUnderOneHour
       ).finally(() => setIsTraceTableLoading(false));
     }

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -79,6 +79,12 @@ export function TracesContent(props: TracesProps) {
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(10);
 
+  const getDefaultSort = () => {
+    return tracesTableMode === 'traces'
+      ? { field: 'last_updated', direction: 'desc' as const }
+      : { field: 'endTime', direction: 'desc' as const };
+  };
+
   const onSort = (sortColumns: Array<{ id: string; direction: 'desc' | 'asc' }>) => {
     if (!sortColumns || sortColumns.length === 0) {
       setSortingColumns([]);
@@ -95,43 +101,40 @@ export function TracesContent(props: TracesProps) {
 
     setSortingColumns(sortColumns);
 
+    const localOnlyFields = ['trace_group', 'percentile_in_trace_group', 'trace_id'];
+
     if (tracesTableMode === 'traces') {
-      const sortedItems = [...tableItems].sort((a, b) => {
-        let valueA = a[sortField];
-        let valueB = b[sortField];
+      //  Client-side sort if field is local-only
+      if (localOnlyFields.includes(sortField)) {
+        const sorted = [...tableItems].sort((a, b) => {
+          let valueA = a[sortField];
+          let valueB = b[sortField];
 
-        if (sortField === 'last_updated') {
-          const dateA = new Date(valueA);
-          const dateB = new Date(valueB);
+          if (typeof valueA === 'string' && typeof valueB === 'string') {
+            valueA = valueA.toLowerCase();
+            valueB = valueB.toLowerCase();
+            return sortDirection === 'asc'
+              ? valueA.localeCompare(valueB)
+              : valueB.localeCompare(valueA);
+          }
 
-          const isValidA = !isNaN(dateA.getTime());
-          const isValidB = !isNaN(dateB.getTime());
+          if (typeof valueA === 'number' && typeof valueB === 'number') {
+            return sortDirection === 'asc' ? valueA - valueB : valueB - valueA;
+          }
 
-          // Treat invalid dates as the lowest value
-          valueA = isValidA ? dateA.getTime() : -Infinity;
-          valueB = isValidB ? dateB.getTime() : -Infinity;
-        } else if (sortField === 'trace_group') {
-          valueA = typeof valueA === 'string' ? valueA.toLowerCase() : '';
-          valueB = typeof valueB === 'string' ? valueB.toLowerCase() : '';
-        }
+          return 0;
+        });
 
-        if (typeof valueA === 'number' && typeof valueB === 'number') {
-          return sortDirection === 'asc' ? valueA - valueB : valueB - valueA;
-        }
+        setTableItems(sorted);
+        return;
+      }
 
-        if (typeof valueA === 'string' && typeof valueB === 'string') {
-          return sortDirection === 'asc'
-            ? valueA.localeCompare(valueB)
-            : valueB.localeCompare(valueA);
-        }
-
-        return 0;
-      });
-
-      setTableItems(sortedItems);
+      // Server-side sort for supported fields
+      const sort = { field: sortField, direction: sortDirection };
+      refreshTracesTableData(sort, 0, pageSize);
     } else {
       const { DSL, isUnderOneHour } = generateDSLs();
-      refreshTableDataOnly(pageIndex, pageSize, DSL, isUnderOneHour, {
+      refreshSpanTableData(pageIndex, pageSize, DSL, isUnderOneHour, {
         field: sortField,
         direction: sortDirection,
       });
@@ -168,7 +171,7 @@ export function TracesContent(props: TracesProps) {
         const currentSort = sortingColumns[0]
           ? { field: sortingColumns[0].id, direction: sortingColumns[0].direction }
           : undefined;
-        refreshTableDataOnly(newPage, pageSize, DSL, isUnderOneHour, currentSort);
+        refreshSpanTableData(newPage, pageSize, DSL, isUnderOneHour, currentSort);
       }
     },
     onChangeItemsPerPage: (newSize) => {
@@ -179,7 +182,7 @@ export function TracesContent(props: TracesProps) {
         const currentSort = sortingColumns[0]
           ? { field: sortingColumns[0].id, direction: sortingColumns[0].direction }
           : undefined;
-        refreshTableDataOnly(0, newSize, DSL, isUnderOneHour, currentSort);
+        refreshSpanTableData(0, newSize, DSL, isUnderOneHour, currentSort);
       }
     },
   };
@@ -252,7 +255,7 @@ export function TracesContent(props: TracesProps) {
     setFilters(newFilters);
   };
 
-  const refreshTableDataOnly = async (
+  const refreshSpanTableData = async (
     newPageIndex: number,
     newPageSize: number,
     DSL: any,
@@ -262,6 +265,7 @@ export function TracesContent(props: TracesProps) {
     setPageIndex(newPageIndex);
     setPageSize(newPageSize);
     setIsTraceTableLoading(true);
+    const sort = sortParams ?? getDefaultSort();
 
     handleCustomIndicesTracesRequest(
       http,
@@ -273,8 +277,53 @@ export function TracesContent(props: TracesProps) {
       newPageSize,
       setTotalHits,
       props.dataSourceMDSId[0]?.id,
-      sortParams,
+      sort,
       tracesTableMode,
+      isUnderOneHour
+    ).finally(() => setIsTraceTableLoading(false));
+  };
+
+  const refreshTracesTableData = async (
+    sortParams?: { field: string; direction: 'desc' | 'asc' },
+    newPageIndex: number = pageIndex,
+    newPageSize: number = pageSize
+  ) => {
+    setPageIndex(newPageIndex);
+    setPageSize(newPageSize);
+    setIsTraceTableLoading(true);
+    const sort = sortParams ?? getDefaultSort();
+
+    const DSL = filtersToDsl(
+      mode,
+      filters,
+      query,
+      processTimeStamp(startTime, mode),
+      processTimeStamp(endTime, mode),
+      page,
+      appConfigs
+    );
+
+    const timeFilterDSL = filtersToDsl(
+      mode,
+      [],
+      '',
+      processTimeStamp(startTime, mode),
+      processTimeStamp(endTime, mode),
+      page
+    );
+
+    const isUnderOneHour = datemath.parse(endTime)?.diff(datemath.parse(startTime), 'hours')! < 1;
+
+    await handleTracesRequest(
+      http,
+      DSL,
+      timeFilterDSL,
+      tableItems,
+      setTableItems,
+      mode,
+      maxTraces,
+      props.dataSourceMDSId[0].id,
+      sort,
       isUnderOneHour
     ).finally(() => setIsTraceTableLoading(false));
   };
@@ -304,6 +353,7 @@ export function TracesContent(props: TracesProps) {
       page
     );
     const isUnderOneHour = datemath.parse(endTime)?.diff(datemath.parse(startTime), 'hours')! < 1;
+    const newSort = sort ?? getDefaultSort();
 
     setIsTraceTableLoading(true);
 
@@ -326,7 +376,7 @@ export function TracesContent(props: TracesProps) {
               newPageSize,
               setTotalHits,
               props.dataSourceMDSId[0]?.id,
-              sort,
+              newSort,
               tracesTableMode,
               isUnderOneHour
             )
@@ -339,7 +389,7 @@ export function TracesContent(props: TracesProps) {
               mode,
               maxTraces,
               props.dataSourceMDSId[0].id,
-              sort,
+              newSort,
               isUnderOneHour
             );
       tracesRequest.finally(() => setIsTraceTableLoading(false));
@@ -363,7 +413,7 @@ export function TracesContent(props: TracesProps) {
         mode,
         maxTraces,
         props.dataSourceMDSId[0].id,
-        sort,
+        newSort,
         isUnderOneHour
       ).finally(() => setIsTraceTableLoading(false));
     }


### PR DESCRIPTION
### Description
1. Add a default sorting of descending time while in the custom trace mode for spans/traces.
2. Fix the sorting of the tracing table under custom source to use the paginated results for 'trace_group', 'percentile_in_trace_group', 'trace_id' as they can not be ran in the query. (Matching behavior of old memory table)
3. Add early return to the traces/custom traces request handlers to prevent toast messages on empty data.
4. Update cypress testing for the custom source to account for the results being sorted now.

Before with invalid/empty span
<img width="1682" alt="Before" src="https://github.com/user-attachments/assets/94b8367c-5902-4d4d-9dc3-2f3a10ab55de" />
After
<img width="1684" alt="InvalidSpan" src="https://github.com/user-attachments/assets/e967172e-e5c3-4348-b74a-35030350db2b" />

Invalid sorting that required it to be local only:
<img width="1491" alt="InvalidSort" src="https://github.com/user-attachments/assets/a96c3d3c-d7db-4ae0-98a9-036c3a403130" />


### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
