### PR TITLE
Fix ReferenceError: _ is not defined in Logs Explorer

### DIFF
--- a/public/components/event_analytics/hooks/use_fetch_direct_events.ts
+++ b/public/components/event_analytics/hooks/use_fetch_direct_events.ts
@@ -5,6 +5,7 @@
 
 import { useState, useRef } from 'react';
 import { batch } from 'react-redux';
+import forEach from 'lodash/forEach';
 import isEmpty from 'lodash/isEmpty';
 import { useDispatch, useSelector } from 'react-redux';
 import { IField } from 'common/types/explorer';
@@ -63,7 +64,7 @@ export const useFetchDirectEvents = ({ pplService, requestParams }: IFetchEvents
 
     const data: any[] = [];
 
-    _.forEach(pplRes.datarows, (row) => {
+    forEach(pplRes.datarows, (row) => {
       const record: any = {};
 
       for (let i = 0; i < pplRes.schema.length; i++) {


### PR DESCRIPTION
### Description

Fixes #2620.

`addSchemaRowMapping` in `use_fetch_direct_events.ts` used `_.forEach` without importing lodash, causing `ReferenceError: _ is not defined` when running PPL queries in Logs Explorer. The sibling file `use_fetch_events.ts` already uses the correct pattern (`import forEach from 'lodash/forEach'`).

### Changes

- Added `import forEach from 'lodash/forEach'` to `use_fetch_direct_events.ts`
- Replaced `_.forEach(...)` with `forEach(...)`

### Testing

- Verified TypeScript compilation passes with no new errors