### PR TITLE
bug fix: ValidationError in ui setting

### DIFF
--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -243,7 +243,7 @@ export class ObservabilityPlugin
         name: 'Observability default dashboard',
         value: '',
         description: 'The default dashboard to display in Observability overview page',
-        schema: schema.string(),
+        schema: schema.nullable(schema.string()),
         scope: core.workspace.isWorkspaceEnabled()
           ? UiSettingScope.WORKSPACE
           : UiSettingScope.GLOBAL,
@@ -255,7 +255,7 @@ export class ObservabilityPlugin
         name: 'Observability overview cards',
         value: true,
         description: 'Show the Observability overview page cards',
-        schema: schema.boolean(),
+        schema: schema.nullable(schema.boolean()),
         scope: core.workspace.isWorkspaceEnabled()
           ? UiSettingScope.WORKSPACE
           : UiSettingScope.GLOBAL,


### PR DESCRIPTION
### Description
this pr fix:
[warning][ui-settings-service] Ignore invalid UiSettings value. ValidationError: [validation [observability:defaultDashboard]]: expected value of type [string] but got [undefined]

after:
<img width="535" height="195" alt="截屏2025-07-31 07 55 11" src="https://github.com/user-attachments/assets/6c89cb59-1f83-4522-9306-95162847ef53" />
before:
<img width="535" height="195" alt="截屏2025-07-31 07 55 35" src="https://github.com/user-attachments/assets/01e9cb42-dc14-42b8-8a85-3c7ffa40167f" />


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
