### PR TITLE
fix: exclude text-only fields from default pattern field selection

### DIFF
--- a/public/components/event_analytics/hooks/use_fetch_patterns.test.ts
+++ b/public/components/event_analytics/hooks/use_fetch_patterns.test.ts
@@ -1,0 +1,266 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useFetchPatterns } from './use_fetch_patterns';
+import { SELECTED_PATTERN_FIELD } from '../../../../common/constants/explorer';
+
+const mockDispatch = jest.fn();
+const mockFetchEvents = jest.fn();
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+  useSelector: () => ({}),
+  batch: (fn: () => void) => fn(),
+}));
+
+jest.mock('./use_fetch_events', () => ({
+  useFetchEvents: () => ({
+    isEventsLoading: false,
+    fetchEvents: mockFetchEvents,
+  }),
+}));
+
+describe('setDefaultPatternsField', () => {
+  const defaultParams = {
+    pplService: {} as any,
+    mlCommonsRCFService: {} as any,
+    requestParams: { tabId: 'tab-1' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // By default, fetchEvents invokes the handler with the provided response
+    mockFetchEvents.mockImplementation((_query, _format, handler) => {
+      return Promise.resolve(handler?.({}));
+    });
+  });
+
+  it('excludes text fields and selects keyword field', async () => {
+    // describe response: body is text, traceId is not
+    mockFetchEvents.mockImplementationOnce((_q, _f, handler) => {
+      return Promise.resolve(
+        handler({
+          schema: [
+            { name: 'COLUMN_NAME', type: 'string' },
+            { name: 'TYPE_NAME', type: 'string' },
+          ],
+          datarows: [
+            ['body', 'TEXT'],
+            ['traceId', 'KEYWORD'],
+          ],
+        })
+      );
+    });
+    // head 1 response: body has longer value but should be excluded
+    mockFetchEvents.mockImplementationOnce((_q, _f, handler) => {
+      return Promise.resolve(
+        handler({
+          schema: [
+            { name: 'body', type: 'string' },
+            { name: 'traceId', type: 'string' },
+          ],
+          jsonData: [{ body: 'a very long log message body text', traceId: 'abc123' }],
+        })
+      );
+    });
+
+    const { result } = renderHook(() => useFetchPatterns(defaultParams));
+    await act(async () => {
+      await result.current.setDefaultPatternsField('test_index', '', undefined);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          query: { [SELECTED_PATTERN_FIELD]: 'traceId' },
+        }),
+      })
+    );
+  });
+
+  it('selects longest string field when no text fields exist', async () => {
+    // describe response: no text fields
+    mockFetchEvents.mockImplementationOnce((_q, _f, handler) => {
+      return Promise.resolve(
+        handler({
+          schema: [
+            { name: 'COLUMN_NAME', type: 'string' },
+            { name: 'TYPE_NAME', type: 'string' },
+          ],
+          datarows: [
+            ['short', 'KEYWORD'],
+            ['longer', 'KEYWORD'],
+          ],
+        })
+      );
+    });
+    // head 1 response
+    mockFetchEvents.mockImplementationOnce((_q, _f, handler) => {
+      return Promise.resolve(
+        handler({
+          schema: [
+            { name: 'short', type: 'string' },
+            { name: 'longer', type: 'string' },
+          ],
+          jsonData: [{ short: 'hi', longer: 'hello world' }],
+        })
+      );
+    });
+
+    const { result } = renderHook(() => useFetchPatterns(defaultParams));
+    await act(async () => {
+      await result.current.setDefaultPatternsField('test_index', '', undefined);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          query: { [SELECTED_PATTERN_FIELD]: 'longer' },
+        }),
+      })
+    );
+  });
+
+  it('falls back gracefully when describe fails', async () => {
+    // describe call throws
+    mockFetchEvents.mockImplementationOnce(() => Promise.reject(new Error('describe failed')));
+    // head 1 response still works
+    mockFetchEvents.mockImplementationOnce((_q, _f, handler) => {
+      return Promise.resolve(
+        handler({
+          schema: [
+            { name: 'body', type: 'string' },
+            { name: 'msg', type: 'string' },
+          ],
+          jsonData: [{ body: 'long body text here', msg: 'hi' }],
+        })
+      );
+    });
+
+    const { result } = renderHook(() => useFetchPatterns(defaultParams));
+    await act(async () => {
+      await result.current.setDefaultPatternsField('test_index', '', undefined);
+    });
+
+    // Without describe info, text fields aren't excluded — body wins as longest
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          query: { [SELECTED_PATTERN_FIELD]: 'body' },
+        }),
+      })
+    );
+  });
+
+  it('handles undefined/null/non-string field values without crashing', async () => {
+    // describe: no text fields
+    mockFetchEvents.mockImplementationOnce((_q, _f, handler) => {
+      return Promise.resolve(
+        handler({
+          schema: [
+            { name: 'COLUMN_NAME', type: 'string' },
+            { name: 'TYPE_NAME', type: 'string' },
+          ],
+          datarows: [
+            ['fieldA', 'KEYWORD'],
+            ['fieldB', 'KEYWORD'],
+            ['fieldC', 'KEYWORD'],
+          ],
+        })
+      );
+    });
+    // head 1: values are undefined, null, and a number
+    mockFetchEvents.mockImplementationOnce((_q, _f, handler) => {
+      return Promise.resolve(
+        handler({
+          schema: [
+            { name: 'fieldA', type: 'string' },
+            { name: 'fieldB', type: 'string' },
+            { name: 'fieldC', type: 'string' },
+            { name: 'fieldD', type: 'string' },
+          ],
+          jsonData: [{ fieldA: undefined, fieldB: null, fieldC: 12345, fieldD: 'valid' }],
+        })
+      );
+    });
+
+    const { result } = renderHook(() => useFetchPatterns(defaultParams));
+    await act(async () => {
+      await result.current.setDefaultPatternsField('test_index', '', undefined);
+    });
+
+    // Only fieldD has a valid string value
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          query: { [SELECTED_PATTERN_FIELD]: 'fieldD' },
+        }),
+      })
+    );
+  });
+
+  it('falls back to text fields when all string fields are text-only', async () => {
+    // describe: all fields are text
+    mockFetchEvents.mockImplementationOnce((_q, _f, handler) => {
+      return Promise.resolve(
+        handler({
+          schema: [
+            { name: 'COLUMN_NAME', type: 'string' },
+            { name: 'TYPE_NAME', type: 'string' },
+          ],
+          datarows: [
+            ['body', 'TEXT'],
+            ['message', 'TEXT'],
+          ],
+        })
+      );
+    });
+    // head 1 response
+    mockFetchEvents.mockImplementationOnce((_q, _f, handler) => {
+      return Promise.resolve(
+        handler({
+          schema: [
+            { name: 'body', type: 'string' },
+            { name: 'message', type: 'string' },
+          ],
+          jsonData: [{ body: 'short', message: 'a longer message field value' }],
+        })
+      );
+    });
+
+    const { result } = renderHook(() => useFetchPatterns(defaultParams));
+    await act(async () => {
+      await result.current.setDefaultPatternsField('test_index', '', undefined);
+    });
+
+    // Fallback picks longest from all string fields including text
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          query: { [SELECTED_PATTERN_FIELD]: 'message' },
+        }),
+      })
+    );
+  });
+
+  it('dispatches provided patternField directly when already set', async () => {
+    const { result } = renderHook(() => useFetchPatterns(defaultParams));
+    await act(async () => {
+      await result.current.setDefaultPatternsField('test_index', 'existingField', undefined);
+    });
+
+    // Should not call fetchEvents at all
+    expect(mockFetchEvents).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          query: { [SELECTED_PATTERN_FIELD]: 'existingField' },
+        }),
+      })
+    );
+  });
+});

--- a/public/components/event_analytics/hooks/use_fetch_patterns.ts
+++ b/public/components/event_analytics/hooks/use_fetch_patterns.ts
@@ -188,23 +188,60 @@ export const useFetchPatterns = ({
     errorHandler?: (error: any) => void
   ) => {
     if (!patternField && index) {
+      // Fetch field types from describe to identify text-only fields
+      const textOnlyFields: Set<string> = new Set();
+      try {
+        await fetchEvents(
+          { query: `describe ${index}` },
+          'jdbc',
+          (descRes: any) => {
+            const colIdx = descRes?.schema?.findIndex((s: IField) => s.name === 'COLUMN_NAME');
+            const typeIdx = descRes?.schema?.findIndex((s: IField) => s.name === 'TYPE_NAME');
+            if (colIdx >= 0 && typeIdx >= 0) {
+              descRes?.datarows?.forEach((row: any[]) => {
+                const typeName = typeof row[typeIdx] === 'string' ? row[typeIdx].toLowerCase() : '';
+                if (typeName === 'text') textOnlyFields.add(row[colIdx]);
+              });
+            }
+          },
+          () => {} // ignore describe errors
+        );
+      } catch {
+        // ignore - proceed without type filtering
+      }
+
       const query = `source = ${index} | head 1`;
       await fetchEvents(
         { query },
         'jdbc',
         async (res: any) => {
-          // Create array of only string type fields
-          const textFields = res.schema.filter((field: IField) => field.type === 'string');
+          // Create array of only string type fields, excluding text-only fields
+          const stringFields = res.schema.filter(
+            (field: IField) => field.type === 'string' && !textOnlyFields.has(field.name)
+          );
           // Loop through array and find field with longest value
           let defaultPatternField = '';
           let maxLength = 0;
-          textFields.forEach((field: IField) => {
-            const curLength = res.jsonData[0][field.name].length;
+          stringFields.forEach((field: IField) => {
+            const value = res.jsonData?.[0]?.[field.name];
+            const curLength = typeof value === 'string' ? value.length : 0;
             if (curLength > maxLength) {
               maxLength = curLength;
               defaultPatternField = field.name;
             }
           });
+          // Fall back to all string fields if no keyword fields found
+          if (!defaultPatternField) {
+            const allStringFields = res.schema.filter((field: IField) => field.type === 'string');
+            allStringFields.forEach((field: IField) => {
+              const value = res.jsonData?.[0]?.[field.name];
+              const curLength = typeof value === 'string' ? value.length : 0;
+              if (curLength > maxLength) {
+                maxLength = curLength;
+                defaultPatternField = field.name;
+              }
+            });
+          }
           patternField = defaultPatternField;
         },
         errorHandler

--- a/public/components/event_analytics/hooks/use_fetch_patterns.ts
+++ b/public/components/event_analytics/hooks/use_fetch_patterns.ts
@@ -230,7 +230,7 @@ export const useFetchPatterns = ({
               defaultPatternField = field.name;
             }
           });
-          // Fall back to all string fields if no keyword fields found
+          // Fall back to including text fields if no non-text string fields were found
           if (!defaultPatternField) {
             const allStringFields = res.schema.filter((field: IField) => field.type === 'string');
             allStringFields.forEach((field: IField) => {


### PR DESCRIPTION
### Description
When selecting the default pattern field in Logs Explorer, the code previously picked the string field with the longest value. For SS4O logs, this often selected `body`, which is a `text` field. Text fields do not support fielddata operations like aggregations (`stats`, `take`), causing the patterns query to fail with:

> Text fields are not optimised for operations that require per-document field data like aggregations and sorting

This fix uses the PPL `describe` command to identify text-only fields and excludes them from the default pattern field selection. If no keyword fields are found, it falls back to all string fields. Also adds null safety when accessing field values.

### Issues Resolved
Resolves #2645

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).