### PR TITLE
Bump serialize to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@babel/helpers": "^7.27.0",
     "@babel/runtime": "^7.27.0",
     "@babel/runtime-corejs3": "^7.27.0",
-    "**/form-data": "^4.0.4"
+    "**/form-data": "^4.0.4",
+    "serialize-javascript": "^6.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3095,10 +3095,10 @@ semver@^6.1.2, semver@^7.5.2, semver@^7.5.3:
   dependencies:
     lru-cache "^6.0.0"
 
-serialize-javascript@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
-  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
+serialize-javascript@6.0.0, serialize-javascript@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
 


### PR DESCRIPTION
### Description
Bump serialize to 6.0.2 

### Issues Resolved
https://nvd.nist.gov/vuln/detail/cve-2024-11831

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
