### PR TITLE
Traces - Update custom source display, add toast.

### DIFF
--- a/public/components/trace_analytics/components/common/shared_components/component_helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/component_helper_functions.tsx
@@ -10,23 +10,34 @@ export const useInjectElementsIntoGrid = (
   rowCount: number,
   maxDisplayRows: number,
   tracesTableMode: string,
-  loadMoreHandler?: () => void
+  loadMoreHandler?: () => void,
+  maxTraces?: number
 ) => {
   useEffect(() => {
     setTimeout(() => {
       const toolbar = document.querySelector<HTMLElement>('.euiDataGrid__controls');
-      if (toolbar && rowCount > maxDisplayRows) {
-        toolbar.style.display = 'flex';
-        toolbar.style.alignItems = 'center';
-        toolbar.style.justifyContent = 'space-between';
 
-        let warningDiv = toolbar.querySelector<HTMLElement>('.trace-table-warning');
-        if (!warningDiv) {
-          warningDiv = document.createElement('div');
+      const shouldShowWarning =
+        (tracesTableMode === 'traces' && maxTraces != null && maxTraces < rowCount) ||
+        (tracesTableMode !== 'traces' && rowCount > maxDisplayRows);
+
+      if (toolbar) {
+        const existingWarning = toolbar.querySelector('.trace-table-warning');
+        if (existingWarning) {
+          existingWarning.remove();
+        }
+
+        if (shouldShowWarning) {
+          toolbar.style.display = 'flex';
+          toolbar.style.alignItems = 'center';
+          toolbar.style.justifyContent = 'space-between';
+
+          const warningDiv = document.createElement('div');
           warningDiv.className = 'trace-table-warning';
 
           const strongElement = document.createElement('strong');
-          strongElement.textContent = `${maxDisplayRows}`;
+          strongElement.textContent =
+            tracesTableMode === 'traces' ? `${maxTraces ?? maxDisplayRows}` : `${maxDisplayRows}`;
 
           const textSpan = document.createElement('span');
           textSpan.appendChild(strongElement);
@@ -69,5 +80,5 @@ export const useInjectElementsIntoGrid = (
         }
       }
     }, 100);
-  }, [rowCount, tracesTableMode, loadMoreHandler]);
+  }, [rowCount, tracesTableMode, loadMoreHandler, maxTraces, maxDisplayRows]);
 };

--- a/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
@@ -110,6 +110,7 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
   isTableDataLoading,
   tracesTableMode,
   setTracesTableMode,
+  maxTraces,
   setMaxTraces,
 }) => {
   const defaultVisibleColumns = useMemo(() => {
@@ -125,7 +126,8 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
   const [isFullScreen, setIsFullScreen] = useState(fullScreen);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  const displayedRowCount = rowCount > MAX_DISPLAY_ROWS ? MAX_DISPLAY_ROWS : rowCount;
+  const displayedRowCount =
+    tracesTableMode === 'traces' ? maxTraces : Math.min(rowCount, MAX_DISPLAY_ROWS);
 
   const isDarkMode = uiSettingsService.get('theme:darkMode');
 
@@ -135,9 +137,15 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
       )
     : [];
 
-  useInjectElementsIntoGrid(rowCount, MAX_DISPLAY_ROWS, tracesTableMode ?? '', () => {
-    setMaxTraces((prevMax: number) => Math.min(prevMax + 500, MAX_DISPLAY_ROWS));
-  });
+  useInjectElementsIntoGrid(
+    rowCount,
+    MAX_DISPLAY_ROWS,
+    tracesTableMode ?? '',
+    () => {
+      setMaxTraces((prevMax: number) => Math.min(prevMax + 500, MAX_DISPLAY_ROWS));
+    },
+    maxTraces
+  );
 
   const disableInteractions = useMemo(() => isFullScreen, [isFullScreen]);
 

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -324,7 +324,8 @@ export function TracesContent(props: TracesProps) {
       maxTraces,
       props.dataSourceMDSId[0].id,
       sort,
-      isUnderOneHour
+      isUnderOneHour,
+      setTotalHits
     ).finally(() => setIsTraceTableLoading(false));
   };
 
@@ -390,7 +391,8 @@ export function TracesContent(props: TracesProps) {
               maxTraces,
               props.dataSourceMDSId[0].id,
               newSort,
-              isUnderOneHour
+              isUnderOneHour,
+              setTotalHits
             );
       tracesRequest.finally(() => setIsTraceTableLoading(false));
 

--- a/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
@@ -123,7 +123,7 @@ export function TracesCustomIndicesTable(props: TracesLandingTableProps) {
             key={columns.map((col) => col.id).join('-')} // Force re-render for switching from spans to traces
             columns={columns}
             renderCellValue={renderCellValue}
-            rowCount={props.tracesTableMode === 'traces' ? items.length : totalHits}
+            rowCount={totalHits}
             sorting={{ columns: sortingColumns, onSort }}
             pagination={pagination}
             isTableDataLoading={loading}

--- a/public/components/trace_analytics/requests/__tests__/helper_funtions.test.tsx
+++ b/public/components/trace_analytics/requests/__tests__/helper_funtions.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { handleError } from '../helper_functions';
+import { coreRefs } from '../../../../../public/framework/core_refs';
+
+describe('handleError in handleDslRequest', () => {
+  const addDangerMock = jest.fn();
+  const addErrorMock = jest.fn();
+
+  beforeAll(() => {
+    coreRefs.core = {
+      notifications: {
+        toasts: {
+          addDanger: addDangerMock,
+          addError: addErrorMock,
+        },
+      },
+    } as any;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('displays danger toast for too_many_buckets_exception', () => {
+    const error = {
+      response: JSON.stringify({
+        error: {
+          caused_by: {
+            type: 'too_many_buckets_exception',
+            reason: 'Too many buckets',
+          },
+        },
+      }),
+    };
+
+    handleError(error);
+
+    expect(addDangerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Too many buckets in aggregation',
+        text: 'Too many buckets',
+      })
+    );
+    expect(addErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('logs error for non-bucket exceptions', () => {
+    const error = {
+      body: {
+        error: {
+          type: 'search_phase_execution_exception',
+          reason: 'Some other error',
+        },
+      },
+    };
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    handleError(error);
+
+    expect(consoleSpy).toHaveBeenCalledWith(error);
+    expect(addDangerMock).not.toHaveBeenCalled();
+    expect(addErrorMock).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('parses nested message JSON string', () => {
+    const error = {
+      body: {
+        message: JSON.stringify({
+          error: {
+            caused_by: {
+              type: 'too_many_buckets_exception',
+              reason: 'Buckets exceeded',
+            },
+          },
+        }),
+      },
+    };
+
+    handleError(error);
+
+    expect(addDangerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Too many buckets in aggregation',
+        text: 'Buckets exceeded',
+      })
+    );
+  });
+});

--- a/public/components/trace_analytics/requests/helper_functions.tsx
+++ b/public/components/trace_analytics/requests/helper_functions.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { coreRefs } from '../../../../public/framework/core_refs';
+
+export const handleError = (error: any) => {
+  let parsedError: any = {};
+
+  const safeJsonParse = (input: string) => {
+    try {
+      return JSON.parse(input);
+    } catch {
+      return null;
+    }
+  };
+
+  if (typeof error?.response === 'string') {
+    parsedError = safeJsonParse(error.response) || {};
+  } else if (typeof error?.body === 'string') {
+    parsedError = safeJsonParse(error.body) || {};
+  } else {
+    parsedError = error?.body || error;
+    if (typeof parsedError.message === 'string') {
+      const nested = safeJsonParse(parsedError.message);
+      if (nested?.error) {
+        parsedError = nested;
+      }
+    }
+  }
+
+  const errorType = parsedError?.error?.caused_by?.type || parsedError?.error?.type || '';
+  const errorReason = parsedError?.error?.caused_by?.reason || parsedError?.error?.reason || '';
+
+  if (errorType === 'too_many_buckets_exception') {
+    coreRefs.core?.notifications.toasts.addDanger({
+      title: 'Too many buckets in aggregation',
+      text:
+        errorReason ||
+        'Try using a shorter time range or increase the "search.max_buckets" cluster setting.',
+      toastLifeTimeMs: 10000,
+    });
+  } else {
+    console.error(error);
+  }
+};

--- a/public/components/trace_analytics/requests/queries/traces_queries.ts
+++ b/public/components/trace_analytics/requests/queries/traces_queries.ts
@@ -187,7 +187,7 @@ export const getTracesQuery = (
         },
       },
     },
-    track_total_hits: false,
+    track_total_hits: true,
   };
   if (traceId) {
     jaegerQuery.query.bool.filter.push({

--- a/public/components/trace_analytics/requests/request_handler.ts
+++ b/public/components/trace_analytics/requests/request_handler.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { coreRefs } from '../../../../public/framework/core_refs';
 import { CoreStart } from '../../../../../../src/core/public';
 import {
   TRACE_ANALYTICS_DATA_PREPPER_INDICES_ROUTE,
@@ -12,6 +11,7 @@ import {
 } from '../../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode } from '../../../../common/types/trace_analytics';
 import { getSpanIndices } from '../components/common/helper_functions';
+import { handleError } from './helper_functions';
 
 export async function handleDslRequest(
   http: CoreStart['http'],
@@ -35,49 +35,6 @@ export async function handleDslRequest(
   }
   const query = {
     dataSourceMDSId,
-  };
-
-  const handleError = (error: any) => {
-    let parsedError = {};
-
-    try {
-      if (typeof error?.response === 'string') {
-        parsedError = JSON.parse(error.response);
-      } else if (typeof error?.body === 'string') {
-        parsedError = JSON.parse(error.body);
-      } else {
-        parsedError = error?.body || error;
-
-        // Check if message is a JSON string
-        if (typeof parsedError.message === 'string') {
-          try {
-            const innerParsed = JSON.parse(parsedError.message);
-            if (innerParsed?.error) {
-              parsedError = innerParsed;
-            }
-          } catch {
-            // not JSON, skip
-          }
-        }
-      }
-    } catch (e) {
-      console.warn('Failed to parse error response as JSON', e);
-    }
-
-    const errorType = parsedError?.error?.caused_by?.type || parsedError?.error?.type || '';
-    const errorReason = parsedError?.error?.caused_by?.reason || parsedError?.error?.reason || '';
-
-    if (errorType === 'too_many_buckets_exception') {
-      coreRefs.core?.notifications.toasts.addDanger({
-        title: 'Too many buckets in aggregation',
-        text:
-          errorReason ||
-          'Try using a shorter time range or increase the "search.max_buckets" cluster setting.',
-        toastLifeTimeMs: 10000,
-      });
-    } else {
-      console.error(error);
-    }
   };
 
   if (setShowTimeoutToast) {

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -113,7 +113,8 @@ export const handleTracesRequest = async (
   maxTraces: number = 500,
   dataSourceMDSId?: string,
   sort?: PropertySort,
-  isUnderOneHour?: boolean
+  isUnderOneHour?: boolean,
+  setTotalHits?: (count: number) => void
 ) => {
   const binarySearch = (arr: number[], target: number) => {
     if (!arr) return Number.NaN;
@@ -166,6 +167,11 @@ export const handleTracesRequest = async (
       const percentileRanges =
         percentileRangesResult.status === 'fulfilled' ? percentileRangesResult.value : {};
       const response = responseResult.value;
+
+      if (setTotalHits) {
+        const totalHits = response?.hits?.total?.value ?? 0;
+        setTotalHits(totalHits);
+      }
 
       if (
         !response?.aggregations?.traces?.buckets ||

--- a/server/routes/trace_analytics_dsl_router.ts
+++ b/server/routes/trace_analytics_dsl_router.ts
@@ -158,7 +158,7 @@ export function registerTraceAnalyticsDslRouter(router: IRouter, dataSourceEnabl
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
           statusCode: error.statusCode || 400,
-          body: error.message,
+          body: error.response,
         });
       }
     }


### PR DESCRIPTION
### Description
1. Add a specific toast message for when a bucket exception happens indicating the query was to large. Was previously silently failing as the server side did not display anything for this exception.
2. Updatd the traces display to also display the totel number of hits included in the query

Toast message:
<img width="258" alt="Screenshot 2025-04-04 at 12 10 21 PM" src="https://github.com/user-attachments/assets/db86fb1f-4c07-4bb7-b1e3-d7eda1347c2a" />

Updated warning in corner:
<img width="1476" alt="Screenshot 2025-04-04 at 12 10 39 PM" src="https://github.com/user-attachments/assets/92f08a66-27a6-44e4-8404-d25395b31c4e" />

### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
