### PR TITLE
[Navigation] Add icon side nav support with trace analytics and APM categories

### DIFF
--- a/public/plugin.test.tsx
+++ b/public/plugin.test.tsx
@@ -84,6 +84,65 @@ describe('#setup', () => {
   });
 });
 
+describe('#setup notebook hiding with investigation plugin', () => {
+  it('should NOT hide notebook entry when capabilities.investigation is not enabled', async () => {
+    const initializerContextMock = coreMock.createPluginInitializerContext();
+    initializerContextMock.config.get = jest.fn().mockReturnValue({
+      query_assist: { enabled: false },
+      summarize: { enabled: false },
+    });
+    const coreSetupContract = coreMock.createSetup();
+    let updater$ = new BehaviorSubject<() => {}>(() => ({}));
+    const coreSetup = {
+      ...coreSetupContract,
+      application: {
+        ...coreSetupContract.application,
+        register: jest.fn((args) => {
+          if (args.id === 'observability-notebooks' && args.updater$) {
+            updater$ = args.updater$;
+          }
+        }),
+      },
+    };
+    const observabilityPlugin = new ObservabilityPlugin(initializerContextMock);
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    coreSetup.uiSettings.get = jest.fn().mockReturnValue(false);
+    await observabilityPlugin.setup(coreSetup, ({
+      embeddable: embeddablePluginMock.createSetupContract(),
+      visualizations: visualizationsPluginMock.createSetupContract(),
+      data: dataPluginMock.createSetupContract(),
+      uiActions: uiActionsPluginMock.createSetupContract(),
+      dataSource: {},
+      contentManagement: contentManagementPluginMocks.createSetupContract(),
+      dashboard: { registerDashboardProvider: jest.fn() },
+    } as unknown) as SetupDependencies);
+
+    const coreStart = coreMock.createStart();
+    const dataStartMock = dataPluginMock.createStartContract();
+    dataStartMock.dataSources.dataSourceFactory.registerDataSourceType = jest.fn();
+
+    observabilityPlugin.start(
+      {
+        ...coreStart,
+        application: {
+          ...coreStart.application,
+          capabilities: {
+            ...coreStart.application.capabilities,
+            investigation: {
+              enabled: false,
+            },
+          },
+        },
+      },
+      ({
+        data: dataStartMock,
+      } as unknown) as AppPluginStartDependencies
+    );
+
+    expect(updater$.getValue()()).toEqual({});
+  });
+});
+
 describe('#setup with APM enabled', () => {
   it('should register both APM applications when MDS and APM are enabled', async () => {
     const intializerContextMock = coreMock.createPluginInitializerContext();

--- a/public/plugin.test.tsx
+++ b/public/plugin.test.tsx
@@ -14,6 +14,12 @@ import { contentManagementPluginMocks } from '../../../src/plugins/content_manag
 import { BehaviorSubject } from 'rxjs';
 import { AppNavLinkStatus } from '../../../src/core/public';
 
+function ensureIconSideNavMock(coreSetup: ReturnType<typeof coreMock.createSetup>) {
+  if (!coreSetup.chrome.getIsIconSideNavEnabled) {
+    coreSetup.chrome.getIsIconSideNavEnabled = jest.fn().mockReturnValue(false);
+  }
+}
+
 describe('#setup', () => {
   it('should hide notebook entry when capabilities.investigation is enabled', async () => {
     const initializerContextMock = coreMock.createPluginInitializerContext();
@@ -26,6 +32,7 @@ describe('#setup', () => {
       },
     });
     const coreSetupContract = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetupContract);
     let updater$ = new BehaviorSubject<() => {}>(() => ({}));
     const coreSetup = {
       ...coreSetupContract,
@@ -92,6 +99,7 @@ describe('#setup notebook hiding with investigation plugin', () => {
       summarize: { enabled: false },
     });
     const coreSetupContract = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetupContract);
     let updater$ = new BehaviorSubject<() => {}>(() => ({}));
     const coreSetup = {
       ...coreSetupContract,
@@ -147,6 +155,7 @@ describe('#setup with APM enabled', () => {
   it('should register both APM applications when MDS and APM are enabled', async () => {
     const intializerContextMock = coreMock.createPluginInitializerContext();
     const coreSetup = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetup);
     const observabilityPlugin = new ObservabilityPlugin(intializerContextMock);
 
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
@@ -180,6 +189,7 @@ describe('#setup with APM enabled', () => {
   it('should register trace analytics when APM setting disabled', async () => {
     const intializerContextMock = coreMock.createPluginInitializerContext();
     const coreSetup = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetup);
     const observabilityPlugin = new ObservabilityPlugin(intializerContextMock);
 
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
@@ -203,6 +213,7 @@ describe('#setup with APM enabled', () => {
   it('should register both APM and Trace Analytics apps when APM setting enabled (visibility controlled by capability in start)', async () => {
     const intializerContextMock = coreMock.createPluginInitializerContext();
     const coreSetup = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetup);
     const observabilityPlugin = new ObservabilityPlugin(intializerContextMock);
 
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
@@ -234,6 +245,7 @@ describe('#setup with APM enabled', () => {
       summarize: { enabled: false },
     });
     const coreSetup = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetup);
     let apmUpdater$ = new BehaviorSubject<() => {}>(() => ({}));
     coreSetup.application.register = jest.fn((args) => {
       if (args.id === 'observability-apm-services' && args.updater$) {
@@ -289,6 +301,7 @@ describe('#setup with APM enabled', () => {
       summarize: { enabled: false },
     });
     const coreSetup = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetup);
     let traceAnalyticsUpdater$ = new BehaviorSubject<() => {}>(() => ({}));
     coreSetup.application.register = jest.fn((args) => {
       if (args.id === 'observability-traces-nav' && args.updater$) {

--- a/public/plugin_helpers/plugin_nav.test.tsx
+++ b/public/plugin_helpers/plugin_nav.test.tsx
@@ -171,7 +171,11 @@ describe('registerAllPluginNavGroups', () => {
     expect(tracesCall).toBeDefined();
 
     const traceAnalyticsCall = observabilityCalls.find((call: any) =>
-      call[1].some((link: any) => link.category === DEFAULT_APP_CATEGORIES.traceAnalytics)
+      call[1].some(
+        (link: any) =>
+          DEFAULT_APP_CATEGORIES.traceAnalytics &&
+          link.category === DEFAULT_APP_CATEGORIES.traceAnalytics
+      )
     );
     expect(traceAnalyticsCall).toBeUndefined();
   });

--- a/public/plugin_helpers/plugin_nav.test.tsx
+++ b/public/plugin_helpers/plugin_nav.test.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { coreMock } from '../../../../src/core/public/mocks';
+import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../../src/core/public';
+import { registerAllPluginNavGroups } from './plugin_nav';
+
+describe('registerAllPluginNavGroups', () => {
+  let coreSetup: ReturnType<typeof coreMock.createSetup>;
+  const applicationMonitoringCategory = {
+    id: 'applicationMonitoring',
+    label: 'Application Monitoring',
+    order: 200,
+  };
+
+  beforeEach(() => {
+    coreSetup = coreMock.createSetup();
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+  });
+
+  it('should call registerIconSideNavGroups when icon side nav is enabled', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(true);
+
+    registerAllPluginNavGroups(coreSetup as any, false, applicationMonitoringCategory);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    // Find the call that registers notebooks under observability
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const notebookObsCall = observabilityCalls.find((call: any) =>
+      call[1].some(
+        (link: any) =>
+          link.id === 'observability-notebooks' &&
+          link.category === DEFAULT_APP_CATEGORIES.observabilityTools
+      )
+    );
+    expect(notebookObsCall).toBeDefined();
+  });
+
+  it('should call registerDefaultNavGroups when icon side nav is disabled', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(false);
+
+    registerAllPluginNavGroups(coreSetup as any, false, applicationMonitoringCategory);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    // Find the call that registers notebooks under observability with the default category
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const notebookDefaultCall = observabilityCalls.find((call: any) =>
+      call[1].some(
+        (link: any) =>
+          link.id === 'observability-notebooks' &&
+          link.category === DEFAULT_APP_CATEGORIES.visualizeAndReport
+      )
+    );
+    expect(notebookDefaultCall).toBeDefined();
+
+    // Default path should also register overview
+    const overviewCall = observabilityCalls.find((call: any) =>
+      call[1].some((link: any) => link.id === 'observability-overview')
+    );
+    expect(overviewCall).toBeDefined();
+  });
+
+  it('should register topology map with startCluster when APM enabled and icon side nav ON', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(true);
+
+    registerAllPluginNavGroups(coreSetup as any, true, applicationMonitoringCategory);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const topologyMapCall = observabilityCalls.find((call: any) =>
+      call[1].some(
+        (link: any) => link.id === 'observability-apm-application-map' && link.startCluster === true
+      )
+    );
+    expect(topologyMapCall).toBeDefined();
+  });
+
+  it('should register APM services with navServiceMap icon when icon side nav ON', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(true);
+
+    registerAllPluginNavGroups(coreSetup as any, true, applicationMonitoringCategory);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const servicesCall = observabilityCalls.find((call: any) =>
+      call[1].some(
+        (link: any) =>
+          link.id === 'observability-apm-services' && link.euiIconType === 'navServiceMap'
+      )
+    );
+    expect(servicesCall).toBeDefined();
+  });
+
+  it('should register trace analytics items under traceAnalytics category when APM disabled and icon side nav ON', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(true);
+
+    registerAllPluginNavGroups(coreSetup as any, false, applicationMonitoringCategory);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const traceAnalyticsCall = observabilityCalls.find((call: any) =>
+      call[1].some(
+        (link: any) =>
+          link.id === 'observability-services-nav' &&
+          link.category === DEFAULT_APP_CATEGORIES.traceAnalytics
+      )
+    );
+    expect(traceAnalyticsCall).toBeDefined();
+
+    const tracesLink = traceAnalyticsCall[1].find(
+      (link: any) => link.id === 'observability-traces-nav'
+    );
+    expect(tracesLink).toBeDefined();
+    expect(tracesLink.category).toBe(DEFAULT_APP_CATEGORIES.traceAnalytics);
+    expect(tracesLink.euiIconType).toBe('apmApp');
+  });
+
+  it('should NOT register APM items when APM disabled and icon side nav ON', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(true);
+
+    registerAllPluginNavGroups(coreSetup as any, false, applicationMonitoringCategory);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const apmCall = observabilityCalls.find((call: any) =>
+      call[1].some((link: any) => link.id === 'observability-apm-services')
+    );
+    expect(apmCall).toBeUndefined();
+  });
+
+  it('should register trace analytics under investigate category when APM disabled and icon side nav OFF', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(false);
+
+    registerAllPluginNavGroups(coreSetup as any, false, applicationMonitoringCategory);
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const tracesCall = observabilityCalls.find((call: any) =>
+      call[1].some(
+        (link: any) =>
+          link.id === 'observability-traces-nav' &&
+          link.category === DEFAULT_APP_CATEGORIES.investigate
+      )
+    );
+    expect(tracesCall).toBeDefined();
+
+    const traceAnalyticsCall = observabilityCalls.find((call: any) =>
+      call[1].some((link: any) => link.category === DEFAULT_APP_CATEGORIES.traceAnalytics)
+    );
+    expect(traceAnalyticsCall).toBeUndefined();
+  });
+});

--- a/public/plugin_helpers/plugin_nav.test.tsx
+++ b/public/plugin_helpers/plugin_nav.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { coreMock } from '../../../../src/core/public/mocks';
-import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../../src/core/public';
+import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../../src/core/utils';
 import { registerAllPluginNavGroups } from './plugin_nav';
 
 describe('registerAllPluginNavGroups', () => {
@@ -18,6 +18,9 @@ describe('registerAllPluginNavGroups', () => {
   beforeEach(() => {
     coreSetup = coreMock.createSetup();
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    if (!coreSetup.chrome.getIsIconSideNavEnabled) {
+      coreSetup.chrome.getIsIconSideNavEnabled = jest.fn();
+    }
   });
 
   it('should call registerIconSideNavGroups when icon side nav is enabled', () => {

--- a/public/plugin_helpers/plugin_nav.tsx
+++ b/public/plugin_helpers/plugin_nav.tsx
@@ -23,7 +23,74 @@ import {
 } from '../../common/constants/apm';
 import { AppPluginStartDependencies } from '../types';
 
-export function registerAllPluginNavGroups(
+function registerIconSideNavGroups(
+  core: CoreSetup<AppPluginStartDependencies>,
+  apmEnabled: boolean
+) {
+  // Notebooks → Tools category
+  core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+    {
+      id: observabilityNotebookID,
+      category: DEFAULT_APP_CATEGORIES.observabilityTools,
+      order: 400,
+      euiIconType: 'notebookApp',
+    },
+  ]);
+  core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS[`security-analytics`], [
+    {
+      id: observabilityNotebookID,
+      category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
+      order: 400,
+    },
+  ]);
+  core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.all, [
+    {
+      id: observabilityNotebookID,
+      category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
+      order: 400,
+    },
+  ]);
+
+  if (apmEnabled) {
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+      {
+        id: observabilityApmServicesID,
+        category: DEFAULT_APP_CATEGORIES.applicationPerformance,
+        showInAllNavGroup: true,
+        order: 200,
+        euiIconType: 'navServiceMap',
+      },
+      {
+        id: observabilityApmApplicationMapID,
+        title: 'Topology Map',
+        category: undefined,
+        showInAllNavGroup: true,
+        order: 400,
+        euiIconType: 'graphApp',
+        startCluster: true,
+      },
+    ]);
+  } else {
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+      {
+        id: 'observability-services-nav',
+        category: DEFAULT_APP_CATEGORIES.traceAnalytics,
+        showInAllNavGroup: true,
+        order: 100,
+        euiIconType: 'navServiceMap',
+      },
+      {
+        id: 'observability-traces-nav',
+        category: DEFAULT_APP_CATEGORIES.traceAnalytics,
+        showInAllNavGroup: true,
+        order: 200,
+        euiIconType: 'apmApp',
+      },
+    ]);
+  }
+}
+
+function registerDefaultNavGroups(
   core: CoreSetup<AppPluginStartDependencies>,
   apmEnabled: boolean,
   applicationMonitoringCategory: AppCategory
@@ -103,8 +170,6 @@ export function registerAllPluginNavGroups(
   ]);
 
   if (apmEnabled) {
-    // APM Mode - register nav links for both APM and Trace Analytics apps
-    // Visibility controlled by explore.discoverTracesEnabled capability in start()
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
       {
         id: observabilityApmServicesID,
@@ -132,7 +197,6 @@ export function registerAllPluginNavGroups(
       },
     ]);
   } else {
-    // Trace Analytics Mode - UI setting disabled
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
       {
         id: 'observability-traces-nav',
@@ -147,5 +211,17 @@ export function registerAllPluginNavGroups(
         order: 100,
       },
     ]);
+  }
+}
+
+export function registerAllPluginNavGroups(
+  core: CoreSetup<AppPluginStartDependencies>,
+  apmEnabled: boolean,
+  applicationMonitoringCategory: AppCategory
+) {
+  if (core.chrome.getIsIconSideNavEnabled()) {
+    registerIconSideNavGroups(core, apmEnabled);
+  } else {
+    registerDefaultNavGroups(core, apmEnabled, applicationMonitoringCategory);
   }
 }


### PR DESCRIPTION
## Summary

Major nav registration update for the Observability plugin to support the new icon-based sidebar navigation in the Observability workspace.

### Nav registration refactor (`plugin_nav.tsx`)
- Split `registerAllPluginNavGroups()` into two dedicated functions:
  - `registerIconSideNavGroups()` — registers nav links for the icon side nav layout
  - `registerDefaultNavGroups()` — preserves existing default nav behavior
- Route between them using `core.chrome.getIsIconSideNavEnabled()`

### Icon side nav layout (when enabled)
- **Notebooks** → `observabilityTools` category (collapsible "Tools" section) with `notebookApp` icon
- **APM enabled**: Services under `applicationPerformance` category with `navServiceMap` icon, Topology Map as standalone item with `startCluster` visual separator
- **APM disabled**: Services and Traces under new `traceAnalytics` category with `navServiceMap` and `apmApp` icons respectively

### Default nav layout (when disabled)
- Preserves all existing behavior: Overview, Getting Started, Metrics, Notebooks, Applications, Integrations
- APM items under `applicationMonitoring` category
- Trace analytics under `investigate` category

### Investigation plugin interop
- When `capabilities.investigation.enabled` is true, the observability notebook nav link is hidden (investigation plugin provides its own notebooks)
- Added test coverage for this capability-driven hiding

**Files changed:**
- `public/plugin_helpers/plugin_nav.tsx` — refactored into icon/default registration functions
- `public/plugin_helpers/plugin_nav.test.tsx` — comprehensive tests for all APM enabled/disabled × icon ON/OFF combinations
- `public/plugin.test.tsx` — test for investigation plugin notebook override

## Related Issue

opensearch-project/OpenSearch-Dashboards#11545

## Test plan
- [ ] Verify icon side nav shows correct categories (Trace Analytics when APM off, Application Performance when APM on)
- [ ] Verify default nav preserves existing behavior
- [ ] Verify notebook hiding when investigation plugin is enabled
- [ ] Run unit tests: `yarn test --testPathPattern=plugin_nav` and `yarn test --testPathPattern=plugin.test`