### PR TITLE
Traces cypress fix

### DIFF
--- a/.cypress/integration/trace_analytics_test/trace_analytics_dashboard.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_dashboard.spec.js
@@ -394,7 +394,9 @@ describe('Testing switch mode to jaeger', () => {
   });
 
   it('Verifies traces links to traces page', () => {
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('[data-test-subj="dashboard-table-traces-button"]').contains('7').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
 
     cy.contains(' (7)').should('exist');
     cy.get("[data-test-subj='filterBadge']").eq(0).contains('process.serviceName: redis');


### PR DESCRIPTION
### Description
Traces cypress fix
One failing test, timing issue on click while load is occurring.
```
  Testing switch mode to jaeger
    ✓ Verifies errors mode columns and data (10942ms)
    1) Verifies traces links to traces page
    ✓ Switches to throughput mode and verifies columns and data (6250ms)


  17 passing (3m)
  1 failing

  1) Testing switch mode to jaeger
       Verifies traces links to traces page:
     AssertionError: Timed out retrying after 60000ms: Expected to find content: ' (7)' but never did.
      at Context.eval (webpack://observability-dashboards/./.cypress/integration/trace_analytics_test/trace_analytics_dashboard.spec.js:399:24)
      ```

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
