### PR TITLE
Adding husky `.only` check hook to test files 

### DIFF
--- a/.husky/hooks/check-test-only.sh
+++ b/.husky/hooks/check-test-only.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Get all staged files
+staged_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|jsx|ts|tsx)$')
+
+if [[ -z "$staged_files" ]]; then
+  exit 0
+fi
+
+# Check for .only in Jest or Cypress test files
+only_pattern="(describe|it|test|context|cy)\.only\("
+found_only=false
+
+for file in $staged_files; do
+  # Check if file has .only
+  if grep -E "$only_pattern" "$file" > /dev/null; then
+    echo "Error: Found .only in $file"
+    echo "Please remove all instances of .only before committing"
+    found_only=true
+  fi
+done
+
+if [[ "$found_only" = true ]]; then
+  exit 1
+fi
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
       "yarn lint --fix"
-    ]
+    ],
+    "*.{test,spec,cy}.{js,ts}": "git diff --cached --name-only | xargs grep -l '.only(' && (echo '❌ Found .only in test files. Remove it before committing!' && exit 1) || exit 0"
   },
   "dependencies": {
     "@algolia/autocomplete-core": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
+      ".husky/hooks/check-test-only.sh",
       "yarn lint --fix"
-    ],
-    "*.{test,spec,cy}.{js,ts}": "git diff --cached --name-only | xargs grep -l '.only(' && (echo '❌ Found .only in test files. Remove it before committing!' && exit 1) || exit 0"
+    ]
   },
   "dependencies": {
     "@algolia/autocomplete-core": "^1.4.1",


### PR DESCRIPTION
### Description
Adding husky `.only` check hook to test files 

### Issues Resolved
This PR introduces a pre-commit hook using Husky & lint-staged to prevent committing test files (*.test.js, *.spec.js, *.cy.js, etc.) that contain `.only`. This ensures that no test runs in isolation unintentionally, improving test reliability and preventing CI/CD pipeline issues. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
