### PR TITLE
Traces - Add traces unique count based on cardinality aggregation

### DIFF
--- a/public/components/trace_analytics/components/common/constants.tsx
+++ b/public/components/trace_analytics/components/common/constants.tsx
@@ -8,6 +8,8 @@ export const NANOS_TO_MS = 1e6;
 
 export const MILI_TO_SEC = 1000;
 
+export const MAX_DISPLAY_ROWS = 10000;
+
 export const pieChartColors = [
   '#7492e7',
   '#c33d69',

--- a/public/components/trace_analytics/components/common/shared_components/component_helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/component_helper_functions.tsx
@@ -36,13 +36,9 @@ export const useInjectElementsIntoGrid = (
           const warningDiv = document.createElement('div');
           warningDiv.className = 'trace-table-warning';
 
-          const strongElement = document.createElement('strong');
-          strongElement.textContent = `${Math.min(rowCount, maxDisplayRows)}`;
-
           const textSpan = document.createElement('span');
-          textSpan.appendChild(strongElement);
           const totalCountText = totalCount > maxDisplayRows ? `${maxDisplayRows}+` : totalCount;
-          textSpan.appendChild(document.createTextNode(` results out of ${totalCountText}`));
+          textSpan.appendChild(document.createTextNode(`Results out of ${totalCountText}`));
 
           warningDiv.appendChild(textSpan);
 

--- a/public/components/trace_analytics/components/common/shared_components/component_helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/component_helper_functions.tsx
@@ -5,23 +5,23 @@
 
 import { useEffect } from 'react';
 
-// Injects the size warning and Load buttons into the corners of EUI Data Grid
+// Injects Size warning and Load more button into the corners of EUI Data Grid
+// 1. When rowCount > maxDisplayRows, show warning (some data is hidden)
+// 2. When rowCount < totalCount, show warning (more data to load), and Load more button when isLastPage is true
 export const useInjectElementsIntoGrid = (
   rowCount: number,
   maxDisplayRows: number,
-  tracesTableMode: string,
+  totalCount: number,
   loadMoreHandler?: () => void,
-  maxTraces?: number,
   isLastPage?: boolean
 ) => {
   useEffect(() => {
     setTimeout(() => {
+      const moreToShow = rowCount > maxDisplayRows;
+      const moreToLoad = rowCount < totalCount;
+      const shouldShowWarning = moreToShow || moreToLoad;
+
       const toolbar = document.querySelector<HTMLElement>('.euiDataGrid__controls');
-
-      const shouldShowWarning =
-        (tracesTableMode === 'traces' && maxTraces != null && maxTraces < rowCount) ||
-        (tracesTableMode !== 'traces' && rowCount > maxDisplayRows);
-
       if (toolbar) {
         const existingWarning = toolbar.querySelector('.trace-table-warning');
         if (existingWarning) {
@@ -37,13 +37,12 @@ export const useInjectElementsIntoGrid = (
           warningDiv.className = 'trace-table-warning';
 
           const strongElement = document.createElement('strong');
-          strongElement.textContent =
-            tracesTableMode === 'traces' ? `${maxTraces ?? maxDisplayRows}` : `${maxDisplayRows}`;
+          strongElement.textContent = `${Math.min(rowCount, maxDisplayRows)}`;
 
           const textSpan = document.createElement('span');
           textSpan.appendChild(strongElement);
           textSpan.appendChild(document.createTextNode(' results shown out of '));
-          textSpan.appendChild(document.createTextNode(` ${rowCount}`));
+          textSpan.appendChild(document.createTextNode(` ${totalCount}`));
 
           warningDiv.appendChild(textSpan);
 
@@ -52,37 +51,32 @@ export const useInjectElementsIntoGrid = (
       }
 
       const pagination = document.querySelector<HTMLElement>('.euiDataGrid__pagination');
-      const existingLoadMoreButton = pagination?.querySelector('.trace-table-load-more');
+      if (pagination) {
+        pagination.style.display = 'flex';
+        pagination.style.alignItems = 'center';
+        pagination.style.justifyContent = 'space-between';
 
-      if (tracesTableMode !== 'traces' || !pagination || !loadMoreHandler || !isLastPage) {
+        const existingLoadMoreButton = pagination.querySelector('.trace-table-load-more');
         if (existingLoadMoreButton) {
           existingLoadMoreButton.remove();
         }
-        return;
-      }
 
-      pagination.style.display = 'flex';
-      pagination.style.alignItems = 'center';
-      pagination.style.justifyContent = 'space-between';
+        if (moreToLoad && loadMoreHandler && isLastPage) {
+          const loadMoreButton = document.createElement('button');
+          loadMoreButton.className = 'trace-table-load-more euiButtonEmpty euiButtonEmpty--text';
+          loadMoreButton.style.marginLeft = '12px';
+          loadMoreButton.innerText = '... Load more';
+          loadMoreButton.onclick = () => loadMoreHandler();
 
-      let loadMoreButton = pagination.querySelector<HTMLElement>('.trace-table-load-more');
-      if (!loadMoreButton) {
-        loadMoreButton = document.createElement('button');
-        loadMoreButton.className = 'trace-table-load-more euiButtonEmpty euiButtonEmpty--text';
-        loadMoreButton.style.marginLeft = '12px';
-        loadMoreButton.innerText = '... Load more';
-
-        loadMoreButton.onclick = () => loadMoreHandler();
-
-        const paginationList = pagination.querySelector('.euiPagination__list');
-
-        if (paginationList) {
-          const listItem = document.createElement('li');
-          listItem.className = 'euiPagination__item trace-table-load-more';
-          listItem.appendChild(loadMoreButton);
-          paginationList.appendChild(listItem);
+          const paginationList = pagination.querySelector('.euiPagination__list');
+          if (paginationList) {
+            const listItem = document.createElement('li');
+            listItem.className = 'euiPagination__item trace-table-load-more';
+            listItem.appendChild(loadMoreButton);
+            paginationList.appendChild(listItem);
+          }
         }
       }
     }, 100);
-  }, [rowCount, tracesTableMode, loadMoreHandler, maxTraces, maxDisplayRows, isLastPage]);
+  }, [rowCount, maxDisplayRows, totalCount, loadMoreHandler, isLastPage]);
 };

--- a/public/components/trace_analytics/components/common/shared_components/component_helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/component_helper_functions.tsx
@@ -40,10 +40,9 @@ export const useInjectElementsIntoGrid = (
           strongElement.textContent = `${Math.min(rowCount, maxDisplayRows)}`;
 
           const textSpan = document.createElement('span');
-          textSpan.appendChild(document.createTextNode('Showing '));
           textSpan.appendChild(strongElement);
           const totalCountText = totalCount > maxDisplayRows ? `${maxDisplayRows}+` : totalCount;
-          textSpan.appendChild(document.createTextNode(` of ${totalCountText} results`));
+          textSpan.appendChild(document.createTextNode(` results out of ${totalCountText}`));
 
           warningDiv.appendChild(textSpan);
 

--- a/public/components/trace_analytics/components/common/shared_components/component_helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/component_helper_functions.tsx
@@ -40,9 +40,10 @@ export const useInjectElementsIntoGrid = (
           strongElement.textContent = `${Math.min(rowCount, maxDisplayRows)}`;
 
           const textSpan = document.createElement('span');
+          textSpan.appendChild(document.createTextNode('Showing '));
           textSpan.appendChild(strongElement);
-          textSpan.appendChild(document.createTextNode(' results shown out of '));
-          textSpan.appendChild(document.createTextNode(` ${totalCount}`));
+          const totalCountText = totalCount > maxDisplayRows ? `${maxDisplayRows}+` : totalCount;
+          textSpan.appendChild(document.createTextNode(` of ${totalCountText} results`));
 
           warningDiv.appendChild(textSpan);
 

--- a/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
@@ -91,9 +91,9 @@ interface RenderCustomDataGridParams {
   isTableDataLoading?: boolean;
   tracesTableMode?: string;
   setTracesTableMode?: (mode: string) => void;
-  maxTraces: number;
-  setMaxTraces: React.Dispatch<React.SetStateAction<number>>;
-  uniqueTraces: number;
+  maxTraces?: number;
+  setMaxTraces?: React.Dispatch<React.SetStateAction<number>>;
+  uniqueTraces?: number;
 }
 
 /**
@@ -123,9 +123,9 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
   isTableDataLoading,
   tracesTableMode,
   setTracesTableMode,
-  maxTraces,
+  maxTraces = 0,
   setMaxTraces,
-  uniqueTraces,
+  uniqueTraces = 0,
 }) => {
   const defaultVisibleColumns = useMemo(() => {
     return columns
@@ -167,7 +167,7 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
     isTracesMode ? uniqueTraces : rowCount,
     isTracesMode
       ? () => {
-          setMaxTraces((prevMax: number) =>
+          setMaxTraces?.((prevMax: number) =>
             Math.min(prevMax + 500, uniqueTraces, MAX_DISPLAY_ROWS)
           );
         }

--- a/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
+++ b/public/components/trace_analytics/components/common/shared_components/custom_datagrid.tsx
@@ -31,8 +31,8 @@ import {
 } from '../../../../../../common/constants/trace_analytics';
 import { useInjectElementsIntoGrid } from './component_helper_functions';
 import { uiSettingsService } from '../../../../../../common/utils';
+import { MAX_DISPLAY_ROWS } from '../constants';
 
-const MAX_DISPLAY_ROWS = 10000;
 interface FullScreenWrapperProps {
   children: React.ReactNode;
   onClose: () => void;
@@ -96,6 +96,18 @@ interface RenderCustomDataGridParams {
   uniqueTraces: number;
 }
 
+/**
+ * A custom data grid component that supports two distinct modes of operation:
+ * 1. All spans mode (all_spans, root_spans, entry_spans): Displays all rows at once, limited to MAX_DISPLAY_ROWS
+ * 2. Traces mode: Implements lazy loading by initially limiting rows to maxTraces, with ability to load more
+ *    traces incrementally up to MAX_DISPLAY_ROWS
+ *
+ * Key properties:
+ * - tracesTableMode: Current mode of the table ('traces', 'all_spans', 'root_spans', or 'entry_spans')
+ * - rowCount: Total number of hits returned from the query for all_spans, root_spans, entry_spans modes (0 if traces mode)
+ * - uniqueTraces: Total number of unique traces returned from the query when in traces mode (0 if all_spans, root_spans, or entry_spans mode)
+ * - maxTraces: Current number of traces is being displayed in the grid (can be increased to load more traces)
+ */
 export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
   columns,
   renderCellValue,
@@ -128,10 +140,11 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
   const [isFullScreen, setIsFullScreen] = useState(fullScreen);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  const displayedRowCount =
-    tracesTableMode === 'traces'
-      ? Math.min(maxTraces, uniqueTraces, MAX_DISPLAY_ROWS)
-      : Math.min(rowCount, MAX_DISPLAY_ROWS);
+  const isTracesMode = tracesTableMode === 'traces';
+  const isEmpty = isTracesMode ? uniqueTraces === 0 : rowCount === 0;
+  const displayedRowCount = isTracesMode
+    ? Math.min(maxTraces, uniqueTraces, MAX_DISPLAY_ROWS)
+    : Math.min(rowCount, MAX_DISPLAY_ROWS);
 
   const isDarkMode = uiSettingsService.get('theme:darkMode');
 
@@ -141,25 +154,25 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
       )
     : [];
 
-  const isLastPage = Boolean(
+  const isTracesModeLastPage = Boolean(
     pagination?.pageSize &&
       (pagination.pageIndex + 1) * pagination.pageSize >= maxTraces &&
-      rowCount > maxTraces &&
+      uniqueTraces > maxTraces &&
       maxTraces < MAX_DISPLAY_ROWS
   );
 
   useInjectElementsIntoGrid(
     displayedRowCount,
     MAX_DISPLAY_ROWS,
-    tracesTableMode === 'traces' ? uniqueTraces : rowCount,
-    tracesTableMode === 'traces'
+    isTracesMode ? uniqueTraces : rowCount,
+    isTracesMode
       ? () => {
           setMaxTraces((prevMax: number) =>
             Math.min(prevMax + 500, uniqueTraces, MAX_DISPLAY_ROWS)
           );
         }
       : undefined,
-    tracesTableMode === 'traces' ? isLastPage : false
+    isTracesMode ? isTracesModeLastPage : false
   );
 
   const disableInteractions = useMemo(() => isFullScreen, [isFullScreen]);
@@ -277,7 +290,7 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
             .join(' ')}
           style={{
             position: 'relative',
-            minHeight: isTableDataLoading && rowCount === 0 ? '100px' : undefined,
+            minHeight: isTableDataLoading && isEmpty ? '100px' : undefined,
           }}
         >
           <EuiDataGrid
@@ -315,7 +328,7 @@ export const RenderCustomDataGrid: React.FC<RenderCustomDataGridParams> = ({
           )}
         </div>
       </FullScreenWrapper>
-      {rowCount === 0 && <NoMatchMessage size={noMatchMessageSize} />}
+      {isEmpty && <NoMatchMessage size={noMatchMessageSize} />}
     </>
   );
 };

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -1476,6 +1476,7 @@ exports[`Traces component renders empty traces page 1`] = `
               mode="data_prepper"
               page="traces"
               refresh={[Function]}
+              uniqueTraces={0}
             >
               <EuiPanel>
                 <div
@@ -3935,6 +3936,7 @@ exports[`Traces component renders jaeger traces page 1`] = `
               mode="jaeger"
               page="traces"
               refresh={[Function]}
+              uniqueTraces={0}
             >
               <EuiPanel>
                 <div
@@ -6223,6 +6225,7 @@ exports[`Traces component renders traces page 1`] = `
               mode="data_prepper"
               page="traces"
               refresh={[Function]}
+              uniqueTraces={0}
             >
               <EuiPanel>
                 <div

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -313,8 +313,7 @@ export function TracesContent(props: TracesProps) {
       maxTraces,
       props.dataSourceMDSId[0].id,
       sort,
-      isUnderOneHour,
-      setTotalHits
+      isUnderOneHour
     ).finally(() => setIsTraceTableLoading(false));
   };
 
@@ -381,7 +380,6 @@ export function TracesContent(props: TracesProps) {
               props.dataSourceMDSId[0].id,
               newSort,
               isUnderOneHour,
-              setTotalHits,
               setUniqueTraces
             );
       tracesRequest.finally(() => setIsTraceTableLoading(false));
@@ -407,7 +405,6 @@ export function TracesContent(props: TracesProps) {
         props.dataSourceMDSId[0].id,
         sort,
         isUnderOneHour,
-        undefined,
         setUniqueTraces
       ).finally(() => setIsTraceTableLoading(false));
     }

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -72,6 +72,7 @@ export function TracesContent(props: TracesProps) {
   const [includeMetrics, setIncludeMetrics] = useState(false);
   const isNavGroupEnabled = coreRefs?.chrome?.navGroup.getNavGroupEnabled();
   const [maxTraces, setMaxTraces] = useState(500);
+  const [uniqueTraces, setUniqueTraces] = useState(0);
   const [sortingColumns, setSortingColumns] = useState<
     Array<{ id: string; direction: 'desc' | 'asc' }>
   >([]);
@@ -384,7 +385,8 @@ export function TracesContent(props: TracesProps) {
               props.dataSourceMDSId[0].id,
               newSort,
               isUnderOneHour,
-              setTotalHits
+              setTotalHits,
+              setUniqueTraces
             );
       tracesRequest.finally(() => setIsTraceTableLoading(false));
 
@@ -408,7 +410,9 @@ export function TracesContent(props: TracesProps) {
         maxTraces,
         props.dataSourceMDSId[0].id,
         sort,
-        isUnderOneHour
+        isUnderOneHour,
+        undefined,
+        setUniqueTraces
       ).finally(() => setIsTraceTableLoading(false));
     }
   };
@@ -479,6 +483,7 @@ export function TracesContent(props: TracesProps) {
               onSort={onSort}
               maxTraces={maxTraces}
               setMaxTraces={setMaxTraces}
+              uniqueTraces={uniqueTraces}
             />
           ) : (
             <TracesTable
@@ -491,6 +496,7 @@ export function TracesContent(props: TracesProps) {
               jaegerIndicesExist={jaegerIndicesExist}
               dataPrepperIndicesExist={dataPrepperIndicesExist}
               page={page}
+              uniqueTraces={uniqueTraces}
             />
           )}
 

--- a/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_custom_indices_table.tsx
@@ -35,6 +35,7 @@ interface TracesLandingTableProps {
   onSort: (columns: Array<{ id: string; direction: 'desc' | 'asc' }>) => void;
   maxTraces: number;
   setMaxTraces: React.Dispatch<React.SetStateAction<number>>;
+  uniqueTraces: number;
 }
 
 export function TracesCustomIndicesTable(props: TracesLandingTableProps) {
@@ -151,6 +152,7 @@ export function TracesCustomIndicesTable(props: TracesLandingTableProps) {
             setTracesTableMode={(mode) => props.setTracesTableMode(mode as TraceQueryMode)}
             maxTraces={props.maxTraces}
             setMaxTraces={props.setMaxTraces}
+            uniqueTraces={props.uniqueTraces}
           />
         ) : (
           <NoMatchMessage size="xl" mode={props.mode} />

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -30,6 +30,7 @@ import {
   NoMatchMessage,
   PanelTitle,
 } from '../common/helper_functions';
+import { MAX_DISPLAY_ROWS } from '../common/constants';
 
 interface TracesTableProps {
   items: any[];
@@ -47,6 +48,8 @@ interface TracesTableProps {
 export function TracesTable(props: TracesTableProps) {
   const { items, refresh, mode, loading, getTraceViewUri, openTraceFlyout, uniqueTraces } = props;
   const renderTitleBar = (rowCount: number, totalCount: number) => {
+    const totalCountText = totalCount > MAX_DISPLAY_ROWS ? `${MAX_DISPLAY_ROWS}+` : totalCount;
+
     return (
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={10}>
@@ -54,7 +57,7 @@ export function TracesTable(props: TracesTableProps) {
         </EuiFlexItem>
         {totalCount > rowCount && (
           <span className="trace-table-warning">
-            {`${rowCount} results shown out of ${totalCount}`}
+            {`${rowCount} results out of ${totalCountText}`}
           </span>
         )}
       </EuiFlexGroup>

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -56,9 +56,7 @@ export function TracesTable(props: TracesTableProps) {
           <PanelTitle title="Traces" totalItems={rowCount} />
         </EuiFlexItem>
         {totalCount > rowCount && (
-          <span className="trace-table-warning">
-            {`${rowCount} results out of ${totalCountText}`}
-          </span>
+          <span className="trace-table-warning">{`Results out of ${totalCountText}`}</span>
         )}
       </EuiFlexGroup>
     );

--- a/public/components/trace_analytics/components/traces/traces_table.tsx
+++ b/public/components/trace_analytics/components/traces/traces_table.tsx
@@ -41,16 +41,22 @@ interface TracesTableProps {
   jaegerIndicesExist: boolean;
   dataPrepperIndicesExist: boolean;
   page?: 'traces' | 'app';
+  uniqueTraces: number;
 }
 
 export function TracesTable(props: TracesTableProps) {
-  const { items, refresh, mode, loading, getTraceViewUri, openTraceFlyout } = props;
-  const renderTitleBar = (totalItems?: number) => {
+  const { items, refresh, mode, loading, getTraceViewUri, openTraceFlyout, uniqueTraces } = props;
+  const renderTitleBar = (rowCount: number, totalCount: number) => {
     return (
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={10}>
-          <PanelTitle title="Traces" totalItems={totalItems} />
+          <PanelTitle title="Traces" totalItems={rowCount} />
         </EuiFlexItem>
+        {totalCount > rowCount && (
+          <span className="trace-table-warning">
+            {`${rowCount} results shown out of ${totalCount}`}
+          </span>
+        )}
       </EuiFlexGroup>
     );
   };
@@ -228,7 +234,10 @@ export function TracesTable(props: TracesTableProps) {
     }
   }, [items]);
 
-  const titleBar = useMemo(() => renderTitleBar(items?.length), [items]);
+  const titleBar = useMemo(() => renderTitleBar(items?.length, uniqueTraces), [
+    items,
+    uniqueTraces,
+  ]);
 
   const [sorting, setSorting] = useState<{ sort: PropertySort }>({
     sort: {

--- a/public/components/trace_analytics/requests/queries/traces_queries.ts
+++ b/public/components/trace_analytics/requests/queries/traces_queries.ts
@@ -135,6 +135,11 @@ export const getTracesQuery = (
       },
     },
     aggs: {
+      unique_traces: {
+        cardinality: {
+          field: 'traceId',
+        },
+      },
       traces: {
         terms: {
           field: 'traceId',

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -115,7 +115,8 @@ export const handleTracesRequest = async (
   dataSourceMDSId?: string,
   sort?: PropertySort,
   isUnderOneHour?: boolean,
-  setTotalHits?: (count: number) => void
+  setTotalHits?: (count: number) => void,
+  setUniqueTraces?: (count: number) => void
 ) => {
   const binarySearch = (arr: number[], target: number) => {
     if (!arr) return Number.NaN;
@@ -200,6 +201,11 @@ export const handleTracesRequest = async (
 
       if (setTotalHits && totalHitsResult?.status === 'fulfilled') {
         setTotalHits(totalHitsResult.value);
+      }
+
+      if (setUniqueTraces) {
+        const uniqueTraces = response?.aggregations?.unique_traces?.value ?? 0;
+        setUniqueTraces(uniqueTraces);
       }
 
       if (

--- a/public/components/trace_analytics/requests/traces_request_handler.ts
+++ b/public/components/trace_analytics/requests/traces_request_handler.ts
@@ -8,7 +8,6 @@ import { isArray, isObject } from 'lodash';
 import get from 'lodash/get';
 import omitBy from 'lodash/omitBy';
 import round from 'lodash/round';
-import cloneDeep from 'lodash/cloneDeep';
 import moment from 'moment';
 import { v1 as uuid } from 'uuid';
 import { HttpSetup } from '../../../../../../src/core/public';
@@ -115,7 +114,6 @@ export const handleTracesRequest = async (
   dataSourceMDSId?: string,
   sort?: PropertySort,
   isUnderOneHour?: boolean,
-  setTotalHits?: (count: number) => void,
   setUniqueTraces?: (count: number) => void
 ) => {
   const binarySearch = (arr: number[], target: number) => {
@@ -159,37 +157,10 @@ export const handleTracesRequest = async (
         })
       : Promise.resolve({});
 
-  let rootSpansTotalHitsPromise: Promise<number> | undefined;
-
-  if (setTotalHits && (mode === 'data_prepper' || mode === 'custom_data_prepper')) {
-    const rootSpansDSL = cloneDeep(timeFilterDSL);
-    rootSpansDSL.query.bool.filter.push({
-      term: {
-        parentSpanId: '',
-      },
-    });
-
-    const rootSpansQuery = {
-      size: 0,
-      query: rootSpansDSL.query,
-      index: getTracesQuery(mode).index,
-      track_total_hits: true, // Override default 10,000 cap
-    };
-
-    rootSpansTotalHitsPromise = handleDslRequest(
-      http,
-      {},
-      rootSpansQuery,
-      mode,
-      dataSourceMDSId
-    ).then((res) => res?.hits?.total?.value ?? 0);
-  }
-
   const promises = [responsePromise, percentileRangesPromise];
-  if (rootSpansTotalHitsPromise) promises.push(rootSpansTotalHitsPromise);
 
   return Promise.allSettled(promises)
-    .then(([responseResult, percentileRangesResult, totalHitsResult]) => {
+    .then(([responseResult, percentileRangesResult]) => {
       if (responseResult.status === 'rejected') {
         setItems([]);
         return;
@@ -198,10 +169,6 @@ export const handleTracesRequest = async (
       const percentileRanges =
         percentileRangesResult.status === 'fulfilled' ? percentileRangesResult.value : {};
       const response = responseResult.value;
-
-      if (setTotalHits && totalHitsResult?.status === 'fulfilled') {
-        setTotalHits(totalHitsResult.value);
-      }
 
       if (setUniqueTraces) {
         const uniqueTraces = response?.aggregations?.unique_traces?.value ?? 0;


### PR DESCRIPTION
### Description
- Count unique traces using a cardinality aggregation on `traceId`.
- Use the unique trace count values for both `data_prepper` and `custom_data_prepper`.
- Display "warning" in the `data_prepper` view if there are more trace records than are currently shown.


https://github.com/user-attachments/assets/15403ce6-e6be-4a74-bb67-2e3a21060c7c



### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
