### PR TITLE
Test fixes

### DIFF
--- a/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Log Config component renders empty log config 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -126,10 +127,12 @@ exports[`Log Config component renders empty log config 1`] = `
       "setBreadcrumbs": [MockFunction],
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   description=""
@@ -688,6 +691,7 @@ exports[`Log Config component renders with query 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -799,10 +803,12 @@ exports[`Log Config component renders with query 1`] = `
       "setBreadcrumbs": [MockFunction],
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   description=""

--- a/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Service Config component renders empty service config 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -126,10 +127,12 @@ exports[`Service Config component renders empty service config 1`] = `
       "setBreadcrumbs": [MockFunction],
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   description=""
@@ -1370,6 +1373,7 @@ exports[`Service Config component renders with one service selected 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -1481,10 +1485,12 @@ exports[`Service Config component renders with one service selected 1`] = `
       "setBreadcrumbs": [MockFunction],
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   description=""

--- a/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Trace Config component renders empty trace config 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -125,10 +126,12 @@ exports[`Trace Config component renders empty trace config 1`] = `
       "setBreadcrumbs": [MockFunction],
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   description=""
@@ -2467,6 +2470,7 @@ exports[`Trace Config component renders with one trace selected 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -2578,10 +2582,12 @@ exports[`Trace Config component renders with one trace selected 1`] = `
       "setBreadcrumbs": [MockFunction],
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   description=""

--- a/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
+++ b/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
@@ -893,6 +893,7 @@ exports[`Panels View Component renders panel view container with visualizations 
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -1298,10 +1299,12 @@ exports[`Panels View Component renders panel view container with visualizations 
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     cloneCustomPanel={[MockFunction]}
@@ -2803,6 +2806,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                         "getBreadcrumbs$": [MockFunction],
                         "getBreadcrumbsEnricher$": [MockFunction],
                         "getCustomNavLink$": [MockFunction],
+                        "getGlobalBanner$": [MockFunction],
                         "getHeaderComponent": [MockFunction],
                         "getHeaderVariant$": [MockFunction],
                         "getHelpExtension$": [MockFunction],
@@ -3208,10 +3212,12 @@ exports[`Panels View Component renders panel view container with visualizations 
                         },
                         "setBreadcrumbsEnricher": [MockFunction],
                         "setCustomNavLink": [MockFunction],
+                        "setGlobalBanner": [MockFunction],
                         "setHeaderVariant": [MockFunction],
                         "setHelpExtension": [MockFunction],
                         "setHelpSupportUrl": [MockFunction],
                         "setIsVisible": [MockFunction],
+                        "useUpdatedHeader": false,
                       }
                     }
                     cloneVisualization={[Function]}
@@ -3378,6 +3384,7 @@ exports[`Panels View Component renders panel view container without visualizatio
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -3672,10 +3679,12 @@ exports[`Panels View Component renders panel view container without visualizatio
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     cloneCustomPanel={[MockFunction]}
@@ -5172,6 +5181,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                         "getBreadcrumbs$": [MockFunction],
                         "getBreadcrumbsEnricher$": [MockFunction],
                         "getCustomNavLink$": [MockFunction],
+                        "getGlobalBanner$": [MockFunction],
                         "getHeaderComponent": [MockFunction],
                         "getHeaderVariant$": [MockFunction],
                         "getHelpExtension$": [MockFunction],
@@ -5466,10 +5476,12 @@ exports[`Panels View Component renders panel view container without visualizatio
                         },
                         "setBreadcrumbsEnricher": [MockFunction],
                         "setCustomNavLink": [MockFunction],
+                        "setGlobalBanner": [MockFunction],
                         "setHeaderVariant": [MockFunction],
                         "setHelpExtension": [MockFunction],
                         "setHelpSupportUrl": [MockFunction],
                         "setIsVisible": [MockFunction],
+                        "useUpdatedHeader": false,
                       }
                     }
                     cloneVisualization={[Function]}

--- a/public/components/custom_panels/panel_modules/panel_grid/__tests__/__snapshots__/panel_grid.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/panel_grid/__tests__/__snapshots__/panel_grid.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Panel Grid Component renders panel grid component with empty visualizat
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -283,10 +284,12 @@ exports[`Panel Grid Component renders panel grid component with empty visualizat
       "setBreadcrumbs": [MockFunction],
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   cloneVisualization={[MockFunction]}

--- a/public/components/metrics/view/__tests__/__snapshots__/metrics_grid.test.tsx.snap
+++ b/public/components/metrics/view/__tests__/__snapshots__/metrics_grid.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`Metrics Grid Component renders Metrics Grid Component 1`] = `
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -136,10 +137,12 @@ exports[`Metrics Grid Component renders Metrics Grid Component 1`] = `
         "setBreadcrumbs": [MockFunction],
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     editActionType="save"
@@ -205,6 +208,7 @@ exports[`Metrics Grid Component renders Metrics Grid Component 1`] = `
           "getBreadcrumbs$": [MockFunction],
           "getBreadcrumbsEnricher$": [MockFunction],
           "getCustomNavLink$": [MockFunction],
+          "getGlobalBanner$": [MockFunction],
           "getHeaderComponent": [MockFunction],
           "getHeaderVariant$": [MockFunction],
           "getHelpExtension$": [MockFunction],
@@ -316,10 +320,12 @@ exports[`Metrics Grid Component renders Metrics Grid Component 1`] = `
           "setBreadcrumbs": [MockFunction],
           "setBreadcrumbsEnricher": [MockFunction],
           "setCustomNavLink": [MockFunction],
+          "setGlobalBanner": [MockFunction],
           "setHeaderVariant": [MockFunction],
           "setHelpExtension": [MockFunction],
           "setHelpSupportUrl": [MockFunction],
           "setIsVisible": [MockFunction],
+          "useUpdatedHeader": false,
         }
       }
       dateSpanFilter={

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`Dashboard component renders dashboard 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -181,10 +182,12 @@ exports[`Dashboard component renders dashboard 1`] = `
       },
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   dataSourceMDSId={
@@ -403,6 +406,7 @@ exports[`Dashboard component renders dashboard 1`] = `
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -556,10 +560,12 @@ exports[`Dashboard component renders dashboard 1`] = `
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     dataSourceMDSId={
@@ -2642,6 +2648,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -2795,10 +2802,12 @@ exports[`Dashboard component renders empty dashboard 1`] = `
       },
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   dataSourceMDSId={
@@ -3016,6 +3025,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -3169,10 +3179,12 @@ exports[`Dashboard component renders empty dashboard 1`] = `
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     dataSourceMDSId={
@@ -5254,6 +5266,7 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -5407,10 +5420,12 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
       },
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   dataSourceMDSId={
@@ -5630,6 +5645,7 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -5783,10 +5799,12 @@ exports[`Dashboard component renders empty jaeger dashboard 1`] = `
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     dataSourceMDSId={

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`Services component renders empty services page 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -174,10 +175,12 @@ exports[`Services component renders empty services page 1`] = `
       },
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   dataSourceMDSId={
@@ -261,6 +264,7 @@ exports[`Services component renders empty services page 1`] = `
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -407,10 +411,12 @@ exports[`Services component renders empty services page 1`] = `
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     dataSourceMDSId={
@@ -3418,6 +3424,7 @@ exports[`Services component renders jaeger services page 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -3561,10 +3568,12 @@ exports[`Services component renders jaeger services page 1`] = `
       },
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   dataSourceMDSId={
@@ -3651,6 +3660,7 @@ exports[`Services component renders jaeger services page 1`] = `
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -3794,10 +3804,12 @@ exports[`Services component renders jaeger services page 1`] = `
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     dataSourceMDSId={
@@ -5918,6 +5930,7 @@ exports[`Services component renders services page 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -6061,10 +6074,12 @@ exports[`Services component renders services page 1`] = `
       },
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   dataSourceMDSId={
@@ -6150,6 +6165,7 @@ exports[`Services component renders services page 1`] = `
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -6293,10 +6309,12 @@ exports[`Services component renders services page 1`] = `
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     dataSourceMDSId={

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`Traces component renders empty traces page 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -184,10 +185,12 @@ exports[`Traces component renders empty traces page 1`] = `
       },
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   dataSourceMDSId={
@@ -270,6 +273,7 @@ exports[`Traces component renders empty traces page 1`] = `
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -426,10 +430,12 @@ exports[`Traces component renders empty traces page 1`] = `
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     dataSourceMDSId={
@@ -3047,6 +3053,7 @@ exports[`Traces component renders jaeger traces page 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -3200,10 +3207,12 @@ exports[`Traces component renders jaeger traces page 1`] = `
       },
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   dataSourceMDSId={
@@ -3289,6 +3298,7 @@ exports[`Traces component renders jaeger traces page 1`] = `
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -3442,10 +3452,12 @@ exports[`Traces component renders jaeger traces page 1`] = `
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     dataSourceMDSId={
@@ -5336,6 +5348,7 @@ exports[`Traces component renders traces page 1`] = `
       "getBreadcrumbs$": [MockFunction],
       "getBreadcrumbsEnricher$": [MockFunction],
       "getCustomNavLink$": [MockFunction],
+      "getGlobalBanner$": [MockFunction],
       "getHeaderComponent": [MockFunction],
       "getHeaderVariant$": [MockFunction],
       "getHelpExtension$": [MockFunction],
@@ -5489,10 +5502,12 @@ exports[`Traces component renders traces page 1`] = `
       },
       "setBreadcrumbsEnricher": [MockFunction],
       "setCustomNavLink": [MockFunction],
+      "setGlobalBanner": [MockFunction],
       "setHeaderVariant": [MockFunction],
       "setHelpExtension": [MockFunction],
       "setHelpSupportUrl": [MockFunction],
       "setIsVisible": [MockFunction],
+      "useUpdatedHeader": false,
     }
   }
   dataSourceMDSId={
@@ -5577,6 +5592,7 @@ exports[`Traces component renders traces page 1`] = `
         "getBreadcrumbs$": [MockFunction],
         "getBreadcrumbsEnricher$": [MockFunction],
         "getCustomNavLink$": [MockFunction],
+        "getGlobalBanner$": [MockFunction],
         "getHeaderComponent": [MockFunction],
         "getHeaderVariant$": [MockFunction],
         "getHelpExtension$": [MockFunction],
@@ -5730,10 +5746,12 @@ exports[`Traces component renders traces page 1`] = `
         },
         "setBreadcrumbsEnricher": [MockFunction],
         "setCustomNavLink": [MockFunction],
+        "setGlobalBanner": [MockFunction],
         "setHeaderVariant": [MockFunction],
         "setHelpExtension": [MockFunction],
         "setHelpSupportUrl": [MockFunction],
         "setIsVisible": [MockFunction],
+        "useUpdatedHeader": false,
       }
     }
     dataSourceMDSId={

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -27,6 +27,12 @@ module.exports = {
     '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/test/__mocks__/fileMock.js',
     '\\@algolia/autocomplete-theme-classic$': '<rootDir>/test/__mocks__/styleMock.js',
     '^!!raw-loader!.*': 'jest-raw-loader',
+    // OpenSearch Dashboards path mappings
+    '^opensearch-dashboards/public$': '<rootDir>/../../src/core/public',
+    '^opensearch-dashboards/public/(.*)$': '<rootDir>/../../src/core/public/$1',
+    '^opensearch-dashboards/server$': '<rootDir>/../../src/core/server',
+    '^opensearch-dashboards/server/(.*)$': '<rootDir>/../../src/core/server/$1',
+    '^opensearch-dashboards$': '<rootDir>/../../opensearch_dashboards',
   },
   testEnvironment: 'jsdom',
 };


### PR DESCRIPTION
### Description
Fix failing test and update snapshots.
```
yarn test public/plugin.test.tsx
```
was failing with
```
$ ../../node_modules/.bin/jest --config ./test/jest.config.js public/plugin.test.tsx
 FAIL  public/plugin.test.tsx
  ● Test suite failed to run

    Cannot find module 'opensearch-dashboards/public' from '../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx'

    Require stack:
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.tsx
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/data_source_management/public/plugin.ts
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/data_source_management/public/index.ts
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/navigation/public/top_nav_menu/create_top_nav_menu.tsx
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/navigation/public/top_nav_menu/index.ts
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/navigation/public/index.ts
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/dashboard/public/application/components/dashboard_top_nav/index.ts
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/dashboard/public/application/utils/index.ts
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/dashboard/public/application/index.tsx
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/dashboard/public/plugin.tsx
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/dashboard/public/index.ts
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/visualizations/public/embeddable/index.ts
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/visualizations/public/plugin.ts
      /Users/tackadam/Documents/OpenSearch-Dashboards/src/plugins/visualizations/public/mocks.ts
      public/plugin.test.tsx

       7 | import { i18n } from '@osd/i18n';
       8 | import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
    >  9 | import {
         | ^
      10 |   SavedObjectsClientContract,
      11 |   ToastsStart,
      12 |   SavedObject,

      at Resolver._throwModNotFoundError (../../node_modules/@jest/core/node_modules/jest-resolve/build/resolver.js:491:11)
      at Object.<anonymous> (../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector.tsx:9:1)
      at Object.<anonymous> (../../src/plugins/data_source_management/public/components/data_source_selector/create_data_source_selector.tsx:9:1)
      at Object.<anonymous> (../../src/plugins/data_source_management/public/plugin.ts:23:1)
      at Object.<anonymous> (../../src/plugins/data_source_management/public/index.ts:7:1)
      at Object.<anonymous> (../../src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx:43:1)
      at Object.<anonymous> (../../src/plugins/navigation/public/top_nav_menu/create_top_nav_menu.tsx:35:1)
      at Object.<anonymous> (../../src/plugins/navigation/public/top_nav_menu/index.ts:31:1)
      at Object.<anonymous> (../../src/plugins/navigation/public/index.ts:38:1)
      at Object.<anonymous> (../../src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx:17:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        18.848 s, estimated 34 s
```
Corrected with
```
    // OpenSearch Dashboards path mappings
    '^opensearch-dashboards/public$': '<rootDir>/../../src/core/public',
    '^opensearch-dashboards/public/(.*)$': '<rootDir>/../../src/core/public/$1',
    '^opensearch-dashboards/server$': '<rootDir>/../../src/core/server',
    '^opensearch-dashboards/server/(.*)$': '<rootDir>/../../src/core/server/$1',
    '^opensearch-dashboards$': '<rootDir>/../../opensearch_dashboards',
```
```
$ ../../node_modules/.bin/jest --config ./test/jest.config.js public/plugin.test.tsx
 PASS  public/plugin.test.tsx (17.771 s)
  #setup
    ✓ should not register notebook application and call add notebook into nav group when investigation plugin present (4 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        21.587 s
```

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
