### PR TITLE
[Test] Traces Cypress Fix

### DIFF
--- a/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
@@ -221,13 +221,12 @@ describe('Testing Service map', () => {
     cy.get('.euiText.euiText--medium .panel-title').contains('Service map');
     cy.get('[data-test-subj="latency"]').should('exist');
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    cy.get('.vis-network canvas').should('exist');
     cy.get('.ytitle').contains('Average duration (ms)');
     cy.get('[data-text = "Errors"]').click();
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.contains('60%');
+    cy.get('.ytitle').contains('Error rate (%)');
     cy.get('[data-text = "Duration"]').click();
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.contains('100');
+    cy.get('.ytitle').contains('Average duration (ms)');
     cy.get('.euiFormLabel.euiFormControlLayout__prepend').contains('Focus on').should('exist');
   });
 
@@ -254,19 +253,41 @@ describe('Testing Service map', () => {
     cy.get('.euiText.euiText--medium .panel-title').contains('Service map');
     cy.get('.vis-network canvas').should('exist');
 
-    // ensure rendering is complete before node click, replace wait
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    cy.get('.ytitle').contains('Average duration (ms)');
     cy.get('[data-text="Errors"]').click();
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.contains('60%');
+    cy.get('.ytitle').contains('Error rate (%)');
     cy.get('[data-text="Duration"]').click();
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.contains('Average duration (ms)');
+    cy.get('.ytitle').contains('Average duration (ms)');
     cy.get("[data-test-subj='tableHeaderCell_average_latency_1']").click();
 
-    // clicks on payment node
-    cy.get('.vis-network canvas').click(707, 388);
-    // checks the duration in node details popover
+    // The vis-network layout can shift by a few pixels run-to-run even with a
+    // fixed randomSeed, so retry a small grid around the expected payment-node
+    // position until the details popover renders.
+    const clickPaymentNode = (offsets) => {
+      if (offsets.length === 0) {
+        throw new Error('Failed to click payment node after all retries');
+      }
+      const [dx, dy] = offsets[0];
+      cy.get('.vis-network canvas').click(707 + dx, 388 + dy);
+      cy.get('body').then(($body) => {
+        if ($body.find('.euiText.euiText--small:contains("Average duration: 216.43ms")').length) {
+          return;
+        }
+        clickPaymentNode(offsets.slice(1));
+      });
+    };
+    clickPaymentNode([
+      [0, 0],
+      [0, -20],
+      [0, 20],
+      [-20, 0],
+      [20, 0],
+      [-20, -20],
+      [20, -20],
+      [-20, 20],
+      [20, 20],
+    ]);
     cy.get('.euiText.euiText--small').contains('Average duration: 216.43ms').should('exist');
   });
 
@@ -274,15 +295,14 @@ describe('Testing Service map', () => {
     cy.get('.euiText.euiText--medium .panel-title').contains('Service map');
     cy.get('[data-test-subj="latency"]').should('exist');
     cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
+    cy.get('.vis-network canvas').should('exist');
     cy.get('.ytitle').contains('Average duration (ms)');
 
     // Test metric selection functionality
     cy.get('[data-text="Errors"]').click();
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.contains('60%');
+    cy.get('.ytitle').contains('Error rate (%)');
     cy.get('[data-text="Duration"]').click();
-    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
-    cy.contains('100');
+    cy.get('.ytitle').contains('Average duration (ms)');
 
     // Focus on "order" by selecting the first option
     cy.get('.euiFormLabel.euiFormControlLayout__prepend').contains('Focus on').should('exist');

--- a/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
+++ b/.cypress/integration/trace_analytics_test/trace_analytics_services.spec.js
@@ -220,10 +220,13 @@ describe('Testing Service map', () => {
   it('Render Service map', () => {
     cy.get('.euiText.euiText--medium .panel-title').contains('Service map');
     cy.get('[data-test-subj="latency"]').should('exist');
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.ytitle').contains('Average duration (ms)');
     cy.get('[data-text = "Errors"]').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.contains('60%');
     cy.get('[data-text = "Duration"]').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.contains('100');
     cy.get('.euiFormLabel.euiFormControlLayout__prepend').contains('Focus on').should('exist');
   });
@@ -252,9 +255,12 @@ describe('Testing Service map', () => {
     cy.get('.vis-network canvas').should('exist');
 
     // ensure rendering is complete before node click, replace wait
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('[data-text="Errors"]').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.contains('60%');
     cy.get('[data-text="Duration"]').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.contains('Average duration (ms)');
     cy.get("[data-test-subj='tableHeaderCell_average_latency_1']").click();
 
@@ -267,12 +273,15 @@ describe('Testing Service map', () => {
   it('Tests focus functionality in Service map', () => {
     cy.get('.euiText.euiText--medium .panel-title').contains('Service map');
     cy.get('[data-test-subj="latency"]').should('exist');
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.get('.ytitle').contains('Average duration (ms)');
 
     // Test metric selection functionality
     cy.get('[data-text="Errors"]').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.contains('60%');
     cy.get('[data-text="Duration"]').click();
+    cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     cy.contains('100');
 
     // Focus on "order" by selecting the first option


### PR DESCRIPTION
### Description
Fixed 3 failing Service map tests

1) Replaced fragile tick-value assertions with axis-title assertions. The tests asserted cy.contains('60%') and cy.contains('100') to verify the metric toggle (Errors / Duration) took effect. Plotly renders each y-axis tick as a separate <text> element containing only the number (e.g. 60) — the % suffix appears only in the axis title, so cy.contains('60%') could never match a single element. Switched all three tests to assert on .ytitle flipping between Average duration (ms) and Error rate (%), which is the actual signal that the metric toggle succeeded.
   • Render Service map (line ~220)
   • Click on a node to see the details (line ~255)
   • Tests focus functionality in Service map (line ~270)

2) Made the payment-node click resilient to layout drift. The Click on a node to see the details test clicked the vis-network canvas at a hardcoded (707, 388). Even with a fixed randomSeed, the force-directed layout can shift the payment node by a few pixels run-to-run, causing intermittent misses and a 60s timeout on the popover assertion. Replaced the single click with a retry helper that tries a 9-point grid around (707, 388) and stops as soon as the Average duration: 216.43ms popover appears — throws a clear error if all attempts fail.

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
