### PR TITLE
Workflows - Version bump to 3.1.0

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 env:
   PLUGIN_NAME: dashboards-observability
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_PLUGIN_VERSION: '3.0.0.0-beta1'
+  OPENSEARCH_PLUGIN_VERSION: '3.1.0.0'
 
 jobs:
   Get-CI-Image-Tag:

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -5,8 +5,8 @@ on: [pull_request, push]
 env:
   PLUGIN_NAME: dashboards-observability
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-beta1'
-  OPENSEARCH_PLUGIN_VERSION: '3.0.0.0-beta1'
+  OPENSEARCH_VERSION: '3.1.0'
+  OPENSEARCH_PLUGIN_VERSION: '3.1.0.0'
 
 jobs:
   tests:

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -5,8 +5,8 @@ on: [pull_request, push]
 env:
   PLUGIN_NAME: dashboards-observability
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-beta1'
-  OPENSEARCH_PLUGIN_VERSION: '3.0.0.0-beta1'
+  OPENSEARCH_VERSION: '3.1.0'
+  OPENSEARCH_PLUGIN_VERSION: '3.1.0.0'
 
 jobs:
   tests:

--- a/.github/workflows/verify-binary-install.yml
+++ b/.github/workflows/verify-binary-install.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Run Opensearch
-        uses: derek-ho/start-opensearch@v2
+        uses: derek-ho/start-opensearch@v6
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           security-enabled: false
@@ -43,7 +43,6 @@ jobs:
           built_plugin_name: observabilityDashboards
           built_plugin_suffix: ${{ env.OPENSEARCH_VERSION }}
           install_zip: true
-          jdk-version: 21
 
       - name: Start the binary
         run: |

--- a/.github/workflows/verify-binary-install.yml
+++ b/.github/workflows/verify-binary-install.yml
@@ -2,7 +2,7 @@ name: 'Install Dashboards with Plugin via Binary'
 
 on: [push, pull_request]
 env:
-  OPENSEARCH_VERSION: '3.0.0-beta1'
+  OPENSEARCH_VERSION: '3.1.0'
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm

--- a/.github/workflows/verify-binary-install.yml
+++ b/.github/workflows/verify-binary-install.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           security-enabled: false
+          jdk-version: 21
 
       - name: Run Dashboard
         id: setup-dashboards

--- a/.github/workflows/verify-binary-install.yml
+++ b/.github/workflows/verify-binary-install.yml
@@ -43,6 +43,7 @@ jobs:
           built_plugin_name: observabilityDashboards
           built_plugin_suffix: ${{ env.OPENSEARCH_VERSION }}
           install_zip: true
+          jdk-version: 21
 
       - name: Start the binary
         run: |


### PR DESCRIPTION
### Description
Workflows - Version fix
Update workflows to 3.1.0

Fix the following error
```
OpenSearch requires Java 21; your Java version from [/opt/hostedtoolcache/jdk/11.0.27/x64] does not meet this requirement
```
By adjusting argument to avoid default version 11
https://github.com/derek-ho/start-opensearch/blob/e9060d3df24b30cdbfac62d749fec3367dade572/action.yml#L30-L33

### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
