### PR TITLE
[Test] Fix notebooks cypress

### DIFF
--- a/.cypress/integration/notebooks_test/notebooks.spec.js
+++ b/.cypress/integration/notebooks_test/notebooks.spec.js
@@ -369,7 +369,7 @@ describe('Testing paragraphs', () => {
     cy.get('div[id$="-error-0"]')
       .should('exist')
       .and('have.class', 'euiFormErrorText')
-      .and('contain.text', 'Error occurred in OpenSearch engine: no such index');
+      .and('contain.text', 'no such index');
 
     cy.get('.euiDataGrid__overflow').should('exist');
   });


### PR DESCRIPTION
### Description
Fix the failing notebook test. Text output for failed ppl changed, update the check.
```
 .and('contain.text', 'no such index');
 ```

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
