### PR TITLE
Traces - Custom Traces mode pagination reset

### DIFF
--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -218,10 +218,6 @@ export function TracesContent(props: TracesProps) {
   }, [maxTraces]);
 
   useEffect(() => {
-    setPageIndex(0);
-  }, [tracesTableMode]);
-
-  useEffect(() => {
     if (mode !== 'custom_data_prepper') {
       setMaxTraces(500);
     }
@@ -473,6 +469,7 @@ export function TracesContent(props: TracesProps) {
               setTracesTableMode={(tableMode) => {
                 setTracesTableMode(tableMode);
                 setSortingColumns([]);
+                setPageIndex(0);
               }}
               sorting={sortingColumns}
               pagination={pagination}


### PR DESCRIPTION
### Description
The pagination for custom sources was not being reset when mode was switched as the react-state in the use effect was updating after the query was ran.

Before:

https://github.com/user-attachments/assets/620c0ce8-ec89-4166-b0a3-e2a2a6a1a288


After:

https://github.com/user-attachments/assets/d84c3978-1e8c-4630-b5ef-e3c5908dfd20


### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/issues/2436

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
