### PR TITLE
[Bug] Fix jaeger end time processing

### DIFF
--- a/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
+++ b/public/components/trace_analytics/components/common/__tests__/helper_functions.test.tsx
@@ -29,6 +29,7 @@ import {
   nanoToMilliSec,
   NoMatchMessage,
   PanelTitle,
+  processTimeStamp,
   renderBenchmark,
 } from '../helper_functions';
 
@@ -236,6 +237,25 @@ describe('Trace analytics helper functions', () => {
     it('handles URIs without a hash router and existing query params', () => {
       const result = appendModeToTraceViewUri('123', (id) => `/traces/${id}?foo=bar`, 'jaeger');
       expect(result).toEqual('/traces/123?foo=bar&mode=jaeger');
+    });
+  });
+
+  describe('processTimeStamp', () => {
+    it('returns microseconds for jaeger mode (start time)', () => {
+      const time = '2024-01-01T00:00:00Z';
+      const expected = Math.floor(new Date(time).getTime() / 1000) * 1000000;
+      expect(processTimeStamp(time, 'jaeger', false)).toEqual(expected);
+    });
+
+    it('returns microseconds for jaeger mode (end time)', () => {
+      const time = '2024-01-01T00:00:00Z';
+      const expected = Math.floor(new Date(time).getTime() / 1000) * 1000000;
+      expect(processTimeStamp(time, 'jaeger', true)).toEqual(expected);
+    });
+
+    it('returns input time for non-jaeger mode', () => {
+      const time = 'now-5m';
+      expect(processTimeStamp(time, 'data_prepper')).toBe(time);
     });
   });
 });

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -696,7 +696,7 @@ export const parseHits = (payloadData: string): ParsedHit[] => {
 
 export const isUnderOneHourRange = (startTime: string, endTime: string): boolean => {
   const start = dateMath.parse(startTime);
-  const end = dateMath.parse(endTime);
+  const end = dateMath.parse(endTime, { roundUp: true });
 
   if (!start || !end) return false;
 

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -113,9 +113,9 @@ export function MissingConfigurationMessage(props: { mode: TraceAnalyticsMode })
 }
 
 // Processes time (like 'now-5y') to microseconds for jaeger since this is how they store the start time. Otherwise leave it the same.
-export function processTimeStamp(time: string, mode: TraceAnalyticsMode) {
+export function processTimeStamp(time: string, mode: TraceAnalyticsMode, isEndTime = false) {
   if (mode === 'jaeger') {
-    const timeMoment = dateMath.parse(time)!;
+    const timeMoment = isEndTime ? dateMath.parse(time, { roundUp: true })! : dateMath.parse(time)!;
     return timeMoment.unix() * 1000000;
   }
   return time;

--- a/public/components/trace_analytics/components/dashboard/dashboard_content.tsx
+++ b/public/components/trace_analytics/components/dashboard/dashboard_content.tsx
@@ -98,7 +98,7 @@ export function DashboardContent(props: DashboardProps) {
       filters,
       query,
       processTimeStamp(startTime, mode),
-      processTimeStamp(endTime, mode),
+      processTimeStamp(endTime, mode, true),
       page,
       appConfigs
     );
@@ -107,7 +107,7 @@ export function DashboardContent(props: DashboardProps) {
       [],
       '',
       processTimeStamp(startTime, mode),
-      processTimeStamp(endTime, mode),
+      processTimeStamp(endTime, mode, true),
       page,
       appConfigs
     );
@@ -120,7 +120,7 @@ export function DashboardContent(props: DashboardProps) {
       filters,
       query,
       processTimeStamp(latencyTrendStartTime, mode),
-      processTimeStamp(endTime, mode),
+      processTimeStamp(endTime, mode, true),
       page,
       appConfigs
     );

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -119,7 +119,7 @@ export function ServiceView(props: ServiceViewProps) {
       props.filters,
       props.query,
       processTimeStamp(props.startTime, mode),
-      processTimeStamp(props.endTime, mode)
+      processTimeStamp(props.endTime, mode, true)
     );
 
     setIsServiceOverviewLoading(true);
@@ -459,7 +459,7 @@ export function ServiceView(props: ServiceViewProps) {
       props.filters,
       props.query,
       processTimeStamp(props.startTime, mode),
-      processTimeStamp(props.endTime, mode)
+      processTimeStamp(props.endTime, mode, true)
     );
     if (mode === 'data_prepper') {
       spanDSL.query.bool.filter.push({

--- a/public/components/trace_analytics/components/services/services_content.tsx
+++ b/public/components/trace_analytics/components/services/services_content.tsx
@@ -105,7 +105,7 @@ export function ServicesContent(props: ServicesProps) {
       filters,
       filterQuery,
       processTimeStamp(startTime, mode),
-      processTimeStamp(endTime, mode),
+      processTimeStamp(endTime, mode, true),
       page,
       appConfigs
     );

--- a/public/components/trace_analytics/components/traces/trace_view.tsx
+++ b/public/components/trace_analytics/components/traces/trace_view.tsx
@@ -228,7 +228,7 @@ export function TraceView(props: TraceViewProps) {
       [],
       '',
       processTimeStamp('now', mode),
-      processTimeStamp('now', mode),
+      processTimeStamp('now', mode, true),
       page
     );
 

--- a/public/components/trace_analytics/components/traces/traces_content.tsx
+++ b/public/components/trace_analytics/components/traces/traces_content.tsx
@@ -121,7 +121,7 @@ export function TracesContent(props: TracesProps) {
         filters,
         query,
         processTimeStamp(startTime, mode),
-        processTimeStamp(endTime, mode),
+        processTimeStamp(endTime, mode, true),
         page,
         appConfigs
       ),
@@ -275,7 +275,7 @@ export function TracesContent(props: TracesProps) {
       filters,
       query,
       processTimeStamp(startTime, mode),
-      processTimeStamp(endTime, mode),
+      processTimeStamp(endTime, mode, true),
       page,
       appConfigs
     );
@@ -285,7 +285,7 @@ export function TracesContent(props: TracesProps) {
       [],
       '',
       processTimeStamp(startTime, mode),
-      processTimeStamp(endTime, mode),
+      processTimeStamp(endTime, mode, true),
       page
     );
 
@@ -317,7 +317,7 @@ export function TracesContent(props: TracesProps) {
       filters,
       filterQuery,
       processTimeStamp(startTime, mode),
-      processTimeStamp(endTime, mode),
+      processTimeStamp(endTime, mode, true),
       page,
       appConfigs
     );
@@ -326,7 +326,7 @@ export function TracesContent(props: TracesProps) {
       [],
       '',
       processTimeStamp(startTime, mode),
-      processTimeStamp(endTime, mode),
+      processTimeStamp(endTime, mode, true),
       page
     );
     const isUnderOneHour = isUnderOneHourRange(startTime, endTime);


### PR DESCRIPTION
### Description

Trace Analytics plugin issues a query in DSL everytime a Jaeger request is made. The time filter needs to be processed separately for start time and end time. If the end time isn't rounded there are some edge cases in the time-picker which lead start & end time being the same and no response is returned. 

This affects cases  `Today,  This year, This month & This day`. The Relative time stamps and the absolute time stamps work as expected. 

### Issues Resolved

Before: 

After: 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
