### PR TITLE
[Traces] Make service map max nodes and max edges values user-configurable

### DIFF
--- a/common/constants/trace_analytics.ts
+++ b/common/constants/trace_analytics.ts
@@ -29,6 +29,7 @@ export const TRACE_CORRELATED_LOGS_INDEX_SETTING =
   'observability:traceAnalyticsCorrelatedLogsIndices';
 export const TRACE_LOGS_FIELD_MAPPNIGS_SETTING =
   'observability:traceAnalyticsCorrelatedLogsFieldMappings';
+export const TRACE_SERVICE_MAP_MAX_NODES = 'observability:traceAnalyticsServiceMapMaxNodes';
 
 export const DEFAULT_SS4O_LOGS_INDEX = 'ss4o_logs-*';
 export const DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS = `
@@ -38,6 +39,7 @@ export const DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS = `
   "timestamp": "time",
   "traceId": "traceId"
 }`;
+export const DEFAULT_SERVICE_MAP_MAX_NODES = 500;
 
 export enum TRACE_TABLE_TITLES {
   all_spans = 'All Spans',

--- a/common/constants/trace_analytics.ts
+++ b/common/constants/trace_analytics.ts
@@ -9,9 +9,6 @@ export const DATA_PREPPER_INDEX_NAME = 'otel-v1-apm-span-*';
 export const DATA_PREPPER_SERVICE_INDEX_NAME = 'otel-v1-apm-service-map*';
 export const TRACE_ANALYTICS_DATE_FORMAT = 'MM/DD/YYYY HH:mm:ss.SSS';
 export const TRACE_ANALYTICS_PLOTS_DATE_FORMAT = 'MMM D, YYYY HH:mm:ss.SSS';
-export const SERVICE_MAP_MAX_NODES = 500;
-// size limit when requesting edge related queries, not necessarily the number of edges
-export const SERVICE_MAP_MAX_EDGES = 1000;
 export const TRACES_MAX_NUM = 500;
 export const TRACE_ANALYTICS_DOCUMENTATION_LINK =
   'https://opensearch.org/docs/latest/observability-plugin/trace/index/';

--- a/common/constants/trace_analytics.ts
+++ b/common/constants/trace_analytics.ts
@@ -30,6 +30,7 @@ export const TRACE_CORRELATED_LOGS_INDEX_SETTING =
 export const TRACE_LOGS_FIELD_MAPPNIGS_SETTING =
   'observability:traceAnalyticsCorrelatedLogsFieldMappings';
 export const TRACE_SERVICE_MAP_MAX_NODES = 'observability:traceAnalyticsServiceMapMaxNodes';
+export const TRACE_SERVICE_MAP_MAX_EDGES = 'observability:traceAnalyticsServiceMapMaxEdges';
 
 export const DEFAULT_SS4O_LOGS_INDEX = 'ss4o_logs-*';
 export const DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS = `
@@ -40,6 +41,7 @@ export const DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS = `
   "traceId": "traceId"
 }`;
 export const DEFAULT_SERVICE_MAP_MAX_NODES = 500;
+export const DEFAULT_SERVICE_MAP_MAX_EDGES = 1000;
 
 export enum TRACE_TABLE_TITLES {
   all_spans = 'All Spans',

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -21,6 +21,7 @@ import {
   TRACE_CUSTOM_SERVICE_INDEX_SETTING,
   TRACE_CUSTOM_SPAN_INDEX_SETTING,
   TRACE_LOGS_FIELD_MAPPNIGS_SETTING,
+  TRACE_SERVICE_MAP_MAX_NODES,
 } from '../../../../../common/constants/trace_analytics';
 import {
   CorrelatedLogsFieldMappings,
@@ -604,6 +605,8 @@ export const TraceSettings = {
 
   getCustomModeSetting: () => uiSettingsService.get(TRACE_CUSTOM_MODE_DEFAULT_SETTING) || false,
 
+  getServiceMapMaxNodes: () => uiSettingsService.get(TRACE_SERVICE_MAP_MAX_NODES),
+
   setCustomSpanIndex: (value: string) =>
     uiSettingsService.set(TRACE_CUSTOM_SPAN_INDEX_SETTING, value),
 
@@ -618,6 +621,9 @@ export const TraceSettings = {
 
   setCustomModeSetting: (value: boolean) =>
     uiSettingsService.set(TRACE_CUSTOM_MODE_DEFAULT_SETTING, value),
+
+  setServiceMapMaxNodes: (value: number) =>
+    uiSettingsService.set(TRACE_SERVICE_MAP_MAX_NODES, value),
 };
 
 export const getSpanIndices = (mode: TraceAnalyticsMode) => {

--- a/public/components/trace_analytics/components/common/helper_functions.tsx
+++ b/public/components/trace_analytics/components/common/helper_functions.tsx
@@ -22,6 +22,7 @@ import {
   TRACE_CUSTOM_SPAN_INDEX_SETTING,
   TRACE_LOGS_FIELD_MAPPNIGS_SETTING,
   TRACE_SERVICE_MAP_MAX_NODES,
+  TRACE_SERVICE_MAP_MAX_EDGES,
 } from '../../../../../common/constants/trace_analytics';
 import {
   CorrelatedLogsFieldMappings,
@@ -607,6 +608,8 @@ export const TraceSettings = {
 
   getServiceMapMaxNodes: () => uiSettingsService.get(TRACE_SERVICE_MAP_MAX_NODES),
 
+  getServiceMapMaxEdges: () => uiSettingsService.get(TRACE_SERVICE_MAP_MAX_EDGES),
+
   setCustomSpanIndex: (value: string) =>
     uiSettingsService.set(TRACE_CUSTOM_SPAN_INDEX_SETTING, value),
 
@@ -624,6 +627,9 @@ export const TraceSettings = {
 
   setServiceMapMaxNodes: (value: number) =>
     uiSettingsService.set(TRACE_SERVICE_MAP_MAX_NODES, value),
+
+  setServiceMapMaxEdges: (value: number) =>
+    uiSettingsService.set(TRACE_SERVICE_MAP_MAX_EDGES, value),
 };
 
 export const getSpanIndices = (mode: TraceAnalyticsMode) => {

--- a/public/components/trace_analytics/requests/queries/services_queries.ts
+++ b/public/components/trace_analytics/requests/queries/services_queries.ts
@@ -3,12 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  SERVICE_MAP_MAX_EDGES,
-  SERVICE_MAP_MAX_NODES,
-} from '../../../../../common/constants/trace_analytics';
+import { SERVICE_MAP_MAX_EDGES } from '../../../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode } from '../../../../../common/types/trace_analytics';
-import { getServiceIndices } from '../../components/common/helper_functions';
+import { TraceSettings, getServiceIndices } from '../../components/common/helper_functions';
 import { ServiceObject } from '../../components/common/plots/service_map';
 
 export const getServicesQuery = (
@@ -91,6 +88,8 @@ export const getServicesQuery = (
 };
 
 export const getServiceMapQuery = (mode: TraceAnalyticsMode) => {
+  const serviceMapMaxNodes = TraceSettings.getServiceMapMaxNodes();
+
   return {
     index: getServiceIndices(mode),
     size: 0,
@@ -106,7 +105,7 @@ export const getServiceMapQuery = (mode: TraceAnalyticsMode) => {
       service_name: {
         terms: {
           field: 'serviceName',
-          size: SERVICE_MAP_MAX_NODES,
+          size: serviceMapMaxNodes,
         },
         aggs: {
           target_resource: {
@@ -190,6 +189,8 @@ export const getServiceMetricsQuery = (
   map: ServiceObject,
   mode: TraceAnalyticsMode
 ) => {
+  const serviceMapMaxNodes = TraceSettings.getServiceMapMaxNodes();
+
   const targetResource = [].concat(
     ...Object.keys(map).map((service) => map[service].targetResources)
   );
@@ -249,7 +250,7 @@ export const getServiceMetricsQuery = (
       service_name: {
         terms: {
           field: 'process.serviceName',
-          size: SERVICE_MAP_MAX_NODES,
+          size: serviceMapMaxNodes,
           min_doc_count: 1,
           shard_min_doc_count: 0,
           show_term_doc_count_error: false,
@@ -359,7 +360,7 @@ export const getServiceMetricsQuery = (
       service_name: {
         terms: {
           field: 'serviceName',
-          size: SERVICE_MAP_MAX_NODES,
+          size: serviceMapMaxNodes,
           min_doc_count: 1,
           shard_min_doc_count: 0,
           show_term_doc_count_error: false,

--- a/public/components/trace_analytics/requests/queries/services_queries.ts
+++ b/public/components/trace_analytics/requests/queries/services_queries.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SERVICE_MAP_MAX_EDGES } from '../../../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode } from '../../../../../common/types/trace_analytics';
 import { TraceSettings, getServiceIndices } from '../../components/common/helper_functions';
 import { ServiceObject } from '../../components/common/plots/service_map';
@@ -89,6 +88,7 @@ export const getServicesQuery = (
 
 export const getServiceMapQuery = (mode: TraceAnalyticsMode) => {
   const serviceMapMaxNodes = TraceSettings.getServiceMapMaxNodes();
+  const serviceMapMaxEdges = TraceSettings.getServiceMapMaxEdges();
 
   return {
     index: getServiceIndices(mode),
@@ -111,25 +111,25 @@ export const getServiceMapQuery = (mode: TraceAnalyticsMode) => {
           target_resource: {
             terms: {
               field: 'target.resource',
-              size: SERVICE_MAP_MAX_EDGES,
+              size: serviceMapMaxEdges,
             },
           },
           target_edges: {
             terms: {
               field: 'target.resource',
-              size: SERVICE_MAP_MAX_EDGES,
+              size: serviceMapMaxEdges,
             },
             aggs: {
               service: {
                 terms: {
                   field: 'target.serviceName',
-                  size: SERVICE_MAP_MAX_EDGES,
+                  size: serviceMapMaxEdges,
                 },
               },
               domain: {
                 terms: {
                   field: 'target.domain',
-                  size: SERVICE_MAP_MAX_EDGES,
+                  size: serviceMapMaxEdges,
                 },
               },
             },
@@ -137,19 +137,19 @@ export const getServiceMapQuery = (mode: TraceAnalyticsMode) => {
           destination_edges: {
             terms: {
               field: 'destination.resource',
-              size: SERVICE_MAP_MAX_EDGES,
+              size: serviceMapMaxEdges,
             },
             aggs: {
               service: {
                 terms: {
                   field: 'destination.serviceName',
-                  size: SERVICE_MAP_MAX_EDGES,
+                  size: serviceMapMaxEdges,
                 },
               },
               domain: {
                 terms: {
                   field: 'destination.domain',
-                  size: SERVICE_MAP_MAX_EDGES,
+                  size: serviceMapMaxEdges,
                 },
               },
             },

--- a/server/plugin_helper/register_settings.ts
+++ b/server/plugin_helper/register_settings.ts
@@ -11,11 +11,13 @@ import {
   DATA_PREPPER_SERVICE_INDEX_NAME,
   DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS,
   DEFAULT_SS4O_LOGS_INDEX,
+  DEFAULT_SERVICE_MAP_MAX_NODES,
   TRACE_CORRELATED_LOGS_INDEX_SETTING,
   TRACE_CUSTOM_MODE_DEFAULT_SETTING,
   TRACE_CUSTOM_SERVICE_INDEX_SETTING,
   TRACE_CUSTOM_SPAN_INDEX_SETTING,
   TRACE_LOGS_FIELD_MAPPNIGS_SETTING,
+  TRACE_SERVICE_MAP_MAX_NODES,
 } from '../../common/constants/trace_analytics';
 
 export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSetup) => {
@@ -97,6 +99,23 @@ export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSet
         spanId: schema.string(),
         timestamp: schema.string(),
         traceId: schema.string(),
+      }),
+    },
+  });
+
+  uiSettings.register({
+    [TRACE_SERVICE_MAP_MAX_NODES]: {
+      name: i18n.translate('observability.traceAnalyticsServiceMapMaxNodes.name', {
+        defaultMessage: 'Trace analytics service map maximum nodes',
+      }),
+      value: DEFAULT_SERVICE_MAP_MAX_NODES,
+      category: ['Observability'],
+      description: i18n.translate('observability.traceAnalyticsServiceMapMaxNodes.description', {
+        defaultMessage:
+          'Set the number of nodes to be displayed, to be used by the trace analytics plugin to display on the service maps',
+      }),
+      schema: schema.number({
+        min: 1,
       }),
     },
   });

--- a/server/plugin_helper/register_settings.ts
+++ b/server/plugin_helper/register_settings.ts
@@ -12,12 +12,14 @@ import {
   DEFAULT_CORRELATED_LOGS_FIELD_MAPPINGS,
   DEFAULT_SS4O_LOGS_INDEX,
   DEFAULT_SERVICE_MAP_MAX_NODES,
+  DEFAULT_SERVICE_MAP_MAX_EDGES,
   TRACE_CORRELATED_LOGS_INDEX_SETTING,
   TRACE_CUSTOM_MODE_DEFAULT_SETTING,
   TRACE_CUSTOM_SERVICE_INDEX_SETTING,
   TRACE_CUSTOM_SPAN_INDEX_SETTING,
   TRACE_LOGS_FIELD_MAPPNIGS_SETTING,
   TRACE_SERVICE_MAP_MAX_NODES,
+  TRACE_SERVICE_MAP_MAX_EDGES,
 } from '../../common/constants/trace_analytics';
 
 export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSetup) => {
@@ -112,10 +114,27 @@ export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSet
       category: ['Observability'],
       description: i18n.translate('observability.traceAnalyticsServiceMapMaxNodes.description', {
         defaultMessage:
-          'Set the number of nodes to be displayed, to be used by the trace analytics plugin to display on the service maps',
+          'Set the number of maximum nodes, to be used by the trace analytics plugin to display on service maps',
       }),
       schema: schema.number({
         min: 1,
+      }),
+    },
+  });
+
+  uiSettings.register({
+    [TRACE_SERVICE_MAP_MAX_EDGES]: {
+      name: i18n.translate('observability.traceAnalyticsServiceMapMaxEdges.name', {
+        defaultMessage: 'Trace analytics service map maximum edges',
+      }),
+      value: DEFAULT_SERVICE_MAP_MAX_EDGES,
+      category: ['Observability'],
+      description: i18n.translate('observability.traceAnalyticsServiceMapMaxEdges.description', {
+        defaultMessage:
+          'Set the number of maximum edges, to be used by the trace analytics plugin to display on service maps',
+      }),
+      schema: schema.number({
+        min: 2,
       }),
     },
   });

--- a/server/plugin_helper/register_settings.ts
+++ b/server/plugin_helper/register_settings.ts
@@ -114,7 +114,7 @@ export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSet
       category: ['Observability'],
       description: i18n.translate('observability.traceAnalyticsServiceMapMaxNodes.description', {
         defaultMessage:
-          'Set the number of maximum nodes, to be used by the trace analytics plugin to display on service maps',
+          'Set the maximum number of nodes that the trace analytics plugin should request for rendering of service maps',
       }),
       schema: schema.number({
         min: 1,
@@ -131,10 +131,10 @@ export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSet
       category: ['Observability'],
       description: i18n.translate('observability.traceAnalyticsServiceMapMaxEdges.description', {
         defaultMessage:
-          'Set the number of maximum edges, to be used by the trace analytics plugin to display on service maps',
+          'Set the maximum number of edges that the trace analytics plugin should request for rendering of service maps',
       }),
       schema: schema.number({
-        min: 2,
+        min: 1,
       }),
     },
   });


### PR DESCRIPTION
### Description
The aim of this PR is to make the max nodes and max edges (used in service map related queries) user-configurable, as they are currently (as of 3.1.0) constant values (500 and 1000 respectively), which can result in inaccurate service maps if service map indices contain more than 500 unique services or more than 1000 unique destinations per service.

I've registered these new settings alongside the existing ones:
<img width="1222" height="915" alt="image" src="https://github.com/user-attachments/assets/a7b032cf-204b-4d00-84f7-5cea579c1bd6" />
The default values come from the existing (now deprecated) constants.

The following comparison shows the changes in service map, once the user updates the max node limit (`observability:traceAnalyticsServiceMapMaxNodes`):
- with the default limit of 500:
<img width="654" height="483" alt="image" src="https://github.com/user-attachments/assets/6332443f-b4bb-41d2-8ec0-80cf5e8cd274" />

- with the updated limit of 5: 
<img width="567" height="435" alt="image" src="https://github.com/user-attachments/assets/ab71c3f2-7bcb-43f7-9803-0ab494610ee4" />

The next comparison shows the changes in service map if the user decides to update the maximum number of edges (`observability:traceAnalyticsServiceMapMaxEdges`) in a service map request:
- with default limit of 1000:
<img width="654" height="483" alt="image" src="https://github.com/user-attachments/assets/6332443f-b4bb-41d2-8ec0-80cf5e8cd274" />

- with the updated limit of 1:
<img width="834" height="851" alt="image" src="https://github.com/user-attachments/assets/84c703ae-3755-48fd-8699-f78dddd6da04" />

### Issues Resolved
#2471 

### Check List
- [] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
