### PR TITLE
fix: register Alert Manager in side nav when enabled

### DIFF
--- a/public/plugin_helpers/plugin_nav.tsx
+++ b/public/plugin_helpers/plugin_nav.tsx
@@ -45,7 +45,7 @@ function registerIconSideNavGroups(
         id: observabilityAlertingID,
         category: DEFAULT_APP_CATEGORIES.observabilityTools,
         showInAllNavGroup: true,
-        order: 500,
+        order: 150,
         euiIconType: 'beaker',
       },
     ]);
@@ -53,7 +53,7 @@ function registerIconSideNavGroups(
       {
         id: observabilityAlertingID,
         category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
-        order: 500,
+        order: 150,
       },
     ]);
   }

--- a/public/plugin_helpers/plugin_nav.tsx
+++ b/public/plugin_helpers/plugin_nav.tsx
@@ -26,7 +26,8 @@ import { AppPluginStartDependencies } from '../types';
 
 function registerIconSideNavGroups(
   core: CoreSetup<AppPluginStartDependencies>,
-  apmEnabled: boolean
+  apmEnabled: boolean,
+  alertManagerEnabled: boolean = false
 ) {
   // Notebooks → Tools category
   core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
@@ -37,6 +38,25 @@ function registerIconSideNavGroups(
       euiIconType: 'notebookApp',
     },
   ]);
+
+  if (alertManagerEnabled) {
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+      {
+        id: observabilityAlertingID,
+        category: DEFAULT_APP_CATEGORIES.observabilityTools,
+        showInAllNavGroup: true,
+        order: 500,
+        euiIconType: 'beaker',
+      },
+    ]);
+    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.all, [
+      {
+        id: observabilityAlertingID,
+        category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
+        order: 500,
+      },
+    ]);
+  }
   core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS[`security-analytics`], [
     {
       id: observabilityNotebookID,
@@ -240,11 +260,12 @@ function registerDefaultNavGroups(
 export function registerAllPluginNavGroups(
   core: CoreSetup<AppPluginStartDependencies>,
   apmEnabled: boolean,
-  applicationMonitoringCategory: AppCategory
+  applicationMonitoringCategory: AppCategory,
+  alertManagerEnabled: boolean = false
 ) {
   if (core.chrome.getIsIconSideNavEnabled()) {
-    registerIconSideNavGroups(core, apmEnabled);
+    registerIconSideNavGroups(core, apmEnabled, alertManagerEnabled);
   } else {
-    registerDefaultNavGroups(core, apmEnabled, applicationMonitoringCategory);
+    registerDefaultNavGroups(core, apmEnabled, applicationMonitoringCategory, alertManagerEnabled);
   }
 }


### PR DESCRIPTION
## Summary

`registerAllPluginNavGroups` was passed the `alertManager` flag from `plugin.tsx` but its signature didn't accept a 4th parameter, so `registerDefaultNavGroups` always fell back to its `alertManagerEnabled = false` default and the alerting nav link was never added to any nav group. The app still loaded via direct URL (because `application.register` ran unconditionally), but it was invisible in the side nav.

- Thread the flag through `registerAllPluginNavGroups` → `registerIconSideNavGroups` / `registerDefaultNavGroups`.
- Register the alerting nav link in the icon side nav branch too (previously only the default branch had the block, and even that one was unreachable).

## Test plan
- [ ] Set `observability.alertManager.enabled: true` in `opensearch_dashboards.yml`, run `yarn start`, verify "Alert manager" appears in the Observability side nav.
- [ ] Toggle the flag off, restart, verify the nav entry is gone.
- [ ] Verify in both the default nav and the icon side nav modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)