### PR TITLE
[Bug] Notebooks - Action popover

### DIFF
--- a/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`Log Config component renders empty log config 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -694,6 +695,7 @@ exports[`Log Config component renders with query 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {

--- a/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`Service Config component renders empty service config 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -1376,6 +1377,7 @@ exports[`Service Config component renders with one service selected 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {

--- a/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`Trace Config component renders empty trace config 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -2473,6 +2474,7 @@ exports[`Trace Config component renders with one trace selected 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {

--- a/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
+++ b/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
@@ -1169,6 +1169,7 @@ exports[`Panels View Component renders panel view container with visualizations 
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {
@@ -3078,6 +3079,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                         "getIsVisible$": [MockFunction],
                         "globalSearch": Object {
                           "getAllSearchCommands": [MockFunction],
+                          "unregisterSearchCommand": [MockFunction],
                         },
                         "logos": Object {
                           "AnimatedMark": Object {
@@ -3541,6 +3543,7 @@ exports[`Panels View Component renders panel view container without visualizatio
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {
@@ -5334,6 +5337,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                         "getIsVisible$": [MockFunction],
                         "globalSearch": Object {
                           "getAllSearchCommands": [MockFunction],
+                          "unregisterSearchCommand": [MockFunction],
                         },
                         "logos": Object {
                           "AnimatedMark": Object {

--- a/public/components/custom_panels/panel_modules/panel_grid/__tests__/__snapshots__/panel_grid.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/panel_grid/__tests__/__snapshots__/panel_grid.test.tsx.snap
@@ -179,6 +179,7 @@ exports[`Panel Grid Component renders panel grid component with empty visualizat
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {

--- a/public/components/metrics/view/__tests__/__snapshots__/metrics_grid.test.tsx.snap
+++ b/public/components/metrics/view/__tests__/__snapshots__/metrics_grid.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`Metrics Grid Component renders Metrics Grid Component 1`] = `
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {
@@ -211,6 +212,7 @@ exports[`Metrics Grid Component renders Metrics Grid Component 1`] = `
           "getIsVisible$": [MockFunction],
           "globalSearch": Object {
             "getAllSearchCommands": [MockFunction],
+            "unregisterSearchCommand": [MockFunction],
           },
           "logos": Object {
             "AnimatedMark": Object {

--- a/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/paragraphs.test.tsx.snap
+++ b/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/paragraphs.test.tsx.snap
@@ -156,23 +156,7 @@ exports[`<Paragraphs /> spec renders the component 1`] = `
               rel="noopener noreferrer"
               target="_blank"
             >
-               
-              SQL 
-              <svg
-                aria-hidden="true"
-                class="euiIcon euiIcon--small euiIcon-isLoading"
-                focusable="false"
-                height="16"
-                role="img"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                />
-              </svg>
-               
+              SQL
               <svg
                 aria-hidden="true"
                 aria-label="External link"
@@ -194,6 +178,7 @@ exports[`<Paragraphs /> spec renders the component 1`] = `
                 (opens in a new tab or window)
               </span>
             </a>
+             
              and 
             <a
               class="euiLink euiLink--primary"
@@ -201,22 +186,7 @@ exports[`<Paragraphs /> spec renders the component 1`] = `
               rel="noopener noreferrer"
               target="_blank"
             >
-               
-              PPL 
-              <svg
-                aria-hidden="true"
-                class="euiIcon euiIcon--small euiIcon-isLoading"
-                focusable="false"
-                height="16"
-                role="img"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                />
-              </svg>
+              PPL
               <svg
                 aria-hidden="true"
                 aria-label="External link"
@@ -238,6 +208,7 @@ exports[`<Paragraphs /> spec renders the component 1`] = `
                 (opens in a new tab or window)
               </span>
             </a>
+             
             .
           </div>
         </div>

--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -540,17 +540,19 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
   };
 
   const sqlIcon = (
-    <EuiLink href={SQL_DOCUMENTATION_URL} target="_blank">
-      {' '}
-      SQL <EuiIcon type="popout" size="s" />{' '}
-    </EuiLink>
+    <>
+      <EuiLink href={SQL_DOCUMENTATION_URL} target="_blank">
+        SQL
+      </EuiLink>{' '}
+    </>
   );
 
   const pplIcon = (
-    <EuiLink href={PPL_DOCUMENTATION_URL} target="_blank">
-      {' '}
-      PPL <EuiIcon type="popout" size="s" />
-    </EuiLink>
+    <>
+      <EuiLink href={PPL_DOCUMENTATION_URL} target="_blank">
+        PPL
+      </EuiLink>{' '}
+    </>
   );
 
   const paragraphLabel = !para.isVizualisation ? (

--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -477,7 +477,7 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
                 <EuiSmallButtonIcon
                   aria-label="Open paragraph menu"
                   iconType="boxesHorizontal"
-                  onClick={() => setIsPopoverOpen(true)}
+                  onClick={() => setIsPopoverOpen(!isPopoverOpen)}
                 />
               }
               isOpen={isPopoverOpen}

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`Dashboard component renders dashboard 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -410,6 +411,7 @@ exports[`Dashboard component renders dashboard 1`] = `
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {
@@ -2649,6 +2651,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -3023,6 +3026,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {
@@ -5261,6 +5265,7 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -5637,6 +5642,7 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`Services component renders empty services page 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -268,6 +269,7 @@ exports[`Services component renders empty services page 1`] = `
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {
@@ -3426,6 +3428,7 @@ exports[`Services component renders jaeger services page 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -3659,6 +3662,7 @@ exports[`Services component renders jaeger services page 1`] = `
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {
@@ -5927,6 +5931,7 @@ exports[`Services component renders services page 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -6159,6 +6164,7 @@ exports[`Services component renders services page 1`] = `
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`Traces component renders empty traces page 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -277,6 +278,7 @@ exports[`Traces component renders empty traces page 1`] = `
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {
@@ -2486,6 +2488,7 @@ exports[`Traces component renders jaeger traces page 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -2728,6 +2731,7 @@ exports[`Traces component renders jaeger traces page 1`] = `
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {
@@ -4775,6 +4779,7 @@ exports[`Traces component renders traces page 1`] = `
       "getIsVisible$": [MockFunction],
       "globalSearch": Object {
         "getAllSearchCommands": [MockFunction],
+        "unregisterSearchCommand": [MockFunction],
       },
       "logos": Object {
         "AnimatedMark": Object {
@@ -5016,6 +5021,7 @@ exports[`Traces component renders traces page 1`] = `
         "getIsVisible$": [MockFunction],
         "globalSearch": Object {
           "getAllSearchCommands": [MockFunction],
+          "unregisterSearchCommand": [MockFunction],
         },
         "logos": Object {
           "AnimatedMark": Object {


### PR DESCRIPTION
### Description
Fix a bug where the note books action pop-over would be stuck open if the button was clicked twice
Fix double pop-out icon

Before:

https://github.com/user-attachments/assets/ee7672cc-d877-4926-b146-52902bfbee93


After:

https://github.com/user-attachments/assets/773ac5b2-addd-4941-8023-5f9268febd47


Before:
<img width="1389" alt="Before" src="https://github.com/user-attachments/assets/5a822e83-e9c9-4db2-8d10-09a07857cd70" />

After:
<img width="1394" alt="After" src="https://github.com/user-attachments/assets/5692eef5-8520-4d70-bf24-f3fbccf1958d" />


### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/issues/1043

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
