### PR TITLE
Fix link checker CI failure

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,5 @@
 opensearch-dashboards
 kubernetes.default.svc.cluster.local
 observability.playground.opensearch.org
+http://frontend-proxy:8080
+https://www.jaegertracing.io/


### PR DESCRIPTION
### Description
The link checker workflow is failing due to two URLs that are unreachable from GitHub Actions:

   - http://frontend-proxy:8080/api/cart — internal Docker Compose service URL from the OTel demo, not
   resolvable in CI
   - https://www.jaegertracing.io/ — intermittently timing out, causing flaky builds

   This PR adds both to .lycheeignore to exclude them from link checking.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
