### PR TITLE
Traces - Add "attributes" field

### DIFF
--- a/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
+++ b/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
@@ -171,13 +171,15 @@ describe('Trace analytics helper functions', () => {
   });
 
   describe('getAttributeFieldNames', () => {
-    it("should return only field names starting with 'resource.attributes' or 'span.attributes'", () => {
+    it("should return only field names starting with 'resource.attributes' or 'span.attributes' or 'attributes'", () => {
       const expectedFields = [
         'span.attributes.http@url',
         'span.attributes.net@peer@ip',
         'span.attributes.http@user_agent.keyword',
         'resource.attributes.telemetry@sdk@version.keyword',
         'resource.attributes.host@hostname.keyword',
+        'attributes.url',
+        'attributes.custom_field.keyword',
       ];
       const result = getAttributeFieldNames(fieldCapQueryResponse1);
       expect(result).toEqual(expectedFields);

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -581,7 +581,10 @@ export const filtersToDsl = (
 
 export const getAttributeFieldNames = (response: FieldCapResponse): string[] => {
   return Object.keys(response.fields).filter(
-    (field) => field.startsWith('resource.attributes') || field.startsWith('span.attributes')
+    (field) =>
+      field.startsWith('resource.attributes') ||
+      field.startsWith('span.attributes') ||
+      field.startsWith('attributes')
   );
 };
 

--- a/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
+++ b/public/components/trace_analytics/components/traces/trace_table_helpers.tsx
@@ -34,7 +34,7 @@ export const fetchDynamicColumns = (columnItems: string[]) => {
         </EuiText>
       ),
       align: 'right',
-      sortable: true,
+      sortable: false,
       truncateText: true,
       render: (item) =>
         item ? (

--- a/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
@@ -50,6 +50,26 @@ export function TracesCustomIndicesTable(props: TracesLandingTableProps) {
     onSort,
   } = props;
 
+  const resolveFieldValue = (item: any, field: string) => {
+    if (!item) return '-';
+
+    const matchPrefix = (prefix: string, container?: any) => {
+      if (field.startsWith(prefix) && container) {
+        const attr = field.slice(prefix.length);
+        return container[attr] ?? '-';
+      }
+      return null;
+    };
+
+    return (
+      matchPrefix('resource.attributes.', item.resource?.attributes) ??
+      matchPrefix('span.attributes.', item.attributes) ??
+      matchPrefix('attributes.', item.attributes) ??
+      item[field] ??
+      '-'
+    );
+  };
+
   const renderCellValue = useMemo(() => {
     return ({ rowIndex, columnId }: { rowIndex: number; columnId: string }) => {
       const isTracesMode = props.tracesTableMode === 'traces';
@@ -58,8 +78,8 @@ export function TracesCustomIndicesTable(props: TracesLandingTableProps) {
         : rowIndex - pagination.pageIndex * pagination.pageSize;
 
       if (!items.hasOwnProperty(adjustedRowIndex)) return '-';
-      const value = items[adjustedRowIndex]?.[columnId];
-
+      const value = resolveFieldValue(items[adjustedRowIndex], columnId);
+      // const value = items[adjustedRowIndex]?.[columnId];//old
       if (!value && columnId !== 'status.code' && columnId !== 'error_count') return '-';
 
       switch (columnId) {

--- a/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
@@ -79,7 +79,7 @@ export function TracesCustomIndicesTable(props: TracesLandingTableProps) {
 
       if (!items.hasOwnProperty(adjustedRowIndex)) return '-';
       const value = resolveFieldValue(items[adjustedRowIndex], columnId);
-      // const value = items[adjustedRowIndex]?.[columnId];//old
+
       if (!value && columnId !== 'status.code' && columnId !== 'error_count') return '-';
 
       switch (columnId) {

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -763,6 +763,20 @@ export const fieldCapQueryResponse1 = {
         aggregatable: false,
       },
     },
+    'attributes.url': {
+      text: {
+        type: 'text',
+        searchable: true,
+        aggregatable: false,
+      },
+    },
+    'attributes.custom_field.keyword': {
+      keyword: {
+        type: 'keyword',
+        searchable: true,
+        aggregatable: true,
+      },
+    },
   },
 };
 


### PR DESCRIPTION
### Description
1. Add "attributes" field to columns to support new OTEL format.
2. Disable sorting on attribute fields.
3. Update testing to reflect new accepted field.

Before on the new format (attributes)
<img width="1558" alt="Before" src="https://github.com/user-attachments/assets/6c9f163e-736e-43c9-b905-b0c25f57acd5" />

After on the new format (attributes)
<img width="1556" alt="After" src="https://github.com/user-attachments/assets/303ef800-dce8-4196-8400-e51dac69e124" />

Testing vrs old cluster (span.attributes)
<img width="1533" alt="WorkingwithOld" src="https://github.com/user-attachments/assets/191faf5e-585d-49ab-89d6-c3a17caa02d7" />

Testing vrs sample data (span.attributes)
<img width="1566" alt="SampleDataTest" src="https://github.com/user-attachments/assets/3df32afa-23a4-4186-9216-791d369f0dd6" />


### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
