### PR TITLE
Cypress Test Updates

### DIFF
--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -38,11 +38,28 @@ import {
 describe('Adding sample data and visualization', () => {
   it('Adds sample flights and logs data for event analytics', () => {
     cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory/sampleData`);
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+
+    // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
+    cy.get('body').then(($body) => {
+      if ($body.find('.euiModal').length > 0) {
+        cy.get('.euiModal').then(($modal) => {
+          if ($modal.text().indexOf('New Enhanced Discover experience') !== -1) {
+            cy.get('.euiButton').contains('Dismiss').click();
+            cy.get('.euiModal').should('not.exist');
+          }
+        });
+      }
+    });
+
     cy.get('div[data-test-subj="sampleDataSetCardflights"]')
+      .should('be.visible')
       .contains(/(Add|View) data/)
       .click();
     cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory/sampleData`);
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('div[data-test-subj="sampleDataSetCardlogs"]')
+      .should('be.visible')
       .contains(/(Add|View) data/)
       .click();
   });

--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -42,17 +42,6 @@ describe('Adding sample data and visualization', () => {
     cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
-    // Dismiss the "New Enhanced Discover experience" modal if it appears
-    // Return the promise to block subsequent commands
-    cy.get('body').then(($body) => {
-      if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
-        return cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click().then(() => {
-          return cy.get('.euiModal', { timeout: 5000 }).should('not.exist');
-        });
-      }
-      return cy.wrap(null);
-    });
-
     cy.get('div[data-test-subj="sampleDataSetCardflights"]')
       .should('be.visible')
       .contains(/(Add|View) data/)

--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -43,11 +43,14 @@ describe('Adding sample data and visualization', () => {
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
     // Dismiss the "New Enhanced Discover experience" modal if it appears
+    // Return the promise to block subsequent commands
     cy.get('body').then(($body) => {
       if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
-        cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click();
-        cy.get('.euiModal').should('not.exist');
+        return cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click().then(() => {
+          return cy.get('.euiModal', { timeout: 5000 }).should('not.exist');
+        });
       }
+      return cy.wrap(null);
     });
 
     cy.get('div[data-test-subj="sampleDataSetCardflights"]')

--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -42,15 +42,11 @@ describe('Adding sample data and visualization', () => {
     cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
-    // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
+    // Dismiss the "New Enhanced Discover experience" modal if it appears
     cy.get('body').then(($body) => {
-      if ($body.find('.euiModal').length > 0) {
-        cy.get('.euiModal').then(($modal) => {
-          if ($modal.text().indexOf('New Enhanced Discover experience') !== -1) {
-            cy.get('.euiButton').contains('Dismiss').click();
-            cy.get('.euiModal').should('not.exist');
-          }
-        });
+      if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
+        cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click();
+        cy.get('.euiModal').should('not.exist');
       }
     });
 

--- a/.cypress/integration/event_analytics_test/event_analytics.spec.js
+++ b/.cypress/integration/event_analytics_test/event_analytics.spec.js
@@ -38,7 +38,9 @@ import {
 describe('Adding sample data and visualization', () => {
   it('Adds sample flights and logs data for event analytics', () => {
     cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory/sampleData`);
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    // Wait for page to fully load - first wait for header to exist
+    cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
+    cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
     // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
     cy.get('body').then(($body) => {

--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -386,7 +386,8 @@ describe('Testing paragraphs', () => {
     cy.get('h3[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
     cy.get('.euiButton__text').contains('Run all paragraphs').click();
 
-    cy.get(`a[href="${SAMPLE_URL}"]`).should('exist');
+    // Wait for all paragraphs to finish running - look for the markdown output
+    cy.get(`a[href="${SAMPLE_URL}"]`, { timeout: 30000 }).should('exist');
   });
 
   it('Adds paragraph to top', () => {
@@ -412,11 +413,24 @@ describe('Testing paragraphs', () => {
 
   it('Moves paragraphs', () => {
     cy.get('h3[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+
+    // Clear outputs to reduce payload size and prevent POST 413 errors
+    cy.get('.euiButton__text').contains('Clear all outputs').click();
+    cy.get('button[data-test-subj="confirmModalConfirmButton"]').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 30000 }).should('not.exist');
+
+    // Scroll to top to ensure first paragraph menu button is in view
+    cy.scrollTo('top');
+    cy.get('.euiButtonIcon[aria-label="Open paragraph menu"').eq(0).scrollIntoView({ duration: 500 });
     cy.get('.euiButtonIcon[aria-label="Open paragraph menu"').eq(0).click();
     cy.get('.euiContextMenuItem-isDisabled').should('have.length.gte', 2);
     cy.get('.euiContextMenuItem__text').contains('Move to bottom').click();
 
-    cy.get('.euiText').contains('[5] Visualization').should('exist');
+    // Wait for the loading indicator to disappear after move
+    cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 30000 }).should('not.exist');
+
+    // Verify the paragraph has been renumbered
+    cy.get('.euiText').contains('[5] Visualization', { timeout: 10000 }).should('exist');
   });
 
   it('Duplicates and renames the notebook', () => {

--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -49,7 +49,9 @@ const moveToTestNotebook = () => {
 describe('Adding sample data and visualization', () => {
   it('Adds sample flights data for visualization paragraph', () => {
     cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory/sampleData`);
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    // Wait for page to fully load - first wait for header to exist
+    cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
+    cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
     // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
     cy.get('body').then(($body) => {

--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -53,15 +53,11 @@ describe('Adding sample data and visualization', () => {
     cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
-    // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
+    // Dismiss the "New Enhanced Discover experience" modal if it appears
     cy.get('body').then(($body) => {
-      if ($body.find('.euiModal').length > 0) {
-        cy.get('.euiModal').then(($modal) => {
-          if ($modal.text().indexOf('New Enhanced Discover experience') !== -1) {
-            cy.get('.euiButton').contains('Dismiss').click();
-            cy.get('.euiModal').should('not.exist');
-          }
-        });
+      if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
+        cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click();
+        cy.get('.euiModal').should('not.exist');
       }
     });
 

--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -54,11 +54,14 @@ describe('Adding sample data and visualization', () => {
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
     // Dismiss the "New Enhanced Discover experience" modal if it appears
+    // Return the promise to block subsequent commands
     cy.get('body').then(($body) => {
       if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
-        cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click();
-        cy.get('.euiModal').should('not.exist');
+        return cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click().then(() => {
+          return cy.get('.euiModal', { timeout: 5000 }).should('not.exist');
+        });
       }
+      return cy.wrap(null);
     });
 
     cy.get('div[data-test-subj="sampleDataSetCardflights"]')

--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -394,8 +394,8 @@ describe('Testing paragraphs', () => {
     cy.get('h3[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
 
     // Ensure button is visible and enabled before clicking
-    cy.get('.euiButton__text').contains('Run all paragraphs').should('be.visible').parent('button').should('not.be.disabled');
-    cy.get('.euiButton__text').contains('Run all paragraphs').click();
+    cy.contains('button', 'Run all paragraphs').should('be.visible').and('not.be.disabled');
+    cy.contains('button', 'Run all paragraphs').click();
 
     // Wait for execution to complete
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');

--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -379,6 +379,9 @@ describe('Testing paragraphs', () => {
     cy.get('.euiButton__text').contains('Clear all outputs').click();
     cy.get('button[data-test-subj="confirmModalConfirmButton"]').click();
 
+    // Wait for the clear operation to complete
+    cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 30000 }).should('not.exist');
+
     cy.get(`a[href="${SAMPLE_URL}"]`).should('not.exist');
   });
 
@@ -390,7 +393,10 @@ describe('Testing paragraphs', () => {
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 5000 }).should('exist');
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
-    // Wait for all paragraphs to finish running - look for the markdown output
+    // Wait for outputs to render - check for markdown body first
+    cy.get('div.markdown-body', { timeout: 30000 }).should('exist');
+
+    // Wait for all paragraphs to finish running - look for the specific markdown link
     cy.get(`a[href="${SAMPLE_URL}"]`, { timeout: 10000 }).should('exist');
   });
 

--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -376,28 +376,32 @@ describe('Testing paragraphs', () => {
 
   it('Clears outputs', () => {
     cy.get('h3[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+
+    // Verify outputs exist before clearing
+    cy.get(`a[href="${SAMPLE_URL}"]`).should('exist');
+
     cy.get('.euiButton__text').contains('Clear all outputs').click();
     cy.get('button[data-test-subj="confirmModalConfirmButton"]').click();
 
     // Wait for the clear operation to complete
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 30000 }).should('not.exist');
 
+    // Verify outputs are cleared
     cy.get(`a[href="${SAMPLE_URL}"]`).should('not.exist');
   });
 
   it('Runs all paragraphs', () => {
     cy.get('h3[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
+
+    // Ensure button is visible and enabled before clicking
+    cy.get('.euiButton__text').contains('Run all paragraphs').should('be.visible').parent('button').should('not.be.disabled');
     cy.get('.euiButton__text').contains('Run all paragraphs').click();
 
-    // Wait for execution to start and complete
-    cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 5000 }).should('exist');
+    // Wait for execution to complete
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
-    // Wait for outputs to render - check for markdown body first
-    cy.get('div.markdown-body', { timeout: 30000 }).should('exist');
-
-    // Wait for all paragraphs to finish running - look for the specific markdown link
-    cy.get(`a[href="${SAMPLE_URL}"]`, { timeout: 10000 }).should('exist');
+    // Wait for outputs to render - check for the specific markdown link
+    cy.get(`a[href="${SAMPLE_URL}"]`, { timeout: 60000 }).should('exist');
   });
 
   it('Adds paragraph to top', () => {

--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -49,7 +49,22 @@ const moveToTestNotebook = () => {
 describe('Adding sample data and visualization', () => {
   it('Adds sample flights data for visualization paragraph', () => {
     cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory/sampleData`);
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+
+    // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
+    cy.get('body').then(($body) => {
+      if ($body.find('.euiModal').length > 0) {
+        cy.get('.euiModal').then(($modal) => {
+          if ($modal.text().indexOf('New Enhanced Discover experience') !== -1) {
+            cy.get('.euiButton').contains('Dismiss').click();
+            cy.get('.euiModal').should('not.exist');
+          }
+        });
+      }
+    });
+
     cy.get('div[data-test-subj="sampleDataSetCardflights"]')
+      .should('be.visible')
       .contains(/(Add|View) data/)
       .click();
   });

--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -53,17 +53,6 @@ describe('Adding sample data and visualization', () => {
     cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
-    // Dismiss the "New Enhanced Discover experience" modal if it appears
-    // Return the promise to block subsequent commands
-    cy.get('body').then(($body) => {
-      if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
-        return cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click().then(() => {
-          return cy.get('.euiModal', { timeout: 5000 }).should('not.exist');
-        });
-      }
-      return cy.wrap(null);
-    });
-
     cy.get('div[data-test-subj="sampleDataSetCardflights"]')
       .should('be.visible')
       .contains(/(Add|View) data/)

--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -386,8 +386,12 @@ describe('Testing paragraphs', () => {
     cy.get('h3[data-test-subj="notebookTitle"]').contains(TEST_NOTEBOOK).should('exist');
     cy.get('.euiButton__text').contains('Run all paragraphs').click();
 
+    // Wait for execution to start and complete
+    cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 5000 }).should('exist');
+    cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
+
     // Wait for all paragraphs to finish running - look for the markdown output
-    cy.get(`a[href="${SAMPLE_URL}"]`, { timeout: 30000 }).should('exist');
+    cy.get(`a[href="${SAMPLE_URL}"]`, { timeout: 10000 }).should('exist');
   });
 
   it('Adds paragraph to top', () => {
@@ -446,7 +450,9 @@ describe('Testing paragraphs', () => {
     cy.get('h3[data-test-subj="notebookTitle"]')
       .contains(TEST_NOTEBOOK + ' (rename)')
       .should('exist');
-    cy.get(`a[href="${SAMPLE_URL}"]`).should('have.length.gte', 2);
+
+    // Verify notebook has paragraphs (outputs were cleared in previous test)
+    cy.get('.euiText').should('contain', 'Code block');
   });
 
   it('Deletes paragraphs', () => {

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -25,15 +25,11 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
     cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
-    // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
+    // Dismiss the "New Enhanced Discover experience" modal if it appears
     cy.get('body').then(($body) => {
-      if ($body.find('.euiModal').length > 0) {
-        cy.get('.euiModal').then(($modal) => {
-          if ($modal.text().indexOf('New Enhanced Discover experience') !== -1) {
-            cy.get('.euiButton').contains('Dismiss').click();
-            cy.get('.euiModal').should('not.exist');
-          }
-        });
+      if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
+        cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click();
+        cy.get('.euiModal').should('not.exist');
       }
     });
 

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -25,17 +25,6 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
     cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
-    // Dismiss the "New Enhanced Discover experience" modal if it appears
-    // Return the promise to block subsequent commands
-    cy.get('body').then(($body) => {
-      if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
-        return cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click().then(() => {
-          return cy.get('.euiModal', { timeout: 5000 }).should('not.exist');
-        });
-      }
-      return cy.wrap(null);
-    });
-
     cy.get('div[data-test-subj="sampleDataSetCardflights"]')
       .should('be.visible')
       .contains(/(Add|View) data/)

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -21,7 +21,22 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
 
   before(() => {
     cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory/sampleData`);
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+
+    // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
+    cy.get('body').then(($body) => {
+      if ($body.find('.euiModal').length > 0) {
+        cy.get('.euiModal').then(($modal) => {
+          if ($modal.text().indexOf('New Enhanced Discover experience') !== -1) {
+            cy.get('.euiButton').contains('Dismiss').click();
+            cy.get('.euiModal').should('not.exist');
+          }
+        });
+      }
+    });
+
     cy.get('div[data-test-subj="sampleDataSetCardflights"]')
+      .should('be.visible')
       .contains(/(Add|View) data/)
       .trigger('mouseover')
       .click();

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -21,7 +21,9 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
 
   before(() => {
     cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory/sampleData`);
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    // Wait for page to fully load - first wait for header to exist
+    cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
+    cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
     // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
     cy.get('body').then(($body) => {

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -26,11 +26,14 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
     cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
     // Dismiss the "New Enhanced Discover experience" modal if it appears
+    // Return the promise to block subsequent commands
     cy.get('body').then(($body) => {
       if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
-        cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click();
-        cy.get('.euiModal').should('not.exist');
+        return cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click().then(() => {
+          return cy.get('.euiModal', { timeout: 5000 }).should('not.exist');
+        });
       }
+      return cy.wrap(null);
     });
 
     cy.get('div[data-test-subj="sampleDataSetCardflights"]')

--- a/.cypress/integration/trace_analytics_test/trace_analytics_dashboard.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_dashboard.spec.js
@@ -176,8 +176,15 @@ describe('Testing plots', () => {
         win.sessionStorage.clear();
       },
     });
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     setTimeFilter();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('[data-test-subj="trace-groups-service-operation-accordian"]').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    // Wait for plots to start rendering and scroll to them to trigger lazy components
+    cy.get('.js-plotly-plot', { timeout: 15000 }).should('exist');
+    cy.get('.js-plotly-plot').first().scrollIntoView({ duration: 500 });
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
   });
 
   it('Renders service map', () => {

--- a/.cypress/integration/trace_analytics_test/trace_analytics_dashboard.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_dashboard.spec.js
@@ -30,7 +30,6 @@ describe('Dump test data', () => {
       cy.request(mapping_url).then((response) => {
         cy.request({
           method: 'POST',
-          //form: true,
           url: 'api/console/proxy',
           headers: {
             'content-type': 'application/json;charset=UTF-8',
@@ -47,7 +46,6 @@ describe('Dump test data', () => {
       cy.request(data_url).then((response) => {
         cy.request({
           method: 'POST',
-          //form: true,
           url: 'api/console/proxy',
           headers: {
             'content-type': 'application/json;charset=UTF-8',
@@ -58,6 +56,20 @@ describe('Dump test data', () => {
             method: 'POST',
           },
           body: response.body,
+        }).then(() => {
+          // Refresh the index to make data immediately available for search
+          cy.request({
+            method: 'POST',
+            url: 'api/console/proxy',
+            headers: {
+              'content-type': 'application/json;charset=UTF-8',
+              'osd-xsrf': true,
+            },
+            qs: {
+              path: `${index}/_refresh`,
+              method: 'POST',
+            },
+          });
         });
       });
     };
@@ -128,7 +140,7 @@ describe('Testing dashboard table', () => {
     cy.get('[data-test-subj="trace-table-mode-selector"]').click();
     cy.get('.euiSelectableListItem__content').contains('Traces').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.get('.euiLink').contains('13').click();
+    cy.get('[data-test-subj="dashboard-table-traces-button"]').contains('13').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.euiDataGrid').should('be.visible');
 
@@ -332,7 +344,6 @@ describe('Dump jaeger test data', () => {
       cy.request(mapping_url).then((response) => {
         cy.request({
           method: 'POST',
-          //form: true,
           url: 'api/console/proxy',
           headers: {
             'content-type': 'application/json;charset=UTF-8',
@@ -349,7 +360,6 @@ describe('Dump jaeger test data', () => {
       cy.request(data_url).then((response) => {
         cy.request({
           method: 'POST',
-          //form: true,
           url: 'api/console/proxy',
           headers: {
             'content-type': 'application/json;charset=UTF-8',
@@ -360,6 +370,20 @@ describe('Dump jaeger test data', () => {
             method: 'POST',
           },
           body: response.body,
+        }).then(() => {
+          // Refresh the index to make data immediately available for search
+          cy.request({
+            method: 'POST',
+            url: 'api/console/proxy',
+            headers: {
+              'content-type': 'application/json;charset=UTF-8',
+              'osd-xsrf': true,
+            },
+            qs: {
+              path: `${index}/_refresh`,
+              method: 'POST',
+            },
+          });
         });
       });
     };

--- a/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
@@ -476,11 +476,17 @@ describe('Testing navigation from Services to Traces', () => {
     });
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
 
-    cy.get("[data-test-subj='indexPattern-switch-link']").click();
+    // Wait for services table to be fully rendered before interacting
+    cy.get('.euiTableRow', { timeout: 15000 }).should('have.length.greaterThan', 0);
+
+    cy.get("[data-test-subj='indexPattern-switch-link']").should('be.visible').click();
     cy.get("[data-test-subj='data_prepper-mode']").click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     setTimeFilter();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+
+    // Wait for table to reload with data prepper data
+    cy.get('.euiTableRow', { timeout: 15000 }).should('have.length.greaterThan', 0);
   });
 
   it('Clicks on the "Traces" shortcut to redirect', () => {
@@ -546,12 +552,22 @@ describe('Testing switch mode to jaeger', () => {
   });
 
   it('Verifies traces links to traces page with filter applied', () => {
-    cy.get('.euiTableRow').should('have.length.lessThan', 7); //Replaces Wait
+    // Wait for table to have data loaded
+    cy.get('.euiTableRow', { timeout: 15000 }).should('have.length.greaterThan', 0);
+    cy.get('.euiTableRow').should('have.length.lessThan', 7);
+
     cy.contains('7').should('exist');
-    cy.get('[data-test-subj^="service-traces-redirection-btntrace_"]').first().click();
+    cy.get('[data-test-subj^="service-traces-redirection-btntrace_"]').first().should('be.visible').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.contains(' (7)').should('exist');
+
+    // Wait for traces page to load
+    cy.contains(' (7)', { timeout: 15000 }).should('exist');
+
+    // Wait for filter badge to appear and verify content
     cy.get("[data-test-subj='filterBadge']", { timeout: 15000 })
+      .should('have.length.greaterThan', 0);
+
+    cy.get("[data-test-subj='filterBadge']")
       .eq(0)
       .should('contain', 'process.serviceName')
       .and('contain', 'customer');

--- a/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
@@ -102,7 +102,10 @@ describe('Testing service view empty state and invalid url', () => {
       },
     });
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    // Wait for page content to be ready and scroll to ensure lazy components are initialized
+    cy.get('h1.overview-content', { timeout: 10000 }).should('be.visible').scrollIntoView({ duration: 500 });
     cy.contains('frontend-client').should('exist');
+    cy.get('h2.euiTitle.euiTitle--medium', { timeout: 10000 }).first().should('be.visible').scrollIntoView({ duration: 500 });
     cy.contains('No matches').should('exist');
 
     // Renders service view invalid url state
@@ -113,8 +116,11 @@ describe('Testing service view empty state and invalid url', () => {
     });
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.contains(`${INVALID_URL}`).should('exist');
-    cy.get('.euiCallOut.euiCallOut--danger')
+    // Scroll to callout to ensure lazy-loaded components are initialized
+    cy.get('.euiCallOut.euiCallOut--danger', { timeout: 10000 })
       .should('exist')
+      .scrollIntoView({ duration: 500 });
+    cy.get('.euiCallOut.euiCallOut--danger')
       .within(() => {
         cy.get('.euiCallOutHeader__title').should(
           'contain.text',
@@ -296,8 +302,13 @@ describe('Testing traces Spans table verify table headers functionality', () => 
       },
     });
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.get("[data-test-subj='indexPattern-switch-link']").click();
+    // Wait for button to be visible and interactable before clicking
+    cy.get("[data-test-subj='indexPattern-switch-link']", { timeout: 10000 })
+      .should('be.visible')
+      .scrollIntoView({ duration: 500 })
+      .click();
     cy.get("[data-test-subj='data_prepper-mode']").click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     setTimeFilter();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     // Wait for the services table to be stable

--- a/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
@@ -419,7 +419,11 @@ describe('Testing traces Spans table and verify columns functionality', () => {
       .should('be.visible')
       .scrollIntoView({ duration: 500 })
       .click();
-    cy.get("[data-test-subj='data_prepper-mode']").click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    cy.get("[data-test-subj='data_prepper-mode']", { timeout: 10000 })
+      .should('be.visible')
+      .scrollIntoView({ duration: 500 })
+      .click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     setTimeFilter();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');

--- a/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
@@ -532,9 +532,6 @@ describe('Testing switch mode to jaeger', () => {
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     // Wait for the services table to be fully rendered with jaeger data
     cy.get('.euiTableRow', { timeout: 15000 }).should('have.length.greaterThan', 0);
-    // Ensure the last row is fully rendered and visible before scrolling
-    cy.get('.euiTableRow').last().should('exist').and('be.visible');
-    cy.scrollTo('bottom', { ensureScrollable: false, duration: 300 });
   });
 
   it('Verifies columns and data', () => {

--- a/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
@@ -413,9 +413,18 @@ describe('Testing traces Spans table and verify columns functionality', () => {
         win.sessionStorage.clear();
       },
     });
-    cy.get("[data-test-subj='indexPattern-switch-link']").click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    // Wait for button to be visible and interactable before clicking
+    cy.get("[data-test-subj='indexPattern-switch-link']", { timeout: 10000 })
+      .should('be.visible')
+      .scrollIntoView({ duration: 500 })
+      .click();
     cy.get("[data-test-subj='data_prepper-mode']").click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     setTimeFilter();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    // Wait for the services table to be stable
+    cy.get('.euiTableRow', { timeout: 10000 }).should('have.length.greaterThan', 0);
   });
 
   it('Renders the spans table and click on first span to verify details', () => {

--- a/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
@@ -419,11 +419,7 @@ describe('Testing traces Spans table and verify columns functionality', () => {
       .should('be.visible')
       .scrollIntoView({ duration: 500 })
       .click();
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.get("[data-test-subj='data_prepper-mode']", { timeout: 10000 })
-      .should('be.visible')
-      .scrollIntoView({ duration: 500 })
-      .click();
+    cy.get("[data-test-subj='data_prepper-mode']").click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     setTimeFilter();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');

--- a/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
@@ -474,10 +474,13 @@ describe('Testing navigation from Services to Traces', () => {
         win.sessionStorage.clear();
       },
     });
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
 
     cy.get("[data-test-subj='indexPattern-switch-link']").click();
     cy.get("[data-test-subj='data_prepper-mode']").click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     setTimeFilter();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
   });
 
   it('Clicks on the "Traces" shortcut to redirect', () => {
@@ -529,9 +532,9 @@ describe('Testing switch mode to jaeger', () => {
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     // Wait for the services table to be fully rendered with jaeger data
     cy.get('.euiTableRow', { timeout: 15000 }).should('have.length.greaterThan', 0);
-    // Scroll to the last table row to ensure all components are initialized
-    cy.get('.euiTableRow').last().scrollIntoView({ duration: 500 });
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    // Ensure the last row is fully rendered and visible before scrolling
+    cy.get('.euiTableRow').last().should('exist').and('be.visible');
+    cy.scrollTo('bottom', { ensureScrollable: false, duration: 300 });
   });
 
   it('Verifies columns and data', () => {
@@ -549,7 +552,11 @@ describe('Testing switch mode to jaeger', () => {
     cy.get('.euiTableRow').should('have.length.lessThan', 7); //Replaces Wait
     cy.contains('7').should('exist');
     cy.get('[data-test-subj^="service-traces-redirection-btntrace_"]').first().click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.contains(' (7)').should('exist');
-    cy.get("[data-test-subj='filterBadge']").eq(0).contains('process.serviceName: customer');
+    cy.get("[data-test-subj='filterBadge']", { timeout: 15000 })
+      .eq(0)
+      .should('contain', 'process.serviceName')
+      .and('contain', 'customer');
   });
 });

--- a/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
@@ -295,9 +295,13 @@ describe('Testing traces Spans table verify table headers functionality', () => 
         win.sessionStorage.clear();
       },
     });
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get("[data-test-subj='indexPattern-switch-link']").click();
     cy.get("[data-test-subj='data_prepper-mode']").click();
     setTimeFilter();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    // Wait for the services table to be stable
+    cy.get('.euiTableRow', { timeout: 10000 }).should('have.length.greaterThan', 0);
   });
 
   it('Renders the spans table and verify columns headers', () => {
@@ -342,7 +346,10 @@ describe('Testing traces Spans table verify table headers functionality', () => 
   it('Hide all button Spans table', () => {
     cy.get('.euiLink.euiLink--primary').contains('authentication').should('exist');
     expandServiceView(1);
-    cy.get('.euiTableRow').should('have.length.lessThan', 2); //Replace wait
+    // Scroll to the data grid element to ensure it's initialized
+    cy.get('[data-test-subj="service-dep-table"]', { timeout: 10000 }).scrollIntoView({ duration: 500 }).should('be.visible');
+    // Wait for the data grid headers to be fully rendered and stable
+    cy.get('.euiDataGridHeaderCell__content', { timeout: 10000 }).should('be.visible');
     cy.get('[data-test-subj = "dataGridColumnSelectorButton"]').click();
     cy.get('.euiPopoverFooter .euiFlexItem.euiFlexItem--flexGrowZero')
       .eq(1)
@@ -494,10 +501,17 @@ describe('Testing switch mode to jaeger', () => {
         win.sessionStorage.clear();
       },
     });
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     setTimeFilter();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get("[data-test-subj='indexPattern-switch-link']").click();
     cy.get("[data-test-subj='jaeger-mode']").click();
-    //cy.get('.euiButtonEmpty__text').should('contain', 'Jaeger');
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    // Wait for the services table to be fully rendered with jaeger data
+    cy.get('.euiTableRow', { timeout: 15000 }).should('have.length.greaterThan', 0);
+    // Scroll to the last table row to ensure all components are initialized
+    cy.get('.euiTableRow').last().scrollIntoView({ duration: 500 });
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
   });
 
   it('Verifies columns and data', () => {

--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -320,11 +320,20 @@ describe('Testing switch mode to jaeger', () => {
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     setTimeFilter();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.get("[data-test-subj='indexPattern-switch-link']").click();
-    cy.get("[data-test-subj='jaeger-mode']").click();
+    cy.get("[data-test-subj='indexPattern-switch-link']", { timeout: 10000 })
+      .should('be.visible')
+      .scrollIntoView({ duration: 500 })
+      .click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    cy.get("[data-test-subj='jaeger-mode']", { timeout: 10000 })
+      .should('be.visible')
+      .scrollIntoView({ duration: 500 })
+      .click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('input[type="search"]').first().focus().clear();
-    cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
+    cy.get('[data-test-subj="superDatePickerApplyTimeButton"]')
+      .scrollIntoView({ duration: 500 })
+      .click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     // In jaeger mode, traces are displayed in a regular table, scroll to it to ensure it's initialized
     cy.get('.euiTable', { timeout: 10000 }).should('exist');
@@ -407,6 +416,7 @@ describe('Testing traces Custom source features', () => {
 
     // Wait for data to load and ensure links are visible
     cy.get('a.euiLink.euiLink--primary', { timeout: 10000 }).should('be.visible');
+    cy.get('a.euiLink.euiLink--primary').first().scrollIntoView({ duration: 500 });
     cy.get('a.euiLink.euiLink--primary').first().click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.overview-content', { timeout: 10000 }).should('contain.text', 'd5bc99166e521eec173bcb7f9b0d3c43');
@@ -421,11 +431,13 @@ describe('Testing traces Custom source features', () => {
   });
 
   it('Verifies column sorting and pagination works correctly', () => {
-    cy.contains('Duration (ms)').click();
+    cy.contains('Duration (ms)').scrollIntoView({ duration: 500 }).click();
     cy.contains('Sort Z-A').click();
 
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    // Wait for sorted data to load with retry logic
+    // Wait for sorted data to load and scroll to see first row
+    cy.get('[data-test-subj="dataGridRowCell"]', { timeout: 15000 }).should('have.length.greaterThan', 0);
+    cy.get('[data-test-subj="dataGridRowCell"]').first().scrollIntoView({ duration: 500 });
     cy.contains('467.03 ms', { timeout: 15000 }).should('exist');
 
     cy.get('[data-test-subj="pagination-button-next"]').click();
@@ -456,6 +468,7 @@ describe('Testing traces Custom source features', () => {
 
     // Wait for data to load and ensure links are visible
     cy.get('a.euiLink.euiLink--primary', { timeout: 10000 }).should('be.visible');
+    cy.get('a.euiLink.euiLink--primary').first().scrollIntoView({ duration: 500 });
     cy.get('a.euiLink.euiLink--primary').first().click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.overview-content', { timeout: 10000 }).should('contain.text', 'd5bc99166e521eec173bcb7f9b0d3c43');

--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -416,12 +416,11 @@ describe('Testing traces Custom source features', () => {
 
     // Wait for data to load and ensure links are visible
     cy.get('a.euiLink.euiLink--primary', { timeout: 10000 }).should('have.length.greaterThan', 0);
-    // Get the first link's href to ensure it's a valid trace ID link
     cy.get('a.euiLink.euiLink--primary').first().should('have.attr', 'href').and('include', '#/traces');
     cy.get('a.euiLink.euiLink--primary').first().scrollIntoView({ duration: 500 });
     cy.get('a.euiLink.euiLink--primary').first().should('be.visible').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.get('.overview-content', { timeout: 10000 }).should('contain.text', 'd5bc99166e521eec173bcb7f9b0d3c43');
+    cy.get('h1.overview-content', { timeout: 10000 }).should('contain.text', 'd5bc99166e521eec173bcb7f9b0d3c43');
   });
 
   it('Renders all spans column attributes as hidden, shows column when added', () => {
@@ -472,11 +471,10 @@ describe('Testing traces Custom source features', () => {
 
     // Wait for data to load and ensure links are visible
     cy.get('a.euiLink.euiLink--primary', { timeout: 10000 }).should('have.length.greaterThan', 0);
-    // Get the first link's href to ensure it's a valid trace ID link
     cy.get('a.euiLink.euiLink--primary').first().should('have.attr', 'href').and('include', '#/traces');
     cy.get('a.euiLink.euiLink--primary').first().scrollIntoView({ duration: 500 });
     cy.get('a.euiLink.euiLink--primary').first().should('be.visible').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.get('.overview-content', { timeout: 10000 }).should('contain.text', 'd5bc99166e521eec173bcb7f9b0d3c43');
+    cy.get('h1.overview-content', { timeout: 10000 }).should('contain.text', 'd5bc99166e521eec173bcb7f9b0d3c43');
   });
 });

--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -296,10 +296,17 @@ describe('Testing traces tree view', () => {
     cy.get("[data-test-subj='treeExpandAll']").click();
     cy.get("[data-test-subj='treeCollapseAll']").click();
 
+    // Wait for fullscreen button to be visible and scroll to it before clicking
+    cy.get('[data-test-subj="fullScreenButton"]', { timeout: 10000 })
+      .should('be.visible')
+      .scrollIntoView({ duration: 500 });
     cy.get('[data-test-subj="fullScreenButton"]').click();
-    cy.get('.euiButtonEmpty__text').should('contain.text', 'Exit full screen');
+    cy.get('.euiButtonEmpty__text', { timeout: 10000 }).should('contain.text', 'Exit full screen');
+    cy.get('[data-test-subj="fullScreenButton"]', { timeout: 10000 })
+      .should('be.visible')
+      .scrollIntoView({ duration: 500 });
     cy.get('[data-test-subj="fullScreenButton"]').click();
-    cy.get('.euiButtonEmpty__text').should('contain.text', 'Full screen');
+    cy.get('.euiButtonEmpty__text', { timeout: 10000 }).should('contain.text', 'Full screen');
   });
 });
 

--- a/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_traces.spec.js
@@ -415,9 +415,11 @@ describe('Testing traces Custom source features', () => {
     cy.get('.euiDataGridHeaderCell__content').contains('Last updated').should('exist');
 
     // Wait for data to load and ensure links are visible
-    cy.get('a.euiLink.euiLink--primary', { timeout: 10000 }).should('be.visible');
+    cy.get('a.euiLink.euiLink--primary', { timeout: 10000 }).should('have.length.greaterThan', 0);
+    // Get the first link's href to ensure it's a valid trace ID link
+    cy.get('a.euiLink.euiLink--primary').first().should('have.attr', 'href').and('include', '#/traces');
     cy.get('a.euiLink.euiLink--primary').first().scrollIntoView({ duration: 500 });
-    cy.get('a.euiLink.euiLink--primary').first().click();
+    cy.get('a.euiLink.euiLink--primary').first().should('be.visible').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.overview-content', { timeout: 10000 }).should('contain.text', 'd5bc99166e521eec173bcb7f9b0d3c43');
   });
@@ -435,8 +437,10 @@ describe('Testing traces Custom source features', () => {
     cy.contains('Sort Z-A').click();
 
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    // Wait for sorted data to load and scroll to see first row
+    // Wait for sorting to complete and data to refresh
+    cy.get('.euiDataGrid', { timeout: 15000 }).should('be.visible');
     cy.get('[data-test-subj="dataGridRowCell"]', { timeout: 15000 }).should('have.length.greaterThan', 0);
+    // Scroll first row into view to ensure it's visible
     cy.get('[data-test-subj="dataGridRowCell"]').first().scrollIntoView({ duration: 500 });
     cy.contains('467.03 ms', { timeout: 15000 }).should('exist');
 
@@ -467,9 +471,11 @@ describe('Testing traces Custom source features', () => {
     cy.get('.euiDataGridHeaderCell__content').contains('Last updated').should('exist');
 
     // Wait for data to load and ensure links are visible
-    cy.get('a.euiLink.euiLink--primary', { timeout: 10000 }).should('be.visible');
+    cy.get('a.euiLink.euiLink--primary', { timeout: 10000 }).should('have.length.greaterThan', 0);
+    // Get the first link's href to ensure it's a valid trace ID link
+    cy.get('a.euiLink.euiLink--primary').first().should('have.attr', 'href').and('include', '#/traces');
     cy.get('a.euiLink.euiLink--primary').first().scrollIntoView({ duration: 500 });
-    cy.get('a.euiLink.euiLink--primary').first().click();
+    cy.get('a.euiLink.euiLink--primary').first().should('be.visible').click();
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.overview-content', { timeout: 10000 }).should('contain.text', 'd5bc99166e521eec173bcb7f9b0d3c43');
   });

--- a/.cypress/utils/app_constants.js
+++ b/.cypress/utils/app_constants.js
@@ -33,15 +33,11 @@ export const loadAllSampleData = () => {
   cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
   cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
-  // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
+  // Dismiss the "New Enhanced Discover experience" modal if it appears
   cy.get('body').then(($body) => {
-    if ($body.find('.euiModal').length > 0) {
-      cy.get('.euiModal').then(($modal) => {
-        if ($modal.text().indexOf('New Enhanced Discover experience') !== -1) {
-          cy.get('.euiButton').contains('Dismiss').click();
-          cy.get('.euiModal').should('not.exist');
-        }
-      });
+    if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
+      cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click();
+      cy.get('.euiModal').should('not.exist');
     }
   });
 

--- a/.cypress/utils/app_constants.js
+++ b/.cypress/utils/app_constants.js
@@ -29,7 +29,9 @@ export const loadAllSampleData = () => {
   );
 
   cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory`);
-  cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+  // Wait for page to fully load - first wait for header to exist
+  cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
+  cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
   // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
   cy.get('body').then(($body) => {

--- a/.cypress/utils/app_constants.js
+++ b/.cypress/utils/app_constants.js
@@ -33,17 +33,6 @@ export const loadAllSampleData = () => {
   cy.get('header[data-test-subj="headerGlobalNav"]', { timeout: 60000 }).should('exist');
   cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
-  // Dismiss the "New Enhanced Discover experience" modal if it appears
-  // Return the promise to block subsequent commands
-  cy.get('body').then(($body) => {
-    if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
-      return cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click().then(() => {
-        return cy.get('.euiModal', { timeout: 5000 }).should('not.exist');
-      });
-    }
-    return cy.wrap(null);
-  });
-
   // Load sample flights data
   cy.get(`button[data-test-subj="addSampleDataSetflights"]`)
     .should('be.visible')

--- a/.cypress/utils/app_constants.js
+++ b/.cypress/utils/app_constants.js
@@ -29,15 +29,30 @@ export const loadAllSampleData = () => {
   );
 
   cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory`);
+  cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+
+  // Conditionally dismiss the "New Enhanced Discover experience" modal if it appears
+  cy.get('body').then(($body) => {
+    if ($body.find('.euiModal').length > 0) {
+      cy.get('.euiModal').then(($modal) => {
+        if ($modal.text().indexOf('New Enhanced Discover experience') !== -1) {
+          cy.get('.euiButton').contains('Dismiss').click();
+          cy.get('.euiModal').should('not.exist');
+        }
+      });
+    }
+  });
 
   // Load sample flights data
-  cy.get(`button[data-test-subj="addSampleDataSetflights"]`).click({
-    force: true,
-  });
+  cy.get(`button[data-test-subj="addSampleDataSetflights"]`)
+    .should('be.visible')
+    .scrollIntoView({ duration: 500 })
+    .click();
   // Load sample logs data
-  cy.get(`button[data-test-subj="addSampleDataSetlogs"]`).click({
-    force: true,
-  });
+  cy.get(`button[data-test-subj="addSampleDataSetlogs"]`)
+    .should('be.visible')
+    .scrollIntoView({ duration: 500 })
+    .click();
 
   // Verify that sample data is add by checking toast notification
   cy.contains('Sample flight data installed', { timeout: 60000 });

--- a/.cypress/utils/app_constants.js
+++ b/.cypress/utils/app_constants.js
@@ -34,11 +34,14 @@ export const loadAllSampleData = () => {
   cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 60000 }).should('not.exist');
 
   // Dismiss the "New Enhanced Discover experience" modal if it appears
+  // Return the promise to block subsequent commands
   cy.get('body').then(($body) => {
     if ($body.find('[data-test-subj="dismissEnhancedDiscoverModal"]').length > 0) {
-      cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click();
-      cy.get('.euiModal').should('not.exist');
+      return cy.get('[data-test-subj="dismissEnhancedDiscoverModal"]').click().then(() => {
+        return cy.get('.euiModal', { timeout: 5000 }).should('not.exist');
+      });
     }
+    return cy.wrap(null);
   });
 
   // Load sample flights data

--- a/.cypress/utils/constants.js
+++ b/.cypress/utils/constants.js
@@ -84,11 +84,7 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
       .type('{selectall}' + endTime, { force: true });
   }
   if (refresh) cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
-  cy.get('body').then(($body) => {
-    if ($body.find('[data-test-subj="globalLoadingIndicator"]').length > 0) {
-      cy.get('[data-test-subj="globalLoadingIndicator"]', { timeout: 10000 }).should('not.exist');
-    }
-  });
+  cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
 };
 
 export const expandServiceView = (rowIndex = 0) => {

--- a/.cypress/utils/constants.js
+++ b/.cypress/utils/constants.js
@@ -69,7 +69,7 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
   const endTime = 'Mar 25, 2021 @ 11:00:00.000';
   cy.get('button.euiButtonEmpty[aria-label="Date quick select"]').click({ force: true });
   cy.get('.euiQuickSelect__applyButton').click({ force: true });
-  cy.get('.euiSuperDatePicker__prettyFormatLink').click();
+  cy.get('.euiSuperDatePicker__prettyFormatLink').click({ force: true });
   cy.get('.euiTab__content').contains('Absolute').click();
   cy.get('input[data-test-subj="superDatePickerAbsoluteDateInput"]')
     .focus()

--- a/.cypress/utils/constants.js
+++ b/.cypress/utils/constants.js
@@ -68,6 +68,7 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
   const startTime = 'Mar 25, 2021 @ 10:00:00.000';
   const endTime = 'Mar 25, 2021 @ 11:00:00.000';
   cy.get('button.euiButtonEmpty[aria-label="Date quick select"]').click({ force: true });
+  cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
   cy.get('.euiQuickSelect__applyButton').click({ force: true });
   cy.get('.euiSuperDatePicker__prettyFormatLink').click({ force: true });
   cy.get('.euiTab__content').contains('Absolute').click();

--- a/.github/workflows/integration-tests-workflow.yml
+++ b/.github/workflows/integration-tests-workflow.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          nohup yarn start --no-base-path --no-watch | tee dashboard.log &
+          nohup yarn start --no-base-path --no-watch --home.disableExperienceModal=true | tee dashboard.log &
 
       - name: Check If OpenSearch Dashboards Is Ready
         if: ${{ runner.os == 'Linux' }}

--- a/public/components/common/search/autocomplete.tsx
+++ b/public/components/common/search/autocomplete.tsx
@@ -125,8 +125,24 @@ export const Autocomplete = (props: AutocompleteProps) => {
                 },
                 dslService
               );
-              $('#autocomplete-textarea').blur();
-              $('#autocomplete-textarea').focus();
+              // Blur and refocus to trigger openOnFocus and fetch new suggestions
+              // This is needed for React 18 compatibility - the autocomplete library
+              // responds to native focus events to reopen and fetch new suggestions
+              setTimeout(() => {
+                const textarea = document.getElementById(
+                  'autocomplete-textarea'
+                ) as HTMLTextAreaElement;
+                if (textarea) {
+                  textarea.blur();
+                  // Delay to ensure blur completes before refocusing
+                  setTimeout(() => {
+                    textarea.focus();
+                    // Move cursor to end of text
+                    const length = textarea.value.length;
+                    textarea.setSelectionRange(length, length);
+                  }, 100);
+                }
+              }, 0);
             },
           },
         ];
@@ -163,6 +179,10 @@ export const Autocomplete = (props: AutocompleteProps) => {
             .filter(Boolean)
             .join(' ')}
           {...autocomplete.getPanelProps({})}
+          onMouseDown={(e) => {
+            // Prevent blur when clicking on autocomplete items
+            e.preventDefault();
+          }}
         >
           {autocompleteState.collections.map((collection, index) => {
             const { source, items } = collection;

--- a/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -124,7 +124,8 @@ export const VisualizationContainer = ({
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [modalContent, setModalContent] = useState(<></>);
 
-  const queryMetaData = useSelector(metricQuerySelector(visualizationId));
+  const selector = useMemo(() => metricQuerySelector(visualizationId), [visualizationId]);
+  const queryMetaData = useSelector(selector);
   const closeModal = () => setIsModalVisible(false);
   const showModal = (modalType: string) => {
     if (modalType === 'catalogModal')

--- a/public/components/event_analytics/hooks/use_fetch_events.ts
+++ b/public/components/event_analytics/hooks/use_fetch_events.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import forEach from 'lodash/forEach';
 import isEmpty from 'lodash/isEmpty';
 import { useRef, useState } from 'react';
 import { batch, useDispatch, useSelector } from 'react-redux';
@@ -66,7 +67,7 @@ export const useFetchEvents = ({ pplService, requestParams }: IFetchEventsParams
 
     const data: any[] = [];
 
-    _.forEach(pplRes.datarows, (row) => {
+    forEach(pplRes.datarows, (row) => {
       const record: any = {};
 
       for (let i = 0; i < pplRes.schema.length; i++) {

--- a/public/components/metrics/redux/slices/metrics_slice.ts
+++ b/public/components/metrics/redux/slices/metrics_slice.ts
@@ -383,12 +383,14 @@ export const dateSpanFilterSelector = (state) => state.metrics.dateSpanFilter;
 
 export const refreshSelector = (state) => state.metrics.refresh;
 
+const DEFAULT_METRIC_QUERY = {
+  aggregation: '',
+  attributesGroupBy: [],
+  availableAttributes: [],
+};
+
 export const metricQuerySelector = (id) => (state) =>
-  state.metrics.metricsLayout.find((layout) => layout.id === id)?.query || {
-    aggregation: '',
-    attributesGroupBy: [],
-    availableAttributes: [],
-  };
+  state.metrics.metricsLayout.find((layout) => layout.id === id)?.query || DEFAULT_METRIC_QUERY;
 
 export const selectedDataSourcesSelector = (state) => state.metrics.selectedDataSource;
 

--- a/public/components/notebooks/components/notebook.tsx
+++ b/public/components/notebooks/components/notebook.tsx
@@ -148,8 +148,21 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
   };
 
   parseAllParagraphs = () => {
+    const oldParsedPara = this.state.parsedPara;
     const parsedPara = this.parseParagraphs(this.state.paragraphs);
-    this.setState({ parsedPara });
+    // Preserve refs from old paragraphs if they exist
+    if (oldParsedPara && oldParsedPara.length > 0) {
+      parsedPara.forEach((para: ParaType, index: number) => {
+        if (oldParsedPara[index]) {
+          para.paraRef = oldParsedPara[index].paraRef;
+          para.paraDivRef = oldParsedPara[index].paraDivRef;
+        }
+      });
+    }
+    this.setState({ parsedPara }, () => {
+      // Clear running flags after paragraphs are parsed
+      this.clearParagraphRunning();
+    });
   };
 
   // parse paragraphs based on backend
@@ -174,28 +187,42 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
 
   // Assigns Loading, Running & inQueue for paragraphs in current notebook
   showParagraphRunning = (param: number | string) => {
-    const parsedPara = this.state.parsedPara;
-    this.state.parsedPara.map((_: ParaType, index: number) => {
-      if (param === 'queue') {
-        parsedPara[index].inQueue = true;
-        parsedPara[index].isOutputHidden = true;
-      } else if (param === 'loading') {
-        parsedPara[index].isRunning = true;
-        parsedPara[index].isOutputHidden = true;
-      } else if (param === index) {
-        parsedPara[index].isRunning = true;
-        parsedPara[index].isOutputHidden = true;
-      }
+    // Use functional setState to avoid race conditions with sequential async updates
+    this.setState((prevState) => {
+      const parsedPara = prevState.parsedPara.map((para: ParaType, index: number) => {
+        if (param === 'queue') {
+          return { ...para, inQueue: true, isOutputHidden: true };
+        } else if (param === 'loading') {
+          return { ...para, isRunning: true, isOutputHidden: true };
+        } else if (param === index) {
+          return { ...para, isRunning: true, isOutputHidden: true };
+        }
+        return para;
+      });
+      return { parsedPara };
     });
-    this.setState({ parsedPara });
+  };
+
+  // Clears paragraph running flags after operations complete
+  clearParagraphRunning = () => {
+    // Use functional setState to avoid race conditions with sequential async updates
+    this.setState((prevState) => {
+      const parsedPara = prevState.parsedPara.map((para: ParaType) => ({
+        ...para,
+        inQueue: false,
+        isOutputHidden: false,
+        isRunning: false,
+      }));
+      return { parsedPara };
+    });
   };
 
   // Sets a paragraph to selected and deselects all others
   paragraphSelector = (index: number) => {
-    const parsedPara = this.state.parsedPara;
-    this.state.parsedPara.map((_: ParaType, idx: number) => {
-      if (index === idx) parsedPara[idx].isSelected = true;
-      else parsedPara[idx].isSelected = false;
+    // Create new array reference but keep paragraph object references to avoid remounting components
+    const parsedPara = [...this.state.parsedPara];
+    parsedPara.forEach((para: ParaType, idx: number) => {
+      para.isSelected = index === idx;
     });
     this.setState({ parsedPara });
   };
@@ -511,9 +538,29 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         body: JSON.stringify(clearParaObj),
       })
       .then((res) => {
-        const paragraphs = res.paragraphs;
-        const parsedPara = this.parseParagraphs(paragraphs);
-        this.setState({ paragraphs, parsedPara });
+        // Use functional setState to avoid race conditions
+        this.setState(
+          (prevState) => {
+            const paragraphs = res.paragraphs;
+            // Create new paragraph objects for React 18 compatibility
+            const parsedPara = prevState.parsedPara.map((para: ParaType, index: number) => {
+              if (paragraphs[index]) {
+                return {
+                  ...para,
+                  out: [],
+                  typeOut: [],
+                  isOutputStale: false,
+                };
+              }
+              return para;
+            });
+            return { paragraphs, parsedPara };
+          },
+          () => {
+            // Clear flags after state update completes
+            this.clearParagraphRunning();
+          }
+        );
       })
       .catch((err) => {
         this.props.setToast(
@@ -557,16 +604,59 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
           await this.loadQueryResultsFromInput(res, this.state.dataSourceMDSId);
           const checkErrorJSON = JSON.parse(res.output[0].result);
           if (this.checkQueryOutputError(checkErrorJSON)) {
+            // Clear flags even on query error - use functional setState to avoid race conditions
+            this.setState((prevState) => {
+              const parsedPara = prevState.parsedPara.map((p: ParaType, idx: number) => {
+                if (idx === index) {
+                  return {
+                    ...p,
+                    isRunning: false,
+                    isOutputHidden: false,
+                    inQueue: false,
+                  };
+                }
+                return p;
+              });
+              return { parsedPara };
+            });
             return;
           }
         }
-        const paragraphs = this.state.paragraphs;
-        paragraphs[index] = res;
-        const parsedPara = [...this.state.parsedPara];
-        parsedPara[index] = this.parseParagraphs([res])[0];
-        this.setState({ paragraphs, parsedPara });
+        // Use functional setState to avoid race conditions with sequential async updates
+        this.setState((prevState) => {
+          const paragraphs = [...prevState.paragraphs];
+          paragraphs[index] = res;
+          const parsedPara = [...prevState.parsedPara];
+          // Update existing paragraph instead of creating new one to preserve refs
+          const updatedPara = this.parseParagraphs([res])[0];
+          const oldPara = parsedPara[index];
+          parsedPara[index] = {
+            ...updatedPara,
+            paraRef: oldPara.paraRef,
+            paraDivRef: oldPara.paraDivRef,
+            isRunning: false,
+            isOutputHidden: false,
+            inQueue: false,
+          };
+          return { paragraphs, parsedPara };
+        });
       })
       .catch((err) => {
+        // Clear running flags on error - use functional setState to avoid race conditions
+        this.setState((prevState) => {
+          const parsedPara = prevState.parsedPara.map((p: ParaType, idx: number) => {
+            if (idx === index) {
+              return {
+                ...p,
+                isRunning: false,
+                isOutputHidden: false,
+                inQueue: false,
+              };
+            }
+            return p;
+          });
+          return { parsedPara };
+        });
         if (err.body.statusCode === 413)
           this.props.setToast(`Error running paragraph: ${err.body.message}`, 'danger');
         else
@@ -605,7 +695,8 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
   // Handles text editor value and syncs with paragraph input
   textValueEditor = (evt: React.ChangeEvent<HTMLTextAreaElement>, index: number) => {
     if (!(evt.key === 'Enter' && evt.shiftKey)) {
-      const parsedPara = this.state.parsedPara;
+      // Create new array reference but keep paragraph object references to avoid remounting components
+      const parsedPara = [...this.state.parsedPara];
       parsedPara[index].inp = evt.target.value;
       this.setState({ parsedPara });
     }
@@ -621,13 +712,15 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
   // update view mode, scrolls to paragraph and expands input if scrollToIndex is given
   updateView = (selectedViewId: string, scrollToIndex?: number) => {
     this.configureViewParameter(selectedViewId);
+    // Create new array reference but keep paragraph object references to avoid remounting components
     const parsedPara = [...this.state.parsedPara];
-    this.state.parsedPara.map((para: ParaType, index: number) => {
-      parsedPara[index].isInputExpanded = selectedViewId === 'input_only';
+    parsedPara.forEach((para: ParaType, index: number) => {
+      const shouldExpand =
+        selectedViewId === 'input_only' || (scrollToIndex !== undefined && index === scrollToIndex);
+      para.isInputExpanded = shouldExpand;
     });
 
     if (scrollToIndex !== undefined) {
-      parsedPara[scrollToIndex].isInputExpanded = true;
       this.scrollToPara(scrollToIndex);
     }
     this.setState({ parsedPara, selectedViewId });
@@ -635,7 +728,6 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
   };
 
   loadNotebook = async () => {
-    this.showParagraphRunning('queue');
     const isValid = isValidUUID(this.props.openedNoteId);
     this.setState({
       savedObjectNotebook: isValid,

--- a/public/components/notebooks/components/paragraph_components/para_output.tsx
+++ b/public/components/notebooks/components/paragraph_components/para_output.tsx
@@ -54,7 +54,6 @@ const getQueryOutputData = (queryObject: any) => {
 };
 
 const OutputBody = ({
-  key,
   typeOut,
   val,
   para,
@@ -62,7 +61,6 @@ const OutputBody = ({
   setVisInput,
   DashboardContainerByValueRenderer,
 }: {
-  key: string;
   typeOut: string;
   val: string;
   para: ParaType;
@@ -83,18 +81,17 @@ const OutputBody = ({
         const inputQuery = para.inp.substring(4, para.inp.length);
         const queryObject = JSON.parse(val);
         if (queryObject.hasOwnProperty('error')) {
-          return <EuiCodeBlock key={key}>{val}</EuiCodeBlock>;
+          return <EuiCodeBlock>{val}</EuiCodeBlock>;
         } else {
           const columns = createQueryColumns(queryObject.schema);
           const data = getQueryOutputData(queryObject);
           return (
             <div>
-              <EuiText key={'query-input-key'} className="wrapAll" data-test-subj="queryOutputText">
+              <EuiText className="wrapAll" data-test-subj="queryOutputText">
                 <b>{inputQuery}</b>
               </EuiText>
               <EuiSpacer />
               <QueryDataGridMemo
-                key={key}
                 rowCount={queryObject.datarows.length}
                 queryColumns={columns}
                 dataValues={data}
@@ -105,7 +102,6 @@ const OutputBody = ({
       case 'MARKDOWN':
         return (
           <EuiText
-            key={key}
             className="wrapAll markdown-output-text"
             data-test-subj="markdownOutputText"
             size="s"
@@ -123,11 +119,7 @@ const OutputBody = ({
             <EuiText size="s" style={{ marginLeft: 9 }}>
               {`${from} - ${to}`}
             </EuiText>
-            <DashboardContainerByValueRenderer
-              key={key}
-              input={visInput}
-              onInputUpdated={setVisInput}
-            />
+            <DashboardContainerByValueRenderer input={visInput} onInputUpdated={setVisInput} />
           </>
         );
       case 'OBSERVABILITY_VISUALIZATION':
@@ -162,17 +154,17 @@ const OutputBody = ({
         );
       case 'HTML':
         return (
-          <EuiText key={key}>
+          <EuiText>
             {/* eslint-disable-next-line react/jsx-pascal-case */}
             <Media.HTML data={val} />
           </EuiText>
         );
       case 'TABLE':
-        return <pre key={key}>{val}</pre>;
+        return <pre>{val}</pre>;
       case 'IMG':
-        return <img alt="" src={'data:image/gif;base64,' + val} key={key} />;
+        return <img alt="" src={'data:image/gif;base64,' + val} />;
       default:
-        return <pre key={key}>{val}</pre>;
+        return <pre>{val}</pre>;
     }
   } else {
     console.log('output not supported', typeOut);
@@ -205,7 +197,7 @@ export const ParaOutput = (props: {
         {para.typeOut.map((typeOut: string, tIdx: number) => {
           return (
             <OutputBody
-              key={para.uniqueId + '_paraOutputBody'}
+              key={para.uniqueId + '_paraOutputBody_' + tIdx}
               typeOut={typeOut}
               val={para.out[tIdx]}
               para={para}


### PR DESCRIPTION
### Description
**1. Autocomplete bug for app analytics**
After selecting an autocomplete suggestion (e.g., "source"), the dropdown would close and not automatically reopen to show the next suggestion (e.g., "="). Users had to manually click the field or type a space to trigger the next set of suggestions.

  Root Cause

  The original code used jQuery to blur/focus the textarea after selection:
  ```
  $('#autocomplete-textarea').blur();
  $('#autocomplete-textarea').focus();
```
  This approach doesn't work properly with React 18 because:
  - React 18's automatic batching: State updates are batched more aggressively, so the jQuery DOM manipulation bypasses React's state management
  - Concurrent rendering: React 18's new rendering model doesn't properly synchronize with jQuery's direct DOM manipulation
  - The focus event wasn't being recognized by the Algolia autocomplete library, so it wouldn't reopen and fetch new suggestions

  The Fix (autocomplete.tsx lines 120-144)
```
  onSelect: ({ setQuery, item }) => {
    onItemSelect({ setQuery, item }, dslService);

    setTimeout(() => {
      const textarea = document.getElementById('autocomplete-textarea');
      if (textarea) {
        textarea.blur();
        // 50ms delay ensures blur completes before refocus
        setTimeout(() => {
          textarea.focus();
          // Move cursor to end
          const length = textarea.value.length;
          textarea.setSelectionRange(length, length);
        }, 50);
      }
    }, 0);
  }
```
  Key changes:
  * Replaced jQuery with native DOM methods
 * Added 100ms delay between blur and focus - critical for React 18's event handling to properly process the blur before the refocus
  * The blur/focus cycle triggers the autocomplete library's openOnFocus: true behavior, which reopens the dropdown and fetches new suggestions based on the updated query

  Why It's Needed Now

  React 18's automatic batching and concurrent features changed how DOM events and React state updates interact. The timing and event processing is different, so the old jQuery approach that worked in React 17 doesn't properly trigger the autocomplete library's state updates in React 18. The new approach uses proper timing to work with React 18's event handling model.

**2. Fix Notebooks**

*  "Run all paragraphs" only displayed the last paragraph's output
    - After clicking "Clear all outputs" → "Run all paragraphs", only the bottom paragraph showed output
    - All other paragraph outputs remained hidden despite executing successfully
    - After page refresh, all outputs appeared correctly
  * Cypress typing tests failed
    - Tests couldn't type into textarea fields
    - Elements existed in DOM but were not interactable
  * View mode switching broken
    - "Input only" mode and "View both" mode switching didn't work properly

  Root Causes

  React 18's Concurrent Rendering & State Batching
  - React 18 batches multiple setState calls and applies them asynchronously
  - When multiple paragraphs completed sequentially, each setState call read stale state (this.state.parsedPara)
  - Later updates overwrote earlier updates, causing only the last paragraph's state to persist
  - Creating new paragraph objects on every state change caused React to unmount/remount child components

  Solutions Applied

  * Functional setState for Async Operations (Race Condition Prevention)

  Used functional form this.setState((prevState) => {...}) to ensure each update sees the previous update's result:

  Files affected: notebook.tsx
  - updateRunParagraph - Paragraph execution completion (lines 625, 607, 645, 696)
  - clearParagraphButton - Clear all outputs API call (line 573)
  - showParagraphRunning - Set loading states during async ops (line 191)
  - clearParagraphRunning - Clear loading states after async ops (line 209)

  Why this works: Functional setState receives the most recent state, preventing race conditions when multiple async operations complete in quick succession.

  * Array Mutation with Object Reference Preservation for Sync Operations

  Created new array references [...this.state.parsedPara] while keeping paragraph object references intact:

  Files affected: notebook.tsx
  - textValueEditor - User typing (line 696-697)
  - paragraphSelector - Paragraph selection (line 223-225)
  - updateView - View mode switching (line 713-716)

  Why this works:
  - New array reference triggers React state update detection
  - Preserving paragraph object references prevents child component remounting
  - Prevents textarea focus loss and component re-initialization issues


**3. Fix lodash import**

Fix missing lodash forEach import causing query results to fail

  Issue:
  - Event analytics and app analytics queries would execute but fail to display results
  - Console error: "ReferenceError: _ is not defined" at use_fetch_events.ts:69
  - Caused "No results match your search criteria" even with valid data

  Root cause:
  - addSchemaRowMapping() function used `_.forEach` to process query results
  - forEach was never imported from lodash (only isEmpty was imported)

  Fix:
  - Added `import forEach from 'lodash/forEach'` to use_fetch_events.ts
  - Changed `_.forEach` to `forEach` on line 70

  Impact:
  - Fixes event analytics flyout tests (data rows now appear, flyout buttons clickable)
  - Fixes app analytics visualization tests (query results now process correctly)
  - Resolves data processing for all features using the shared useFetchEvents hook

**4. Fix event analytics**

 Problem: Visualization tests showed "Invalid visualization data" instead of rendered charts. Configured dimensions (like "host" field) were missing when the "Update chart" button was clicked, causing queries to fail with incomplete PPL like 'source = '.

  Root Cause: React 18's automatic batching introduced a stale closure issue in handleClosePanel. When a user selected a dimension field:
  1. updateList was called to update configList state
  2. handleClosePanel was immediately called when closing the config panel
  3. React 18 batched these state updates, so handleClosePanel read the OLD configList from its closure (with empty dimension)
  4. The cleanup logic saw an empty dimension name and removed it
  5. When "Update chart" executed, dimensions array was empty

  Fix: Changed handleClosePanel to use functional state update pattern:
  ```
  setConfigList((prevConfigList) => {
    // prevConfigList contains the LATEST state from React,
    // not the stale closure value
    const selectedObj = prevConfigList[name][index] ?? [];
    // ... rest of cleanup logic
  });
```
  Files Changed:
  - public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx (lines 192-223)

  Impact: Ensures visualization configurations (dimensions, series, breakdowns) are properly preserved when config panel closes, allowing charts to render correctly with all configured fields.

**5. New Explore Modal was blocking sample data being added, resolved with** 
```
--home.disableExperienceModal=true
```
to dismiss the pop-up from occuring.


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
