### PR TITLE
[Traces] Spans hierarchical timeline

### DIFF
--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -332,7 +332,7 @@ describe('Testing switch mode to jaeger', () => {
     cy.contains('08ee9fd9bf964384').should('exist');
     cy.contains('08ee9fd9bf964384').click();
     cy.contains('Time spent by service').should('exist');
-    cy.get("[data-test-subj='span-gantt-chart-panel']").should('exist');
+    cy.get("[data-test-subj='span-timeline-panel']").should('exist');
   });
 
   it('Checks tree view for specific traceId in Jaeger mode', () => {

--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces_span_timeline.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces_span_timeline.spec.js
@@ -1,0 +1,161 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="cypress" />
+
+import { timeoutDelay } from '../../utils/app_constants';
+import { TRACE_ID } from '../../utils/constants';
+
+describe('Testing Span Detail Timeline', () => {
+  beforeEach(() => {
+    cy.visit(`app/observability-traces#/traces?datasourceId=&traceId=${TRACE_ID}`, {
+      timeout: 60000,
+      onBeforeLoad: (win) => {
+        win.sessionStorage.clear();
+      },
+    });
+
+    cy.get('body', { timeout: timeoutDelay }).should('be.visible');
+    cy.get('[data-test-subj="span-detail-timeline"]', { timeout: timeoutDelay }).should('exist');
+    cy.get('[data-test-subj="span-gantt-chart-panel"]').scrollIntoView({
+      offset: { top: -120 }, // dashboards page has a fixed header
+    });
+    cy.get('input[data-test-subj="timeline"]').should('be.checked');
+    cy.get('[data-test-subj="timeline-reset-button"]', { timeout: timeoutDelay }).then(($btn) => {
+      if ($btn.length > 0 && !$btn.prop('disabled')) {
+        cy.wrap($btn).click();
+      }
+    });
+  });
+
+  describe('Service Filtering', () => {
+    it('Displays correct number of services in the filter', () => {
+      cy.get('[data-test-subj="service-filter"]').should('be.visible');
+      cy.get('[data-test-subj="service-filter"]').within(() => {
+        cy.get('button[aria-label="Clear input"]').should('not.exist');
+        cy.get('li[role="option"]').should('have.length.gt', 1);
+      });
+    });
+
+    it('Filters services by search input', () => {
+      cy.get('[data-test-subj="service-filter"]').should('be.visible');
+      cy.get('[data-test-subj="service-filter"]').within(() => {
+        cy.get('button[aria-label="Clear input"]').should('not.exist');
+        cy.get('input[type="search"]').type('order');
+        cy.get('li[role="option"]').should('have.length', 1);
+        cy.get('li[role="option"]').should('contain.text', 'order');
+        cy.get('button[aria-label="Clear input"]').should('be.visible').click();
+        cy.get('input[type="search"]').should('be.empty');
+      });
+    });
+
+    it('Show spans according to selected service', () => {
+      cy.get('[data-test-subj="service-filter"]').should('be.visible');
+
+      cy.get('[data-test-subj^="timeline-row-"]')
+        .should('have.length.gte', 1)
+        .its('length')
+        .as('initialCount');
+
+      cy.get('[data-test-subj="service-filter"]').within(() => {
+        cy.get('li[role="option"]').first().invoke('text').as('serviceOptionText');
+        cy.get('li[role="option"]').first().click();
+        cy.get('button[aria-label="Clear focus and service filter selection"]').should(
+          'be.visible'
+        );
+      });
+
+      cy.get('@serviceOptionText').then((text) => {
+        const match = text.trim().match(/\((\d+)\)/);
+        const expectedCount = parseInt(match[1]);
+        cy.get('[data-test-subj^="timeline-row-"]').should('have.length', expectedCount);
+        cy.get('[data-test-subj="service-filter"]').within(() => {
+          cy.get('button[aria-label="Clear focus and service filter selection"]')
+            .should('be.visible')
+            .click();
+        });
+        cy.get('@initialCount').then((initialCount) => {
+          cy.get('[data-test-subj^="timeline-row-"]').should('have.length', initialCount);
+        });
+      });
+    });
+  });
+
+  describe('Timeline Rendering', () => {
+    it('Renders the timeline container with all components', () => {
+      cy.get('[data-test-subj="span-detail-timeline"]').should('be.visible');
+      cy.get('[data-test-subj="timeline-minimap"]').should('be.visible');
+      cy.get('[data-test-subj="timeline-controls"]').should('be.visible');
+      cy.get('[data-test-subj="timeline-ruler"]').should('be.visible');
+      cy.get('[data-test-subj="timeline-grid"]').should('be.visible');
+      cy.get('[data-test-subj^="timeline-row-"]').should('have.length.gte', 1);
+      cy.get('[data-test-subj^="timeline-span-bar-"]').should('have.length.gte', 1);
+    });
+
+    it('Displays correct tick marks and time labels when data is available', () => {
+      cy.get('[data-test-subj^="timeline-row-"]').should('have.length.gte', 1);
+      cy.get('[data-test-subj="timeline-tick-mark"]').should('have.length.gte', 5);
+      cy.get('[data-test-subj="timeline-tick-label"]').should('have.length.gte', 5);
+      cy.get('[data-test-subj="timeline-tick-label"]').each(($label) => {
+        cy.wrap($label).should('contain.text', 'ms');
+      });
+      cy.get('[data-test-subj="timeline-tick-label"]').first().should('contain.text', '0 ms');
+      cy.get('[data-test-subj="timeline-grid-line"]').should('have.length.gte', 2);
+    });
+  });
+
+  describe('Collapse and Expand Spans', () => {
+    it('Displays collapse and expand all spans buttons', () => {
+      cy.get('button[aria-label="Collapse all spans"]').should('be.visible');
+      cy.get('button[aria-label="Expand all spans"]').should('not.exist');
+      cy.get('[data-test-subj^="timeline-row-"]').should('have.length.gte', 1);
+
+      // Count the number of root-level spans (those at the first indentation level)
+      // Root spans don't have any parent span indentation, so they should be at paddingLeft: 0px
+      cy.get('[data-test-subj^="timeline-row-"]')
+        .then(($rows) => {
+          let rootSpanCount = 0;
+          $rows.each((_, row) => {
+            const paddingLeft = Cypress.$(row).css('padding-left');
+            if (paddingLeft === '0px') {
+              rootSpanCount++;
+            }
+          });
+          return rootSpanCount;
+        })
+        .then((rootSpanCount) => {
+          cy.get('button[aria-label="Collapse all spans"]').click();
+          cy.get('button[aria-label="Expand all spans"]').should('be.visible');
+          cy.get('button[aria-label="Collapse all spans"]').should('not.exist');
+          cy.get('[data-test-subj^="timeline-row-"]', { timeout: timeoutDelay }).should(
+            'have.length',
+            rootSpanCount
+          );
+        });
+    });
+
+    it('Collapse and expand individual spans correctly', () => {
+      let initialCount;
+      cy.get('[data-test-subj^="timeline-row-"]').should('have.length.gte', 1);
+      cy.get('[data-test-subj^="timeline-row-"]').then(($els) => {
+        initialCount = $els.length;
+      });
+
+      // Find a span that has children (has a collapse button)
+      cy.get('[data-test-subj^="span-collapse-"]').first().as('collapseButton');
+      cy.get('@collapseButton')
+        .invoke('attr', 'data-test-subj')
+        .then((testSubj) => {
+          const spanId = testSubj.replace('span-collapse-', '');
+
+          cy.get(`[data-test-subj="span-collapse-${spanId}"]`).click();
+          cy.get('[data-test-subj^="timeline-row-"]').should('have.length.lt', initialCount);
+
+          cy.get(`[data-test-subj="span-collapse-${spanId}"]`).click();
+          cy.get('[data-test-subj^="timeline-row-"]').should('have.length', initialCount);
+        });
+    });
+  });
+});

--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces_span_timeline.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces_span_timeline.spec.js
@@ -19,7 +19,7 @@ describe('Testing Span Detail Timeline', () => {
 
     cy.get('body', { timeout: timeoutDelay }).should('be.visible');
     cy.get('[data-test-subj="span-detail-timeline"]', { timeout: timeoutDelay }).should('exist');
-    cy.get('[data-test-subj="span-gantt-chart-panel"]').scrollIntoView({
+    cy.get('[data-test-subj="span-timeline-panel"]').scrollIntoView({
       offset: { top: -120 }, // dashboards page has a fixed header
     });
     cy.get('input[data-test-subj="timeline"]').should('be.checked');

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ajv": "^8.11.0",
     "antlr4": "4.8.0",
     "antlr4ts": "^0.5.0-alpha.4",
+    "d3-scale": "^4.0.2",
     "json5": "^2.2.3",
     "mime": "^3.0.0",
     "performance-now": "^2.1.0",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@cypress/skip-test": "^2.6.1",
+    "@types/d3-scale": "^4.0.9",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/mime": "^3.0.1",
     "@types/react-plotly.js": "^2.6.3",

--- a/public/components/application_analytics/__tests__/__snapshots__/flyout.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/flyout.test.tsx.snap
@@ -748,19 +748,185 @@ exports[`Trace Detail Render Flyout component render trace detail 1`] = `
     http={[MockFunction]}
     isApplicationFlyout={true}
     mode="jaeger"
-    openSpanFlyout={[Function]}
-    page="app"
+    onSpanClick={[Function]}
     payloadData=""
     setSpanFiltersWithStorage={[Function]}
     spanFilters={Array []}
     traceId="mockTrace"
   >
     <EuiPanel
-      data-test-subj="span-gantt-chart-panel"
+      data-test-subj="span-timeline-panel"
+      panelRef={
+        Object {
+          "current": <div
+            class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+            data-test-subj="span-timeline-panel"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--directionColumn euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <div
+                  class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+                >
+                  <div
+                    class="euiFlexItem"
+                  >
+                    <div
+                      class="euiText euiText--medium"
+                    >
+                      <span
+                        class="panel-title"
+                      >
+                        Spans
+                      </span>
+                      <span
+                        class="panel-title-count"
+                      >
+                         (0)
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="euiFlexItem euiFlexItem--flexGrowZero"
+                  >
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <fieldset
+                          class="euiButtonGroup euiButtonGroup--small euiButtonGroup--text"
+                        >
+                          <legend
+                            class="euiScreenReaderOnly"
+                          >
+                            Select view of spans
+                          </legend>
+                          <div
+                            class="euiButtonGroup__buttons"
+                          >
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Timeline"
+                                  title="Timeline"
+                                >
+                                  <input
+                                    checked=""
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="timeline"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Timeline
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Span list"
+                                  title="Span list"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="span_list"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Span list
+                                </span>
+                              </span>
+                            </label>
+                            <label
+                              class="euiButtonGroupButton euiButtonGroupButton--text euiButtonGroupButton--small"
+                              for="random_html_id"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text euiButtonGroupButton__textShift"
+                                  data-text="Tree view"
+                                  title="Tree view"
+                                >
+                                  <input
+                                    class="euiScreenReaderOnly"
+                                    data-test-subj="hierarchy_span_list"
+                                    id="random_html_id"
+                                    name="random_html_id"
+                                    type="radio"
+                                    value=""
+                                  />
+                                  Tree view
+                                </span>
+                              </span>
+                            </label>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <hr
+                class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+              />
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiEmptyPrompt"
+                >
+                  <h2
+                    class="euiTitle euiTitle--medium"
+                  >
+                    No spans found
+                  </h2>
+                  <span
+                    class="euiTextColor euiTextColor--subdued"
+                  >
+                    <div
+                      class="euiSpacer euiSpacer--m"
+                    />
+                    <div
+                      class="euiText euiText--medium"
+                    >
+                      <p>
+                        No spans found for the selected filters
+                      </p>
+                    </div>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>,
+        }
+      }
     >
       <div
         className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        data-test-subj="span-gantt-chart-panel"
+        data-test-subj="span-timeline-panel"
       >
         <EuiFlexGroup
           direction="column"
@@ -822,67 +988,6 @@ exports[`Trace Detail Render Flyout component render trace detail 1`] = `
                           <div
                             className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentFlexEnd euiFlexGroup--directionRow euiFlexGroup--responsive"
                           >
-                            <EuiFlexItem
-                              grow={false}
-                            >
-                              <div
-                                className="euiFlexItem euiFlexItem--flexGrowZero"
-                              >
-                                <EuiSmallButton
-                                  isDisabled={true}
-                                  onClick={[Function]}
-                                >
-                                  <EuiButton
-                                    isDisabled={true}
-                                    onClick={[Function]}
-                                    size="s"
-                                  >
-                                    <EuiButtonDisplay
-                                      baseClassName="euiButton"
-                                      disabled={true}
-                                      element="button"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      size="s"
-                                      type="button"
-                                    >
-                                      <button
-                                        className="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
-                                        disabled={true}
-                                        onClick={[Function]}
-                                        style={
-                                          Object {
-                                            "minWidth": undefined,
-                                          }
-                                        }
-                                        type="button"
-                                      >
-                                        <EuiButtonContent
-                                          className="euiButton__content"
-                                          iconGap="m"
-                                          iconSide="left"
-                                          textProps={
-                                            Object {
-                                              "className": "euiButton__text",
-                                            }
-                                          }
-                                        >
-                                          <span
-                                            className="euiButtonContent euiButton__content"
-                                          >
-                                            <span
-                                              className="euiButton__text"
-                                            >
-                                              Reset zoom
-                                            </span>
-                                          </span>
-                                        </EuiButtonContent>
-                                      </button>
-                                    </EuiButtonDisplay>
-                                  </EuiButton>
-                                </EuiSmallButton>
-                              </div>
-                            </EuiFlexItem>
                             <EuiFlexItem
                               grow={false}
                             >
@@ -1187,289 +1292,69 @@ exports[`Trace Detail Render Flyout component render trace detail 1`] = `
                 className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
               />
             </EuiHorizontalRule>
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <Plt
-                  data={Array []}
-                  layout={
-                    Object {
-                      "dragmode": "select",
-                      "height": 100,
-                      "margin": Object {
-                        "b": 30,
-                        "l": 150,
-                        "r": 5,
-                        "t": 30,
-                      },
-                      "paper_bgcolor": "rgba(0, 0, 0, 0)",
-                      "plot_bgcolor": "rgba(0, 0, 0, 0)",
-                      "shapes": Array [
-                        Object {
-                          "editable": true,
-                          "fillcolor": "rgba(128, 128, 128, 0.3)",
-                          "line": Object {
-                            "color": "rgba(255, 0, 0, 0.6)",
-                            "width": 1,
-                          },
-                          "type": "rect",
-                          "x0": 0,
-                          "x1": 0,
-                          "xref": "x",
-                          "y0": 0,
-                          "y1": 1,
-                          "yref": "paper",
-                        },
-                      ],
-                      "width": 412,
-                      "xaxis": Object {
-                        "color": "#91989c",
-                        "range": Array [
-                          0,
-                          0,
-                        ],
-                        "showline": true,
-                        "side": "top",
-                        "ticksuffix": " ms",
-                      },
-                      "yaxis": Object {
-                        "fixedrange": true,
-                        "visible": false,
-                      },
-                    }
-                  }
-                  onRelayout={[Function]}
-                  onSelectedHandler={[Function]}
-                >
-                  <PlotlyComponent
-                    config={
-                      Object {
-                        "displayModeBar": false,
-                      }
-                    }
-                    data={Array []}
-                    debug={false}
-                    divId="explorerPlotComponent"
-                    layout={
-                      Object {
-                        "autosize": true,
-                        "barmode": "stack",
-                        "dragmode": "select",
-                        "height": 100,
-                        "hovermode": "closest",
-                        "layout": Object {
-                          "annotations": Array [
-                            Object {
-                              "showarrow": true,
-                              "xanchor": "right",
-                            },
-                          ],
-                        },
-                        "legend": Object {
-                          "orientation": "h",
-                          "traceorder": "normal",
-                        },
-                        "margin": Object {
-                          "b": 30,
-                          "l": 150,
-                          "r": 5,
-                          "t": 30,
-                        },
-                        "paper_bgcolor": "rgba(0, 0, 0, 0)",
-                        "plot_bgcolor": "rgba(0, 0, 0, 0)",
-                        "shapes": Array [
-                          Object {
-                            "editable": true,
-                            "fillcolor": "rgba(128, 128, 128, 0.3)",
-                            "line": Object {
-                              "color": "rgba(255, 0, 0, 0.6)",
-                              "width": 1,
-                            },
-                            "type": "rect",
-                            "x0": 0,
-                            "x1": 0,
-                            "xref": "x",
-                            "y0": 0,
-                            "y1": 1,
-                            "yref": "paper",
-                          },
-                        ],
-                        "showlegend": false,
-                        "width": 412,
-                        "xaxis": Object {
-                          "color": "#91989c",
-                          "range": Array [
-                            0,
-                            0,
-                          ],
-                          "showline": true,
-                          "side": "top",
-                          "ticksuffix": " ms",
-                        },
-                        "yaxis": Object {
-                          "fixedrange": true,
-                          "visible": false,
-                        },
-                      }
-                    }
-                    onRelayout={[Function]}
-                    onSelected={[Function]}
-                    style={
-                      Object {
-                        "height": "100%",
-                        "width": "100%",
-                      }
-                    }
-                    useResizeHandler={true}
-                  >
-                    <div
-                      id="explorerPlotComponent"
-                      style={
-                        Object {
-                          "height": "100%",
-                          "width": "100%",
-                        }
-                      }
-                    />
-                  </PlotlyComponent>
-                </Plt>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem
-              style={
-                Object {
-                  "maxHeight": 500,
-                  "overflowY": "auto",
-                }
-              }
-            >
+            <EuiFlexItem>
               <div
                 className="euiFlexItem"
-                style={
-                  Object {
-                    "maxHeight": 500,
-                    "overflowY": "auto",
-                  }
-                }
               >
-                <Plt
-                  data={Array []}
-                  layout={
-                    Object {
-                      "height": 60,
-                      "margin": Object {
-                        "b": 30,
-                        "l": 150,
-                        "r": 5,
-                        "t": 30,
-                      },
-                      "paper_bgcolor": "rgba(0, 0, 0, 0)",
-                      "plot_bgcolor": "rgba(0, 0, 0, 0)",
-                      "width": 412,
-                      "xaxis": Object {
-                        "color": "#91989c",
-                        "range": Array [
-                          0,
-                          0,
-                        ],
-                        "showline": true,
-                        "side": "top",
-                        "ticksuffix": " ms",
-                      },
-                      "yaxis": Object {
-                        "fixedrange": true,
-                        "showgrid": false,
-                        "ticktext": Array [],
-                        "tickvals": Array [],
-                      },
-                    }
-                  }
-                  onClickHandler={[Function]}
-                  onHoverHandler={[Function]}
-                  onRelayout={[Function]}
-                  onUnhoverHandler={[Function]}
+                <SpanDetailTimeline
+                  colorMap={Object {}}
+                  compact={true}
+                  filters={Array []}
+                  mode="jaeger"
+                  onSpanClick={[Function]}
+                  payloadData=""
                 >
-                  <PlotlyComponent
-                    config={
-                      Object {
-                        "displayModeBar": false,
-                      }
+                  <EuiEmptyPrompt
+                    body={
+                      <p>
+                        No spans found for the selected filters
+                      </p>
                     }
-                    data={Array []}
-                    debug={false}
-                    divId="explorerPlotComponent"
-                    layout={
-                      Object {
-                        "autosize": true,
-                        "barmode": "stack",
-                        "height": 60,
-                        "hovermode": "closest",
-                        "layout": Object {
-                          "annotations": Array [
-                            Object {
-                              "showarrow": true,
-                              "xanchor": "right",
-                            },
-                          ],
-                        },
-                        "legend": Object {
-                          "orientation": "h",
-                          "traceorder": "normal",
-                        },
-                        "margin": Object {
-                          "b": 30,
-                          "l": 150,
-                          "r": 5,
-                          "t": 30,
-                        },
-                        "paper_bgcolor": "rgba(0, 0, 0, 0)",
-                        "plot_bgcolor": "rgba(0, 0, 0, 0)",
-                        "showlegend": false,
-                        "width": 412,
-                        "xaxis": Object {
-                          "color": "#91989c",
-                          "range": Array [
-                            0,
-                            0,
-                          ],
-                          "showline": true,
-                          "side": "top",
-                          "ticksuffix": " ms",
-                        },
-                        "yaxis": Object {
-                          "fixedrange": true,
-                          "showgrid": false,
-                          "ticktext": Array [],
-                          "tickvals": Array [],
-                        },
-                      }
+                    title={
+                      <h2>
+                        No spans found
+                      </h2>
                     }
-                    onClick={[Function]}
-                    onHover={[Function]}
-                    onRelayout={[Function]}
-                    onUnhover={[Function]}
-                    style={
-                      Object {
-                        "height": "100%",
-                        "width": "100%",
-                      }
-                    }
-                    useResizeHandler={true}
                   >
                     <div
-                      id="explorerPlotComponent"
-                      style={
-                        Object {
-                          "height": "100%",
-                          "width": "100%",
-                        }
-                      }
-                    />
-                  </PlotlyComponent>
-                </Plt>
+                      className="euiEmptyPrompt"
+                    >
+                      <EuiTitle
+                        size="m"
+                      >
+                        <h2
+                          className="euiTitle euiTitle--medium"
+                        >
+                          No spans found
+                        </h2>
+                      </EuiTitle>
+                      <EuiTextColor
+                        color="subdued"
+                      >
+                        <span
+                          className="euiTextColor euiTextColor--subdued"
+                        >
+                          <EuiSpacer
+                            size="m"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--m"
+                            />
+                          </EuiSpacer>
+                          <EuiText>
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              <p>
+                                No spans found for the selected filters
+                              </p>
+                            </div>
+                          </EuiText>
+                        </span>
+                      </EuiTextColor>
+                    </div>
+                  </EuiEmptyPrompt>
+                </SpanDetailTimeline>
               </div>
             </EuiFlexItem>
           </div>

--- a/public/components/application_analytics/components/flyout_components/trace_detail_render.tsx
+++ b/public/components/application_analytics/components/flyout_components/trace_detail_render.tsx
@@ -91,6 +91,7 @@ export const TraceDetailRender = ({
           spanFilters={spanFilters}
           setSpanFiltersWithStorage={setSpanFiltersWithStorage}
           onSpanClick={openSpanFlyout}
+          isApplicationFlyout={true}
         />
         <EuiSpacer size="xs" />
         <EuiHorizontalRule margin="s" />

--- a/public/components/application_analytics/components/flyout_components/trace_detail_render.tsx
+++ b/public/components/application_analytics/components/flyout_components/trace_detail_render.tsx
@@ -85,14 +85,12 @@ export const TraceDetailRender = ({
           traceId={traceId}
           http={http}
           colorMap={colorMap}
-          page="app"
-          openSpanFlyout={openSpanFlyout}
           mode={mode}
           dataSourceMDSId={dataSourceMDSId}
-          isApplicationFlyout={true}
           payloadData={payloadData}
           spanFilters={spanFilters}
           setSpanFiltersWithStorage={setSpanFiltersWithStorage}
+          onSpanClick={openSpanFlyout}
         />
         <EuiSpacer size="xs" />
         <EuiHorizontalRule margin="s" />

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_panel.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_panel.test.tsx.snap
@@ -3,7 +3,12 @@
 exports[`SpanDetailPanel component renders correctly with default props 1`] = `
 <Fragment>
   <EuiPanel
-    data-test-subj="span-gantt-chart-panel"
+    data-test-subj="span-timeline-panel"
+    panelRef={
+      Object {
+        "current": null,
+      }
+    }
   >
     <EuiFlexGroup
       direction="column"
@@ -27,16 +32,6 @@ exports[`SpanDetailPanel component renders correctly with default props 1`] = `
               gutterSize="s"
               justifyContent="flexEnd"
             >
-              <EuiFlexItem
-                grow={false}
-              >
-                <EuiSmallButton
-                  isDisabled={true}
-                  onClick={[Function]}
-                >
-                  Reset zoom
-                </EuiSmallButton>
-              </EuiFlexItem>
               <EuiFlexItem
                 grow={false}
               >
@@ -69,105 +64,17 @@ exports[`SpanDetailPanel component renders correctly with default props 1`] = `
       <EuiHorizontalRule
         margin="m"
       />
-      <EuiFlexItem
-        grow={false}
-      >
-        <Plt
-          data={Array []}
-          layout={
+      <EuiFlexItem>
+        <SpanDetailTimeline
+          colorMap={
             Object {
-              "dragmode": "select",
-              "height": 100,
-              "margin": Object {
-                "b": 30,
-                "l": 150,
-                "r": 5,
-                "t": 30,
-              },
-              "paper_bgcolor": "rgba(0, 0, 0, 0)",
-              "plot_bgcolor": "rgba(0, 0, 0, 0)",
-              "shapes": Array [
-                Object {
-                  "editable": true,
-                  "fillcolor": "rgba(128, 128, 128, 0.3)",
-                  "line": Object {
-                    "color": "rgba(255, 0, 0, 0.6)",
-                    "width": 1,
-                  },
-                  "type": "rect",
-                  "x0": 0,
-                  "x1": 0,
-                  "xref": "x",
-                  "y0": 0,
-                  "y1": 1,
-                  "yref": "paper",
-                },
-              ],
-              "width": 824,
-              "xaxis": Object {
-                "color": "#91989c",
-                "range": Array [
-                  0,
-                  0,
-                ],
-                "showline": true,
-                "side": "top",
-                "ticksuffix": " ms",
-              },
-              "yaxis": Object {
-                "fixedrange": true,
-                "visible": false,
-              },
+              "service1": "#7492e7",
             }
           }
-          onRelayout={[Function]}
-          onSelectedHandler={[Function]}
-        />
-      </EuiFlexItem>
-      <EuiFlexItem
-        style={
-          Object {
-            "maxHeight": 500,
-            "overflowY": "auto",
-          }
-        }
-      >
-        <Plt
-          data={Array []}
-          layout={
-            Object {
-              "height": 60,
-              "margin": Object {
-                "b": 30,
-                "l": 150,
-                "r": 5,
-                "t": 30,
-              },
-              "paper_bgcolor": "rgba(0, 0, 0, 0)",
-              "plot_bgcolor": "rgba(0, 0, 0, 0)",
-              "width": 824,
-              "xaxis": Object {
-                "color": "#91989c",
-                "range": Array [
-                  0,
-                  0,
-                ],
-                "showline": true,
-                "side": "top",
-                "ticksuffix": " ms",
-              },
-              "yaxis": Object {
-                "fixedrange": true,
-                "showgrid": false,
-                "ticktext": Array [],
-                "tickvals": Array [],
-              },
-            }
-          }
-          onClickHandler={[Function]}
-          onHoverHandler={[Function]}
-          onRelayout={[Function]}
-          onUnhoverHandler={[Function]}
+          filters={Array []}
+          mode="data_prepper"
+          onSpanClick={[MockFunction]}
+          payloadData="{\\"traceId\\":\\"trace1\\",\\"spanId\\":\\"span1\\",\\"parentSpanId\\":\\"span0\\",\\"operationName\\":\\"GET /api/users\\",\\"serviceName\\":\\"user-service\\",\\"startTime\\":1640995200000,\\"endTime\\":1640995210000,\\"duration\\":10000,\\"tags\\":{\\"http.method\\":\\"GET\\",\\"http.url\\":\\"/api/users\\",\\"http.status_code\\":200,\\"component\\":\\"spring-web\\"},\\"process\\":{\\"serviceName\\":\\"user-service\\",\\"tags\\":{\\"jaeger.version\\":\\"1.35.0\\",\\"hostname\\":\\"user-service-pod-123\\"}}}"
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/trace_view.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/trace_view.test.tsx.snap
@@ -157,21 +157,13 @@ exports[`Trace view component renders trace view 1`] = `
         <EuiFlexItem>
           <SpanDetailPanel
             colorMap={Object {}}
-            data={
-              Object {
-                "gantt": Array [],
-                "ganttMaxX": 0,
-                "table": Array [],
-              }
-            }
             dataSourceMDSId=""
             dataSourceMDSLabel=""
             http={[MockFunction]}
-            isGanttChartLoading={false}
+            isLoading={false}
             mode="data_prepper"
+            onSpanClick={[Function]}
             payloadData=""
-            setGanttChartLoading={[Function]}
-            setGanttData={[Function]}
             setSpanFiltersWithStorage={[Function]}
             spanFilters={Array []}
             traceId="test"

--- a/public/components/trace_analytics/components/traces/__tests__/span_detail_panel.test.tsx
+++ b/public/components/trace_analytics/components/traces/__tests__/span_detail_panel.test.tsx
@@ -3,84 +3,53 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiSmallButton } from '@elastic/eui';
-import { waitFor } from '@testing-library/react';
 import { configure, mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { Plt } from '../../../../visualizations/plotly/plot';
 import { SpanDetailPanel } from '../span_detail_panel';
+import { HttpSetup } from '../../../../../../../../src/core/public';
 
 configure({ adapter: new Adapter() });
 
-jest.mock('../../../../visualizations/plotly/plot', () => ({
-  Plt: (props: any) => (
-    <div
-      data-test-subj="mocked-plt"
-      tabIndex={0}
-      role="button"
-      onClick={() => {
-        if (props.onSelectedHandler) {
-          props.onSelectedHandler({ range: { x: [5, 15] } });
-        }
-      }}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          if (props.onSelectedHandler) {
-            props.onSelectedHandler({ range: { x: [5, 15] } });
-          }
-        }
-      }}
-    />
-  ),
-}));
-
-const mockHttp = {
+const mockHttp = ({
   post: jest.fn(),
-};
+} as unknown) as HttpSetup;
 
 const mockData = {
-  gantt: [
-    {
-      x: [10],
-      y: ['service1'],
-      marker: { color: '#fff' },
-      width: 0.4,
-      type: 'bar',
-      orientation: 'h',
-      hoverinfo: 'none',
-      showlegend: false,
+  traceId: 'trace1',
+  spanId: 'span1',
+  parentSpanId: 'span0',
+  operationName: 'GET /api/users',
+  serviceName: 'user-service',
+  startTime: 1640995200000,
+  endTime: 1640995210000,
+  duration: 10000,
+  tags: {
+    'http.method': 'GET',
+    'http.url': '/api/users',
+    'http.status_code': 200,
+    component: 'spring-web',
+  },
+  process: {
+    serviceName: 'user-service',
+    tags: {
+      'jaeger.version': '1.35.0',
+      hostname: 'user-service-pod-123',
     },
-  ],
-  table: [
-    {
-      service_name: 'service1',
-      span_id: 'span1',
-      latency: 10,
-      error: 'Error',
-      start_time: '2023-01-01T00:00:00Z',
-      end_time: '2023-01-01T00:00:10Z',
-    },
-  ],
-  ganttMaxX: 20,
+  },
 };
 
-const mockSetData = jest.fn();
-const mockAddSpanFilter = jest.fn();
 const mockProps = {
   http: mockHttp,
   traceId: 'trace1',
   colorMap: { service1: '#7492e7' },
-  mode: 'data_prepper',
+  mode: 'data_prepper' as const,
   dataSourceMDSId: 'mock-id',
   dataSourceMDSLabel: 'mock-label',
-  data: mockData,
-  setData: mockSetData,
-  addSpanFilter: mockAddSpanFilter,
-  removeSpanFilter: jest.fn(),
   spanFilters: [],
   setSpanFiltersWithStorage: jest.fn(),
+  onSpanClick: jest.fn(),
+  payloadData: JSON.stringify(mockData),
 };
 
 describe('SpanDetailPanel component', () => {
@@ -89,86 +58,13 @@ describe('SpanDetailPanel component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('displays loading chart when isGanttChartLoading is true', () => {
-    const wrapper = mount(<SpanDetailPanel {...mockProps} isGanttChartLoading={true} />);
+  it('displays loading chart when isLoading is true', () => {
+    const wrapper = mount(<SpanDetailPanel {...mockProps} isLoading={true} />);
     expect(wrapper.find('EuiLoadingChart')).toHaveLength(1);
   });
 
-  it('does not display loading chart when isGanttChartLoading is false', () => {
-    const wrapper = mount(<SpanDetailPanel {...mockProps} isGanttChartLoading={false} />);
+  it('does not display loading chart when isLoading is false', () => {
+    const wrapper = mount(<SpanDetailPanel {...mockProps} isLoading={false} />);
     expect(wrapper.find('EuiLoadingChart')).toHaveLength(0);
-  });
-
-  it('renders gantt chart and mini-map correctly', async () => {
-    const wrapper = mount(<SpanDetailPanel {...mockProps} />);
-
-    await waitFor(() => {
-      wrapper.update();
-      expect(wrapper.find(Plt)).toHaveLength(2); // Gantt chart and mini-map appear
-    });
-  });
-
-  it('handles zoom reset button correctly', async () => {
-    const wrapper = mount(<SpanDetailPanel {...mockProps} />);
-
-    await waitFor(() => {
-      wrapper.update();
-      expect(wrapper.find(Plt)).toHaveLength(2); // Gantt chart and mini-map appear
-    });
-    // Verify that the reset button is initially disabled
-    let resetButton = wrapper
-      .find(EuiSmallButton)
-      .filterWhere((btn) => btn.text().includes('Reset zoom'));
-    expect(resetButton.prop('isDisabled')).toBe(true);
-
-    // Simulate a click on the mini-map
-    const miniMap = wrapper.find('[data-test-subj="mocked-plt"]').at(0);
-    act(() => {
-      miniMap.simulate('click');
-    });
-
-    await waitFor(() => {
-      wrapper.update();
-      resetButton = wrapper
-        .find(EuiSmallButton)
-        .filterWhere((btn) => btn.text().includes('Reset zoom'));
-      expect(resetButton.prop('isDisabled')).toBe(false); // Should now be enabled
-    });
-
-    // Simulate clicking the reset button
-    act(() => {
-      resetButton.prop('onClick')!();
-    });
-
-    await waitFor(() => {
-      wrapper.update();
-      resetButton = wrapper
-        .find(EuiSmallButton)
-        .filterWhere((btn) => btn.text().includes('Reset zoom'));
-      expect(resetButton.prop('isDisabled')).toBe(true); // Should reset
-    });
-  });
-
-  it('handles user-defined zoom range via mini-map', async () => {
-    const wrapper = mount(<SpanDetailPanel {...mockProps} />);
-
-    await waitFor(() => {
-      wrapper.update();
-      expect(wrapper.find(Plt)).toHaveLength(2); // Gantt chart and mini-map appear
-    });
-
-    // Find the mini-map and simulate click
-    const miniMap = wrapper.find('[data-test-subj="mocked-plt"]').at(0);
-    act(() => {
-      miniMap.simulate('click');
-    });
-
-    await waitFor(() => {
-      wrapper.update();
-      const resetButton = wrapper
-        .find(EuiSmallButton)
-        .filterWhere((btn) => btn.text().includes('Reset zoom'));
-      expect(resetButton.prop('isDisabled')).toBe(false);
-    });
   });
 });

--- a/public/components/trace_analytics/components/traces/span_detail_panel.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_panel.tsx
@@ -22,6 +22,7 @@ import { coreRefs } from '../../../../framework/core_refs';
 import { TraceFilter } from '../common/constants';
 import { PanelTitle, parseHits } from '../common/helper_functions';
 import { SpanDetailTable, SpanDetailTableHierarchy } from './span_detail_table';
+import { SpanDetailTimeline } from './span_detail_timeline/span_detail_timeline';
 
 export function SpanDetailPanel(props: {
   http: HttpSetup;
@@ -35,6 +36,7 @@ export function SpanDetailPanel(props: {
   onSpanClick: (spanId: string) => void;
   payloadData: string;
   isLoading?: boolean;
+  isApplicationFlyout?: boolean;
 }) {
   const { chrome } = coreRefs;
   const { mode } = props;
@@ -82,17 +84,14 @@ export function SpanDetailPanel(props: {
     }
   };
 
-  useEffect(() => {
+  const spansCount = useMemo(() => {
     if (!props.payloadData) {
-      return;
+      return 0;
     }
 
     const hits = parseHits(props.payloadData);
-
-    if (hits.length === 0) {
-      return;
-    }
-  }, [props.payloadData, props.colorMap, mode, props.spanFilters]);
+    return hits.length;
+  }, [props.payloadData]);
 
   const renderFilters = useMemo(() => {
     return props.spanFilters.map(({ field, value }) => (
@@ -167,12 +166,12 @@ export function SpanDetailPanel(props: {
 
   return (
     <>
-      <EuiPanel data-test-subj="span-gantt-chart-panel">
+      <EuiPanel data-test-subj="span-gantt-chart-panel" panelRef={containerRef}>
         <EuiFlexGroup direction="column" gutterSize="m">
           <EuiFlexItem grow={false}>
             <EuiFlexGroup>
               <EuiFlexItem>
-                <PanelTitle title="Spans" totalItems={0} />
+                <PanelTitle title="Spans" totalItems={spansCount} />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiFlexGroup justifyContent="flexEnd" alignItems="center" gutterSize="s">
@@ -206,9 +205,16 @@ export function SpanDetailPanel(props: {
 
               <EuiHorizontalRule margin="m" />
 
-              <EuiFlexItem style={{ overflowY: 'auto', maxHeight: 500 }}>
+              <EuiFlexItem>
                 {toggleIdSelected === 'timeline' ? (
-                  <div>New Timeline Here</div>
+                  <SpanDetailTimeline
+                    mode={mode}
+                    payloadData={props.payloadData}
+                    colorMap={props.colorMap}
+                    onSpanClick={props.onSpanClick}
+                    filters={props.spanFilters}
+                    compact={props.isApplicationFlyout}
+                  />
                 ) : toggleIdSelected === 'span_list' ? (
                   spanDetailTable
                 ) : (

--- a/public/components/trace_analytics/components/traces/span_detail_panel.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_panel.tsx
@@ -166,7 +166,7 @@ export function SpanDetailPanel(props: {
 
   return (
     <>
-      <EuiPanel data-test-subj="span-gantt-chart-panel" panelRef={containerRef}>
+      <EuiPanel data-test-subj="span-timeline-panel" panelRef={containerRef}>
         <EuiFlexGroup direction="column" gutterSize="m">
           <EuiFlexItem grow={false}>
             <EuiFlexGroup>

--- a/public/components/trace_analytics/components/traces/span_detail_panel.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_panel.tsx
@@ -12,59 +12,34 @@ import {
   EuiHorizontalRule,
   EuiLoadingChart,
   EuiPanel,
-  EuiSmallButton,
   EuiSpacer,
 } from '@elastic/eui';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import { HttpSetup } from '../../../../../../../src/core/public';
 import { TraceAnalyticsMode } from '../../../../../common/types/trace_analytics';
 import { coreRefs } from '../../../../framework/core_refs';
-import { Plt } from '../../../visualizations/plotly/plot';
-import { hitsToSpanDetailData } from '../../requests/traces_request_handler';
 import { TraceFilter } from '../common/constants';
 import { PanelTitle, parseHits } from '../common/helper_functions';
-import { SpanDetailFlyout } from './span_detail_flyout';
 import { SpanDetailTable, SpanDetailTableHierarchy } from './span_detail_table';
 
 export function SpanDetailPanel(props: {
   http: HttpSetup;
   traceId: string;
-  colorMap: any;
+  colorMap: Record<string, string>;
   mode: TraceAnalyticsMode;
   dataSourceMDSId: string;
-  dataSourceMDSLabel: string | undefined;
+  dataSourceMDSLabel?: string;
   spanFilters: TraceFilter[];
   setSpanFiltersWithStorage: (newFilters: TraceFilter[]) => void;
-  page?: string;
-  openSpanFlyout?: any;
-  data?: { gantt: any[]; table: any[]; ganttMaxX: number };
-  setGanttData?: (data: { gantt: any[]; table: any[]; ganttMaxX: number }) => void;
-  isApplicationFlyout?: boolean;
+  onSpanClick: (spanId: string) => void;
   payloadData: string;
-  isGanttChartLoading?: boolean;
-  setGanttChartLoading?: (loading: boolean) => void;
+  isLoading?: boolean;
 }) {
   const { chrome } = coreRefs;
   const { mode } = props;
-  const fromApp = props.page === 'app';
 
-  let data: { gantt: any[]; table: any[]; ganttMaxX: number };
-  let setData: (data: { gantt: any[]; table: any[]; ganttMaxX: number }) => void;
-  const [localData, localSetData] = useState<{ gantt: any[]; table: any[]; ganttMaxX: number }>({
-    gantt: [],
-    table: [],
-    ganttMaxX: 0,
-  });
-  if (props.data && props.setGanttData) {
-    [data, setData] = [props.data, props.setGanttData];
-  } else {
-    [data, setData] = [localData, localSetData];
-  }
-  const fullRange = [0, data.ganttMaxX * 1.1];
-  const [selectedRange, setSelectedRange] = useState(fullRange);
   const isLocked = useObservable(chrome!.getIsNavDrawerLocked$() ?? false);
-  const [isFullScreen, setIsFullScreen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [availableWidth, setAvailableWidth] = useState<number>(window.innerWidth);
   const newNavigation = coreRefs?.chrome?.navGroup.getNavGroupEnabled?.();
@@ -77,16 +52,10 @@ export function SpanDetailPanel(props: {
     }
   };
 
-  const handleFullScreenChange = () => {
-    const isFullscreenActive = !!document.fullscreenElement;
-    setIsFullScreen(isFullscreenActive);
-    updateAvailableWidth();
-  };
-
   useEffect(() => {
     // Add event listeners for window resize and full-screen toggling
     window.addEventListener('resize', updateAvailableWidth);
-    document.addEventListener('fullscreenchange', handleFullScreenChange);
+    document.addEventListener('fullscreenchange', updateAvailableWidth);
 
     // Initial update
     updateAvailableWidth();
@@ -94,7 +63,7 @@ export function SpanDetailPanel(props: {
     return () => {
       // Clean up event listeners
       window.removeEventListener('resize', updateAvailableWidth);
-      document.removeEventListener('fullscreenchange', handleFullScreenChange);
+      document.removeEventListener('fullscreenchange', updateAvailableWidth);
     };
   }, []);
 
@@ -103,22 +72,6 @@ export function SpanDetailPanel(props: {
     const leftNavAdjustment = newNavigation ? 125 : 75;
     return isLocked ? availableWidth - adjustment : availableWidth - leftNavAdjustment;
   }, [isLocked, availableWidth]);
-
-  // Update selectedRange whenever data.ganttMaxX changes to ensure it starts fully zoomed out
-  useEffect(() => {
-    setSelectedRange(fullRange);
-  }, [data.ganttMaxX]);
-
-  const addSpanFilter = (field: string, value: any) => {
-    const newFilters = [...props.spanFilters];
-    const index = newFilters.findIndex(({ field: filterField }) => field === filterField);
-    if (index === -1) {
-      newFilters.push({ field, value });
-    } else {
-      newFilters.splice(index, 1, { field, value });
-    }
-    props.setSpanFiltersWithStorage(newFilters);
-  };
 
   const removeSpanFilter = (field: string) => {
     const newFilters = [...props.spanFilters];
@@ -131,7 +84,6 @@ export function SpanDetailPanel(props: {
 
   useEffect(() => {
     if (!props.payloadData) {
-      props.setGanttChartLoading?.(false);
       return;
     }
 
@@ -140,142 +92,7 @@ export function SpanDetailPanel(props: {
     if (hits.length === 0) {
       return;
     }
-
-    hitsToSpanDetailData(hits, props.colorMap, mode)
-      .then((transformedData) => {
-        setData(transformedData);
-      })
-      .catch((error) => {
-        console.error('Error in hitsToSpanDetailData:', error);
-      })
-      .finally(() => {
-        props.setGanttChartLoading?.(false);
-      });
   }, [props.payloadData, props.colorMap, mode, props.spanFilters]);
-
-  const getSpanDetailLayout = (
-    plotTraces: Plotly.Data[],
-    _maxX: number
-  ): Partial<Plotly.Layout> => {
-    const dynamicWidthAdjustment = !isLocked
-      ? 200
-      : newNavigation
-      ? 390 // If locked and new navigation
-      : 410; // If locked and new navigation is disabled
-    // get unique labels from traces
-    const yLabels = plotTraces
-      .map((d) => d.y[0])
-      .filter((label, i, self) => self.indexOf(label) === i);
-    // remove uuid when displaying y-ticks
-    const yTexts = yLabels.map((label) => label.substring(0, label.length - 36));
-
-    // Calculate the maximum label length dynamically
-    const maxLabelLength = Math.max(...yTexts.map((text) => text.length));
-
-    // Dynamically set left margin based on the longest label
-    let dynamicLeftMargin = Math.max(150, maxLabelLength * 5);
-    dynamicLeftMargin = Math.min(dynamicLeftMargin, 500);
-
-    return {
-      plot_bgcolor: 'rgba(0, 0, 0, 0)',
-      paper_bgcolor: 'rgba(0, 0, 0, 0)',
-      height: 25 * plotTraces.length + 60,
-      width: props.isApplicationFlyout
-        ? availableWidth / 2 - 100 // Allow gantt chart to fit in flyout
-        : availableWidth - dynamicWidthAdjustment, // Allow gantt chart to render full screen
-      margin: {
-        l: dynamicLeftMargin,
-        r: 5,
-        b: 30,
-        t: 30,
-      },
-      xaxis: {
-        ticksuffix: ' ms',
-        side: 'top',
-        color: '#91989c',
-        showline: true,
-        range: selectedRange, // Apply selected range to main chart
-      },
-      yaxis: {
-        showgrid: false,
-        tickvals: yLabels,
-        ticktext: yTexts,
-        fixedrange: true, // Prevent panning/scrolling in main chart
-      },
-    };
-  };
-
-  const layout = useMemo(() => getSpanDetailLayout(data.gantt, data.ganttMaxX), [
-    data.gantt,
-    data.ganttMaxX,
-    selectedRange,
-    availableWidth,
-    isLocked,
-    isFullScreen,
-  ]);
-  const miniMapLayout = {
-    ...layout,
-    height: 100,
-    dragmode: 'select', // Allow users to define their zoom range
-    xaxis: { ...layout.xaxis, range: fullRange },
-    yaxis: { visible: false, fixedrange: true },
-    shapes: [
-      {
-        type: 'rect',
-        xref: 'x',
-        yref: 'paper',
-        x0: selectedRange[0],
-        x1: selectedRange[1],
-        y0: 0,
-        y1: 1,
-        fillcolor: 'rgba(128, 128, 128, 0.3)', // Highlight the selection area
-        line: {
-          width: 1,
-          color: 'rgba(255, 0, 0, 0.6)', // Border of the selection
-        },
-        editable: true,
-      },
-    ],
-  };
-
-  const miniMap = useMemo(
-    () => (
-      <Plt
-        data={data.gantt.map((trace) => ({
-          ...trace,
-        }))}
-        layout={miniMapLayout}
-        onSelectedHandler={(event) => {
-          if (event && event.range) {
-            const { x } = event.range;
-            setSelectedRange(x); // Update selected range to reflect user-defined zoom
-          }
-        }}
-        onRelayout={(event) => {
-          if (event && event['shapes[0].x0'] && event['shapes[0].x1']) {
-            // Update selected range when the shape (rectangle) is moved
-            setSelectedRange([event['shapes[0].x0'], event['shapes[0].x1']]);
-          }
-        }}
-      />
-    ),
-    [data.gantt, miniMapLayout, setSelectedRange]
-  );
-
-  const [currentSpan, setCurrentSpan] = useState('');
-
-  const onClick = useCallback(
-    (event: any) => {
-      if (!event?.points) return;
-      const point = event.points[0];
-      if (fromApp) {
-        props.openSpanFlyout(point.data.spanId);
-      } else {
-        setCurrentSpan(point.data.spanId);
-      }
-    },
-    [props.openSpanFlyout, setCurrentSpan, fromApp]
-  );
 
   const renderFilters = useMemo(() => {
     return props.spanFilters.map(({ field, value }) => (
@@ -291,29 +108,6 @@ export function SpanDetailPanel(props: {
       </EuiFlexItem>
     ));
   }, [props.spanFilters]);
-
-  const onHover = useCallback(() => {
-    const dragLayer = document.getElementsByClassName('nsewdrag')?.[0];
-    dragLayer.style.cursor = 'pointer';
-  }, []);
-
-  const onUnhover = useCallback(() => {
-    const dragLayer = document.getElementsByClassName('nsewdrag')?.[0];
-    dragLayer.style.cursor = '';
-  }, []);
-
-  const onRelayoutHandler = useCallback(
-    (event) => {
-      // Handle x-axis range update
-      if (event && event['xaxis.range[0]'] && event['xaxis.range[1]']) {
-        const newRange = [event['xaxis.range[0]'], event['xaxis.range[1]']];
-        setSelectedRange(newRange);
-      } else {
-        setSelectedRange(fullRange);
-      }
-    },
-    [setSelectedRange, fullRange]
-  );
 
   const toggleOptions = [
     {
@@ -339,11 +133,7 @@ export function SpanDetailPanel(props: {
           hiddenColumns={mode === 'jaeger' ? ['traceID', 'traceGroup'] : ['traceId', 'traceGroup']}
           mode={mode}
           openFlyout={(spanId: string) => {
-            if (fromApp) {
-              props.openSpanFlyout(spanId);
-            } else {
-              setCurrentSpan(spanId);
-            }
+            props.onSpanClick(spanId);
           }}
           dataSourceMDSId={props.dataSourceMDSId}
           availableWidth={dynamicLayoutAdjustment}
@@ -352,7 +142,7 @@ export function SpanDetailPanel(props: {
         />
       </div>
     ),
-    [setCurrentSpan, dynamicLayoutAdjustment, props.payloadData, props.spanFilters]
+    [dynamicLayoutAdjustment, props.payloadData, props.spanFilters]
   );
 
   const spanDetailTableHierarchy = useMemo(
@@ -363,11 +153,7 @@ export function SpanDetailPanel(props: {
           hiddenColumns={mode === 'jaeger' ? ['traceID', 'traceGroup'] : ['traceId', 'traceGroup']}
           mode={mode}
           openFlyout={(spanId: string) => {
-            if (fromApp) {
-              props.openSpanFlyout(spanId);
-            } else {
-              setCurrentSpan(spanId);
-            }
+            props.onSpanClick(spanId);
           }}
           dataSourceMDSId={props.dataSourceMDSId}
           availableWidth={dynamicLayoutAdjustment}
@@ -376,38 +162,7 @@ export function SpanDetailPanel(props: {
         />
       </div>
     ),
-    [setCurrentSpan, dynamicLayoutAdjustment, props.payloadData, props.spanFilters]
-  );
-
-  const ganttChart = useMemo(
-    () => (
-      <Plt
-        data={data.gantt.map((trace) => {
-          const hasError = trace.text && trace.text[0] && trace.text[0].includes('Error');
-
-          if (hasError) {
-            return {
-              ...trace,
-            };
-          }
-
-          const duration = trace.x[0] ? trace.x[0].toFixed(2) : '0.00'; // Format duration to 2 decimal places
-
-          return {
-            ...trace,
-            text: `${duration} ms`,
-            textposition: 'outside',
-            hoverinfo: 'none',
-          };
-        })}
-        layout={layout}
-        onClickHandler={onClick}
-        onHoverHandler={onHover}
-        onUnhoverHandler={onUnhover}
-        onRelayout={onRelayoutHandler}
-      />
-    ),
-    [data.gantt, layout, onClick, onHover, onUnhover, setSelectedRange]
+    [dynamicLayoutAdjustment, props.payloadData, props.spanFilters]
   );
 
   return (
@@ -417,25 +172,13 @@ export function SpanDetailPanel(props: {
           <EuiFlexItem grow={false}>
             <EuiFlexGroup>
               <EuiFlexItem>
-                <PanelTitle title="Spans" totalItems={data.gantt.length / 2} />
+                <PanelTitle title="Spans" totalItems={0} />
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiFlexGroup justifyContent="flexEnd" alignItems="center" gutterSize="s">
-                  {toggleIdSelected === 'timeline' && (
-                    <EuiFlexItem grow={false}>
-                      <EuiSmallButton
-                        onClick={() => setSelectedRange(fullRange)}
-                        isDisabled={
-                          selectedRange[0] === fullRange[0] && selectedRange[1] === fullRange[1]
-                        }
-                      >
-                        Reset zoom
-                      </EuiSmallButton>
-                    </EuiFlexItem>
-                  )}
                   <EuiFlexItem grow={false}>
                     <EuiButtonGroup
-                      isDisabled={props.isGanttChartLoading}
+                      isDisabled={props.isLoading}
                       legend="Select view of spans"
                       options={toggleOptions}
                       idSelected={toggleIdSelected}
@@ -446,7 +189,7 @@ export function SpanDetailPanel(props: {
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
-          {props.isGanttChartLoading ? (
+          {props.isLoading ? (
             <div className="center-loading-div">
               <EuiLoadingChart size="l" />
             </div>
@@ -463,31 +206,19 @@ export function SpanDetailPanel(props: {
 
               <EuiHorizontalRule margin="m" />
 
-              {toggleIdSelected === 'timeline' && <EuiFlexItem grow={false}>{miniMap}</EuiFlexItem>}
-
               <EuiFlexItem style={{ overflowY: 'auto', maxHeight: 500 }}>
-                {toggleIdSelected === 'timeline'
-                  ? ganttChart
-                  : toggleIdSelected === 'span_list'
-                  ? spanDetailTable
-                  : spanDetailTableHierarchy}
+                {toggleIdSelected === 'timeline' ? (
+                  <div>New Timeline Here</div>
+                ) : toggleIdSelected === 'span_list' ? (
+                  spanDetailTable
+                ) : (
+                  spanDetailTableHierarchy
+                )}
               </EuiFlexItem>
             </>
           )}
         </EuiFlexGroup>
       </EuiPanel>
-      {!!currentSpan && (
-        <SpanDetailFlyout
-          http={props.http}
-          spanId={currentSpan}
-          isFlyoutVisible={!!currentSpan}
-          closeFlyout={() => setCurrentSpan('')}
-          addSpanFilter={addSpanFilter}
-          mode={mode}
-          dataSourceMDSId={props.dataSourceMDSId}
-          dataSourceMDSLabel={props.dataSourceMDSLabel}
-        />
-      )}
     </>
   );
 }

--- a/public/components/trace_analytics/components/traces/span_detail_timeline/span_detail_timeline.scss
+++ b/public/components/trace_analytics/components/traces/span_detail_timeline/span_detail_timeline.scss
@@ -1,0 +1,290 @@
+.span-detail-timeline {
+  @include euiScrollBar;
+  position: relative;
+  max-height: 500px;
+  overflow-y: auto;
+  isolation: isolate;
+  border-bottom: 1px solid $ouiColorLightShade;
+  --z-index-header: 150;
+
+  .timeline-selection {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background-color: rgba(0, 179, 164, 0.2);
+    pointer-events: none;
+    z-index: 100;
+  }
+
+  .timeline-container {
+    position: relative;
+    display: grid;
+    font-size: 16px;
+  }
+
+  .timeline-grid {
+    position: absolute;
+    top: 20px;
+    right: 0;
+    bottom: 0;
+    border-bottom: 1px solid $ouiColorLightShade;
+    opacity: 0.2;
+  }
+
+  .timeline-grid-line {
+    position: absolute;
+    bottom: 0;
+    width: 1px;
+    height: 100%;
+    background-color: $ouiColorLightShade;
+
+    &--transform-end {
+      transform: translateX(-100%);
+    }
+  }
+
+  .timeline-controls {
+    position: sticky;
+    top: 0;
+    background-color: $ouiColorEmptyShade;
+    z-index: var(--z-index-header);
+    display: flex;
+    align-items: center;
+  }
+
+  .timeline-header {
+    position: sticky;
+    top: 0;
+    background-color: $ouiColorEmptyShade;
+    z-index: var(--z-index-header);
+    border-bottom: 1px solid $ouiColorLightShade;
+  }
+
+  .timeline-tick-mark {
+    position: absolute;
+    bottom: 0;
+    padding-bottom: 4px;
+
+    &::before {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 1px;
+      height: 4px;
+      background-color: $ouiColorLightShade;
+    }
+
+    &--transform-end {
+      transform: translateX(-100%);
+
+      &::before {
+        left: auto;
+        right: 0;
+      }
+    }
+  }
+
+  .timeline-tick-label {
+    transform: translateX(-50%);
+
+    &--transform-start,
+    &--transform-end {
+      transform: translateX(0);
+    }
+  }
+
+  .span-row {
+    display: flex;
+    position: relative;
+    min-height: 42px;
+    min-width: 0;
+    border-left: 1px solid $ouiColorLightShade;
+  }
+
+  .span-row[data-index='0'] .span-connector--horizontal {
+    display: none;
+  }
+
+  .span-timeline-bar-container[data-index='0'] {
+    border-top-color: transparent;
+  }
+
+  .span-connector {
+    position: absolute;
+    width: 1px;
+    background-color: $ouiColorLightShade;
+
+    &--vertical {
+      top: 0;
+      bottom: 0;
+    }
+
+    &--vertical-half {
+      top: 0;
+      height: 50%;
+    }
+
+    &--horizontal {
+      right: 0;
+      width: auto;
+      height: 1px;
+    }
+  }
+
+  .span-toggle-container {
+    position: relative;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+  }
+
+  .span-toggle-button {
+    position: relative;
+    width: 16px;
+    height: 16px;
+    border: 1px solid $ouiColorLightShade;
+    background-color: $ouiColorEmptyShade;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  }
+
+  .span-details {
+    display: flex;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .span-timeline-bar-container {
+    width: 100%;
+    position: relative;
+    cursor: crosshair;
+    user-select: none;
+    overflow: hidden;
+    min-height: 42px;
+    border-top: 1px solid $ouiColorLightShade;
+    border-right: 1px solid $ouiColorLightShade;
+  }
+
+  .span-row:hover,
+  .span-row:has(+ .span-timeline-bar-container:hover),
+  .span-timeline-bar-container:hover,
+  .span-row:hover + .span-timeline-bar-container {
+    background-color: rgba($ouiColorLightestShade, 0.7);
+  }
+
+  .span-timeline-bar {
+    position: absolute;
+    top: 16%;
+    height: 40%;
+    min-width: 2px;
+    border-radius: 2px;
+
+    &:has(.span-timeline-bar-button:hover) {
+      box-shadow: 0 0 0 $ouiFocusRingSize $ouiFocusRingColor;
+    }
+  }
+
+  .span-timeline-bar-button {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    min-width: 20px;
+    height: 100%;
+    cursor: pointer;
+    border-radius: 2px;
+  }
+
+  .span-timeline-bar-label {
+    position: absolute;
+    top: 56%;
+  }
+}
+
+.span-detail-timeline-minimap {
+  border: 1px solid $ouiColorLightShade;
+  cursor: pointer;
+  user-select: none;
+  position: sticky;
+  top: 0;
+  z-index: var(--z-index-header);
+  background-color: $ouiColorEmptyShade;
+  overflow: hidden;
+
+  .minimap-container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+
+  .minimap-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+  }
+
+  .minimap-selection {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background-color: rgba(0, 179, 164, 0.2);
+    pointer-events: all;
+  }
+
+  .minimap-handle {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 6px;
+    background-color: rgba(0, 179, 164, 0.5);
+    cursor: ew-resize;
+    opacity: 1;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 1;
+      background-color: rgba(0, 179, 164, 0.8);
+    }
+
+    &--left {
+      left: 0;
+    }
+
+    &--right {
+      right: 0;
+    }
+  }
+
+  .minimap-move-area {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 6px;
+    right: 6px;
+    cursor: grab;
+    background-color: transparent;
+
+    &:active {
+      cursor: grabbing;
+    }
+
+    &:hover {
+      background-color: rgba(0, 179, 164, 0.1);
+    }
+  }
+
+  &:hover {
+    background-color: $ouiColorEmptyShade;
+  }
+}

--- a/public/components/trace_analytics/components/traces/span_detail_timeline/span_detail_timeline.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_timeline/span_detail_timeline.tsx
@@ -1,0 +1,523 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import { scaleLinear } from 'd3-scale';
+import throttle from 'lodash/throttle';
+import classNames from 'classnames';
+import {
+  EuiText,
+  EuiButtonIcon,
+  EuiSelectable,
+  EuiSelectableOption,
+  EuiIcon,
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiEmptyPrompt,
+} from '@elastic/eui';
+import './span_detail_timeline.scss';
+import { TraceAnalyticsMode } from '../../../../../../common/types/trace_analytics';
+import { parseHits } from '../../common/helper_functions';
+import { Span, TraceFilter } from '../../common/constants';
+import { SpanWithChildren } from './types';
+import { TimelineMinimap } from './timeline_minimap';
+import { TimelineRow } from './timeline_row';
+import {
+  DEFAULT_DOMAIN,
+  MINIMAP_HEIGHT,
+  RULER_HEIGHT,
+  isDefaultDomain,
+  buildHierarchy,
+  getStartTimeInMs,
+  getDurationInMs,
+} from './utils';
+
+interface SpanDetailTimelineProps {
+  mode: TraceAnalyticsMode;
+  payloadData: string;
+  colorMap: Record<string, string>;
+  onSpanClick: (spanId: string) => void;
+  filters: TraceFilter[];
+  compact?: boolean;
+}
+
+export function SpanDetailTimeline(props: SpanDetailTimelineProps) {
+  const [collapsedSpans, setCollapsedSpans] = useState<Set<string>>(new Set());
+  const [showCollapseButton, setShowCollapseButton] = useState(true);
+
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragStart, setDragStart] = useState<number | null>(null);
+  const [selection, setSelection] = useState<{ start?: number; end?: number }>({});
+  const [selectedDomain, setSelectedDomain] = useState<[number, number]>(DEFAULT_DOMAIN);
+  const [options, setOptions] = useState<EuiSelectableOption[]>([]);
+
+  const isCompact = props.compact;
+
+  const { spans, min, max } = useMemo(() => {
+    if (!props.payloadData) return { spans: [], min: 0, max: 0 };
+
+    let spanList: Span[] = [];
+    let minTime = Number.POSITIVE_INFINITY;
+    let maxTime = Number.NEGATIVE_INFINITY;
+
+    parseHits(props.payloadData).forEach((hit) => {
+      const span = hit._source;
+      spanList.push(span);
+
+      const minStartTime = getStartTimeInMs(props.mode, span);
+      const duration = getDurationInMs(props.mode, span);
+
+      minTime = Math.min(minTime, minStartTime);
+      maxTime = Math.max(maxTime, minStartTime + duration);
+    });
+
+    if (props.filters.length > 0) {
+      spanList = spanList.filter((span) => {
+        return props.filters.every(({ field, value }) => (span as any)[field] === value);
+      });
+    }
+
+    const hierarchy = buildHierarchy(props.mode, spanList);
+    return {
+      spans: hierarchy,
+      min: minTime,
+      max: maxTime,
+    };
+  }, [props.payloadData, props.filters, props.mode]);
+
+  // Get service names from spans and initialize filter options
+  const serviceOptions = useMemo(() => {
+    const extractServiceNamesAndCounts = (spanList: SpanWithChildren[]): Map<string, number> => {
+      const serviceCounts = new Map<string, number>();
+      const traverse = (_spanList: SpanWithChildren[]) => {
+        _spanList.forEach((span) => {
+          serviceCounts.set(span.serviceName, (serviceCounts.get(span.serviceName) || 0) + 1);
+          if (span.children.length > 0) {
+            traverse(span.children);
+          }
+        });
+      };
+      traverse(spanList);
+      return serviceCounts;
+    };
+
+    const serviceNameCounts = extractServiceNamesAndCounts(spans);
+    const serviceNames: EuiSelectableOption[] = Array.from(serviceNameCounts.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([serviceName, count]) => ({
+        key: serviceName,
+        label: `${serviceName} (${count})`,
+        prepend: <EuiIcon type="dot" color={props.colorMap[serviceName]} />,
+      }));
+    return serviceNames;
+  }, [spans, props.colorMap]);
+
+  // Initialize options with service names on first load
+  useEffect(() => {
+    if (options.length === 0 && serviceOptions.length > 0) {
+      setOptions(serviceOptions);
+    }
+  }, [serviceOptions, options.length]);
+
+  // Get currently selected services
+  const selectedServices = useMemo(() => {
+    const checkedOptions = options.filter((option) => option.checked === 'on');
+
+    // If no services are checked, select all services
+    if (checkedOptions.length === 0) {
+      return new Set(
+        options.map((option) => option.key).filter((key): key is string => key !== undefined)
+      );
+    }
+
+    return new Set(
+      checkedOptions.map((option) => option.key).filter((key): key is string => key !== undefined)
+    );
+  }, [options]);
+
+  // Default is min width of reset button + 8px padding
+  const [collapsibleColumnWidth, setCollapsibleColumnWidth] = useState<number>(112 + 8);
+
+  const timeScale = useMemo(() => {
+    const totalRange = max - min;
+    const currentStartTime = (selectedDomain[0] / 100) * totalRange;
+    const currentEndTime = (selectedDomain[1] / 100) * totalRange;
+
+    const scale = scaleLinear().domain([currentStartTime, currentEndTime]).range([0, 100]);
+    if (isDefaultDomain(selectedDomain)) {
+      return scale.nice();
+    }
+    return scale;
+  }, [selectedDomain, min, max]);
+
+  const minimapScale = useMemo(() => {
+    return scaleLinear()
+      .domain([0, max - min])
+      .range([0, 100]);
+  }, [min, max]);
+
+  const handleMinimapDomainUpdate = (newDomain: [number, number]) => {
+    setSelectedDomain(newDomain);
+  };
+
+  const throttledSelectionUpdate = useMemo(
+    () =>
+      throttle((newSelection: { start?: number; end?: number }) => {
+        setSelection(newSelection);
+      }, Math.round(1000 / 60)),
+    []
+  );
+
+  useEffect(() => {
+    return () => {
+      throttledSelectionUpdate.cancel();
+    };
+  }, [throttledSelectionUpdate]);
+
+  const handleToggleCollapse = useCallback((spanId: string) => {
+    setCollapsedSpans((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(spanId)) {
+        newSet.delete(spanId);
+      } else {
+        newSet.add(spanId);
+      }
+      return newSet;
+    });
+  }, []);
+
+  const handleExpandAll = useCallback(() => {
+    setCollapsedSpans(new Set());
+    setShowCollapseButton(true);
+  }, []);
+
+  const handleCollapseAll = useCallback(() => {
+    const collectSpansWithChildren = (spanList: SpanWithChildren[]): string[] => {
+      const spansWithChildren: string[] = [];
+      const traverse = (_spanList: SpanWithChildren[]) => {
+        _spanList.forEach((span) => {
+          if (span.children.length > 0) {
+            spansWithChildren.push(span.spanId);
+            traverse(span.children);
+          }
+        });
+      };
+      traverse(spanList);
+      return spansWithChildren;
+    };
+
+    const allParentSpanIds = collectSpansWithChildren(spans);
+    setCollapsedSpans(new Set(allParentSpanIds));
+    setShowCollapseButton(false);
+  }, [spans]);
+
+  const ticks = useMemo(() => {
+    return timeScale.ticks(isCompact ? 2 : isDefaultDomain(selectedDomain) ? 10 : 5);
+  }, [timeScale, isCompact, selectedDomain]);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (!gridRef.current) return;
+
+    const gridRect = gridRef.current.getBoundingClientRect();
+    const gridLeft = gridRect.left;
+    const gridRight = gridRect.right;
+    const gridWidth = gridRect.width;
+
+    if (e.clientX < gridLeft || e.clientX > gridRight) return;
+
+    const dragStartPosition = (e.clientX - gridLeft) / gridWidth;
+    setIsDragging(true);
+    setDragStart(dragStartPosition);
+    setSelection({ start: dragStartPosition, end: dragStartPosition });
+  }, []);
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isDragging || !gridRef.current || dragStart === null) return;
+
+      const gridRect = gridRef.current.getBoundingClientRect();
+      const gridLeft = gridRect.left;
+      const gridWidth = gridRect.width;
+
+      const currentPosition = Math.max(0, Math.min(1, (e.clientX - gridLeft) / gridWidth));
+      const start = Math.min(dragStart, currentPosition);
+      const end = Math.max(dragStart, currentPosition);
+
+      // Use throttled update to reduce re-renders during dragging
+      throttledSelectionUpdate({ start, end });
+    },
+    [isDragging, dragStart, throttledSelectionUpdate]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    if (isDragging && selection.start !== undefined && selection.end !== undefined) {
+      const selectionStart = Math.min(selection.start, selection.end);
+      const selectionEnd = Math.max(selection.start, selection.end);
+
+      // Calculate the new domain relative to the current domain
+      const currentDomainSize = selectedDomain[1] - selectedDomain[0];
+      const newStart = selectedDomain[0] + selectionStart * currentDomainSize;
+      const newEnd = selectedDomain[0] + selectionEnd * currentDomainSize;
+
+      if (Math.abs(newStart - newEnd) > 2) {
+        setSelectedDomain([newStart, newEnd]);
+      }
+    }
+    setIsDragging(false);
+    setDragStart(null);
+    setSelection({});
+    // Cancel any pending throttled updates
+    throttledSelectionUpdate.cancel();
+  }, [isDragging, selection, selectedDomain, throttledSelectionUpdate]);
+
+  const gridRef = useRef<HTMLDivElement>(null);
+  const minimapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mouseup', handleMouseUp);
+    }
+
+    return () => {
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging, handleMouseUp]);
+
+  const onOptionsChange = (selectedOptions: EuiSelectableOption[]) => {
+    setOptions(selectedOptions);
+  };
+
+  const isResetButtonDisabled = isDefaultDomain(selectedDomain) && collapsedSpans.size === 0;
+
+  const handleReset = () => {
+    setSelectedDomain(DEFAULT_DOMAIN);
+    handleExpandAll();
+  };
+
+  if (!spans.length) {
+    return (
+      <EuiEmptyPrompt
+        title={<h2>No spans found</h2>}
+        body={<p>No spans found for the selected filters</p>}
+      />
+    );
+  }
+
+  return (
+    <>
+      <EuiFlexGroup direction="row" alignItems="flexStart" gutterSize="m">
+        {!isCompact && (
+          <EuiFlexItem grow={false} style={{ width: 280 }}>
+            <EuiSelectable
+              options={options}
+              onChange={onOptionsChange}
+              searchable
+              searchProps={{
+                placeholder: 'Service name',
+                append: (
+                  <EuiButtonIcon
+                    size="xs"
+                    iconType="refresh"
+                    aria-label="Clear focus and service filter selection"
+                    disabled={selectedServices.size === serviceOptions.length}
+                    style={{
+                      display: selectedServices.size === serviceOptions.length ? 'none' : undefined,
+                    }}
+                    onClick={() => {
+                      setOptions(
+                        serviceOptions.map((option) => ({
+                          ...option,
+                          checked: undefined,
+                          isFocused: false,
+                        }))
+                      );
+                    }}
+                  />
+                ),
+              }}
+              listProps={{
+                bordered: true,
+                'data-test-subj': 'service-filter-list',
+              }}
+              height={Math.min(400, options.length * 32)}
+              data-test-subj="service-filter"
+            >
+              {(list, search) => (
+                <>
+                  {search}
+                  {list}
+                </>
+              )}
+            </EuiSelectable>
+          </EuiFlexItem>
+        )}
+        <EuiFlexItem
+          className="span-detail-timeline"
+          data-test-subj="span-detail-timeline"
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+        >
+          <div
+            className="timeline-container"
+            style={{
+              gridTemplateColumns: isCompact ? '1fr' : 'auto 1fr',
+            }}
+          >
+            <div
+              ref={gridRef}
+              className="timeline-grid"
+              data-test-subj="timeline-grid"
+              style={{
+                display: collapsibleColumnWidth ? 'block' : 'none',
+                top: MINIMAP_HEIGHT + RULER_HEIGHT,
+                left: collapsibleColumnWidth,
+              }}
+            >
+              {ticks.map((tick, index) => (
+                <div
+                  key={index}
+                  data-test-subj="timeline-grid-line"
+                  className={classNames('timeline-grid-line', {
+                    'timeline-grid-line--transform-end': index === ticks.length - 1,
+                  })}
+                  style={{
+                    left: `${timeScale(tick)}%`,
+                  }}
+                />
+              ))}
+              {selection.start !== undefined && selection.end !== undefined && (
+                <div
+                  className="timeline-selection"
+                  data-test-subj="timeline-selection"
+                  style={{
+                    left: `${selection.start * 100}%`,
+                    width: `${(selection.end - selection.start) * 100}%`,
+                  }}
+                />
+              )}
+            </div>
+            <div
+              className="timeline-controls"
+              style={{
+                display: isCompact ? 'none' : 'flex',
+              }}
+            >
+              <EuiButton
+                size="s"
+                onClick={handleReset}
+                data-test-subj="timeline-reset-button"
+                isDisabled={isResetButtonDisabled}
+                style={{
+                  visibility: isResetButtonDisabled ? 'hidden' : 'visible',
+                }}
+              >
+                Reset
+              </EuiButton>
+            </div>
+            <TimelineMinimap
+              ref={minimapRef}
+              spans={spans}
+              mode={props.mode}
+              min={min}
+              selectedDomain={selectedDomain}
+              colorMap={props.colorMap}
+              onDomainUpdate={handleMinimapDomainUpdate}
+              scale={minimapScale}
+              data-test-subj="timeline-minimap"
+            />
+            <div
+              ref={(el) => {
+                if (el) {
+                  const width = el.getBoundingClientRect().width;
+                  if (width > (collapsibleColumnWidth ?? 0)) {
+                    setCollapsibleColumnWidth(width);
+                  }
+                }
+              }}
+              className="timeline-header"
+              data-test-subj="timeline-controls"
+              style={{
+                display: isCompact ? 'none' : 'block',
+                top: MINIMAP_HEIGHT,
+                height: RULER_HEIGHT,
+                minWidth: collapsibleColumnWidth ? collapsibleColumnWidth + 'px' : 'auto',
+              }}
+            >
+              {showCollapseButton ? (
+                <EuiButtonIcon
+                  size="xs"
+                  iconType="fold"
+                  aria-label="Collapse all spans"
+                  onClick={handleCollapseAll}
+                />
+              ) : (
+                <EuiButtonIcon
+                  size="xs"
+                  iconType="unfold"
+                  aria-label="Expand all spans"
+                  onClick={handleExpandAll}
+                />
+              )}
+            </div>
+            <div
+              className="timeline-header timeline-header--time"
+              data-test-subj="timeline-ruler"
+              style={{
+                top: MINIMAP_HEIGHT,
+                height: RULER_HEIGHT,
+              }}
+            >
+              {ticks.map((tick, index) => {
+                return (
+                  <div
+                    key={index}
+                    data-test-subj="timeline-tick-mark"
+                    className={classNames('timeline-tick-mark', {
+                      'timeline-tick-mark--transform-end': index === ticks.length - 1,
+                    })}
+                    style={{
+                      left: `${timeScale(tick)}%`,
+                    }}
+                  >
+                    <EuiText
+                      size="xs"
+                      color="subdued"
+                      data-test-subj="timeline-tick-label"
+                      className={classNames('eui-textNoWrap', 'timeline-tick-label', {
+                        'timeline-tick-label--transform-start': index === 0,
+                        'timeline-tick-label--transform-end': index === ticks.length - 1,
+                      })}
+                    >
+                      {`${tick} ms`}
+                    </EuiText>
+                  </div>
+                );
+              })}
+            </div>
+            {spans.map((span, index) => (
+              <TimelineRow
+                key={span.spanId}
+                index={`${index}`}
+                mode={props.mode}
+                span={span}
+                level={0}
+                collapsedSpans={collapsedSpans}
+                onToggleCollapse={handleToggleCollapse}
+                onSpanClick={props.onSpanClick}
+                colorMap={props.colorMap}
+                scale={timeScale}
+                min={min}
+                compact={isCompact}
+                selectedServices={selectedServices}
+              />
+            ))}
+          </div>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+}

--- a/public/components/trace_analytics/components/traces/span_detail_timeline/timeline_minimap.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_timeline/timeline_minimap.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import throttle from 'lodash/throttle';
+import { ScaleLinear } from 'd3-scale';
+import { TraceAnalyticsMode } from '../../../../../../common/types/trace_analytics';
+import { drawSpansOnCanvas, MINIMAP_HEIGHT } from './utils';
+import { SpanWithChildren } from './types';
+
+interface TimelineMinimapProps {
+  spans: SpanWithChildren[];
+  mode: TraceAnalyticsMode;
+  min: number;
+  selectedDomain: [number, number];
+  colorMap: Record<string, string>;
+  onDomainUpdate: (newDomain: [number, number]) => void;
+  scale: ScaleLinear<number, number>;
+}
+
+export const TimelineMinimap = React.forwardRef<HTMLDivElement, TimelineMinimapProps>(
+  ({ spans, mode, min, selectedDomain, colorMap, onDomainUpdate, scale }, ref) => {
+    const [isMinimapDragging, setIsMinimapDragging] = useState(false);
+    const [dragType, setDragType] = useState<'move' | 'resize-left' | 'resize-right' | null>(null);
+    const [dragStartPosition, setDragStartPosition] = useState<number>(0);
+    const [initialDomain, setInitialDomain] = useState<[number, number]>([0, 100]);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    const throttledDomainUpdate = useMemo(() => throttle(onDomainUpdate, 16), [onDomainUpdate]);
+
+    useEffect(() => {
+      return () => {
+        throttledDomainUpdate.cancel();
+      };
+    }, [throttledDomainUpdate]);
+
+    const handleMouseDown = (
+      e: React.MouseEvent<HTMLDivElement>,
+      type: 'move' | 'resize-left' | 'resize-right'
+    ) => {
+      e.stopPropagation();
+      e.preventDefault();
+      if (!ref || typeof ref === 'function' || !ref.current) return;
+
+      const rect = ref.current.getBoundingClientRect();
+      const clickPosition = (e.clientX - rect.left) / rect.width;
+
+      setIsMinimapDragging(true);
+      setDragType(type);
+      setDragStartPosition(clickPosition);
+      setInitialDomain(selectedDomain);
+    };
+
+    const handleGeneralClick = (e: React.MouseEvent<HTMLDivElement>) => {
+      // Only handle clicks outside the selection area
+      if (!ref || typeof ref === 'function' || !ref.current) return;
+
+      const rect = ref.current.getBoundingClientRect();
+      const clickPosition = ((e.clientX - rect.left) / rect.width) * 100;
+
+      // Check if click is outside current selection
+      if (clickPosition < selectedDomain[0] || clickPosition > selectedDomain[1]) {
+        // Center the view around the click position
+        const currentDomainSize = selectedDomain[1] - selectedDomain[0];
+        const newStart = Math.max(0, clickPosition - currentDomainSize / 2);
+        const newEnd = Math.min(100, newStart + currentDomainSize);
+
+        onDomainUpdate([newStart, newEnd]);
+      }
+    };
+
+    const handleMouseMove = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isMinimapDragging || !dragType || !ref || typeof ref === 'function' || !ref.current)
+          return;
+
+        const rect = ref.current.getBoundingClientRect();
+        const currentPosition = ((e.clientX - rect.left) / rect.width) * 100;
+        const deltaPosition = currentPosition - dragStartPosition * 100;
+
+        let newDomain: [number, number] = [...selectedDomain];
+
+        switch (dragType) {
+          case 'move':
+            const domainSize = initialDomain[1] - initialDomain[0];
+            const newStart = Math.max(
+              0,
+              Math.min(100 - domainSize, initialDomain[0] + deltaPosition)
+            );
+            newDomain = [newStart, newStart + domainSize];
+            break;
+
+          case 'resize-left':
+            const newLeft = Math.max(
+              0,
+              Math.min(selectedDomain[1] - 2, initialDomain[0] + deltaPosition)
+            );
+            newDomain = [newLeft, selectedDomain[1]];
+            break;
+
+          case 'resize-right':
+            const newRight = Math.min(
+              100,
+              Math.max(selectedDomain[0] + 2, initialDomain[1] + deltaPosition)
+            );
+            newDomain = [selectedDomain[0], newRight];
+            break;
+        }
+
+        throttledDomainUpdate(newDomain);
+      },
+      [
+        isMinimapDragging,
+        dragType,
+        dragStartPosition,
+        initialDomain,
+        selectedDomain,
+        throttledDomainUpdate,
+      ]
+    );
+
+    const handleMouseUp = useCallback(() => {
+      setIsMinimapDragging(false);
+      setDragType(null);
+      throttledDomainUpdate.cancel();
+    }, [throttledDomainUpdate]);
+
+    useEffect(() => {
+      if (isMinimapDragging) {
+        const handleDocumentMouseMove = (e: MouseEvent) => {
+          handleMouseMove(e as any);
+        };
+
+        document.addEventListener('mouseup', handleMouseUp);
+        document.addEventListener('mousemove', handleDocumentMouseMove);
+
+        return () => {
+          document.removeEventListener('mouseup', handleMouseUp);
+          document.removeEventListener('mousemove', handleDocumentMouseMove);
+        };
+      }
+    }, [isMinimapDragging, handleMouseMove, handleMouseUp]);
+
+    const layoutMetrics = useMemo(() => {
+      // Calculate total number of rows needed
+      const calculateTotalRows = (spanList: any[], depth: number = 0): number => {
+        let maxRows = 0;
+        spanList.forEach((span) => {
+          maxRows += 1;
+          if (span.children.length > 0) {
+            maxRows += calculateTotalRows(span.children, depth + 1);
+          }
+        });
+        return maxRows;
+      };
+
+      const totalRows = calculateTotalRows(spans);
+      const availableHeight = MINIMAP_HEIGHT - 2; // Minimap height - 1px padding (top + bottom)
+      const rowHeight = totalRows > 0 ? availableHeight / totalRows : 1;
+      const spanBarHeight = Math.min(4, rowHeight); // Max 4px height per span
+
+      const totalContentHeight = totalRows * spanBarHeight;
+      const verticalOffset = Math.max(1, (MINIMAP_HEIGHT - totalContentHeight) / 2);
+
+      return {
+        totalRows,
+        rowHeight,
+        spanBarHeight,
+        verticalOffset,
+      };
+    }, [spans]);
+
+    useEffect(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      drawSpansOnCanvas(canvas, spans, mode, min, scale, colorMap, layoutMetrics);
+    }, [spans, mode, min, scale, colorMap, layoutMetrics]);
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onDomainUpdate([0, 100]);
+      }
+    };
+
+    return (
+      <div
+        ref={ref}
+        className="span-detail-timeline-minimap"
+        data-test-subj="timeline-minimap"
+        style={{ height: `${MINIMAP_HEIGHT}px` }}
+        onClick={handleGeneralClick}
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
+      >
+        <div className="minimap-container" style={{ width: '100%', height: MINIMAP_HEIGHT }}>
+          <canvas
+            ref={canvasRef}
+            className="minimap-canvas"
+            data-test-subj="minimap-canvas"
+            style={{ width: '100%', height: MINIMAP_HEIGHT }}
+          />
+          <div
+            className="minimap-selection"
+            data-test-subj="minimap-selection"
+            style={{
+              left: `${selectedDomain[0]}%`,
+              width: `${selectedDomain[1] - selectedDomain[0]}%`,
+            }}
+          >
+            <div className="minimap-move-area" onMouseDown={(e) => handleMouseDown(e, 'move')} />
+            <div
+              className="minimap-handle minimap-handle--left"
+              onMouseDown={(e) => handleMouseDown(e, 'resize-left')}
+            />
+            <div
+              className="minimap-handle minimap-handle--right"
+              onMouseDown={(e) => handleMouseDown(e, 'resize-right')}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+);

--- a/public/components/trace_analytics/components/traces/span_detail_timeline/timeline_minimap.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_timeline/timeline_minimap.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useMemo, useRef, useEffect } from 'react';
 import throttle from 'lodash/throttle';
 import { ScaleLinear } from 'd3-scale';
 import { TraceAnalyticsMode } from '../../../../../../common/types/trace_analytics';
@@ -71,61 +71,51 @@ export const TimelineMinimap = React.forwardRef<HTMLDivElement, TimelineMinimapP
       }
     };
 
-    const handleMouseMove = useCallback(
-      (e: React.MouseEvent<HTMLDivElement>) => {
-        if (!isMinimapDragging || !dragType || !ref || typeof ref === 'function' || !ref.current)
-          return;
+    const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isMinimapDragging || !dragType || !ref || typeof ref === 'function' || !ref.current)
+        return;
 
-        const rect = ref.current.getBoundingClientRect();
-        const currentPosition = ((e.clientX - rect.left) / rect.width) * 100;
-        const deltaPosition = currentPosition - dragStartPosition * 100;
+      const rect = ref.current.getBoundingClientRect();
+      const currentPosition = ((e.clientX - rect.left) / rect.width) * 100;
+      const deltaPosition = currentPosition - dragStartPosition * 100;
 
-        let newDomain: [number, number] = [...selectedDomain];
+      let newDomain: [number, number] = [...selectedDomain];
 
-        switch (dragType) {
-          case 'move':
-            const domainSize = initialDomain[1] - initialDomain[0];
-            const newStart = Math.max(
-              0,
-              Math.min(100 - domainSize, initialDomain[0] + deltaPosition)
-            );
-            newDomain = [newStart, newStart + domainSize];
-            break;
+      switch (dragType) {
+        case 'move':
+          const domainSize = initialDomain[1] - initialDomain[0];
+          const newStart = Math.max(
+            0,
+            Math.min(100 - domainSize, initialDomain[0] + deltaPosition)
+          );
+          newDomain = [newStart, newStart + domainSize];
+          break;
 
-          case 'resize-left':
-            const newLeft = Math.max(
-              0,
-              Math.min(selectedDomain[1] - 2, initialDomain[0] + deltaPosition)
-            );
-            newDomain = [newLeft, selectedDomain[1]];
-            break;
+        case 'resize-left':
+          const newLeft = Math.max(
+            0,
+            Math.min(initialDomain[1] - 2, initialDomain[0] + deltaPosition)
+          );
+          newDomain = [newLeft, initialDomain[1]];
+          break;
 
-          case 'resize-right':
-            const newRight = Math.min(
-              100,
-              Math.max(selectedDomain[0] + 2, initialDomain[1] + deltaPosition)
-            );
-            newDomain = [selectedDomain[0], newRight];
-            break;
-        }
+        case 'resize-right':
+          const newRight = Math.min(
+            100,
+            Math.max(initialDomain[0] + 2, initialDomain[1] + deltaPosition)
+          );
+          newDomain = [initialDomain[0], newRight];
+          break;
+      }
 
-        throttledDomainUpdate(newDomain);
-      },
-      [
-        isMinimapDragging,
-        dragType,
-        dragStartPosition,
-        initialDomain,
-        selectedDomain,
-        throttledDomainUpdate,
-      ]
-    );
+      throttledDomainUpdate(newDomain);
+    };
 
-    const handleMouseUp = useCallback(() => {
+    const handleMouseUp = () => {
       setIsMinimapDragging(false);
       setDragType(null);
       throttledDomainUpdate.cancel();
-    }, [throttledDomainUpdate]);
+    };
 
     useEffect(() => {
       if (isMinimapDragging) {
@@ -141,7 +131,7 @@ export const TimelineMinimap = React.forwardRef<HTMLDivElement, TimelineMinimapP
           document.removeEventListener('mousemove', handleDocumentMouseMove);
         };
       }
-    }, [isMinimapDragging, handleMouseMove, handleMouseUp]);
+    }, [isMinimapDragging]);
 
     const layoutMetrics = useMemo(() => {
       // Calculate total number of rows needed

--- a/public/components/trace_analytics/components/traces/span_detail_timeline/timeline_row.tsx
+++ b/public/components/trace_analytics/components/traces/span_detail_timeline/timeline_row.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useMemo } from 'react';
+import sortBy from 'lodash/sortBy';
+import { EuiButtonEmpty, EuiText } from '@elastic/eui';
+import { ScaleLinear } from 'd3-scale';
+
+import { TraceAnalyticsMode } from '../../../../../../common/types/trace_analytics';
+import { SpanWithChildren } from './types';
+import {
+  getStartTimeInMs,
+  getDurationInMs,
+  hasError,
+  SPAN_ROW_INDENTATION_IN_PIXELS,
+} from './utils';
+
+interface TimelineRowProps {
+  index: string;
+  mode: TraceAnalyticsMode;
+  span: SpanWithChildren;
+  level: number;
+  collapsedSpans: Set<string>;
+  onToggleCollapse: (spanId: string) => void;
+  onSpanClick: (spanId: string) => void;
+  colorMap: Record<string, string>;
+  scale: ScaleLinear<number, number>;
+  min: number;
+  compact?: boolean;
+  selectedServices: Set<string>;
+}
+
+export const TimelineRow = React.memo<TimelineRowProps>(function TimelineRow({
+  index,
+  mode,
+  span,
+  level,
+  collapsedSpans,
+  onToggleCollapse,
+  onSpanClick,
+  colorMap,
+  scale,
+  min,
+  compact,
+  selectedServices,
+}) {
+  const start = scale(getStartTimeInMs(mode, span) - min);
+  const end = scale(getDurationInMs(mode, span) + getStartTimeInMs(mode, span) - min);
+  const barWidth = end - start;
+  const hasChildren = span.children.length > 0;
+
+  // Simple placement: start (left) if bar is in the left half, end (right) if bar is in the right half
+  // Empty dependency array is intended to avoid replacement on domain/scale change
+  const labelPlacement = useMemo(() => {
+    return start + barWidth / 2 <= 50 ? 'start' : 'end';
+  }, []);
+
+  const handleToggle = () => onToggleCollapse(span.spanId);
+  const handleSpanClick = () => onSpanClick(span.spanId);
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleToggle();
+    }
+  };
+
+  const sortedChildren = useMemo(() => {
+    return sortBy(span.children, (child) => getStartTimeInMs(mode, child));
+  }, [span.children, mode]);
+
+  return (
+    <>
+      {selectedServices.size > 0 && selectedServices.has(span.serviceName) && (
+        <>
+          <div
+            role={hasChildren ? 'button' : undefined}
+            data-index={index}
+            data-test-subj={`timeline-row-${index}`}
+            onClick={hasChildren ? handleToggle : undefined}
+            onKeyDown={hasChildren ? handleKeyDown : undefined}
+            tabIndex={hasChildren ? 0 : undefined}
+            className="span-row"
+            style={{
+              paddingLeft: `${level * SPAN_ROW_INDENTATION_IN_PIXELS}px`,
+              display: compact ? 'none' : 'block',
+            }}
+          >
+            {Array.from({ length: level + 1 }, (_, i) => (
+              <>
+                {i !== 0 && (
+                  <div
+                    key={i}
+                    className="span-connector span-connector--vertical"
+                    style={{
+                      left: `${i * SPAN_ROW_INDENTATION_IN_PIXELS}px`,
+                    }}
+                  />
+                )}
+                {i === level && (
+                  <div
+                    className="span-connector span-connector--horizontal"
+                    style={{
+                      left: `${i * SPAN_ROW_INDENTATION_IN_PIXELS}px`,
+                    }}
+                  />
+                )}
+              </>
+            ))}
+            <div className="span-toggle-container">
+              {hasChildren && (
+                <>
+                  <EuiButtonEmpty
+                    size="xs"
+                    color="text"
+                    iconType={collapsedSpans.has(span.spanId) ? 'arrowRight' : 'arrowDown'}
+                    iconGap="s"
+                    aria-label="Toggle collapse"
+                    data-test-subj={`span-collapse-${span.spanId}`}
+                  >
+                    {`${span.children.length}`}
+                  </EuiButtonEmpty>
+                </>
+              )}
+            </div>
+          </div>
+          <div data-index={index} className="span-timeline-bar-container">
+            <div
+              className="span-timeline-bar"
+              data-test-subj={`timeline-span-bar-${span.spanId}`}
+              style={{
+                backgroundColor: colorMap[span.serviceName],
+                left: `${start}%`,
+                width: `${barWidth}%`,
+              }}
+            >
+              <button
+                className="span-timeline-bar-button"
+                onClick={handleSpanClick}
+                aria-label="View span details"
+                data-test-subj={`timeline-span-button-${span.spanId}`}
+              />
+            </div>
+            <div
+              className={`span-timeline-bar-label`}
+              style={
+                labelPlacement === 'start'
+                  ? {
+                      left: `${start}%`,
+                    }
+                  : {
+                      left: `${end}%`,
+                      transform: 'translateX(-100%)',
+                    }
+              }
+            >
+              <div className="eui-textNoWrap span-details">
+                <EuiText size="xs">{span.name}</EuiText>
+                <EuiText size="xs" color="subdued">
+                  {getDurationInMs(mode, span)} ms
+                </EuiText>
+                {hasError(mode, span) && (
+                  <EuiText size="xs" color="danger">
+                    &nbsp;&#9888; Error
+                  </EuiText>
+                )}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+      {!collapsedSpans.has(span.spanId) && (
+        <>
+          {sortedChildren.map((child, childIndex) => {
+            return (
+              <TimelineRow
+                index={`${index}-${childIndex}`}
+                key={child.spanId}
+                mode={mode}
+                span={child}
+                level={level + 1}
+                collapsedSpans={collapsedSpans}
+                onToggleCollapse={onToggleCollapse}
+                onSpanClick={onSpanClick}
+                colorMap={colorMap}
+                scale={scale}
+                min={min}
+                compact={compact}
+                selectedServices={selectedServices}
+              />
+            );
+          })}
+        </>
+      )}
+    </>
+  );
+});

--- a/public/components/trace_analytics/components/traces/span_detail_timeline/types.ts
+++ b/public/components/trace_analytics/components/traces/span_detail_timeline/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Span } from '../../common/constants';
+
+export interface SpanWithChildren extends Span {
+  children: SpanWithChildren[];
+}
+
+export interface SpanReference {
+  refType: 'CHILD_OF' | 'FOLLOWS_FROM';
+  spanID: string;
+}
+
+export type JaegerSpan = Omit<Span, 'spanId'> & {
+  spanID: string;
+  duration: number;
+  references: SpanReference[];
+};
+
+export type SpanMap = Record<string, SpanWithChildren>;

--- a/public/components/trace_analytics/components/traces/span_detail_timeline/utils.ts
+++ b/public/components/trace_analytics/components/traces/span_detail_timeline/utils.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ScaleLinear } from 'd3-scale';
+import round from 'lodash/round';
+import sortBy from 'lodash/sortBy';
+import { TraceAnalyticsMode } from '../../../../../../common/types/trace_analytics';
+import { microToMilliSec, nanoToMilliSec, parseIsoToNano } from '../../common/helper_functions';
+import { Span } from '../../common/constants';
+import { SpanWithChildren, JaegerSpan, SpanMap, SpanReference } from './types';
+
+export const DEFAULT_DOMAIN: [number, number] = [0, 100];
+export const MINIMAP_HEIGHT = 42;
+export const RULER_HEIGHT = 28;
+export const SPAN_ROW_INDENTATION_IN_PIXELS = 12;
+
+export const isDefaultDomain = (domain: [number, number]) =>
+  domain[0] === DEFAULT_DOMAIN[0] && domain[1] === DEFAULT_DOMAIN[1];
+
+export const drawSpansOnCanvas = (
+  canvas: HTMLCanvasElement,
+  spans: SpanWithChildren[],
+  mode: TraceAnalyticsMode,
+  min: number,
+  scale: ScaleLinear<number, number>,
+  colorMap: Record<string, string>,
+  layoutMetrics: { spanBarHeight: number; verticalOffset: number }
+) => {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  // Set canvas size to match container
+  const rect = canvas.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  ctx.scale(dpr, dpr);
+
+  ctx.clearRect(0, 0, rect.width, rect.height);
+
+  const { spanBarHeight, verticalOffset } = layoutMetrics;
+
+  // Draw spans recursively
+  const drawSpanGroup = (spanList: SpanWithChildren[], rowOffset: number = 0): number => {
+    let currentRow = rowOffset;
+
+    spanList.forEach((span) => {
+      const startTime = getStartTimeInMs(mode, span) - min;
+      const duration = getDurationInMs(mode, span);
+      const start = scale(startTime);
+      const width = scale(duration);
+
+      // Calculate pixel positions with 6px horizontal padding (minimap left/right handles)
+      const availableWidth = rect.width - 12; // 6px left + 6px right padding
+      const x = (start / 100) * availableWidth + 6; // 6px left padding
+      const y = currentRow * spanBarHeight + verticalOffset; // Draw at current row
+      const w = Math.max(1, (width / 100) * availableWidth);
+      const h = spanBarHeight;
+
+      // Only draw if within bounds
+      if (y + h <= rect.height) {
+        // Set color and draw rectangle
+        ctx.fillStyle = colorMap[span.serviceName] || '#ccc';
+        ctx.fillRect(x, y, w, h);
+      }
+
+      // Move to the next row (this span occupies currentRow, so next available is currentRow + 1)
+      currentRow++;
+
+      // Draw children recursively if they exist (minimap always shows all spans expanded)
+      if (span.children.length > 0) {
+        currentRow = drawSpanGroup(
+          sortBy(span.children, (child) => getStartTimeInMs(mode, child)),
+          currentRow
+        );
+      }
+    });
+
+    return currentRow;
+  };
+
+  drawSpanGroup(spans);
+};
+
+export const addRootSpan = (
+  spanId: string,
+  spanMap: SpanMap,
+  rootSpans: SpanWithChildren[],
+  alreadyAddedRootSpans: Set<string>
+) => {
+  if (!alreadyAddedRootSpans.has(spanId)) {
+    rootSpans.push(spanMap[spanId]);
+    alreadyAddedRootSpans.add(spanId);
+  }
+};
+
+export const buildHierarchy = (mode: TraceAnalyticsMode, spans: Span[]): SpanWithChildren[] => {
+  const spanMap: SpanMap = {};
+
+  spans.forEach((span) => {
+    const spanId = mode === 'jaeger' ? ((span as unknown) as JaegerSpan).spanID : span.spanId;
+    spanMap[spanId] = { ...span, spanId, children: [] } as SpanWithChildren;
+  });
+
+  const rootSpans: SpanWithChildren[] = [];
+  const alreadyAddedRootSpans: Set<string> = new Set(); // Track added root spans
+
+  spans.forEach((span) => {
+    const spanId = mode === 'jaeger' ? ((span as unknown) as JaegerSpan).spanID : span.spanId;
+    const references = ((span as unknown) as JaegerSpan).references || [];
+
+    if (mode === 'jaeger') {
+      references.forEach((ref: SpanReference) => {
+        if (ref.refType === 'CHILD_OF') {
+          const parentSpan = spanMap[ref.spanID];
+          if (parentSpan) {
+            parentSpan.children.push(spanMap[spanId]);
+          }
+        }
+
+        if (ref.refType === 'FOLLOWS_FROM' && !alreadyAddedRootSpans.has(spanId)) {
+          addRootSpan(spanId, spanMap, rootSpans, alreadyAddedRootSpans);
+        }
+      });
+
+      if (references.length === 0 || references.every((ref) => ref.refType === 'FOLLOWS_FROM')) {
+        addRootSpan(spanId, spanMap, rootSpans, alreadyAddedRootSpans);
+      }
+    } else {
+      // Data Prepper
+      if (span.parentSpanId && spanMap[span.parentSpanId]) {
+        spanMap[span.parentSpanId].children.push(spanMap[spanId]);
+      } else {
+        addRootSpan(spanId, spanMap, rootSpans, alreadyAddedRootSpans);
+      }
+    }
+  });
+
+  return sortBy(rootSpans, (span) => getStartTimeInMs(mode, span));
+};
+
+export const getStartTimeInMs = (mode: TraceAnalyticsMode, span: Span) => {
+  return mode === 'jaeger'
+    ? microToMilliSec(Number(span.startTime))
+    : nanoToMilliSec(parseIsoToNano(span.startTime));
+};
+
+export const getDurationInMs = (mode: TraceAnalyticsMode, span: Span) => {
+  return mode === 'jaeger'
+    ? round(microToMilliSec(((span as unknown) as JaegerSpan).duration), 2)
+    : round(nanoToMilliSec(span.durationInNanos), 2);
+};
+
+export const hasError = (mode: TraceAnalyticsMode, span: any) => {
+  return mode === 'jaeger' ? span.tag?.['error'] === true : span['status.code'] === 2;
+};

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -21,7 +21,7 @@ module.exports = {
     '<rootDir>/test/',
     '<rootDir>/public/requests/',
   ],
-  transformIgnorePatterns: ['<rootDir>/node_modules'],
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(d3-.+|internmap))'],
   moduleNameMapper: {
     '\\.(css|less|sass|scss)$': '<rootDir>/test/__mocks__/styleMock.js',
     '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/test/__mocks__/fileMock.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,6 +205,18 @@
   dependencies:
     "@types/node" "*"
 
+"@types/d3-scale@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-time@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+
 "@types/dom4@^2.0.1":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.2.tgz#6495303f049689ce936ed328a3e5ede9c51408ee"
@@ -753,6 +765,55 @@ cypress-watch-and-reload@^1.10.6:
     async-wait-until "1.2.6"
     chokidar "3.5.3"
     ws "8.13.0"
+
+"d3-array@2 - 3", "d3-array@2.10.0 - 3":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+"d3-color@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+"d3-format@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
+  integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+
+"d3-interpolate@1.2.0 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-scale@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+"d3-time-format@2 - 4":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -1452,6 +1513,11 @@ inquirer@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 is-alphabetical@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
### Description
This PR replaces the previous Gantt chart component in Trace with a more comprehensive hierarchical timeline. While the Gantt chart showed span lifetimes well, it didn’t effectively communicate parent-child relationships between spans. The tree view solved this to some extent, but switching between tree and timeline views was disruptive, as both reset their state.

We also introduce a new side panel with a service filter to help navigate relevant spans. It's built using raw canvas (for the minimap) and HTML for better customization, as Plotly's bar chart isn’t well-suited for hierarchical layouts.

Basic Cypress tests are included for both the timeline and service filter components.

| Before    | After |
| -------- | ------- |
| <img width="1171" height="602" alt="Screenshot 2025-07-22 at 18 16 04" src="https://github.com/user-attachments/assets/ae8117ff-573c-4fff-b26c-0e0aafa38756" /> |  <img width="1171" height="453" alt="Screenshot 2025-07-22 at 18 15 53" src="https://github.com/user-attachments/assets/3f414f16-28d4-478e-843b-e275679c7cc2" /> |


https://github.com/user-attachments/assets/bcba7309-9751-463e-be2e-96cd9e1dd3c3



### Issues Resolved

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
