### PR TITLE
[Traces] Span Flyout - support new format

### DIFF
--- a/public/components/trace_analytics/components/traces/__tests__/span_detail_flyout.test.tsx
+++ b/public/components/trace_analytics/components/traces/__tests__/span_detail_flyout.test.tsx
@@ -11,8 +11,9 @@ import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import { HttpResponse } from '../../../../../../../../src/core/public';
 import { TEST_SPAN_RESPONSE } from '../../../../../../test/constants';
+// eslint-disable-next-line jest/no-mocks-import
 import httpClientMock from '../../../../../../test/__mocks__/httpClientMock';
-import { SpanDetailFlyout , flattenObject } from '../span_detail_flyout';
+import { SpanDetailFlyout, flattenObject } from '../span_detail_flyout';
 
 describe('<SpanDetailFlyout /> spec', () => {
   configure({ adapter: new Adapter() });
@@ -43,7 +44,7 @@ describe('<SpanDetailFlyout /> spec', () => {
     httpClientMock.post = jest.fn(() =>
       Promise.resolve((TEST_SPAN_RESPONSE as unknown) as HttpResponse)
     );
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     const closeFlyout = jest.fn();
     const addSpanFilter = jest.fn();
     await act(() => {
@@ -124,8 +125,7 @@ describe('flattenObject', () => {
     const actual = flattenObject(sample);
     const expected = {
       traceId: '005cf53c07193a497fae2aa9ebedb8d3',
-      'instrumentationScope.name':
-        '@opentelemetry/instrumentation-http',
+      'instrumentationScope.name': '@opentelemetry/instrumentation-http',
       'instrumentationScope.version': '0.57.1',
       'resource.attributes.service.name': 'frontend',
       'resource.attributes.host.name': '1e4c87e3bcaf',

--- a/public/components/trace_analytics/components/traces/__tests__/span_detail_flyout.test.tsx
+++ b/public/components/trace_analytics/components/traces/__tests__/span_detail_flyout.test.tsx
@@ -12,7 +12,7 @@ import { act } from 'react-dom/test-utils';
 import { HttpResponse } from '../../../../../../../../src/core/public';
 import { TEST_SPAN_RESPONSE } from '../../../../../../test/constants';
 import httpClientMock from '../../../../../../test/__mocks__/httpClientMock';
-import { SpanDetailFlyout } from '../span_detail_flyout';
+import { SpanDetailFlyout , flattenObject } from '../span_detail_flyout';
 
 describe('<SpanDetailFlyout /> spec', () => {
   configure({ adapter: new Adapter() });
@@ -60,5 +60,79 @@ describe('<SpanDetailFlyout /> spec', () => {
       );
     });
     expect(container).toMatchSnapshot();
+  });
+});
+
+describe('flattenObject', () => {
+  it('flattens a simple nested object', () => {
+    const input = {
+      a: {
+        b: 1,
+        c: { d: 2 },
+      },
+      e: 3,
+    };
+
+    const expected = {
+      'a.b': 1,
+      'a.c.d': 2,
+      e: 3,
+    };
+
+    expect(flattenObject(input)).toEqual(expected);
+  });
+
+  it('treats arrays as values without recursing into them', () => {
+    const input = {
+      arr: [1, 2],
+      nested: {
+        x: [3, 4],
+        y: { z: 5 },
+      },
+    };
+
+    const expected = {
+      arr: [1, 2],
+      'nested.x': [3, 4],
+      'nested.y.z': 5,
+    };
+
+    expect(flattenObject(input)).toEqual(expected);
+  });
+
+  it('flattens a sample span _source object with multiple levels of nesting', () => {
+    const sample = {
+      traceId: '005cf53c07193a497fae2aa9ebedb8d3',
+      instrumentationScope: {
+        name: '@opentelemetry/instrumentation-http',
+        version: '0.57.1',
+      },
+      resource: {
+        attributes: {
+          'service.name': 'frontend',
+          'host.name': '1e4c87e3bcaf',
+        },
+      },
+      attributes: {
+        'http.method': 'GET',
+        nested: {
+          deep: true,
+        },
+      },
+    };
+
+    const actual = flattenObject(sample);
+    const expected = {
+      traceId: '005cf53c07193a497fae2aa9ebedb8d3',
+      'instrumentationScope.name':
+        '@opentelemetry/instrumentation-http',
+      'instrumentationScope.version': '0.57.1',
+      'resource.attributes.service.name': 'frontend',
+      'resource.attributes.host.name': '1e4c87e3bcaf',
+      'attributes.http.method': 'GET',
+      'attributes.nested.deep': true,
+    };
+
+    expect(actual).toEqual(expected);
   });
 });

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -74,6 +74,31 @@ const getSpanValue = (span: object, mode: TraceAnalyticsMode, field: SpanField) 
   return get(span, fieldKey);
 };
 
+// Flatten nested objects with dot notation
+const flattenObject = (
+  obj: any,
+  prefix = '',
+  result: Record<string, any> = {}
+): Record<string, any> => {
+  for (const key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      const newKey = prefix ? `${prefix}.${key}` : key;
+
+      if (obj[key] !== null && typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
+        flattenObject(obj[key], newKey, result);
+      } else {
+        result[newKey] = obj[key];
+      }
+    }
+  }
+  return result;
+};
+
+// Get all span attributes including nested ones
+const getAllSpanAttributes = (span: any): Record<string, any> => {
+  return flattenObject(span);
+};
+
 export function SpanDetailFlyout(props: {
   http: HttpSetup;
   spanId: string;
@@ -267,18 +292,20 @@ export function SpanDetailFlyout(props: {
       'traceGroupFields.statusCode',
       'traceGroupFields.durationInNanos',
     ]);
-    const attributesList = Object.keys(span)
+    const allAttributes = getAllSpanAttributes(span);
+
+    const attributesList = Object.keys(allAttributes)
       .filter((key) => !ignoredKeys.has(key))
       .sort((keyA, keyB) => {
-        const isANull = _isEmpty(span[keyA]);
-        const isBNull = _isEmpty(span[keyB]);
+        const isANull = _isEmpty(allAttributes[keyA]);
+        const isBNull = _isEmpty(allAttributes[keyB]);
         if ((isANull && isBNull) || (!isANull && !isBNull)) return keyA < keyB ? -1 : 1;
         if (isANull) return 1;
         return -1;
       })
       .map((key) => {
-        if (_isEmpty(span[key])) return getListItem(key, key, '-');
-        let value = span[key];
+        if (_isEmpty(allAttributes[key])) return getListItem(key, key, '-');
+        let value = allAttributes[key];
         if (typeof value === 'object') value = JSON.stringify(value);
         return getListItem(key, key, value);
       });

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -299,10 +299,28 @@ export function SpanDetailFlyout(props: {
         return -1;
       })
       .map((key) => {
-        if (_isEmpty(allAttributes[key])) return getListItem(key, key, '-');
+        if (_isEmpty(allAttributes[key])) {
+          return (
+            <FlyoutListItem
+              title={key}
+              description="-"
+              key={`list-item-${key}`}
+              addSpanFilter={() => props.addSpanFilter(key, allAttributes[key])}
+            />
+          );
+        }
+
         let value = allAttributes[key];
         if (typeof value === 'object') value = JSON.stringify(value);
-        return getListItem(key, key, value);
+
+        return (
+          <FlyoutListItem
+            title={key}
+            description={value}
+            key={`list-item-${key}`}
+            addSpanFilter={() => props.addSpanFilter(key, allAttributes[key])}
+          />
+        );
       });
 
     const eventsComponent = isEmpty(span.events) ? null : (

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -75,7 +75,7 @@ const getSpanValue = (span: object, mode: TraceAnalyticsMode, field: SpanField) 
 };
 
 // Flatten nested objects with dot notation
-const flattenObject = (
+export const flattenObject = (
   obj: any,
   prefix = '',
   result: Record<string, any> = {}
@@ -92,11 +92,6 @@ const flattenObject = (
     }
   }
   return result;
-};
-
-// Get all span attributes including nested ones
-const getAllSpanAttributes = (span: any): Record<string, any> => {
-  return flattenObject(span);
 };
 
 export function SpanDetailFlyout(props: {
@@ -292,7 +287,7 @@ export function SpanDetailFlyout(props: {
       'traceGroupFields.statusCode',
       'traceGroupFields.durationInNanos',
     ]);
-    const allAttributes = getAllSpanAttributes(span);
+    const allAttributes = flattenObject(span);
 
     const attributesList = Object.keys(allAttributes)
       .filter((key) => !ignoredKeys.has(key))

--- a/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_flyout.tsx
@@ -135,7 +135,9 @@ export function SpanDetailFlyout(props: {
         description={description}
         key={`list-item-${title}`}
         addSpanFilter={
-          fieldKey ? () => props.addSpanFilter(fieldKey, get(span, fieldKey)) : undefined
+          fieldKey
+            ? () => props.addSpanFilter(fieldKey, get(flattenObject(span), fieldKey))
+            : undefined
         }
       />
     );
@@ -299,28 +301,10 @@ export function SpanDetailFlyout(props: {
         return -1;
       })
       .map((key) => {
-        if (_isEmpty(allAttributes[key])) {
-          return (
-            <FlyoutListItem
-              title={key}
-              description="-"
-              key={`list-item-${key}`}
-              addSpanFilter={() => props.addSpanFilter(key, allAttributes[key])}
-            />
-          );
-        }
-
+        if (_isEmpty(allAttributes[key])) return getListItem(key, key, '-');
         let value = allAttributes[key];
         if (typeof value === 'object') value = JSON.stringify(value);
-
-        return (
-          <FlyoutListItem
-            title={key}
-            description={value}
-            key={`list-item-${key}`}
-            addSpanFilter={() => props.addSpanFilter(key, allAttributes[key])}
-          />
-        );
+        return getListItem(key, key, value);
       });
 
     const eventsComponent = isEmpty(span.events) ? null : (


### PR DESCRIPTION
### Description
[Traces] Span Flyout - support new format
1. New DataPrepper format has nested fields that need to be flattened for the span detail fly-out to show up correctly and allow filters to be added. This change supports the old format as well as the new format.

2. Fixes a bug where the ignore fields were being shown if nested in the old format. ie traceGroupFields:endtime

Problem:
<img width="373" alt="Screenshot 2025-06-02 at 2 33 52 PM" src="https://github.com/user-attachments/assets/4ed04ae7-a66e-4317-8feb-bf7ebe0d082c" />


Old format before:

https://github.com/user-attachments/assets/f51a1866-135d-4b25-80c1-0c22d75f1aa5


Old format after:

https://github.com/user-attachments/assets/f765cf79-a2fd-4d1b-9618-23f286d0e52b


New format before:

https://github.com/user-attachments/assets/25581dc4-c29a-4fd0-9977-6fdac73b2ca3


New format after:

https://github.com/user-attachments/assets/f465efc7-49d3-4b60-8609-1d4fc337a2ba


### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
