### PR TITLE
[APM] Update service map PPL queries and response processors

### DIFF
--- a/public/components/apm/shared/hooks/__tests__/use_service_attributes.test.ts
+++ b/public/components/apm/shared/hooks/__tests__/use_service_attributes.test.ts
@@ -94,7 +94,7 @@ describe('useServiceAttributes', () => {
       const mockResponse = {
         jsonData: [
           {
-            'service.groupByAttributes': {
+            'sourceNode.groupByAttributes': {
               telemetry: {
                 sdk: {
                   language: 'python',
@@ -131,7 +131,7 @@ describe('useServiceAttributes', () => {
       const mockResponse = {
         jsonData: [
           {
-            'service.groupByAttributes': JSON.stringify({
+            'sourceNode.groupByAttributes': JSON.stringify({
               telemetry: {
                 sdk: {
                   language: 'java',
@@ -159,7 +159,7 @@ describe('useServiceAttributes', () => {
       const mockResponse = {
         jsonData: [
           {
-            'service.groupByAttributes': {
+            'sourceNode.groupByAttributes': {
               language: 'python',
               version: '1.0',
             },
@@ -185,7 +185,7 @@ describe('useServiceAttributes', () => {
       const mockResponse = {
         jsonData: [
           {
-            'service.groupByAttributes': {
+            'sourceNode.groupByAttributes': {
               count: 42,
               enabled: true,
             },
@@ -237,7 +237,7 @@ describe('useServiceAttributes', () => {
       const mockResponse = {
         jsonData: [
           {
-            'service.groupByAttributes': 'invalid json {',
+            'sourceNode.groupByAttributes': 'invalid json {',
           },
         ],
       };

--- a/public/components/apm/shared/hooks/use_service_attributes.ts
+++ b/public/components/apm/shared/hooks/use_service_attributes.ts
@@ -120,14 +120,17 @@ export const useServiceAttributes = (
         // Extract groupByAttributes from the first row
         const rows = response.jsonData || [];
         if (rows.length > 0) {
-          let groupByAttributes = rows[0]['service.groupByAttributes'] || {};
+          let groupByAttributes = rows[0]['sourceNode.groupByAttributes'] || {};
 
           // Parse JSON string if needed
           if (typeof groupByAttributes === 'string') {
             try {
               groupByAttributes = JSON.parse(groupByAttributes);
             } catch (e) {
-              console.error('[useServiceAttributes] Failed to parse service.groupByAttributes:', e);
+              console.error(
+                '[useServiceAttributes] Failed to parse sourceNode.groupByAttributes:',
+                e
+              );
               groupByAttributes = {};
             }
           }


### PR DESCRIPTION
### Description

Data prepper service map processor adheres to this mapping now: https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v2-apm-service-map-index-template.json 

This is a deviation from the older service map mappings: https://github.com/san81/data-prepper/blob/39af12424c6d368aadd4aa80b329d2b21b6406f3/data-prepper-plugins/opensearch/src/main/resources/otel-v2-apm-service-map-index-template.json


### Issues Resolved
* Updates the PPL Queries to support new mappings
* Updates the PPL response processor to support the PPL responses form the new mappings.
#2545 

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
