### PR TITLE
[Bug] Notebooks - fix set_paragraphs API

### DIFF
--- a/server/routes/notebooks/paraRouter.ts
+++ b/server/routes/notebooks/paraRouter.ts
@@ -223,7 +223,9 @@ export function registerParaRoute(router: IRouter) {
         const updateResponse = await opensearchNotebooksClient.update(
           NOTEBOOK_SAVED_OBJECT,
           request.body.noteId,
-          updateNotebook
+          {
+            savedNotebook: updateNotebook,
+          }
         );
         return response.ok({
           body: updateResponse,


### PR DESCRIPTION
### Description
This PR solve the issue where calling the `/api/observability/notebooks/savedNotebook/set_paragraphs` API unable to set paragraphs successfully.

### Issues Resolved
#2416 

### How to test?
1. Open a notebook.
2. Move the position of a paragraph up or down.
3. Refresh the page.
4. Should show the latest paragraphs version.

### Check List
- [ ] New functionality includes testing.
- [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
- [ ] New functionality has javadoc added
- [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
