### PR TITLE
fix(alerting): route local-endpoint data sources through primary client

### DIFF
--- a/common/utils/local_endpoint.ts
+++ b/common/utils/local_endpoint.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Endpoints that should be treated as equivalent to the OSD-primary cluster
+ * connection (`opensearch.hosts` in `opensearch_dashboards.yml`).
+ *
+ * Used by Alert Manager on both sides:
+ *   - UI (`use_datasources.ts`) collapses matching `data-source` saved objects
+ *     onto the synthetic "Local Cluster" row so users do not see duplicate
+ *     entries for the same physical cluster.
+ *   - Server (`getAlertingClient`) routes requests for matching saved
+ *     objects through `ctx.core.opensearch.client` instead of the MDS
+ *     scoped client, because the stored hostname (e.g. the
+ *     docker-compose service name `opensearch`) may not resolve from the
+ *     OSD process itself.
+ *
+ * The pattern is a heuristic — it can misroute an SSH-tunneled remote
+ * cluster forwarded to a local port. That tradeoff is accepted for dev
+ * parity with the UI's existing behaviour.
+ */
+export const LOCAL_ENDPOINT_PATTERN = /localhost|127\.0\.0\.1|0\.0\.0\.0|::1|opensearch:9200|opensearch-cluster-master|opensearch-master/i;
+
+export function isLocalEndpoint(endpoint: string | undefined | null): boolean {
+  if (!endpoint) return false;
+  return LOCAL_ENDPOINT_PATTERN.test(endpoint);
+}

--- a/public/components/alerting/hooks/use_datasources.ts
+++ b/public/components/alerting/hooks/use_datasources.ts
@@ -27,6 +27,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { SavedObject } from '../../../../../../src/core/public';
 import { coreRefs } from '../../../framework/core_refs';
 import type { Datasource } from '../../../../common/types/alerting';
+import { isLocalEndpoint } from '../../../../common/utils/local_endpoint';
 
 // Attribute shapes for the two saved-object types we consume.
 // These mirror the server-side types in server/routes/alerting/types.ts so
@@ -43,8 +44,6 @@ interface DataConnectionSOAttributes {
   meta?: Record<string, unknown>;
 }
 
-const LOCAL_ENDPOINT_PATTERN = /localhost|127\.0\.0\.1|0\.0\.0\.0|::1|opensearch:9200|opensearch-cluster-master|opensearch-master/i;
-
 /**
  * Map both saved-object types into the unified `Datasource` shape that
  * Alert Manager UI code already consumes. Mirrors server-side mapping in
@@ -59,12 +58,8 @@ export function mapSavedObjectsToDatasources(
   // local cluster, surface their entry (with their chosen title) instead
   // of the hardcoded "Local Cluster" placeholder — avoids showing two rows
   // for the same physical cluster.
-  const osLocal = osSavedObjects.filter((so) =>
-    LOCAL_ENDPOINT_PATTERN.test(so.attributes?.endpoint || '')
-  );
-  const osRemote = osSavedObjects.filter(
-    (so) => !LOCAL_ENDPOINT_PATTERN.test(so.attributes?.endpoint || '')
-  );
+  const osLocal = osSavedObjects.filter((so) => isLocalEndpoint(so.attributes?.endpoint));
+  const osRemote = osSavedObjects.filter((so) => !isLocalEndpoint(so.attributes?.endpoint));
 
   const localRows: Datasource[] =
     osLocal.length > 0

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -18,6 +18,7 @@
 import { schema } from '@osd/config-schema';
 import { IRouter, RequestHandlerContext, SavedObject } from '../../../../../src/core/server';
 import type { AlertingOSClient, Datasource, Logger } from '../../../common/types/alerting';
+import { isLocalEndpoint } from '../../../common/utils/local_endpoint';
 import {
   HttpOpenSearchBackend,
   MultiBackendAlertService,
@@ -173,6 +174,13 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
    * Get the right OpenSearch client for a datasource.
    * MDS data sources use context.dataSource.opensearch.getClient(id).
    * Local cluster uses context.core.opensearch.client.asCurrentUser.
+   *
+   * A `data-source` saved object whose endpoint matches the local-cluster
+   * heuristic is routed through the primary client instead of the MDS
+   * scoped client. The stored hostname (e.g. the docker-compose service
+   * name `opensearch`) may not resolve from the OSD process, and the UI
+   * already collapses these entries onto the "Local Cluster" row — the
+   * server now matches that behaviour so monitors remain reachable.
    */
   async function getAlertingClient(
     ctx: AlertingHandlerContext,
@@ -184,7 +192,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
     }
     if (dsId && ctx.dataSource) {
       const ds = await resolveOpenSearchDatasource(ctx, dsId);
-      if (ds?.mdsId) {
+      if (ds?.mdsId && !isLocalEndpoint(ds.url)) {
         return await ctx.dataSource.opensearch.getClient(ds.mdsId);
       }
     }


### PR DESCRIPTION
## Summary

An Alert Manager unified rules/alerts request fans out across every registered `data-source` saved object. If an SO stores an endpoint that only resolves inside a container network (e.g. the docker-compose service name `opensearch`), the OSD process hits `getaddrinfo ENOTFOUND opensearch` — and the monitors from that cluster silently disappear from the unified view.

The UI hook (`use_datasources.ts`) already recognizes these endpoints as equivalent to the primary cluster connection (`opensearch.hosts`) and collapses them onto the "Local Cluster" row. The server had no matching logic.

- New `common/utils/local_endpoint.ts` exports `LOCAL_ENDPOINT_PATTERN` + `isLocalEndpoint(url)` so both sides share one heuristic.
- `use_datasources.ts` imports the helper instead of inlining the regex.
- `getAlertingClient` (`server/routes/alerting/index.ts`) now skips MDS resolution when the resolved data-source endpoint is local and falls back to `ctx.core.opensearch.client.asCurrentUser` — the same client the primary OSD connection uses.

## Tradeoff

The pattern is a heuristic and can misroute an SSH-tunneled remote cluster forwarded to a localhost port. That's the same tradeoff the UI already accepts; the change is about bringing the server into parity.

## Test plan

- [x] `yarn test` — 130 alerting tests (routes + services + hooks) pass on Node 22.
- [x] `yarn lint:es` clean on touched files.
- [ ] Manual: against `observability-stack` (docker-compose Cortex + OpenSearch), the `local_cluster` `data-source` SO whose `endpoint` is `https://opensearch:9200` now returns monitors in the unified Alert Manager view; `Failed to fetch alerts/rules from local_cluster: ConnectionError: getaddrinfo ENOTFOUND opensearch` log lines no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)