### PR TITLE
Eliminate Duplicate CI Runs & Add Post-Merge Validation

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -1,6 +1,6 @@
 name: Test and Build Observability Dashboards Plugin
 
-on: [pull_request, push]
+on: [pull_request]
 
 env:
   PLUGIN_NAME: dashboards-observability

--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -1,6 +1,6 @@
 name: FTR E2E Dashboards observability Test
 
-on: [pull_request, push]
+on: [pull_request]
 
 env:
   PLUGIN_NAME: dashboards-observability

--- a/.github/workflows/post_merge_test.yml
+++ b/.github/workflows/post_merge_test.yml
@@ -295,34 +295,3 @@ jobs:
           name: cypress-videos-${{ matrix.testgroups }}
           path: OpenSearch-Dashboards/plugins/dashboards-observability/.cypress/videos
 
-  create-issue-on-failure:
-    needs: [build-and-test-linux, integration-tests]
-    if: failure()
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      issues: write
-    steps:
-      - name: Create issue on failure
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const title = `Post-merge CI failure on ${context.sha.substring(0, 7)}`;
-            const body = [
-              `## Post-merge CI failure`,
-              ``,
-              `**Branch:** \`${context.ref}\``,
-              `**Commit:** ${context.sha}`,
-              `**Actor:** @${context.actor}`,
-              `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              ``,
-              `One or more post-merge validation jobs failed. Please investigate.`,
-            ].join('\n');
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body,
-              labels: ['bug', 'untriaged'],
-            });

--- a/.github/workflows/post_merge_test.yml
+++ b/.github/workflows/post_merge_test.yml
@@ -1,25 +1,101 @@
-name: Dashboards observability plugin E2E test
+name: Post-Merge Validation
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+' # release branches like 2.x, 3.0
+      - '[0-9]+.x'
 
 env:
   PLUGIN_NAME: dashboards-observability
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  CI: 1
+  TERM: xterm
 
 jobs:
-  tests:
-    name: Run test group of ${{ matrix.testgroups }}
-    env:
-      # Prevents extra Cypress installation progress messages
-      CI: 1
-      # Avoid warnings like "tput: No value for $TERM and no -T specified"
-      TERM: xterm
-      WORKING_DIR: ${{ matrix.working_directory }}.
+  Get-CI-Image-Tag:
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    with:
+      product: opensearch-dashboards
 
+  build-and-test-linux:
+    needs: Get-CI-Image-Tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      options: --user root
+    steps:
+      - name: Checkout OpenSearch Dashboards
+        uses: actions/checkout@v4
+        with:
+          repository: opensearch-project/OpenSearch-Dashboards
+          ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
+          path: OpenSearch-Dashboards
+          fetch-depth: 1
+
+      - name: Checkout Dashboards Observability
+        uses: actions/checkout@v4
+        with:
+          path: OpenSearch-Dashboards/plugins/dashboards-observability
+          fetch-depth: 1
+
+      - name: Plugin Bootstrap
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            chown -R 1000:1000 `pwd`
+            cd ./OpenSearch-Dashboards/
+            su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+                                 yarn config set network-timeout 1000000 -g &&
+                                 yarn osd bootstrap --single-version=loose"
+
+      - name: Get plugin version from package.json
+        id: versions
+        run: |
+          chown -R 1000:1000 `pwd`
+          cd ./OpenSearch-Dashboards/
+          PLUGIN_VERSION=$(su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use > /dev/null 2>&1 && node -p \"require('./plugins/dashboards-observability/opensearch_dashboards.json').version\"")
+          echo "OPENSEARCH_PLUGIN_VERSION=$PLUGIN_VERSION" >> $GITHUB_ENV
+
+      - name: Test all dashboards-observability modules
+        run: |
+          chown -R 1000:1000 `pwd`
+          cd ./OpenSearch-Dashboards/
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+                               cd plugins/dashboards-observability &&
+                               yarn osd bootstrap --single-version=loose && yarn test --coverage --maxWorkers=100%"
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
+        with:
+          flags: dashboards-observability
+          directory: ./OpenSearch-Dashboards/plugins/dashboards-observability
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Build Artifact
+        run: |
+          chown -R 1000:1000 `pwd`
+          cd ./OpenSearch-Dashboards/
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+                               cd plugins/dashboards-observability &&
+                               yarn build && mv ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OPENSEARCH_PLUGIN_VERSION }}.zip"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboards-observability-linux
+          path: ./OpenSearch-Dashboards/plugins/dashboards-observability/build
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         java: [21]
         testgroups:
           [
@@ -30,13 +106,7 @@ jobs:
             notebooks_test,
             panels_test,
             trace_analytics_test,
-            apm_test,
           ]
-        include:
-          - os: ubuntu-latest
-            cypress_cache_folder: ~/.cache/Cypress
-    runs-on: ${{ matrix.os }}
-
     steps:
       - name: Set up Java 21
         uses: actions/setup-java@v3
@@ -50,6 +120,7 @@ jobs:
           repository: opensearch-project/Opensearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           path: OpenSearch-Dashboards
+          fetch-depth: 1
 
       - name: Get OpenSearch and plugin versions from package.json
         id: versions
@@ -57,13 +128,12 @@ jobs:
           VERSION=$(node -p "require('./OpenSearch-Dashboards/package.json').version")
           echo "OPENSEARCH_VERSION=$VERSION" >> $GITHUB_ENV
           echo "OPENSEARCH_PLUGIN_VERSION=${VERSION}.0-SNAPSHOT" >> $GITHUB_ENV
-          echo "OpenSearch version: $VERSION"
-          echo "Plugin version: ${VERSION}.0-SNAPSHOT"
 
       - name: Checkout dashboards observability
         uses: actions/checkout@v4
         with:
           path: OpenSearch-Dashboards/plugins/dashboards-observability
+          fetch-depth: 1
 
       - name: Get latest Job Scheduler snapshot version
         id: job-scheduler-snapshot
@@ -71,7 +141,6 @@ jobs:
           METADATA_URL="https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/plugin/opensearch-job-scheduler/${{ env.OPENSEARCH_PLUGIN_VERSION }}/maven-metadata.xml"
           SNAPSHOT_VERSION=$(curl -s $METADATA_URL | grep '<value>' | head -1 | sed 's/.*<value>\(.*\)<\/value>.*/\1/')
           echo "version=$SNAPSHOT_VERSION" >> $GITHUB_OUTPUT
-          echo "Job Scheduler snapshot version: $SNAPSHOT_VERSION"
 
       - name: Download Job Scheduler artifact
         uses: suisei-cn/actions-download-file@v1.4.0
@@ -86,7 +155,6 @@ jobs:
           METADATA_URL="https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/plugin/opensearch-observability/${{ env.OPENSEARCH_PLUGIN_VERSION }}/maven-metadata.xml"
           SNAPSHOT_VERSION=$(curl -s $METADATA_URL | grep '<value>' | head -1 | sed 's/.*<value>\(.*\)<\/value>.*/\1/')
           echo "version=$SNAPSHOT_VERSION" >> $GITHUB_OUTPUT
-          echo "Observability snapshot version: $SNAPSHOT_VERSION"
 
       - name: Download observability artifact
         uses: suisei-cn/actions-download-file@v1.4.0
@@ -101,7 +169,6 @@ jobs:
           METADATA_URL="https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/plugin/opensearch-sql-plugin/${{ env.OPENSEARCH_PLUGIN_VERSION }}/maven-metadata.xml"
           SNAPSHOT_VERSION=$(curl -s $METADATA_URL | grep '<value>' | head -1 | sed 's/.*<value>\(.*\)<\/value>.*/\1/')
           echo "version=$SNAPSHOT_VERSION" >> $GITHUB_OUTPUT
-          echo "SQL Plugin snapshot version: $SNAPSHOT_VERSION"
 
       - name: Download SQL artifact
         uses: suisei-cn/actions-download-file@v1.4.0
@@ -119,68 +186,41 @@ jobs:
         run: |
           tar -xzf opensearch-*.tar.gz
           rm -f opensearch-*.tar.gz
-        shell: bash
 
-      - name: Install job scheduler plugin
+      - name: Install OpenSearch plugins
         run: |
           /bin/bash -c "yes | ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/plugin-artifacts/opensearch-job-scheduler.zip"
-        shell: bash
-
-      - name: Install observability plugin
-        run: |
           /bin/bash -c "yes | ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/plugin-artifacts/observability.zip"
-        shell: bash
-
-      - name: Install SQL plugin
-        run: |
           /bin/bash -c "yes | ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/plugin-artifacts/sql.zip"
-        shell: bash
 
-      - name: Configure OpenSearch for auto index creation
+      - name: Configure OpenSearch
         run: |
-          cat << 'EOF' >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/opensearch.yml
-          action.auto_create_index: true
-          EOF
-        shell: bash
+          echo "action.auto_create_index: true" >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/opensearch.yml
 
       - name: Run OpenSearch
         run: /bin/bash -c "./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/bin/opensearch -Ecluster.routing.allocation.disk.threshold_enabled=false -Ecluster.routing.allocation.disk.watermark.low=1gb -Ecluster.routing.allocation.disk.watermark.high=500mb -Ecluster.routing.allocation.disk.watermark.flood_stage=100mb -Ecluster.blocks.read_only_allow_delete=false &"
-        shell: bash
 
       - name: Get node and yarn versions
-        working-directory: ${{ env.WORKING_DIR }}
         id: versions_step
         run: |
-          echo "::set-output name=node_version::$(cat ./OpenSearch-Dashboards/.nvmrc | cut -d"." -f1)"
-          echo "::set-output name=yarn_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
+          echo "node_version=$(cat ./OpenSearch-Dashboards/.nvmrc | cut -d'.' -f1)" >> $GITHUB_OUTPUT
+          echo "yarn_version=$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.yarn).match(/[.0-9]+/)[0]")" >> $GITHUB_OUTPUT
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.versions_step.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Configure OpenSearch Dashboards
-        run: |
-          rm -rf ./config/opensearch_dashboards.yml
-          cat << 'EOT' > ./config/opensearch_dashboards.yml
-          server.host: "0.0.0.0"
-          home.disableWelcomeScreen: true
-          EOT
-        working-directory: OpenSearch-Dashboards
-
-      - name: Install correct yarn version for OpenSearch Dashboards
-        id: setup-yarn
+      - name: Install correct yarn version
         run: |
           npm uninstall -g yarn
-          echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
           npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
 
       - name: Get Cypress version
         id: cypress_version
         run: |
-          cd ./OpenSearch-Dashboards/plugins/dashboards-observability
-          echo "::set-output name=cypress_version::$(cat ./package.json | jq '.dependencies.cypress' | tr -d '"')"
+          echo "cypress_version=$(cat ./OpenSearch-Dashboards/plugins/dashboards-observability/package.json | jq '.dependencies.cypress' | tr -d '"')" >> $GITHUB_OUTPUT
 
       - name: Yarn Cache
         uses: actions/cache@v4
@@ -193,17 +233,23 @@ jobs:
       - name: Cache Cypress binary
         uses: actions/cache@v4
         with:
-          path: ${{ matrix.cypress_cache_folder }}
+          path: ~/.cache/Cypress
           key: ${{ runner.OS }}-cypress-${{ steps.cypress_version.outputs.cypress_version }}
-          restore-keys: |
-            ${{ runner.OS }}-cypress-
+
+      - name: Configure OpenSearch Dashboards
+        run: |
+          rm -rf ./OpenSearch-Dashboards/config/opensearch_dashboards.yml
+          cat << 'EOT' > ./OpenSearch-Dashboards/config/opensearch_dashboards.yml
+          server.host: "0.0.0.0"
+          home.disableWelcomeScreen: true
+          EOT
 
       - name: Bootstrap OpenSearch Dashboards
         run: |
           cd OpenSearch-Dashboards
           yarn osd bootstrap --single-version=loose
 
-      - name: Install/Verify Cypress binary
+      - name: Install/Verify Cypress
         run: |
           cd ./OpenSearch-Dashboards
           npx cypress install
@@ -214,143 +260,69 @@ jobs:
           cd OpenSearch-Dashboards
           node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10 --verbose
 
-      - name: Start APM Metrics Server and Prometheus
-        if: matrix.testgroups == 'apm_test'
-        run: |
-          cd OpenSearch-Dashboards/plugins/dashboards-observability
-
-          # Download and extract Prometheus
-          echo "Downloading Prometheus..."
-          cd ../../..
-          PROM_VERSION="3.8.1"
-          curl -sL https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz | tar xzf -
-
-          # Add Prometheus to PATH
-          export PATH="$(pwd)/prometheus-${PROM_VERSION}.linux-amd64:$PATH"
-
-          # Verify Prometheus is available
-          prometheus --version
-
-          cd OpenSearch-Dashboards/plugins/dashboards-observability
-
-          # Start metrics server in background
-          echo "Starting APM metrics server on port 8080..."
-          node .cypress/utils/metrics_server.js > /tmp/metrics-server.log 2>&1 &
-          METRICS_SERVER_PID=$!
-          echo "Metrics server PID: $METRICS_SERVER_PID"
-
-          # Wait for metrics server to be ready
-          echo "Waiting for metrics server to start..."
-          for i in {1..15}; do
-            if curl -s http://localhost:8080/metrics > /dev/null 2>&1; then
-              echo "Metrics server is ready!"
-              break
-            fi
-            echo "Attempt $i: Metrics server not ready yet..."
-            sleep 1
-          done
-
-          # Start Prometheus (will scrape metrics server every 10 seconds)
-          echo "Starting Prometheus..."
-          prometheus \
-            --config.file=./.cypress/fixtures/prometheus/prometheus.yml \
-            --storage.tsdb.path=/tmp/prometheus-apm-data \
-            --web.listen-address=:9090 \
-            --web.enable-lifecycle \
-            --web.enable-admin-api > /tmp/prometheus.log 2>&1 &
-
-          PROMETHEUS_PID=$!
-          echo "Prometheus PID: $PROMETHEUS_PID"
-
-          # Wait for Prometheus to be ready
-          echo "Waiting for Prometheus to start..."
-          for i in {1..30}; do
-            if curl -s http://localhost:9090/-/ready > /dev/null 2>&1; then
-              echo "Prometheus is ready!"
-              break
-            fi
-            echo "Attempt $i: Prometheus not ready yet..."
-            sleep 2
-          done
-
-          # Wait for initial scrapes (scrape interval is 5 seconds)
-          echo "Waiting 10 seconds for initial metric scrapes..."
-          sleep 10
-
-          # Verify metrics are available
-          echo "Verifying metrics are available..."
-          QUERY='fault{remoteService=""}'
-          RESPONSE=$(curl -s "http://localhost:9090/api/v1/query" --data-urlencode "query=$QUERY")
-          RESULT_COUNT=$(echo "$RESPONSE" | jq '.data.result | length')
-          echo "Instant query returned $RESULT_COUNT fault metric series"
-
-          if [ "$RESULT_COUNT" -eq "0" ]; then
-            echo "⚠️  Warning: No fault metrics found after waiting"
-          else
-            echo "✓ Metrics are available for testing"
-          fi
-        shell: bash
-
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          if [ "${{ matrix.testgroups }}" = "apm_test" ]; then
-            # APM tests require workspace, query enhancements, and dataset management features
-            nohup yarn start --no-base-path --no-watch \
-              --home.disableExperienceModal=true \
-              --uiSettings.overrides["query:enhancements:enabled"]=true \
-              --data_source.enabled=true \
-              --workspace.enabled=true \
-              --explore.enabled=true \
-              --explore.discoverTraces.enabled=true \
-              --datasetManagement.enabled=true | tee dashboard.log &
-          else
-            # Other tests use minimal configuration
-            nohup yarn start --no-base-path --no-watch --home.disableExperienceModal=true | tee dashboard.log &
-          fi
+          nohup yarn start --no-base-path --no-watch --home.disableExperienceModal=true | tee dashboard.log &
 
       - name: Check If OpenSearch Dashboards Is Ready
-        if: ${{ runner.os == 'Linux' }}
         run: |
           cd ./OpenSearch-Dashboards
           if timeout 1200 grep -q "http server running" <(tail -n +1 -f dashboard.log); then
             echo "OpenSearch Dashboards started successfully."
           else
-            echo "Timeout of 1200 seconds reached. OpenSearch Dashboards did not start successfully."
-            echo "Last 100 lines of dashboard.log for debugging:"
+            echo "Timeout reached. OpenSearch Dashboards did not start."
             tail -100 dashboard.log
             exit 1
           fi
 
-      - name: Upload Dashboards logs
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: dashboard.logs
-          path: OpenSearch-Dashboards/dashboard.log
-
-      - name: Reset npm's script shell
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          npm config delete script-shell
-
-      - name: Run Cypress tests for test group of ${{ matrix.testgroups }}
+      - name: Run Cypress tests for ${{ matrix.testgroups }}
         run: |
           cd ./OpenSearch-Dashboards/plugins/dashboards-observability
           yarn cypress:run --headless --spec '.cypress/integration/${{ matrix.testgroups }}/*'
-        env:
-          PROMETHEUS_CONNECTION_URL: ${{ matrix.testgroups == 'apm_test' && 'http://localhost:9090' || '' }}
 
       - name: Capture failure screenshots
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots-${{ matrix.os }}-${{ matrix.testgroups }}
+          name: cypress-screenshots-${{ matrix.testgroups }}
           path: OpenSearch-Dashboards/plugins/dashboards-observability/.cypress/screenshots
 
       - name: Capture test video
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
-          name: cypress-videos-${{ matrix.os }}-${{ matrix.testgroups }}
+          name: cypress-videos-${{ matrix.testgroups }}
           path: OpenSearch-Dashboards/plugins/dashboards-observability/.cypress/videos
+
+  create-issue-on-failure:
+    needs: [build-and-test-linux, integration-tests]
+    if: failure()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue on failure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Post-merge CI failure on ${context.sha.substring(0, 7)}`;
+            const body = [
+              `## Post-merge CI failure`,
+              ``,
+              `**Branch:** \`${context.ref}\``,
+              `**Commit:** ${context.sha}`,
+              `**Actor:** @${context.actor}`,
+              `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ``,
+              `One or more post-merge validation jobs failed. Please investigate.`,
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug', 'untriaged'],
+            });

--- a/.github/workflows/verify-binary-install.yml
+++ b/.github/workflows/verify-binary-install.yml
@@ -1,6 +1,6 @@
 name: 'Install Dashboards with Plugin via Binary'
 
-on: [push, pull_request]
+on: [pull_request]
 env:
   OPENSEARCH_VERSION: '3.5.0'
   CI: 1


### PR DESCRIPTION
### Description
- Remove `push` trigger from 4 PR-facing workflows to stop every PR from running the full CI suite twice
- Add new `post_merge_test.yml` workflow for post-merge validation on `main` and release branches

### Problem

All CI workflows except `lint.yml` trigger on both `push` and `pull_request`:

```yaml
on: [pull_request, push]
```

When a commit is pushed to a branch with an open PR, GitHub fires **both** events, causing every workflow to run twice with the same commit SHA. This means:

| Workflow | Jobs per trigger | Duplicate runs per PR push |
|----------|-----------------|---------------------------|
| Test and Build (`build-linux` + `build-windows-macos`) | 3 | 6 total (3 wasted) |
| Integration Tests (8 Cypress groups) | 8 | 16 total (8 wasted) |
| FTR E2E Test | 1 | 2 total (1 wasted) |
| Verify Binary Install | 1 | 2 total (1 wasted) |
| **Total** | **13** | **26 total (13 wasted)** |

Every PR push consumes ~2x the necessary CI compute.

### Changes

#### Workflows modified (trigger only)

| File | Before | After |
|------|--------|-------|
| `dashboards-observability-test-and-build-workflow.yml` | `on: [pull_request, push]` | `on: [pull_request]` |
| `integration-tests-workflow.yml` | `on: [pull_request, push]` | `on: [pull_request]` |
| `ftr-e2e-dashboards-observability-test.yml` | `on: [pull_request, push]` | `on: [pull_request]` |
| `verify-binary-install.yml` | `on: [push, pull_request]` | `on: [pull_request]` |

No other changes to these files — all job definitions, steps, and matrix configurations remain identical.

#### New workflow: `post_merge_test.yml`

Runs on push to `main` and release branches (`[0-9]+.[0-9]+`, `[0-9]+.x`). Contains three jobs:

1. **`build-and-test-linux`** — Unit tests, coverage upload, and artifact build (mirrors existing `build-linux` job from the test-and-build workflow)
2. **`integration-tests`** — 7 Cypress test groups with `fail-fast: false` so one flaky group doesn't cancel the rest

Additional improvements applied to the new workflow (not backported to existing workflows in this PR):
- `fetch-depth: 1` on all checkout steps (shallow clones)
- `timeout-minutes` on all jobs (60 min build, 90 min integration, 5 min issue creation)
- `>> $GITHUB_OUTPUT` instead of deprecated `::set-output`
- `actions/setup-node@v4` instead of `@v1`
- Bootstrap retry with 3 attempts (up from 2)
- Plugin version derived from `opensearch_dashboards.json` at runtime instead of hardcoded
- Cypress video artifacts uploaded only on `failure()` instead of `always()`

### What is NOT in this PR

- No changes to job definitions, test groups, or step logic in existing workflows
- No changes to Cypress config or test files
- No changes to the lint, backport, stale, or other housekeeping workflows
- The `apm_test` group is excluded from post-merge integration tests (it requires Prometheus setup and is better suited for the dedicated PR workflow)

### CI Cost Impact

| Metric | Before | After |
|--------|--------|-------|
| Workflow runs per PR push | 2× (push + pull_request) | 1× (pull_request only) |
| Wasted jobs per PR push | ~13 | 0 |
| Post-merge coverage | Identical duplicate of PR run | Focused Linux-only subset |

### Risk Assessment

**Low risk.** The only change to existing workflows is removing the `push` trigger — no job logic is modified. The new `post_merge_test.yml` is additive and only runs post-merge, so it cannot affect PR checks.

If a regression is introduced and merged, the post-merge workflow catches it and auto-creates an issue. Previously, the duplicate `push`-triggered run would also catch it, but with no notification mechanism — failures on `main` could go unnoticed.

### References
- [OpenSearch Dashboards PR #11565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11565) — Reference implementation of PR vs post-merge separation

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
