### PR TITLE
Alert Manager — Time Range Selector on the Alerts page

### DIFF
--- a/common/services/alerting/__tests__/time_range.test.ts
+++ b/common/services/alerting/__tests__/time_range.test.ts
@@ -31,6 +31,7 @@ import {
   dateMathToDSLString,
   computeStep,
   validateDateMath,
+  validateTimeRangeQuery,
 } from '../time_range';
 
 describe('time_range helpers', () => {
@@ -39,7 +40,7 @@ describe('time_range helpers', () => {
   const FIXED_NOW_MS = 1705320000000;
 
   beforeEach(() => {
-    jest.useFakeTimers('modern' as never);
+    jest.useFakeTimers();
     jest.setSystemTime(new Date(FIXED_NOW_MS));
   });
 
@@ -179,6 +180,44 @@ describe('time_range helpers', () => {
       // Route-layer validators may get garbage; guard explicitly.
       expect(validateDateMath((null as unknown) as string)).toBe(false);
       expect(validateDateMath((123 as unknown) as string)).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // validateTimeRangeQuery — cross-field rules (one-sided + inverted)
+  // =========================================================================
+
+  describe('validateTimeRangeQuery', () => {
+    it('accepts both absent (legacy no-range path)', () => {
+      expect(validateTimeRangeQuery({})).toBeUndefined();
+    });
+
+    it('accepts both present and well-ordered', () => {
+      expect(validateTimeRangeQuery({ startTime: 'now-1h', endTime: 'now' })).toBeUndefined();
+    });
+
+    it('rejects startTime without endTime', () => {
+      expect(validateTimeRangeQuery({ startTime: 'now-1h' })).toMatch(/supplied together/);
+    });
+
+    it('rejects endTime without startTime', () => {
+      expect(validateTimeRangeQuery({ endTime: 'now' })).toMatch(/supplied together/);
+    });
+
+    it('rejects inverted ranges', () => {
+      expect(validateTimeRangeQuery({ startTime: 'now', endTime: 'now-1h' })).toMatch(
+        /on or after/
+      );
+    });
+
+    it('allows equal bounds (zero-length window)', () => {
+      expect(validateTimeRangeQuery({ startTime: 'now', endTime: 'now' })).toBeUndefined();
+    });
+
+    it('silently accepts malformed input (per-field validator handles it)', () => {
+      // Malformed inputs are rejected upstream by `validateDateMath`; the
+      // cross-field validator stays silent on them so we don't double-report.
+      expect(validateTimeRangeQuery({ startTime: 'gibberish', endTime: 'now' })).toBeUndefined();
     });
   });
 });

--- a/common/services/alerting/__tests__/time_range.test.ts
+++ b/common/services/alerting/__tests__/time_range.test.ts
@@ -111,7 +111,7 @@ describe('time_range helpers', () => {
     });
 
     it('1h window ⇒ 15s (exactly the floor)', () => {
-      // span = 3600s, 3600/500 = 7.2 → 7 → max(7, 15) = 15.
+      // span = 3600s, 3600/500 = 7.2 → 7 → clamped to 15.
       const start = 0;
       const end = 60 * 60;
       expect(computeStep(start, end)).toBe(15);
@@ -134,21 +134,6 @@ describe('time_range helpers', () => {
       const start = 0;
       const end = 30 * 24 * 3600;
       expect(computeStep(start, end)).toBe(300);
-    });
-
-    it('prefers evalInterval when it exceeds point-based step', () => {
-      // 1h window, evalInterval 60 ⇒ max(7, 60) = 60.
-      expect(computeStep(0, 3600, 60)).toBe(60);
-    });
-
-    it('evalInterval still subject to the 300s ceiling', () => {
-      // Absurd 10min eval interval on a 1h window ⇒ capped at 300.
-      expect(computeStep(0, 3600, 600)).toBe(300);
-    });
-
-    it('evalInterval still subject to the 15s floor', () => {
-      // 5m window with a 1s eval ⇒ floor is 15.
-      expect(computeStep(0, 300, 1)).toBe(15);
     });
 
     it('zero-length window ⇒ 15s floor (no divide-by-zero)', () => {

--- a/common/services/alerting/__tests__/time_range.test.ts
+++ b/common/services/alerting/__tests__/time_range.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for the shared time-range helpers.
+ *
+ * `@elastic/datemath` anchors `"now"` to the real clock, so each
+ * `parseDateMath*` test pins `Date.now()` via `jest.useFakeTimers()` to keep
+ * assertions stable.
+ *
+ * Timezone robustness: datemath delegates rounding (`/d`, `/h`, etc.) to
+ * `moment`, and `moment().startOf('day')` rounds relative to the process's
+ * local timezone — NOT UTC. `jest.config.js` sets `process.env.TZ = 'UTC'`
+ * globally for this repo, but we also compute expected values via `moment`
+ * itself in the rounding tests rather than hard-coding `Date.UTC(...)`
+ * constants. This way the tests stay green even if the TZ-setter fires
+ * after datemath has already cached moment's locale.
+ */
+// Set TZ=UTC before any imports that reach `moment` / `@elastic/datemath`.
+// Jest runs setupFiles before test modules load, but being explicit here is
+// belt-and-suspenders — some environments load `moment` from cached lazy
+// imports in other test modules.
+process.env.TZ = 'UTC';
+
+import moment from 'moment';
+import {
+  parseDateMath,
+  parseDateMathMs,
+  dateMathToDSLString,
+  computeStep,
+  validateDateMath,
+} from '../time_range';
+
+describe('time_range helpers', () => {
+  // Use a stable "now" so `now-1h`, `now`, etc. resolve deterministically.
+  // 2024-01-15T12:00:00.000Z
+  const FIXED_NOW_MS = 1705320000000;
+
+  beforeEach(() => {
+    jest.useFakeTimers('modern' as never);
+    jest.setSystemTime(new Date(FIXED_NOW_MS));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // =========================================================================
+  // parseDateMath / parseDateMathMs
+  // =========================================================================
+
+  describe('parseDateMath', () => {
+    it('parses "now" at the fixed system time (epoch seconds)', () => {
+      expect(parseDateMath('now', false)).toBe(Math.floor(FIXED_NOW_MS / 1000));
+    });
+
+    it('parses "now-1h" to one hour before now', () => {
+      expect(parseDateMath('now-1h', false)).toBe(Math.floor((FIXED_NOW_MS - 3600_000) / 1000));
+    });
+
+    it('parses an absolute ISO timestamp', () => {
+      const iso = '2024-06-01T00:00:00.000Z';
+      expect(parseDateMath(iso, false)).toBe(Math.floor(new Date(iso).getTime() / 1000));
+    });
+
+    it('roundUp=false floors "now/d" to start-of-day (isEndTime=false)', () => {
+      const start = parseDateMathMs('now/d', /* isEndTime */ false);
+      // Datemath delegates `/d` rounding to moment's `startOf('day')`, which
+      // is TZ-dependent. Compute the same value via moment so the assertion
+      // holds regardless of process TZ.
+      expect(start).toBe(moment(FIXED_NOW_MS).startOf('day').valueOf());
+    });
+
+    it('roundUp=true ceils "now/d" to end-of-day (isEndTime=true)', () => {
+      const end = parseDateMathMs('now/d', /* isEndTime */ true);
+      expect(end).toBe(moment(FIXED_NOW_MS).endOf('day').valueOf());
+    });
+
+    it('throws on a malformed expression', () => {
+      expect(() => parseDateMath('not-a-date', false)).toThrow(/Invalid date-math/);
+      expect(() => parseDateMathMs('', true)).toThrow();
+    });
+  });
+
+  // =========================================================================
+  // dateMathToDSLString
+  // =========================================================================
+
+  describe('dateMathToDSLString', () => {
+    it('is a pass-through for valid expressions', () => {
+      expect(dateMathToDSLString('now-1h')).toBe('now-1h');
+      expect(dateMathToDSLString('2024-06-01T00:00:00Z')).toBe('2024-06-01T00:00:00Z');
+    });
+  });
+
+  // =========================================================================
+  // computeStep
+  // =========================================================================
+
+  describe('computeStep', () => {
+    // Representative windows: 5m, 1h, 24h, 7d, 30d.
+
+    it('5m window ⇒ 15s floor (point-based < 15)', () => {
+      // span = 300s, 300/500 = 0.6 → 0 → clamped to 15.
+      const start = 0;
+      const end = 5 * 60;
+      expect(computeStep(start, end)).toBe(15);
+    });
+
+    it('1h window ⇒ 15s (exactly the floor)', () => {
+      // span = 3600s, 3600/500 = 7.2 → 7 → max(7, 15) = 15.
+      const start = 0;
+      const end = 60 * 60;
+      expect(computeStep(start, end)).toBe(15);
+    });
+
+    it('24h window ⇒ floor(86400/500) = 172s', () => {
+      const start = 0;
+      const end = 24 * 3600;
+      expect(computeStep(start, end)).toBe(172);
+    });
+
+    it('7d window ⇒ capped at 300s ceiling', () => {
+      // span = 604800s, /500 = 1209.6 → 1209 → clamped to 300.
+      const start = 0;
+      const end = 7 * 24 * 3600;
+      expect(computeStep(start, end)).toBe(300);
+    });
+
+    it('30d window ⇒ capped at 300s ceiling', () => {
+      const start = 0;
+      const end = 30 * 24 * 3600;
+      expect(computeStep(start, end)).toBe(300);
+    });
+
+    it('prefers evalInterval when it exceeds point-based step', () => {
+      // 1h window, evalInterval 60 ⇒ max(7, 60) = 60.
+      expect(computeStep(0, 3600, 60)).toBe(60);
+    });
+
+    it('evalInterval still subject to the 300s ceiling', () => {
+      // Absurd 10min eval interval on a 1h window ⇒ capped at 300.
+      expect(computeStep(0, 3600, 600)).toBe(300);
+    });
+
+    it('evalInterval still subject to the 15s floor', () => {
+      // 5m window with a 1s eval ⇒ floor is 15.
+      expect(computeStep(0, 300, 1)).toBe(15);
+    });
+
+    it('zero-length window ⇒ 15s floor (no divide-by-zero)', () => {
+      expect(computeStep(100, 100)).toBe(15);
+    });
+
+    it('negative (inverted) window treated as zero span ⇒ 15s floor', () => {
+      expect(computeStep(200, 100)).toBe(15);
+    });
+  });
+
+  // =========================================================================
+  // validateDateMath
+  // =========================================================================
+
+  describe('validateDateMath', () => {
+    it.each([['now'], ['now-1h'], ['now-7d/d'], ['now+5m'], ['2024-06-01T00:00:00Z']])(
+      'accepts "%s"',
+      (expr) => {
+        expect(validateDateMath(expr)).toBe(true);
+      }
+    );
+
+    it.each([['gibberish'], ['now-'], [''], ['now+notaunit']])('rejects "%s"', (expr) => {
+      expect(validateDateMath(expr)).toBe(false);
+    });
+
+    it('rejects non-string input', () => {
+      // Route-layer validators may get garbage; guard explicitly.
+      expect(validateDateMath((null as unknown) as string)).toBe(false);
+      expect(validateDateMath((123 as unknown) as string)).toBe(false);
+    });
+  });
+});

--- a/common/services/alerting/index.ts
+++ b/common/services/alerting/index.ts
@@ -7,3 +7,4 @@ export * from './filter';
 export * from './serializer';
 export * from './validators';
 export * from './promql_validator';
+export * from './time_range';

--- a/common/services/alerting/time_range.ts
+++ b/common/services/alerting/time_range.ts
@@ -106,6 +106,13 @@ export function computeStep(
  * Returns `true` for any string `@elastic/datemath` can parse (both as a
  * start AND as an end — we check both since some expressions are only
  * valid in one rounding mode).
+ *
+ * Known leniency: `@elastic/datemath` falls through to `moment()` for
+ * non-date-math strings, which accepts partial ISO forms (`'2024'`,
+ * `'2024-06'`, `'Jan 15'`, etc). This matches the permissiveness of the
+ * OpenSearch query DSL and `EuiSuperDatePicker`, so we do not tighten it
+ * here — the UI surfaces malformed-input errors through `parseDateMath*`
+ * on the handler side.
  */
 export function validateDateMath(expr: string): boolean {
   if (typeof expr !== 'string' || expr.length === 0) return false;
@@ -116,4 +123,44 @@ export function validateDateMath(expr: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Cross-field validator for a route query schema carrying optional
+ * `startTime`/`endTime` date-math strings. Called from the `validate`
+ * option on `schema.object(...)` — returns a string to reject, `undefined`
+ * to accept. Enforces two invariants beyond per-field `validateDateMath`:
+ *
+ *   1. Both fields are supplied together or neither. One-sided ranges are
+ *      ambiguous — the backend would silently treat the missing side as
+ *      "open", which is usually not what the client meant.
+ *   2. When both are supplied and resolvable, `endTime` is not strictly
+ *      before `startTime`. An inverted range passes the post-fetch filter
+ *      as "zero matches" rather than a client error, which is a footgun
+ *      when debugging an empty dashboard.
+ *
+ * Malformed inputs are already rejected by the per-field validator; a
+ * resolve failure here is treated as a no-op (let the per-field error
+ * propagate with its own message).
+ */
+export function validateTimeRangeQuery(query: {
+  startTime?: string;
+  endTime?: string;
+}): string | undefined {
+  const hasStart = typeof query.startTime === 'string' && query.startTime.length > 0;
+  const hasEnd = typeof query.endTime === 'string' && query.endTime.length > 0;
+  if (hasStart !== hasEnd) {
+    return 'startTime and endTime must be supplied together';
+  }
+  if (!hasStart || !hasEnd) return undefined;
+  try {
+    const startMs = parseDateMathMs(query.startTime as string, false);
+    const endMs = parseDateMathMs(query.endTime as string, true);
+    if (endMs < startMs) {
+      return 'endTime must be on or after startTime';
+    }
+  } catch {
+    // Per-field validator owns the malformed-input message; stay silent here.
+  }
+  return undefined;
 }

--- a/common/services/alerting/time_range.ts
+++ b/common/services/alerting/time_range.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared time-range helpers — consumed by both the server (alerting routes,
+ * `MultiBackendAlertService`) and the browser (`AlarmsPage`, `useAlerts`).
+ *
+ * Pure, framework-free — no React, no http, no OSD imports. `@elastic/datemath`
+ * is already bundled in both server and browser builds (it's a direct
+ * dependency of OSD core), so this module is safe to import from either side.
+ *
+ * Design notes:
+ *   - We accept date-math strings (e.g. `"now-1h"`, `"now-7d/d"`) and absolute
+ *     ISO timestamps. The caller decides whether the string is meant to
+ *     express the start or the end of the window via the `isEndTime` flag;
+ *     date-math rounding (e.g. `"now/d"`) depends on which side of the window
+ *     we're on (start ⇒ floor, end ⇒ ceil).
+ *   - `parseDateMath*` throw on invalid input. Route-layer validators should
+ *     call `validateDateMath` first to reject malformed input with a 400
+ *     instead of crashing a handler.
+ *   - `computeStep` derives the Prometheus `query_range` step in seconds from
+ *     the window size, with a floor + ceiling + rule-eval-interval preference.
+ */
+import dateMath from '@elastic/datemath';
+
+/**
+ * Parse a date-math expression (e.g. `"now-1h"`) into an epoch-seconds value.
+ *
+ * @param expr       Date-math string or absolute ISO timestamp.
+ * @param isEndTime  When `true`, rounds UP (end-of-day semantics, so
+ *                   `"now/d"` → end-of-today); when `false`, rounds DOWN
+ *                   (`"now/d"` → start-of-today). Matches `EuiSuperDatePicker`
+ *                   semantics for the two ends of a picked window.
+ * @returns Epoch seconds (integer).
+ * @throws If the expression cannot be parsed.
+ */
+export function parseDateMath(expr: string, isEndTime: boolean): number {
+  return Math.floor(parseDateMathMs(expr, isEndTime) / 1000);
+}
+
+/**
+ * Same as {@link parseDateMath} but returns epoch milliseconds — useful for
+ * the OpenSearch backend's post-fetch filter where `start_time` / `end_time`
+ * are epoch ms, and for `new Date(ms).toISOString()` conversions.
+ *
+ * @throws If the expression cannot be parsed.
+ */
+export function parseDateMathMs(expr: string, isEndTime: boolean): number {
+  const parsed = dateMath.parse(expr, { roundUp: isEndTime });
+  if (!parsed || !parsed.isValid()) {
+    throw new Error(`Invalid date-math expression: ${expr}`);
+  }
+  return parsed.valueOf();
+}
+
+/**
+ * Pass-through helper for OpenSearch DSL `range` clauses. OpenSearch's
+ * query DSL accepts date-math natively (`"gte": "now-1h"`), so the common
+ * case is simply forwarding the string. Declared as a function for
+ * call-site clarity and to reserve a seam if we later need to strip
+ * whitespace / normalize.
+ */
+export function dateMathToDSLString(expr: string): string {
+  return expr;
+}
+
+/**
+ * Derive the Prometheus `query_range` step (seconds) for the given window.
+ *
+ * Formula:
+ *   `clamp(max(floor((end - start) / 500), evalIntervalSec ?? 15), 15, 300)`
+ *
+ * Bounds rationale:
+ *   - 15s floor: Prometheus default scrape interval; a finer step wastes
+ *     resolution on empty points.
+ *   - 300s (5min) ceiling: caps the point count per series to keep
+ *     payload + plot-render cost predictable on 30d+ ranges.
+ *   - 500-point denominator: approximately fills a `AlertTimeline` chart at
+ *     typical bucket-counts (12..24) with a few sub-pixels of dither.
+ *   - `evalIntervalSec` preference: when the rule's evaluation interval is
+ *     known, never ask Prometheus for a finer step than the source rule is
+ *     evaluated at — finer would return stale repeats.
+ */
+export function computeStep(
+  startEpochSec: number,
+  endEpochSec: number,
+  evalIntervalSec?: number
+): number {
+  const span = Math.max(0, endEpochSec - startEpochSec);
+  const pointBased = Math.floor(span / 500);
+  const eval_ = evalIntervalSec ?? 15;
+  const preferred = Math.max(pointBased, eval_);
+  // clamp to [15, 300]
+  if (preferred < 15) return 15;
+  if (preferred > 300) return 300;
+  return preferred;
+}
+
+/**
+ * Lightweight predicate used by route-layer schema validators to reject
+ * malformed date-math input at the HTTP boundary (400) instead of letting
+ * it crash a handler later.
+ *
+ * Returns `true` for any string `@elastic/datemath` can parse (both as a
+ * start AND as an end — we check both since some expressions are only
+ * valid in one rounding mode).
+ */
+export function validateDateMath(expr: string): boolean {
+  if (typeof expr !== 'string' || expr.length === 0) return false;
+  try {
+    const parsedStart = dateMath.parse(expr, { roundUp: false });
+    const parsedEnd = dateMath.parse(expr, { roundUp: true });
+    return !!(parsedStart && parsedStart.isValid() && parsedEnd && parsedEnd.isValid());
+  } catch {
+    return false;
+  }
+}

--- a/common/services/alerting/time_range.ts
+++ b/common/services/alerting/time_range.ts
@@ -70,7 +70,7 @@ export function dateMathToDSLString(expr: string): string {
  * Derive the Prometheus `query_range` step (seconds) for the given window.
  *
  * Formula:
- *   `clamp(max(floor((end - start) / 500), evalIntervalSec ?? 15), 15, 300)`
+ *   `clamp(floor((end - start) / 500), 15, 300)`
  *
  * Bounds rationale:
  *   - 15s floor: Prometheus default scrape interval; a finer step wastes
@@ -79,23 +79,14 @@ export function dateMathToDSLString(expr: string): string {
  *     payload + plot-render cost predictable on 30d+ ranges.
  *   - 500-point denominator: approximately fills a `AlertTimeline` chart at
  *     typical bucket-counts (12..24) with a few sub-pixels of dither.
- *   - `evalIntervalSec` preference: when the rule's evaluation interval is
- *     known, never ask Prometheus for a finer step than the source rule is
- *     evaluated at — finer would return stale repeats.
  */
-export function computeStep(
-  startEpochSec: number,
-  endEpochSec: number,
-  evalIntervalSec?: number
-): number {
+export function computeStep(startEpochSec: number, endEpochSec: number): number {
   const span = Math.max(0, endEpochSec - startEpochSec);
   const pointBased = Math.floor(span / 500);
-  const eval_ = evalIntervalSec ?? 15;
-  const preferred = Math.max(pointBased, eval_);
   // clamp to [15, 300]
-  if (preferred < 15) return 15;
-  if (preferred > 300) return 300;
-  return preferred;
+  if (pointBased < 15) return 15;
+  if (pointBased > 300) return 300;
+  return pointBased;
 }
 
 /**

--- a/common/types/alerting/opensearch_types.ts
+++ b/common/types/alerting/opensearch_types.ts
@@ -242,7 +242,10 @@ export interface OpenSearchBackend {
   deleteMonitor(client: AlertingOSClient, monitorId: string): Promise<boolean>;
 
   // Alerts — read + acknowledge.
-  getAlerts(client: AlertingOSClient): Promise<{ alerts: OSAlert[]; totalAlerts: number }>;
+  getAlerts(
+    client: AlertingOSClient,
+    options?: { startMs?: number; endMs?: number }
+  ): Promise<{ alerts: OSAlert[]; totalAlerts: number; truncated: boolean }>;
   acknowledgeAlerts(
     client: AlertingOSClient,
     monitorId: string,

--- a/common/types/alerting/prometheus_types.ts
+++ b/common/types/alerting/prometheus_types.ts
@@ -14,6 +14,7 @@
  */
 
 import type { AlertingOSClient, Datasource } from './unified_types';
+import type { UnifiedAlertSummary } from './unified_types';
 
 // ============================================================================
 // Prometheus Workspace
@@ -242,6 +243,34 @@ export interface PrometheusBackend {
     query: string,
     time?: number
   ): Promise<PromTimeSeriesPoint[]>;
+
+  /**
+   * Reconstruct historical alert episodes from the `ALERTS` metric's range
+   * matrix. Optional on the interface because only backends that can route
+   * PromQL range queries (today: `DirectQueryPrometheusBackend`) support it.
+   * `MultiBackendAlertService.fetchAlertsRaw` checks for the method before
+   * calling, so alternate backends can omit it and degrade cleanly to the
+   * legacy `getAlerts` path.
+   *
+   * Returns:
+   *   - `alerts`:   unified alert summaries, one per firing-run episode
+   *                 (runs of `value === 1` in the ALERTS matrix).
+   *   - `fallback`: set to `'prometheus-alerts-current-only'` when the
+   *                 matrix was empty AND the range included `now`, causing
+   *                 the backend to fall back to legacy `/api/v1/alerts`.
+   *   - `error`:    transport / parse error; `alerts` is empty in this case.
+   */
+  getHistoricalAlerts?(
+    client: AlertingOSClient,
+    ds: Datasource,
+    startEpochSec: number,
+    endEpochSec: number,
+    stepSec: number
+  ): Promise<{
+    alerts: UnifiedAlertSummary[];
+    fallback?: 'prometheus-alerts-current-only';
+    error?: string;
+  }>;
 
   // ---- Alertmanager operations (optional — only available when alertmanagerUrl is set) ----
   // Alertmanager is a global endpoint reached through any Prometheus datasource,

--- a/common/types/alerting/prometheus_types.ts
+++ b/common/types/alerting/prometheus_types.ts
@@ -252,11 +252,22 @@ export interface PrometheusBackend {
    * calling, so alternate backends can omit it and degrade cleanly to the
    * legacy `getAlerts` path.
    *
+   * Parameters:
+   *   - `endIsNow`: the caller (service layer) indicates whether the
+   *                 request's `endTime` was date-math relative to `now`
+   *                 (e.g. `'now'`, `'now-5m'`). When `true` AND the matrix
+   *                 is empty, the backend falls back to `/api/v1/alerts`
+   *                 (current-active only) and sets `fallback`. When `false`
+   *                 the empty matrix is treated as a legitimate "no alerts
+   *                 fired in this past window" result. Passing this
+   *                 explicitly avoids ambiguity with wall-clock-based
+   *                 heuristics.
+   *
    * Returns:
    *   - `alerts`:   unified alert summaries, one per firing-run episode
    *                 (runs of `value === 1` in the ALERTS matrix).
    *   - `fallback`: set to `'prometheus-alerts-current-only'` when the
-   *                 matrix was empty AND the range included `now`, causing
+   *                 matrix was empty AND `endIsNow === true`, causing
    *                 the backend to fall back to legacy `/api/v1/alerts`.
    *   - `error`:    transport / parse error; `alerts` is empty in this case.
    */
@@ -265,7 +276,8 @@ export interface PrometheusBackend {
     ds: Datasource,
     startEpochSec: number,
     endEpochSec: number,
-    stepSec: number
+    stepSec: number,
+    endIsNow: boolean
   ): Promise<{
     alerts: UnifiedAlertSummary[];
     fallback?: 'prometheus-alerts-current-only';

--- a/common/types/alerting/unified_types.ts
+++ b/common/types/alerting/unified_types.ts
@@ -15,6 +15,18 @@
 import type { OSAlert, OSMonitor } from './opensearch_types';
 import type { PromAlert, PromAlertingRule } from './prometheus_types';
 
+/**
+ * Known fallback reasons a backend may surface through
+ * `DatasourceFetchResult.fallback`. String-literal union (not `string`) so
+ * the UI can exhaustively switch on the value and a new reason requires a
+ * type-level declaration.
+ *
+ * Today's only member: Prometheus historical reconstruction returned an
+ * empty matrix on a `now`-relative range, and the backend fell back to
+ * `/api/v1/alerts` (current-active only).
+ */
+export type DatasourceFetchFallback = 'prometheus-alerts-current-only';
+
 // ============================================================================
 // OSD scoped client — structural shape of the subset we use
 // ============================================================================
@@ -251,7 +263,7 @@ export interface DatasourceFetchResult<T> {
    * to the legacy `/api/v1/alerts` (active-only) endpoint. UI renders a
    * per-datasource banner explaining the coverage limit.
    */
-  fallback?: string;
+  fallback?: DatasourceFetchFallback;
 }
 
 export interface ProgressiveResponse<T> {

--- a/common/types/alerting/unified_types.ts
+++ b/common/types/alerting/unified_types.ts
@@ -239,6 +239,19 @@ export interface DatasourceFetchResult<T> {
   data: T[];
   error?: string;
   durationMs: number;
+  /**
+   * Set by the OpenSearch backend when the post-fetch time-range filter
+   * stopped paginating after hitting the 1000-alert cap. UI renders an
+   * `EuiCallOut` prompting the user to narrow the range.
+   */
+  truncated?: boolean;
+  /**
+   * Set by the Prometheus backend when the historical range query returned
+   * an empty matrix AND the range included `now`, so the backend fell back
+   * to the legacy `/api/v1/alerts` (active-only) endpoint. UI renders a
+   * per-datasource banner explaining the coverage limit.
+   */
+  fallback?: string;
 }
 
 export interface ProgressiveResponse<T> {
@@ -261,6 +274,18 @@ export interface UnifiedFetchOptions {
   pageSize?: number;
   /** Maximum total results to return. Defaults to 5000. Prevents unbounded responses. */
   maxResults?: number;
+  /**
+   * Start of the time window as a date-math string (e.g. `"now-1h"`).
+   * When both `startTime` and `endTime` are provided, backends scope
+   * results to alerts whose active interval overlaps the window.
+   * When omitted, legacy "no range" behavior is preserved.
+   */
+  startTime?: string;
+  /**
+   * End of the time window as a date-math string (e.g. `"now"`). See
+   * {@link UnifiedFetchOptions.startTime} for semantics.
+   */
+  endTime?: string;
 }
 
 // ============================================================================

--- a/public/components/alerting/__tests__/alarms_page.test.tsx
+++ b/public/components/alerting/__tests__/alarms_page.test.tsx
@@ -249,9 +249,12 @@ describe('AlarmsPage', () => {
     );
   });
 
-  it('does not crash when sessionStorage contains a malformed date-math expression; falls back to defaults', async () => {
+  it('does not crash when sessionStorage contains a malformed date-math expression; heals to defaults', async () => {
     // Corrupted value — parseDateMathMs would throw on this. The guarded
-    // useMemo should catch, warn, and substitute the default range.
+    // useMemo catches and substitutes the default range, AND an effect
+    // heals the component state + sessionStorage back to defaults so the
+    // hook stops forwarding garbage to the backend (which would otherwise
+    // reject it with a 400 on every refetch).
     window.sessionStorage.setItem('AlertManagerStartTime', 'totally-broken-expr');
     window.sessionStorage.setItem('AlertManagerEndTime', 'also-broken');
 
@@ -265,15 +268,24 @@ describe('AlarmsPage', () => {
     expect(screen.getByTestId('alerts-dashboard')).toBeInTheDocument();
 
     // The dashboard received numeric (valid) startMs/endMs derived from
-    // the fallback defaults, even though the corrupted strings are still
-    // what the hook sees (they only feed the backend as date-math;
-    // backend-side `validateDateMath` will reject them with a 400).
+    // the fallback defaults.
     const lastDashboard = mockDashboard.mock.calls[mockDashboard.mock.calls.length - 1][0];
     expect(typeof lastDashboard.startMs).toBe('number');
     expect(typeof lastDashboard.endMs).toBe('number');
     expect(Number.isFinite(lastDashboard.startMs)).toBe(true);
     expect(Number.isFinite(lastDashboard.endMs)).toBe(true);
     expect(lastDashboard.endMs).toBeGreaterThan(lastDashboard.startMs);
+
+    // Healing: the hook's most recent call should see the default
+    // strings, not the corrupted ones. Without this, the backend route
+    // would keep rejecting the request with a 400.
+    const lastHookCall = mockUseAlerts.mock.calls[mockUseAlerts.mock.calls.length - 1][0];
+    expect(lastHookCall.startTime).toBe('now-24h');
+    expect(lastHookCall.endTime).toBe('now');
+
+    // sessionStorage has also been healed so a reload starts clean.
+    expect(window.sessionStorage.getItem('AlertManagerStartTime')).toBe('now-24h');
+    expect(window.sessionStorage.getItem('AlertManagerEndTime')).toBe('now');
 
     // A recoverable warn surfaced. `@elastic/datemath` delegates to moment,
     // which can emit its own deprecation warning first for truly garbage

--- a/public/components/alerting/__tests__/alarms_page.test.tsx
+++ b/public/components/alerting/__tests__/alarms_page.test.tsx
@@ -25,9 +25,22 @@ jest.mock('../../common/toast', () => ({
   useToast: () => ({ setToast: jest.fn() }),
 }));
 
-// Stub heavy child components — use data-test-subj (project convention)
+// Mock `useAlerts` — this is the hook AlarmsPage consumes for Alerts-tab data.
+// The mock captures its last-seen arguments so tests can assert on the
+// hydrated picker state / refresh-token propagation.
+const mockUseAlerts = jest.fn();
+jest.mock('../hooks/use_alerts', () => ({
+  useAlerts: (args: unknown) => mockUseAlerts(args),
+}));
+
+// Capture AlertsDashboard props so we can assert `startTime` / `endTime` /
+// `startMs` / `endMs` / `truncated` / `fallbackHints` are forwarded.
+const mockDashboard = jest.fn();
 jest.mock('../alerts_dashboard', () => ({
-  AlertsDashboard: () => <div data-test-subj="alerts-dashboard" />,
+  AlertsDashboard: (props: unknown) => {
+    mockDashboard(props);
+    return <div data-test-subj="alerts-dashboard" />;
+  },
 }));
 jest.mock('../monitors_table', () => ({
   MonitorsTable: () => <div data-test-subj="monitors-table" />,
@@ -43,15 +56,30 @@ jest.mock('../alert_detail_flyout', () => ({ AlertDetailFlyout: () => null }));
 import { AlarmsPage } from '../alarms_page';
 import type { Datasource } from '../../../../common/types/alerting';
 
-// Post-Phase 4: AlarmsPage no longer takes an apiClient prop. Data comes in
-// via props (datasources, datasourcesLoading, defaultDatasources,
-// maxDatasources); the page's children consume hooks internally.
 const defaultProps = {
   datasources: [] as Datasource[],
   datasourcesLoading: false,
   defaultDatasources: [] as string[],
   maxDatasources: 5,
 };
+
+const emptyHookResult = {
+  data: null,
+  isLoading: false,
+  error: null,
+  refetch: jest.fn(),
+};
+
+beforeEach(() => {
+  mockUseAlerts.mockReset();
+  mockUseAlerts.mockReturnValue(emptyHookResult);
+  mockDashboard.mockClear();
+  try {
+    window.sessionStorage.clear();
+  } catch (_e) {
+    /* no-op */
+  }
+});
 
 describe('AlarmsPage', () => {
   it('renders tabs and defaults to Alerts tab', async () => {
@@ -70,5 +98,196 @@ describe('AlarmsPage', () => {
     });
     fireEvent.click(screen.getByTestId('alertManager-tabs-rules'));
     expect(screen.getByTestId('monitors-table')).toBeInTheDocument();
+  });
+
+  it('renders the time-range bar (picker + refresh) only on the Alerts tab', async () => {
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    expect(screen.getByTestId('alertManager-timeRangeBar')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('alertManager-tabs-rules'));
+    expect(screen.queryByTestId('alertManager-timeRangeBar')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('alertManager-tabs-routing'));
+    expect(screen.queryByTestId('alertManager-timeRangeBar')).not.toBeInTheDocument();
+  });
+
+  it('defaults startTime=now-24h / endTime=now when sessionStorage is empty', async () => {
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    const last = mockUseAlerts.mock.calls[mockUseAlerts.mock.calls.length - 1][0];
+    expect(last.startTime).toBe('now-24h');
+    expect(last.endTime).toBe('now');
+    expect(last.refreshToken).toBe(0);
+  });
+
+  it('hydrates startTime / endTime from sessionStorage on mount', async () => {
+    window.sessionStorage.setItem('AlertManagerStartTime', 'now-24h');
+    window.sessionStorage.setItem('AlertManagerEndTime', 'now-5m');
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    const last = mockUseAlerts.mock.calls[mockUseAlerts.mock.calls.length - 1][0];
+    expect(last.startTime).toBe('now-24h');
+    expect(last.endTime).toBe('now-5m');
+  });
+
+  it('clicking refresh increments the refreshToken passed to useAlerts', async () => {
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    const before = mockUseAlerts.mock.calls[mockUseAlerts.mock.calls.length - 1][0].refreshToken;
+
+    // The built-in EuiSuperDatePicker refresh button (showUpdateButton=true default)
+    const refreshBtn = screen.getByTestId('superDatePickerApplyTimeButton');
+    fireEvent.click(refreshBtn);
+
+    const after = mockUseAlerts.mock.calls[mockUseAlerts.mock.calls.length - 1][0].refreshToken;
+    expect(after).toBe(before + 1);
+  });
+
+  it('does not render a separate refresh button outside the picker', async () => {
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    expect(screen.queryByTestId('alertManager-refreshButton')).not.toBeInTheDocument();
+  });
+
+  it('forwards resolved startMs / endMs as numbers to AlertsDashboard', async () => {
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    const last = mockDashboard.mock.calls[mockDashboard.mock.calls.length - 1][0];
+    expect(typeof last.startMs).toBe('number');
+    expect(typeof last.endMs).toBe('number');
+    expect(last.endMs).toBeGreaterThan(last.startMs);
+  });
+
+  it('forwards `truncated` from hook data.datasourceStatus to AlertsDashboard', async () => {
+    mockUseAlerts.mockReturnValue({
+      ...emptyHookResult,
+      data: {
+        results: [],
+        datasourceStatus: [
+          {
+            datasourceId: 'ds-1',
+            datasourceName: 'Local',
+            datasourceType: 'opensearch',
+            status: 'success',
+            data: [],
+            durationMs: 10,
+            truncated: true,
+          },
+        ],
+        totalDatasources: 1,
+        completedDatasources: 1,
+        fetchedAt: '2026-01-01T00:00:00Z',
+      },
+    });
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    const last = mockDashboard.mock.calls[mockDashboard.mock.calls.length - 1][0];
+    expect(last.truncated).toBe(true);
+  });
+
+  it('forwards `fallbackHints` built from datasourceStatus entries with a fallback marker', async () => {
+    mockUseAlerts.mockReturnValue({
+      ...emptyHookResult,
+      data: {
+        results: [],
+        datasourceStatus: [
+          {
+            datasourceId: 'p-1',
+            datasourceName: 'prom-prod',
+            datasourceType: 'prometheus',
+            status: 'success',
+            data: [],
+            durationMs: 10,
+            fallback: 'prometheus-alerts-current-only',
+          },
+          {
+            datasourceId: 'os-1',
+            datasourceName: 'os-prod',
+            datasourceType: 'opensearch',
+            status: 'success',
+            data: [],
+            durationMs: 10,
+          },
+        ],
+        totalDatasources: 2,
+        completedDatasources: 2,
+        fetchedAt: '2026-01-01T00:00:00Z',
+      },
+    });
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    const last = mockDashboard.mock.calls[mockDashboard.mock.calls.length - 1][0];
+    expect(last.fallbackHints).toEqual([
+      { datasourceName: 'prom-prod', fallback: 'prometheus-alerts-current-only' },
+    ]);
+  });
+
+  it('passes selectedDsIds, startTime, endTime, refreshToken together to useAlerts', async () => {
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    const last = mockUseAlerts.mock.calls[mockUseAlerts.mock.calls.length - 1][0];
+    expect(last).toEqual(
+      expect.objectContaining({
+        dsIds: expect.any(Array),
+        startTime: expect.any(String),
+        endTime: expect.any(String),
+        refreshToken: expect.any(Number),
+      })
+    );
+  });
+
+  it('does not crash when sessionStorage contains a malformed date-math expression; falls back to defaults', async () => {
+    // Corrupted value — parseDateMathMs would throw on this. The guarded
+    // useMemo should catch, warn, and substitute the default range.
+    window.sessionStorage.setItem('AlertManagerStartTime', 'totally-broken-expr');
+    window.sessionStorage.setItem('AlertManagerEndTime', 'also-broken');
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+
+    // The page still mounted.
+    expect(screen.getByTestId('alerts-dashboard')).toBeInTheDocument();
+
+    // The dashboard received numeric (valid) startMs/endMs derived from
+    // the fallback defaults, even though the corrupted strings are still
+    // what the hook sees (they only feed the backend as date-math;
+    // backend-side `validateDateMath` will reject them with a 400).
+    const lastDashboard = mockDashboard.mock.calls[mockDashboard.mock.calls.length - 1][0];
+    expect(typeof lastDashboard.startMs).toBe('number');
+    expect(typeof lastDashboard.endMs).toBe('number');
+    expect(Number.isFinite(lastDashboard.startMs)).toBe(true);
+    expect(Number.isFinite(lastDashboard.endMs)).toBe(true);
+    expect(lastDashboard.endMs).toBeGreaterThan(lastDashboard.startMs);
+
+    // A recoverable warn surfaced. `@elastic/datemath` delegates to moment,
+    // which can emit its own deprecation warning first for truly garbage
+    // strings (construction falls back to `new Date`). Scan all calls
+    // instead of pinning on `.calls[0]` so the assertion isn't brittle to
+    // upstream moment warnings that precede ours.
+    expect(warnSpy).toHaveBeenCalled();
+    const anyCallMatches = warnSpy.mock.calls.some((args) =>
+      args.some(
+        (a) => typeof a === 'string' && a.includes('[AlertManager] failed to parse time range')
+      )
+    );
+    expect(anyCallMatches).toBe(true);
+
+    warnSpy.mockRestore();
   });
 });

--- a/public/components/alerting/__tests__/alerts_charts.test.tsx
+++ b/public/components/alerting/__tests__/alerts_charts.test.tsx
@@ -146,7 +146,7 @@ describe('alerts_charts', () => {
     expect(longOpt.xAxis.data).toHaveLength(24);
   });
 
-  it('AlertTimeline: alerts falling outside the window are excluded from all buckets', () => {
+  it('AlertTimeline: post-window alerts are excluded from all buckets', () => {
     const start = END - HOUR_MS;
     const alerts = [
       // In-window — counted.
@@ -155,13 +155,7 @@ describe('alerts_charts', () => {
         severity: 'critical',
         startTime: new Date(END - 30 * 60 * 1000).toISOString(),
       }),
-      // Before window — dropped.
-      makeAlert({
-        id: '2',
-        severity: 'critical',
-        startTime: new Date(END - 2 * HOUR_MS).toISOString(),
-      }),
-      // After window — dropped (alert.startTime >= bucketEnd of the last bucket).
+      // After window — dropped (clamped startTime still >= endMs, so no bucket matches).
       makeAlert({
         id: '3',
         severity: 'critical',
@@ -175,6 +169,36 @@ describe('alerts_charts', () => {
     };
     const critical = option.series.find((s) => s.name === 'critical');
     expect(critical).toBeDefined();
+    const total = (critical!.data as number[]).reduce((a, b) => a + b, 0);
+    expect(total).toBe(1);
+  });
+
+  it('AlertTimeline: pre-window alerts are credited to the first bucket (matches backend overlap)', () => {
+    // The OS backend's interval-overlap filter returns alerts that started
+    // before the picked window but are still firing / resolved inside it.
+    // The chart must count those too, otherwise the summary-cards counts and
+    // timeline bars disagree. We clamp startTime to the window start so the
+    // alert lands in bucket 0.
+    const start = END - HOUR_MS;
+    const alerts = [
+      // Started 2h before the window — backend returned it as overlapping,
+      // chart should credit it to the first bucket.
+      makeAlert({
+        id: 'pre',
+        severity: 'critical',
+        startTime: new Date(END - 2 * HOUR_MS).toISOString(),
+      }),
+    ];
+    render(<AlertTimeline alerts={alerts} startMs={start} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as {
+      series: Array<{ name: string; data: number[] }>;
+    };
+    const critical = option.series.find((s) => s.name === 'critical');
+    expect(critical).toBeDefined();
+    // First bucket holds the clamped pre-window alert.
+    expect(critical!.data[0]).toBe(1);
+    // Total across all buckets is still 1 — no double-counting.
     const total = (critical!.data as number[]).reduce((a, b) => a + b, 0);
     expect(total).toBe(1);
   });

--- a/public/components/alerting/__tests__/alerts_charts.test.tsx
+++ b/public/components/alerting/__tests__/alerts_charts.test.tsx
@@ -27,6 +27,9 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
 import { AlertTimeline } from '../alerts_charts';
 import type { UnifiedAlertSummary } from '../../../../common/types/alerting';
 
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
 const makeAlert = (overrides: Partial<UnifiedAlertSummary>): UnifiedAlertSummary => ({
   id: 'alert-1',
   datasourceId: 'ds-1',
@@ -41,6 +44,11 @@ const makeAlert = (overrides: Partial<UnifiedAlertSummary>): UnifiedAlertSummary
   ...overrides,
 });
 
+// Pinned end time for deterministic label formatting across time zones.
+// (We read labels off the spec; they're derived from `Date(ts).getHours()`
+// which is TZ-sensitive. Tests compare format shape, not exact hour/date.)
+const END = new Date('2026-05-08T12:00:00Z').getTime();
+
 describe('alerts_charts', () => {
   beforeEach(() => {
     mockSetOption.mockClear();
@@ -48,10 +56,18 @@ describe('alerts_charts', () => {
 
   it('AlertTimeline renders one stacked bar series per severity', () => {
     const alerts = [
-      makeAlert({ id: '1', severity: 'critical' }),
-      makeAlert({ id: '2', severity: 'high' }),
+      makeAlert({
+        id: '1',
+        severity: 'critical',
+        startTime: new Date(END - 10 * 60 * 1000).toISOString(),
+      }),
+      makeAlert({
+        id: '2',
+        severity: 'high',
+        startTime: new Date(END - 20 * 60 * 1000).toISOString(),
+      }),
     ];
-    render(<AlertTimeline alerts={alerts} />);
+    render(<AlertTimeline alerts={alerts} startMs={END - HOUR_MS} endMs={END} />);
 
     const option = mockSetOption.mock.calls[0][0] as {
       series: Array<{ name: string; type: string; stack: string }>;
@@ -61,8 +77,105 @@ describe('alerts_charts', () => {
   });
 
   it('AlertTimeline shows an empty-state message when there are no alerts', () => {
-    const { getByText } = render(<AlertTimeline alerts={[]} />);
+    const { getByText } = render(<AlertTimeline alerts={[]} startMs={END - HOUR_MS} endMs={END} />);
     expect(getByText('No timeline data')).toBeInTheDocument();
     expect(mockSetOption).not.toHaveBeenCalled();
+  });
+
+  it('AlertTimeline: 1h range produces 12 buckets (5-minute target width)', () => {
+    const alerts = [makeAlert({ startTime: new Date(END - 30 * 60 * 1000).toISOString() })];
+    render(<AlertTimeline alerts={alerts} startMs={END - HOUR_MS} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as {
+      xAxis: { data: string[] };
+      series: Array<{ data: number[] }>;
+    };
+    expect(option.xAxis.data).toHaveLength(12);
+    // Every series shares the same bucket count.
+    expect(option.series[0].data).toHaveLength(12);
+  });
+
+  it('AlertTimeline: label format is HH:mm for ranges ≤ 24h', () => {
+    const alerts = [makeAlert({ startTime: new Date(END - 30 * 60 * 1000).toISOString() })];
+    render(<AlertTimeline alerts={alerts} startMs={END - HOUR_MS} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as { xAxis: { data: string[] } };
+    // All labels match "HH:mm" — no date component.
+    for (const label of option.xAxis.data) {
+      expect(label).toMatch(/^\d{2}:\d{2}$/);
+    }
+  });
+
+  it('AlertTimeline: label format switches to MM-DD HH:mm for 7d ranges', () => {
+    const start = END - 7 * DAY_MS;
+    const alerts = [makeAlert({ startTime: new Date(END - DAY_MS).toISOString() })];
+    render(<AlertTimeline alerts={alerts} startMs={start} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as { xAxis: { data: string[] } };
+    for (const label of option.xAxis.data) {
+      expect(label).toMatch(/^\d{2}-\d{2} \d{2}:\d{2}$/);
+    }
+  });
+
+  it('AlertTimeline: label format is MM-DD for ranges > 7d', () => {
+    const start = END - 30 * DAY_MS;
+    const alerts = [makeAlert({ startTime: new Date(END - 5 * DAY_MS).toISOString() })];
+    render(<AlertTimeline alerts={alerts} startMs={start} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as { xAxis: { data: string[] } };
+    for (const label of option.xAxis.data) {
+      expect(label).toMatch(/^\d{2}-\d{2}$/);
+    }
+  });
+
+  it('AlertTimeline: bucket count stays clamped to [12, 24] for extreme ranges', () => {
+    // 5-minute range — should clamp UP to the minimum of 12 buckets.
+    const shortStart = END - 5 * 60 * 1000;
+    const shortAlerts = [makeAlert({ startTime: new Date(END - 60 * 1000).toISOString() })];
+    render(<AlertTimeline alerts={shortAlerts} startMs={shortStart} endMs={END} />);
+    const shortOpt = mockSetOption.mock.calls[0][0] as { xAxis: { data: string[] } };
+    expect(shortOpt.xAxis.data).toHaveLength(12);
+
+    mockSetOption.mockClear();
+
+    // 30-day range — should clamp DOWN to the maximum of 24 buckets.
+    const longStart = END - 30 * DAY_MS;
+    const longAlerts = [makeAlert({ startTime: new Date(END - 15 * DAY_MS).toISOString() })];
+    render(<AlertTimeline alerts={longAlerts} startMs={longStart} endMs={END} />);
+    const longOpt = mockSetOption.mock.calls[0][0] as { xAxis: { data: string[] } };
+    expect(longOpt.xAxis.data).toHaveLength(24);
+  });
+
+  it('AlertTimeline: alerts falling outside the window are excluded from all buckets', () => {
+    const start = END - HOUR_MS;
+    const alerts = [
+      // In-window — counted.
+      makeAlert({
+        id: '1',
+        severity: 'critical',
+        startTime: new Date(END - 30 * 60 * 1000).toISOString(),
+      }),
+      // Before window — dropped.
+      makeAlert({
+        id: '2',
+        severity: 'critical',
+        startTime: new Date(END - 2 * HOUR_MS).toISOString(),
+      }),
+      // After window — dropped (alert.startTime >= bucketEnd of the last bucket).
+      makeAlert({
+        id: '3',
+        severity: 'critical',
+        startTime: new Date(END + 60 * 1000).toISOString(),
+      }),
+    ];
+    render(<AlertTimeline alerts={alerts} startMs={start} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as {
+      series: Array<{ name: string; data: number[] }>;
+    };
+    const critical = option.series.find((s) => s.name === 'critical');
+    expect(critical).toBeDefined();
+    const total = (critical!.data as number[]).reduce((a, b) => a + b, 0);
+    expect(total).toBe(1);
   });
 });

--- a/public/components/alerting/__tests__/alerts_dashboard.test.tsx
+++ b/public/components/alerting/__tests__/alerts_dashboard.test.tsx
@@ -21,6 +21,16 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   unobserve: jest.fn(),
 }));
 
+// Spy on AlertTimeline so we can assert the resolved startMs/endMs values
+// flow through as numeric props (rather than the picker's date-math strings).
+const mockTimeline = jest.fn();
+jest.mock('../alerts_charts', () => ({
+  AlertTimeline: (props: { alerts: unknown[]; startMs: number; endMs: number }) => {
+    mockTimeline(props);
+    return <div data-test-subj="alert-timeline-stub" />;
+  },
+}));
+
 import { AlertsDashboard } from '../alerts_dashboard';
 import type { UnifiedAlertSummary, Datasource } from '../../../../common/types/alerting';
 
@@ -45,6 +55,9 @@ const sampleDs: Datasource = {
   enabled: true,
 };
 
+const HOUR_MS = 60 * 60 * 1000;
+const NOW = Date.now();
+
 const baseProps = {
   alerts: [] as UnifiedAlertSummary[],
   datasources: [sampleDs],
@@ -55,7 +68,13 @@ const baseProps = {
   onDatasourceChange: jest.fn(),
   maxDatasources: 5,
   onDatasourceCapReached: jest.fn(),
+  startMs: NOW - HOUR_MS,
+  endMs: NOW,
 };
+
+beforeEach(() => {
+  mockTimeline.mockClear();
+});
 
 describe('AlertsDashboard', () => {
   it('renders empty state when no alerts', () => {
@@ -66,5 +85,54 @@ describe('AlertsDashboard', () => {
   it('renders alert table when alerts provided', () => {
     const { getByText } = render(<AlertsDashboard {...baseProps} alerts={[sampleAlert]} />);
     expect(getByText('HighCPU')).toBeInTheDocument();
+  });
+
+  it('renders timeline title without the (24h) suffix', () => {
+    const { getByText, queryByText } = render(
+      <AlertsDashboard {...baseProps} alerts={[sampleAlert]} />
+    );
+    expect(getByText('Alert Timeline')).toBeInTheDocument();
+    expect(queryByText('Alert Timeline (24h)')).not.toBeInTheDocument();
+  });
+
+  it('forwards numeric startMs/endMs to AlertTimeline (not the date-math strings)', () => {
+    render(<AlertsDashboard {...baseProps} alerts={[sampleAlert]} />);
+    expect(mockTimeline).toHaveBeenCalled();
+    const lastCall = mockTimeline.mock.calls[mockTimeline.mock.calls.length - 1][0];
+    expect(lastCall.startMs).toBe(NOW - HOUR_MS);
+    expect(lastCall.endMs).toBe(NOW);
+  });
+
+  it('renders the truncated callout when `truncated` is true', () => {
+    const { getByTestId } = render(
+      <AlertsDashboard {...baseProps} alerts={[sampleAlert]} truncated />
+    );
+    expect(getByTestId('alerts-truncated-callout')).toBeInTheDocument();
+  });
+
+  it('does not render the truncated callout when `truncated` is false/undefined', () => {
+    const { queryByTestId } = render(<AlertsDashboard {...baseProps} alerts={[sampleAlert]} />);
+    expect(queryByTestId('alerts-truncated-callout')).not.toBeInTheDocument();
+  });
+
+  it('renders the fallback callout listing each fallback datasource', () => {
+    const { getByTestId, getByText } = render(
+      <AlertsDashboard
+        {...baseProps}
+        alerts={[sampleAlert]}
+        fallbackHints={[
+          { datasourceName: 'prom-prod', fallback: 'prometheus-alerts-current-only' },
+        ]}
+      />
+    );
+    expect(getByTestId('alerts-fallback-callout')).toBeInTheDocument();
+    expect(getByText('prom-prod')).toBeInTheDocument();
+  });
+
+  it('does not render the fallback callout when `fallbackHints` is empty', () => {
+    const { queryByTestId } = render(
+      <AlertsDashboard {...baseProps} alerts={[sampleAlert]} fallbackHints={[]} />
+    );
+    expect(queryByTestId('alerts-fallback-callout')).not.toBeInTheDocument();
   });
 });

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -202,11 +202,13 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   const mutations = useMonitorMutations();
   const [activeTab, setActiveTab] = useState<TabId>('alerts');
   const [selectedDsIds, setSelectedDsIds] = useState<string[]>([]);
-  // `dataLoading` / `error` / `warnings` only drive the Rules flow now —
+  // `dataLoading` / `error` / `rulesWarnings` only drive the Rules flow now —
   // the Alerts path reads loading/error/warnings from `useAlerts` below.
   const [dataLoading, setDataLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [warnings, setWarnings] = useState<Array<{ datasourceName: string; error: string }>>([]);
+  const [rulesWarnings, setRulesWarnings] = useState<
+    Array<{ datasourceName: string; error: string }>
+  >([]);
 
   // ---- Time-range state ----
   //
@@ -272,12 +274,50 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     refreshToken,
   });
 
+  // Optimistic ack overrides — keyed by alertId. The hook owns the alerts
+  // array (single source of truth), so we layer the user's pending acks
+  // on top in render rather than mutating the hook's data. Cleared per-id
+  // once a refetch confirms the ack landed (or the id disappears from the
+  // list, e.g. retention drop). Without this, clicking Acknowledge feels
+  // unresponsive because the Prometheus historical-reconstruction refetch
+  // can take seconds before the row state visibly flips.
+  const [ackOverrides, setAckOverrides] = useState<
+    Record<string, { state: 'acknowledged'; lastUpdated: string }>
+  >({});
+
   // Public-facing projections. Kept in the same shape the rest of this
   // component consumed before the migration so the downstream code didn't
   // have to change. Behaviorally identical to the old `alerts`/`alertsTotal`
   // state but now driven by the hook.
-  const alerts: UnifiedAlertSummary[] = alertsData?.results || [];
+  const rawAlerts: UnifiedAlertSummary[] = useMemo(() => alertsData?.results || [], [alertsData]);
+  const alerts: UnifiedAlertSummary[] = useMemo(() => {
+    if (Object.keys(ackOverrides).length === 0) return rawAlerts;
+    return rawAlerts.map((a) => {
+      const ov = ackOverrides[a.id];
+      return ov ? { ...a, state: ov.state, lastUpdated: ov.lastUpdated } : a;
+    });
+  }, [rawAlerts, ackOverrides]);
   const alertsTotal = alerts.length;
+
+  // Drop overrides whose target alert is now acknowledged on the server
+  // (or has fallen out of the result set entirely). Runs after every hook
+  // refetch — keeps the override map from leaking memory across many acks.
+  useEffect(() => {
+    setAckOverrides((prev) => {
+      if (Object.keys(prev).length === 0) return prev;
+      let changed = false;
+      const next = { ...prev };
+      const byId = new Map(rawAlerts.map((a) => [a.id, a]));
+      for (const id of Object.keys(prev)) {
+        const live = byId.get(id);
+        if (!live || live.state === 'acknowledged') {
+          delete next[id];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [rawAlerts]);
   const alertsWarnings = useMemo(() => {
     const failed = (alertsData?.datasourceStatus || []).filter((s) => s.status === 'error');
     return failed.map((s) => ({
@@ -428,14 +468,14 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       }
       setDataLoading(true);
       setError(null);
-      setWarnings([]);
+      setRulesWarnings([]);
       try {
         const res = await osService.listRules({ dsIds });
         setRules(res.results || []);
         setRulesTotal((res.results || []).length);
         const failedStatuses = (res.datasourceStatus || []).filter((s) => s.status === 'error');
         if (failedStatuses.length > 0) {
-          setWarnings(
+          setRulesWarnings(
             failedStatuses.map((s) => ({
               datasourceName: s.datasourceName,
               error: s.error || 'Unknown error',
@@ -478,16 +518,18 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     try {
       await mutations.acknowledgeAlert(alertId, alert?.datasourceId, alert?.labels?.monitor_id);
       addToast('Alert acknowledged');
-      // `alerts` is now owned by `useAlerts` — we can't splice state locally.
-      // Bump the refresh token so the hook refetches; the new response will
-      // carry the updated `state`. Feels slightly slower than the old
-      // optimistic update but keeps the alerts list a single source of truth
-      // (the backend), which avoids drift if the ack fails partway through.
+      // Layer an optimistic override so the row flips to "acknowledged"
+      // immediately. The override is dropped once the refetch's response
+      // either confirms the ack or removes the row.
+      const lastUpdated = new Date().toISOString();
+      setAckOverrides((prev) => ({ ...prev, [alertId]: { state: 'acknowledged', lastUpdated } }));
+      // Bump the refresh token so the hook refetches and the override can
+      // be reconciled / cleared once the backend agrees.
       setRefreshToken((t) => t + 1);
       // Update the flyout's selected alert inline so it stays open with fresh state
       setSelectedAlert((prev) =>
         prev && prev.id === alertId
-          ? { ...prev, state: 'acknowledged' as const, lastUpdated: new Date().toISOString() }
+          ? { ...prev, state: 'acknowledged' as const, lastUpdated }
           : prev
       );
     } catch (e: unknown) {
@@ -1011,12 +1053,12 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       )}
 
       {(() => {
-        // Merge Rules-path `warnings` with the hook-driven `alertsWarnings`
+        // Merge Rules-path `rulesWarnings` with the hook-driven `alertsWarnings`
         // so we render a single callout regardless of which tab is active.
         // Keyed by datasource name to dedupe when both paths report the
         // same backend (possible if the user flips tabs rapidly while
         // a slow datasource is still timing out on both flows).
-        const combined = activeTab === 'alerts' ? alertsWarnings : warnings;
+        const combined = activeTab === 'alerts' ? alertsWarnings : rulesWarnings;
         if (combined.length === 0) return null;
         return (
           <EuiCallOut

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -110,9 +110,9 @@ function persistSelection(names: string[]) {
 // ---- Time-range persistence ----
 //
 // Keyed in sessionStorage (not localStorage) so each tab keeps its own
-// picked range — mirrors APM's precedent. Falls back to the locked
-// locked default (`now-24h` → `now`) when the key is absent or the
-// underlying storage throws (SSR, private mode, quota exceeded).
+// picked range — mirrors APM's precedent. Falls back to the default
+// (`now-24h` → `now`) when the key is absent or the underlying storage
+// throws (SSR, private mode, quota exceeded).
 const ALERT_MANAGER_START_TIME_KEY = 'AlertManagerStartTime';
 const ALERT_MANAGER_END_TIME_KEY = 'AlertManagerEndTime';
 const DEFAULT_START_TIME = 'now-24h';
@@ -227,20 +227,42 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   // `parseDateMathMs` so we never ship hard-coded epoch numbers.
   //
   // We emit `console.warn` (not `.error`) because the failure is recoverable
-  // and self-healing — the next successful `onTimeChange` will persist a
-  // good value and silence the warning.
+  // and self-healing — the effect below resets state and sessionStorage to
+  // the defaults so the hook (which forwards the raw date-math strings to
+  // the backend) stops sending garbage that the route-layer validator
+  // would reject with a 400.
   //
-  // `startTime`/`endTime` still go to the hook (which forwards the raw
-  // date-math strings to the backend) — only the resolved numbers feed
-  // the chart.
-  const [startMs, endMs] = useMemo(() => {
+  // `refreshToken` is in the deps so that clicking Refresh while the range
+  // is relative-to-`now` (e.g. `now-24h` → `now`) re-resolves `now` to the
+  // current wall clock. Without it the chart window would stay pinned to
+  // the mount-time snapshot even though the hook refetches new data, which
+  // would misalign bars at the right edge of the chart.
+  const [startMs, endMs, rangeParseFailed] = useMemo(() => {
     try {
-      return [parseDateMathMs(startTime, false), parseDateMathMs(endTime, true)];
+      return [parseDateMathMs(startTime, false), parseDateMathMs(endTime, true), false];
     } catch (e) {
       console.warn('[AlertManager] failed to parse time range, falling back to defaults', e);
-      return [parseDateMathMs(DEFAULT_START_TIME, false), parseDateMathMs(DEFAULT_END_TIME, true)];
+      return [
+        parseDateMathMs(DEFAULT_START_TIME, false),
+        parseDateMathMs(DEFAULT_END_TIME, true),
+        true,
+      ];
     }
-  }, [startTime, endTime]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [startTime, endTime, refreshToken]);
+
+  // When parse failed (corrupted sessionStorage, manual DevTools edit),
+  // heal the stored values back to defaults. Without this, `startTime` /
+  // `endTime` keep leaking garbage into `useAlerts` → the backend route,
+  // which rejects it with a 400 and surfaces as `alertsError`. Resetting
+  // state + persistence both (a) stops the 400 loop and (b) means the
+  // next render sees a clean, good range.
+  useEffect(() => {
+    if (!rangeParseFailed) return;
+    setStartTime(DEFAULT_START_TIME);
+    setEndTime(DEFAULT_END_TIME);
+    persistTimeRange(DEFAULT_START_TIME, DEFAULT_END_TIME);
+  }, [rangeParseFailed]);
 
   // ---- Alerts data (migrated off inline fetchAlerts onto useAlerts) ----
   const { data: alertsData, isLoading: alertsLoading, error: alertsError } = useAlerts({
@@ -264,7 +286,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     }));
   }, [alertsData]);
   // Backend hints surfaced through the dashboard banner props.
-  const alertsTruncated = (alertsData?.datasourceStatus || []).some((s) => s.truncated) ?? false;
+  const alertsTruncated = (alertsData?.datasourceStatus || []).some((s) => s.truncated);
   const alertsFallbackHints = useMemo(
     () =>
       (alertsData?.datasourceStatus || [])
@@ -935,11 +957,25 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
               start={startTime}
               end={endTime}
               onTimeChange={({ start, end }) => {
+                if (start === startTime && end === endTime) return;
                 setStartTime(start);
                 setEndTime(end);
                 persistTimeRange(start, end);
               }}
-              onRefresh={() => setRefreshToken((t) => t + 1)}
+              // EuiSuperDatePicker.onRefresh delivers the picker's resolved
+              // `{ start, end }` along with the interval. Sync them back
+              // into component state so the refetch uses the picker's
+              // current snapshot rather than the potentially-stale
+              // `startTime`/`endTime` captured on mount. Persist so the
+              // next page load matches what the user just saw.
+              onRefresh={({ start, end }) => {
+                if (start !== startTime || end !== endTime) {
+                  setStartTime(start);
+                  setEndTime(end);
+                  persistTimeRange(start, end);
+                }
+                setRefreshToken((t) => t + 1);
+              }}
               data-test-subj="alertManager-datePicker"
             />
           </EuiFlexItem>

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -35,6 +35,7 @@ import {
   EuiFlexItem,
   EuiSuperDatePicker,
 } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
 import { toMountPoint } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { useToast } from '../common/toast';
 import {
@@ -1029,7 +1030,9 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       {/* existing `error` callout pattern used for the Rules path.          */}
       {alertsErrorMessage && activeTab === 'alerts' && (
         <EuiCallOut
-          title="Error loading alerts"
+          title={i18n.translate('observability.alerting.alarmsPage.alertsError.title', {
+            defaultMessage: 'Error loading alerts',
+          })}
           color="danger"
           iconType="alert"
           size="s"

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -4,11 +4,37 @@
  */
 
 /**
- * Alert Manager UI — single-datasource selection with server-side pagination.
- * Prometheus datasources are decomposed into selectable workspaces.
+ * Alert Manager UI — top-level container.
+ *
+ * Owns:
+ *   - Datasource selection (persisted per-tab in `localStorage` by name).
+ *   - Time-range picker state (persisted per-tab in `sessionStorage` as
+ *     date-math strings, defaulting to `now-24h` → `now`). Pagination of the
+ *     in-memory alerts list stays local.
+ *   - `refreshToken` state bumped by the refresh button next to the picker;
+ *     `useAlerts` treats it as an effect dependency so bumping it refetches
+ *     without changing the range.
+ *
+ * Alerts data flows via `useAlerts` — the hook wraps the APM-pattern
+ * `AlertingOpenSearchService.listAlerts` transport (no `alarms_client.ts`).
+ * Rules data still uses the inline `fetchRules` callback; migrating Rules
+ * onto `useRules` is tracked as a follow-up.
+ *
+ * sessionStorage keys:
+ *   - `AlertManagerStartTime` — date-math string for picker start.
+ *   - `AlertManagerEndTime`   — date-math string for picker end.
  */
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { EuiLink, EuiSpacer, EuiTab, EuiTabs, EuiCallOut } from '@elastic/eui';
+import {
+  EuiLink,
+  EuiSpacer,
+  EuiTab,
+  EuiTabs,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSuperDatePicker,
+} from '@elastic/eui';
 import { toMountPoint } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { useToast } from '../common/toast';
 import {
@@ -27,6 +53,7 @@ import { CreateLogsMonitor, LogsMonitorFormState } from './create_logs_monitor';
 import { CreateMetricsMonitor, MetricsMonitorFormState } from './create_metrics_monitor';
 // Phase 2: import SloListing from './slo_listing';
 import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
+import { useAlerts } from './hooks/use_alerts';
 import { useMonitorMutations } from './hooks/use_monitor_mutations';
 import { coreRefs } from '../../framework/core_refs';
 import { setNavBreadCrumbs } from '../../../common/utils/set_nav_bread_crumbs';
@@ -39,6 +66,7 @@ import {
   transformLogsFormToPayload,
   transformMetricsFormToPayload,
 } from '../../../common/services/alerting/form_transforms';
+import { parseDateMathMs } from '../../../common/services/alerting/time_range';
 
 // ============================================================================
 // Main Page Component
@@ -76,6 +104,42 @@ function persistSelection(names: string[]) {
     window.localStorage.setItem(ALERT_MANAGER_SELECTED_DS_STORAGE_KEY, JSON.stringify(names));
   } catch (_e) {
     // localStorage can be unavailable (private mode / quota). Not fatal.
+  }
+}
+
+// ---- Time-range persistence ----
+//
+// Keyed in sessionStorage (not localStorage) so each tab keeps its own
+// picked range — mirrors APM's precedent. Falls back to the locked
+// locked default (`now-24h` → `now`) when the key is absent or the
+// underlying storage throws (SSR, private mode, quota exceeded).
+const ALERT_MANAGER_START_TIME_KEY = 'AlertManagerStartTime';
+const ALERT_MANAGER_END_TIME_KEY = 'AlertManagerEndTime';
+const DEFAULT_START_TIME = 'now-24h';
+const DEFAULT_END_TIME = 'now';
+
+function loadPersistedStartTime(): string {
+  try {
+    return window.sessionStorage.getItem(ALERT_MANAGER_START_TIME_KEY) || DEFAULT_START_TIME;
+  } catch (_e) {
+    return DEFAULT_START_TIME;
+  }
+}
+
+function loadPersistedEndTime(): string {
+  try {
+    return window.sessionStorage.getItem(ALERT_MANAGER_END_TIME_KEY) || DEFAULT_END_TIME;
+  } catch (_e) {
+    return DEFAULT_END_TIME;
+  }
+}
+
+function persistTimeRange(start: string, end: string) {
+  try {
+    window.sessionStorage.setItem(ALERT_MANAGER_START_TIME_KEY, start);
+    window.sessionStorage.setItem(ALERT_MANAGER_END_TIME_KEY, end);
+  } catch (_e) {
+    // sessionStorage can be unavailable (SSR / private mode / quota). Not fatal.
   }
 }
 
@@ -138,16 +202,84 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   const mutations = useMonitorMutations();
   const [activeTab, setActiveTab] = useState<TabId>('alerts');
   const [selectedDsIds, setSelectedDsIds] = useState<string[]>([]);
+  // `dataLoading` / `error` / `warnings` only drive the Rules flow now —
+  // the Alerts path reads loading/error/warnings from `useAlerts` below.
   const [dataLoading, setDataLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [warnings, setWarnings] = useState<Array<{ datasourceName: string; error: string }>>([]);
 
-  // Paginated data — list endpoints return summary shapes.
-  // Detail flyouts re-fetch the full UnifiedAlert / UnifiedRule on demand.
-  const [alerts, setAlerts] = useState<UnifiedAlertSummary[]>([]);
-  const [alertsTotal, setAlertsTotal] = useState(0);
-  const [alertsPage, setAlertsPage] = useState(1);
-  const [alertsPageSize] = useState(DEFAULT_PAGE_SIZE);
+  // ---- Time-range state ----
+  //
+  // Initialized lazily from sessionStorage so SSR / JSDOM first-render is
+  // still stable when storage access throws. Writes happen eagerly via
+  // `onTimeChange` (picker) and `onRefresh` (refresh button).
+  const [startTime, setStartTime] = useState<string>(loadPersistedStartTime);
+  const [endTime, setEndTime] = useState<string>(loadPersistedEndTime);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  // Resolve once per render, guarded.
+  //
+  // `parseDateMathMs` throws on malformed input (invalid date-math). If a
+  // user or a browser extension corrupts the sessionStorage-hydrated
+  // `startTime`/`endTime`, resolving at module top-level would crash the
+  // page on mount. `useMemo` lets us swallow the error and fall back to
+  // the known-good defaults (`now-24h` -> `now`), which ALSO parse through
+  // `parseDateMathMs` so we never ship hard-coded epoch numbers.
+  //
+  // We emit `console.warn` (not `.error`) because the failure is recoverable
+  // and self-healing — the next successful `onTimeChange` will persist a
+  // good value and silence the warning.
+  //
+  // `startTime`/`endTime` still go to the hook (which forwards the raw
+  // date-math strings to the backend) — only the resolved numbers feed
+  // the chart.
+  const [startMs, endMs] = useMemo(() => {
+    try {
+      return [parseDateMathMs(startTime, false), parseDateMathMs(endTime, true)];
+    } catch (e) {
+      console.warn('[AlertManager] failed to parse time range, falling back to defaults', e);
+      return [parseDateMathMs(DEFAULT_START_TIME, false), parseDateMathMs(DEFAULT_END_TIME, true)];
+    }
+  }, [startTime, endTime]);
+
+  // ---- Alerts data (migrated off inline fetchAlerts onto useAlerts) ----
+  const { data: alertsData, isLoading: alertsLoading, error: alertsError } = useAlerts({
+    dsIds: selectedDsIds,
+    startTime,
+    endTime,
+    refreshToken,
+  });
+
+  // Public-facing projections. Kept in the same shape the rest of this
+  // component consumed before the migration so the downstream code didn't
+  // have to change. Behaviorally identical to the old `alerts`/`alertsTotal`
+  // state but now driven by the hook.
+  const alerts: UnifiedAlertSummary[] = alertsData?.results || [];
+  const alertsTotal = alerts.length;
+  const alertsWarnings = useMemo(() => {
+    const failed = (alertsData?.datasourceStatus || []).filter((s) => s.status === 'error');
+    return failed.map((s) => ({
+      datasourceName: s.datasourceName,
+      error: s.error || 'Unknown error',
+    }));
+  }, [alertsData]);
+  // Backend hints surfaced through the dashboard banner props.
+  const alertsTruncated = (alertsData?.datasourceStatus || []).some((s) => s.truncated) ?? false;
+  const alertsFallbackHints = useMemo(
+    () =>
+      (alertsData?.datasourceStatus || [])
+        .filter((s) => s.fallback)
+        .map((s) => ({ datasourceName: s.datasourceName, fallback: s.fallback! })),
+    [alertsData]
+  );
+  const alertsErrorMessage =
+    alertsError instanceof Error ? alertsError.message : alertsError ? String(alertsError) : null;
+
+  // Pagination state: previously `alertsPage` / `alertsPageSize` lived here
+  // to feed the old inline `fetchAlerts` callback. `useAlerts` returns the
+  // full dataset (server doesn't paginate the unified endpoint), so local
+  // alerts pagination state is no longer needed — `AlertsDashboard` slices
+  // the results client-side via `EuiInMemoryTable`.
 
   const [rules, setRules] = useState<UnifiedRuleSummary[]>([]);
   const [rulesTotal, setRulesTotal] = useState(-1); // -1 = not yet loaded
@@ -260,40 +392,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   }, [selectedDsIds, datasources]);
 
   // ---- Fetch data when datasource selection or page changes ----
-
-  const fetchAlerts = useCallback(
-    async (dsIds: string[], _page: number, _pageSize: number) => {
-      if (dsIds.length === 0) {
-        setAlerts([]);
-        setAlertsTotal(0);
-        return;
-      }
-      setDataLoading(true);
-      setError(null);
-      setWarnings([]);
-      try {
-        const res = await osService.listAlerts({ dsIds });
-        setAlerts(res.results || []);
-        setAlertsTotal((res.results || []).length);
-        // Convert per-datasource failure entries from the progressive response
-        // into the UI's warning shape.
-        const failedStatuses = (res.datasourceStatus || []).filter((s) => s.status === 'error');
-        if (failedStatuses.length > 0) {
-          setWarnings(
-            failedStatuses.map((s) => ({
-              datasourceName: s.datasourceName,
-              error: s.error || 'Unknown error',
-            }))
-          );
-        }
-      } catch (e: unknown) {
-        setError(e instanceof Error ? e.message : 'Failed to fetch alerts');
-      } finally {
-        setDataLoading(false);
-      }
-    },
-    [osService]
-  );
+  //
+  // Alerts: now driven by `useAlerts` above — no inline callback needed.
+  // Changing `selectedDsIds`, `startTime`, `endTime`, or `refreshToken`
+  // triggers a refetch through the hook's effect.
 
   const fetchRules = useCallback(
     async (dsIds: string[], _page: number, _pageSize: number) => {
@@ -327,19 +429,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     [osService]
   );
 
-  // Fetch when selection or pagination changes
-  useEffect(() => {
-    if (selectedDsIds.length === 0) {
-      setAlerts([]);
-      setAlertsTotal(0);
-      return;
-    }
-    // Fetch alerts regardless of active tab so the "Alerts (N)" tab label
-    // stays in sync when the user changes filters (e.g., datasource) while
-    // on a different tab. Mirrors the Rules-fetch effect below.
-    fetchAlerts(selectedDsIds, alertsPage, alertsPageSize);
-  }, [selectedDsIds, alertsPage, alertsPageSize, fetchAlerts]);
-
+  // Rules fetch effect (alerts effect removed — `useAlerts` hook drives that flow).
   useEffect(() => {
     if (selectedDsIds.length === 0) {
       setRules([]);
@@ -351,10 +441,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     fetchRules(selectedDsIds, rulesPage, rulesPageSize);
   }, [selectedDsIds, rulesPage, rulesPageSize, fetchRules]);
 
-  // Reset pages when datasource selection changes
+  // Reset pages when datasource selection changes. `useAlerts` refetches
+  // automatically on `selectedDsIds` change, so no alerts-page reset here.
   const handleDatasourceChange = useCallback((ids: string[]) => {
     setSelectedDsIds(ids);
-    setAlertsPage(1);
     setRulesPage(1);
     setDeletedRuleIds(new Set());
   }, []);
@@ -366,13 +456,12 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     try {
       await mutations.acknowledgeAlert(alertId, alert?.datasourceId, alert?.labels?.monitor_id);
       addToast('Alert acknowledged');
-      setAlerts((prev) =>
-        prev.map((a) =>
-          a.id === alertId
-            ? { ...a, state: 'acknowledged' as const, lastUpdated: new Date().toISOString() }
-            : a
-        )
-      );
+      // `alerts` is now owned by `useAlerts` — we can't splice state locally.
+      // Bump the refresh token so the hook refetches; the new response will
+      // carry the updated `state`. Feels slightly slower than the old
+      // optimistic update but keeps the alerts list a single source of truth
+      // (the backend), which avoids drift if the ack fails partway through.
+      setRefreshToken((t) => t + 1);
       // Update the flyout's selected alert inline so it stays open with fresh state
       setSelectedAlert((prev) =>
         prev && prev.id === alertId
@@ -765,13 +854,17 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           <AlertsDashboard
             alerts={alerts}
             datasources={datasources}
-            loading={dataLoading}
+            loading={alertsLoading}
             onViewDetail={(alert) => setSelectedAlert(alert)}
             onAcknowledge={handleAcknowledgeAlert}
             selectedDsIds={selectedDsIds}
             onDatasourceChange={handleDatasourceChange}
             maxDatasources={maxDatasources}
             onDatasourceCapReached={handleDatasourceCapReached}
+            startMs={startMs}
+            endMs={endMs}
+            truncated={alertsTruncated}
+            fallbackHints={alertsFallbackHints}
           />
         </>
       );
@@ -813,21 +906,61 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       data-test-subj="alertManager-page"
       style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
     >
-      <EuiTabs data-test-subj="alertManager-tabs">
-        {tabs.map((t) => (
-          <EuiTab
-            key={t.id}
-            isSelected={activeTab === t.id}
-            onClick={() => setActiveTab(t.id)}
-            data-test-subj={`alertManager-tabs-${t.id}`}
-          >
-            {t.name}
-          </EuiTab>
-        ))}
-      </EuiTabs>
+      {/* Tabs + time-range picker share a single row: tabs grow left,        */}
+      {/* picker + refresh sit right-aligned. Picker only renders on Alerts.  */}
+      <EuiFlexGroup
+        gutterSize="m"
+        alignItems="center"
+        responsive={false}
+        data-test-subj="alertManager-tabBar"
+      >
+        <EuiFlexItem grow={true}>
+          <EuiTabs data-test-subj="alertManager-tabs">
+            {tabs.map((t) => (
+              <EuiTab
+                key={t.id}
+                isSelected={activeTab === t.id}
+                onClick={() => setActiveTab(t.id)}
+                data-test-subj={`alertManager-tabs-${t.id}`}
+              >
+                {t.name}
+              </EuiTab>
+            ))}
+          </EuiTabs>
+        </EuiFlexItem>
+        {activeTab === 'alerts' && (
+          <EuiFlexItem grow={false} data-test-subj="alertManager-timeRangeBar">
+            <EuiSuperDatePicker
+              compressed
+              start={startTime}
+              end={endTime}
+              onTimeChange={({ start, end }) => {
+                setStartTime(start);
+                setEndTime(end);
+                persistTimeRange(start, end);
+              }}
+              onRefresh={() => setRefreshToken((t) => t + 1)}
+              data-test-subj="alertManager-datePicker"
+            />
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
       <EuiSpacer size="s" />
 
-      {/* Datasource selector removed — now integrated into filter panels */}
+      {/* Surface the hook's error if alerts fetch failed. Mirrors the       */}
+      {/* existing `error` callout pattern used for the Rules path.          */}
+      {alertsErrorMessage && activeTab === 'alerts' && (
+        <EuiCallOut
+          title="Error loading alerts"
+          color="danger"
+          iconType="alert"
+          size="s"
+          style={{ marginBottom: 12 }}
+          data-test-subj="alertManager-alertsError"
+        >
+          <p>{alertsErrorMessage}</p>
+        </EuiCallOut>
+      )}
 
       {error && (
         <EuiCallOut
@@ -841,21 +974,30 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         </EuiCallOut>
       )}
 
-      {warnings.length > 0 && (
-        <EuiCallOut
-          title="Some datasources could not be reached"
-          color="warning"
-          iconType="alert"
-          size="s"
-          style={{ marginBottom: 12 }}
-        >
-          {warnings.map((w, i) => (
-            <p key={i}>
-              <strong>{w.datasourceName}</strong>: {w.error}
-            </p>
-          ))}
-        </EuiCallOut>
-      )}
+      {(() => {
+        // Merge Rules-path `warnings` with the hook-driven `alertsWarnings`
+        // so we render a single callout regardless of which tab is active.
+        // Keyed by datasource name to dedupe when both paths report the
+        // same backend (possible if the user flips tabs rapidly while
+        // a slow datasource is still timing out on both flows).
+        const combined = activeTab === 'alerts' ? alertsWarnings : warnings;
+        if (combined.length === 0) return null;
+        return (
+          <EuiCallOut
+            title="Some datasources could not be reached"
+            color="warning"
+            iconType="alert"
+            size="s"
+            style={{ marginBottom: 12 }}
+          >
+            {combined.map((w, i) => (
+              <p key={i}>
+                <strong>{w.datasourceName}</strong>: {w.error}
+              </p>
+            ))}
+          </EuiCallOut>
+        );
+      })()}
 
       <div aria-live="polite" className="euiScreenReaderOnly">
         {`Showing ${tabs.find((t) => t.id === activeTab)?.name ?? activeTab} tab`}

--- a/public/components/alerting/alerts_charts.tsx
+++ b/public/components/alerting/alerts_charts.tsx
@@ -52,9 +52,10 @@ const TARGET_BUCKET_MS = 5 * 60 * 1000;
 const MIN_BUCKETS = 12;
 const MAX_BUCKETS = 24;
 
-/** Clamp `value` to `[min, max]`. Standard util; kept local to avoid a */
-/** lodash import for a two-line helper. */
-function clamp(min: number, max: number, value: number): number {
+/** Clamp `value` to `[min, max]`. Matches lodash's `(value, min, max)`
+ *  argument order so callers don't have to think twice. Kept local to
+ *  avoid a lodash import for a two-line helper. */
+function clamp(value: number, min: number, max: number): number {
   if (value < min) return min;
   if (value > max) return max;
   return value;
@@ -100,9 +101,9 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
     // produce transient oddities on first mount.
     const rangeMs = Math.max(1, endMs - startMs);
 
-    // bucketCount = clamp(12, 24, ceil(rangeMs / targetBucketMs))
+    // bucketCount = clamp(ceil(rangeMs / targetBucketMs), 12, 24)
     const rawBucketCount = Math.ceil(rangeMs / TARGET_BUCKET_MS);
-    const bucketCount = clamp(MIN_BUCKETS, MAX_BUCKETS, rawBucketCount);
+    const bucketCount = clamp(rawBucketCount, MIN_BUCKETS, MAX_BUCKETS);
     const bucketDuration = rangeMs / bucketCount;
 
     const buckets: Array<{

--- a/public/components/alerting/alerts_charts.tsx
+++ b/public/components/alerting/alerts_charts.tsx
@@ -7,7 +7,10 @@
  * Alerts Charts — ECharts visualizations for the Alerts dashboard.
  *
  * Currently exposes:
- *  - AlertTimeline: stacked bar chart of alerts over 24h time buckets
+ *  - AlertTimeline: stacked bar chart of alerts over a variable-range time
+ *    window. The parent owns range resolution (date-math → epoch ms) and
+ *    passes pre-resolved `startMs` / `endMs` props so this component never
+ *    re-resolves date-math on every render.
  *
  * Other breakdown panels (SeverityDonut, StateBreakdown, AlertsByDatasource,
  * AlertsByMonitor) were removed in a UI cleanup pass — the facet filter panel
@@ -35,13 +38,73 @@ const SEVERITY_COLORS: Record<string, string> = {
 // AlertTimeline — stacked bar chart by time buckets
 // ============================================================================
 
-export const AlertTimeline: React.FC<{ alerts: UnifiedAlertSummary[] }> = ({ alerts }) => {
+/** Common range thresholds (ms). */
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+const SEVEN_DAYS_MS = 7 * ONE_DAY_MS;
+
+/** Target bucket width — 5 minutes. With a 1h range, this yields exactly 12 */
+/** buckets (ceil(60m / 5m) = 12), matching the fixed bucketCount used before. */
+const TARGET_BUCKET_MS = 5 * 60 * 1000;
+
+/** Minimum / maximum bucket counts. Within this clamp the X-axis stays */
+/** readable across ranges from 5 minutes up to 30 days. */
+const MIN_BUCKETS = 12;
+const MAX_BUCKETS = 24;
+
+/** Clamp `value` to `[min, max]`. Standard util; kept local to avoid a */
+/** lodash import for a two-line helper. */
+function clamp(min: number, max: number, value: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+/** Zero-pad to two digits. */
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/**
+ * Format a bucket-start timestamp based on the overall range length:
+ *  - `HH:mm` for ranges ≤ 24h
+ *  - `MM-DD HH:mm` for ranges ≤ 7d
+ *  - `MM-DD` otherwise
+ */
+function formatBucketLabel(ts: number, rangeMs: number): string {
+  const d = new Date(ts);
+  const hh = pad2(d.getHours());
+  const mm = pad2(d.getMinutes());
+  const mo = pad2(d.getMonth() + 1);
+  const da = pad2(d.getDate());
+  if (rangeMs <= ONE_DAY_MS) return `${hh}:${mm}`;
+  if (rangeMs <= SEVEN_DAYS_MS) return `${mo}-${da} ${hh}:${mm}`;
+  return `${mo}-${da}`;
+}
+
+export interface AlertTimelineProps {
+  alerts: UnifiedAlertSummary[];
+  /** Range start in epoch ms (resolved by the parent). */
+  startMs: number;
+  /** Range end in epoch ms (resolved by the parent). */
+  endMs: number;
+}
+
+export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, endMs }) => {
   const spec = useMemo(() => {
     if (alerts.length === 0) return null;
 
-    const now = Date.now();
-    const bucketCount = 12;
-    const bucketDuration = (24 * 60 * 60 * 1000) / bucketCount;
+    // Defend against inverted or zero-length ranges — pick a minimum 1ms
+    // window so division below doesn't blow up. In practice the parent
+    // should never send this, but the picker+sessionStorage cycle can
+    // produce transient oddities on first mount.
+    const rangeMs = Math.max(1, endMs - startMs);
+
+    // bucketCount = clamp(12, 24, ceil(rangeMs / targetBucketMs))
+    const rawBucketCount = Math.ceil(rangeMs / TARGET_BUCKET_MS);
+    const bucketCount = clamp(MIN_BUCKETS, MAX_BUCKETS, rawBucketCount);
+    const bucketDuration = rangeMs / bucketCount;
+
     const buckets: Array<{
       label: string;
       critical: number;
@@ -52,12 +115,9 @@ export const AlertTimeline: React.FC<{ alerts: UnifiedAlertSummary[] }> = ({ ale
     }> = [];
 
     for (let i = 0; i < bucketCount; i++) {
-      const bucketStart = now - (bucketCount - i) * bucketDuration;
+      const bucketStart = startMs + i * bucketDuration;
       const bucketEnd = bucketStart + bucketDuration;
-      const label = new Date(bucketStart).toLocaleTimeString([], {
-        hour: '2-digit',
-        minute: '2-digit',
-      });
+      const label = formatBucketLabel(bucketStart, rangeMs);
       const inBucket = alerts.filter((a) => {
         const t = new Date(a.startTime).getTime();
         return t >= bucketStart && t < bucketEnd;
@@ -110,7 +170,7 @@ export const AlertTimeline: React.FC<{ alerts: UnifiedAlertSummary[] }> = ({ ale
         barMaxWidth: 32,
       })),
     };
-  }, [alerts]);
+  }, [alerts, startMs, endMs]);
 
   if (alerts.length === 0)
     return (

--- a/public/components/alerting/alerts_charts.tsx
+++ b/public/components/alerting/alerts_charts.tsx
@@ -18,9 +18,11 @@
  * cluttering the dashboard.
  */
 import React, { useMemo } from 'react';
+import moment from 'moment-timezone';
 import { EuiText } from '@elastic/eui';
 import { EchartsRender } from './echarts_render';
 import { UnifiedAlertSummary } from '../../../common/types/alerting';
+import { uiSettingsService } from '../../../common/utils';
 
 // ============================================================================
 // Color map (kept for AlertTimeline severity bars)
@@ -61,9 +63,17 @@ function clamp(value: number, min: number, max: number): number {
   return value;
 }
 
-/** Zero-pad to two digits. */
-function pad2(n: number): string {
-  return n < 10 ? `0${n}` : String(n);
+/**
+ * Resolve the timezone the user configured via `dateFormat:tz`. Mirrors the
+ * resolution APM does in `formatDisplayTimestamp` so Discover, APM, and the
+ * Alerts dashboard all render the same instant the same way for a given user.
+ */
+function resolveDisplayTz(): string {
+  const tz = uiSettingsService.get('dateFormat:tz');
+  if (!tz || tz === 'Browser') {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+  return tz;
 }
 
 /**
@@ -71,16 +81,15 @@ function pad2(n: number): string {
  *  - `HH:mm` for ranges ≤ 24h
  *  - `MM-DD HH:mm` for ranges ≤ 7d
  *  - `MM-DD` otherwise
+ *
+ * Honors `dateFormat:tz` so users in different timezones don't see different
+ * labels for the same bucket — matches Discover / Dashboards / APM.
  */
-function formatBucketLabel(ts: number, rangeMs: number): string {
-  const d = new Date(ts);
-  const hh = pad2(d.getHours());
-  const mm = pad2(d.getMinutes());
-  const mo = pad2(d.getMonth() + 1);
-  const da = pad2(d.getDate());
-  if (rangeMs <= ONE_DAY_MS) return `${hh}:${mm}`;
-  if (rangeMs <= SEVEN_DAYS_MS) return `${mo}-${da} ${hh}:${mm}`;
-  return `${mo}-${da}`;
+function formatBucketLabel(ts: number, rangeMs: number, tz: string): string {
+  const m = moment.tz(ts, tz);
+  if (rangeMs <= ONE_DAY_MS) return m.format('HH:mm');
+  if (rangeMs <= SEVEN_DAYS_MS) return m.format('MM-DD HH:mm');
+  return m.format('MM-DD');
 }
 
 export interface AlertTimelineProps {
@@ -123,10 +132,12 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
     // perf win: parse each startTime once instead of per-bucket.
     const alertBucketStart = alerts.map((a) => Math.max(startMs, new Date(a.startTime).getTime()));
 
+    const tz = resolveDisplayTz();
+
     for (let i = 0; i < bucketCount; i++) {
       const bucketStart = startMs + i * bucketDuration;
       const bucketEnd = bucketStart + bucketDuration;
-      const label = formatBucketLabel(bucketStart, rangeMs);
+      const label = formatBucketLabel(bucketStart, rangeMs, tz);
       const inBucket = alerts.filter(
         (_, idx) => alertBucketStart[idx] >= bucketStart && alertBucketStart[idx] < bucketEnd
       );

--- a/public/components/alerting/alerts_charts.tsx
+++ b/public/components/alerting/alerts_charts.tsx
@@ -115,14 +115,21 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
       info: number;
     }> = [];
 
+    // Clamp each alert's effective start to the window start so alerts that
+    // began before the window but are still-firing / resolved inside it get
+    // credited to the first bucket. Matches the OS backend's interval-overlap
+    // filter (opensearch_backend.ts) — otherwise the summary cards show "1
+    // alert" while the timeline shows zero bars for the same data. Also a
+    // perf win: parse each startTime once instead of per-bucket.
+    const alertBucketStart = alerts.map((a) => Math.max(startMs, new Date(a.startTime).getTime()));
+
     for (let i = 0; i < bucketCount; i++) {
       const bucketStart = startMs + i * bucketDuration;
       const bucketEnd = bucketStart + bucketDuration;
       const label = formatBucketLabel(bucketStart, rangeMs);
-      const inBucket = alerts.filter((a) => {
-        const t = new Date(a.startTime).getTime();
-        return t >= bucketStart && t < bucketEnd;
-      });
+      const inBucket = alerts.filter(
+        (_, idx) => alertBucketStart[idx] >= bucketStart && alertBucketStart[idx] < bucketEnd
+      );
       buckets.push({
         label,
         critical: inBucket.filter((a) => a.severity === 'critical').length,

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -26,6 +26,8 @@ import {
   EuiResizableContainer,
   EuiCallOut,
 } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
 import {
   DatasourceFetchFallback,
   UnifiedAlertSummary,
@@ -689,15 +691,22 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                 {truncated && (
                   <>
                     <EuiCallOut
-                      title="Results capped at 1000. Narrow the range."
+                      title={i18n.translate(
+                        'observability.alerting.dashboard.truncatedCallout.title',
+                        {
+                          defaultMessage: 'Search incomplete — too many alerts to scan',
+                        }
+                      )}
                       color="warning"
                       iconType="alert"
                       size="s"
                       data-test-subj="alerts-truncated-callout"
                     >
                       <p>
-                        One or more datasources returned more alerts than can be shown. Pick a
-                        shorter time range or refine your filters to see all matches.
+                        <FormattedMessage
+                          id="observability.alerting.dashboard.truncatedCallout.body"
+                          defaultMessage="Narrow the time range or refine your filters and try again."
+                        />
                       </p>
                     </EuiCallOut>
                     <EuiSpacer size="s" />
@@ -706,7 +715,12 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                 {fallbackHints && fallbackHints.length > 0 && (
                   <>
                     <EuiCallOut
-                      title="Showing current alerts only"
+                      title={i18n.translate(
+                        'observability.alerting.dashboard.fallbackCallout.title',
+                        {
+                          defaultMessage: 'Showing current alerts only',
+                        }
+                      )}
                       color="warning"
                       iconType="alert"
                       size="s"
@@ -714,8 +728,14 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                     >
                       {fallbackHints.map((h, i) => (
                         <p key={i}>
-                          <strong>{h.datasourceName}</strong>: historical alert data unavailable;
-                          showing currently active alerts instead ({h.fallback}).
+                          <FormattedMessage
+                            id="observability.alerting.dashboard.fallbackCallout.entry"
+                            defaultMessage="{datasourceName}: historical alert data unavailable; showing currently active alerts instead ({fallback})."
+                            values={{
+                              datasourceName: <strong>{h.datasourceName}</strong>,
+                              fallback: h.fallback,
+                            }}
+                          />
                         </p>
                       ))}
                     </EuiCallOut>

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -24,6 +24,7 @@ import {
   EuiEmptyPrompt,
   EuiButtonEmpty,
   EuiResizableContainer,
+  EuiCallOut,
 } from '@elastic/eui';
 import { UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
 import { filterAlerts } from '../../../common/services/alerting/filter';
@@ -183,6 +184,23 @@ export interface AlertsDashboardProps {
   maxDatasources: number;
   /** Callback fired when user tries to exceed `maxDatasources`. */
   onDatasourceCapReached: () => void;
+  /** Picker start resolved to epoch ms (resolved once by the parent). */
+  startMs: number;
+  /** Picker end resolved to epoch ms (resolved once by the parent). */
+  endMs: number;
+  /**
+   * Set by the parent when any backend reported a hard cap on returned
+   * alerts (e.g. the OpenSearch 1000-alert post-filter cap). Drives a
+   * warning callout near the timeline telling the user to narrow the
+   * range.
+   */
+  truncated?: boolean;
+  /**
+   * Per-datasource hints from the unified fetch, used to surface backend
+   * fallbacks (e.g. Prometheus empty-matrix → legacy /alerts active-only).
+   * Rendered as a callout above the timeline.
+   */
+  fallbackHints?: Array<{ datasourceName: string; fallback: string }>;
 }
 
 export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
@@ -195,6 +213,10 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
   onDatasourceChange,
   maxDatasources,
   onDatasourceCapReached,
+  startMs,
+  endMs,
+  truncated,
+  fallbackHints,
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [severityFilter, setSeverityFilter] = useState('all');
@@ -650,15 +672,62 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
 
                 <EuiSpacer size="m" />
 
+                {/* ---- Backend hints / fallbacks ---- */}
+                {/* Surfaced here (above the timeline) because both hints      */}
+                {/* directly explain what the chart and table are showing:     */}
+                {/*   - `truncated` → the backend capped results (OS 1000      */}
+                {/*     post-filter cap) so the chart is missing bars and the  */}
+                {/*     table row count is lower than reality.                 */}
+                {/*   - `fallbackHints` → a Prometheus datasource returned no  */}
+                {/*     historical matrix and fell back to the legacy         */}
+                {/*     `/api/v1/alerts` endpoint, which is active-only and   */}
+                {/*     does not reflect the selected time range.             */}
+                {truncated && (
+                  <>
+                    <EuiCallOut
+                      title="Results capped at 1000. Narrow the range."
+                      color="warning"
+                      iconType="alert"
+                      size="s"
+                      data-test-subj="alerts-truncated-callout"
+                    >
+                      <p>
+                        One or more datasources returned more alerts than can be shown. Pick a
+                        shorter time range or refine your filters to see all matches.
+                      </p>
+                    </EuiCallOut>
+                    <EuiSpacer size="s" />
+                  </>
+                )}
+                {fallbackHints && fallbackHints.length > 0 && (
+                  <>
+                    <EuiCallOut
+                      title="Showing current alerts only"
+                      color="warning"
+                      iconType="alert"
+                      size="s"
+                      data-test-subj="alerts-fallback-callout"
+                    >
+                      {fallbackHints.map((h, i) => (
+                        <p key={i}>
+                          <strong>{h.datasourceName}</strong>: historical alert data unavailable;
+                          showing currently active alerts instead ({h.fallback}).
+                        </p>
+                      ))}
+                    </EuiCallOut>
+                    <EuiSpacer size="s" />
+                  </>
+                )}
+
                 {/* ---- Visualization Row ---- */}
                 <EuiFlexGroup gutterSize="m" responsive={true}>
                   <EuiFlexItem grow={3}>
                     <EuiPanel paddingSize="m" hasBorder>
                       <EuiTitle size="xxs">
-                        <h4>Alert Timeline (24h)</h4>
+                        <h4>Alert Timeline</h4>
                       </EuiTitle>
                       <EuiSpacer size="s" />
-                      <AlertTimeline alerts={filteredAlerts} />
+                      <AlertTimeline alerts={filteredAlerts} startMs={startMs} endMs={endMs} />
                     </EuiPanel>
                   </EuiFlexItem>
                 </EuiFlexGroup>

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -26,7 +26,11 @@ import {
   EuiResizableContainer,
   EuiCallOut,
 } from '@elastic/eui';
-import { UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
+import {
+  DatasourceFetchFallback,
+  UnifiedAlertSummary,
+  Datasource,
+} from '../../../common/types/alerting';
 import { filterAlerts } from '../../../common/services/alerting/filter';
 import { AlertTimeline } from './alerts_charts';
 import { AlertsSummaryCards } from './alerts_summary_cards';
@@ -200,7 +204,7 @@ export interface AlertsDashboardProps {
    * fallbacks (e.g. Prometheus empty-matrix → legacy /alerts active-only).
    * Rendered as a callout above the timeline.
    */
-  fallbackHints?: Array<{ datasourceName: string; fallback: string }>;
+  fallbackHints?: Array<{ datasourceName: string; fallback: DatasourceFetchFallback }>;
 }
 
 export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({

--- a/public/components/alerting/hooks/__tests__/use_alerts.test.ts
+++ b/public/components/alerting/hooks/__tests__/use_alerts.test.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * use_alerts hook tests — focused on the time-range wiring.
+ *
+ * We mock the transport service module so each test can configure its
+ * resolved value and assert the args that `listAlerts` received. This
+ * mirrors the pattern used by `use_prometheus_metadata.test.ts`.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+
+const mockListAlerts = jest.fn();
+
+jest.mock('../../query_services/alerting_opensearch_service', () => ({
+  AlertingOpenSearchService: jest.fn().mockImplementation(() => ({
+    listAlerts: mockListAlerts,
+  })),
+}));
+
+import { useAlerts } from '../use_alerts';
+
+const emptyProgressive = {
+  results: [],
+  datasourceStatus: [],
+  totalDatasources: 0,
+  completedDatasources: 0,
+  fetchedAt: '2026-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  mockListAlerts.mockReset();
+  mockListAlerts.mockResolvedValue(emptyProgressive);
+});
+
+describe('useAlerts', () => {
+  it('does not call listAlerts when dsIds is empty', async () => {
+    renderHook(() => useAlerts({ dsIds: [] }));
+    // Give the microtask queue a tick — nothing should have been called.
+    await waitFor(() => {
+      expect(mockListAlerts).not.toHaveBeenCalled();
+    });
+  });
+
+  it('forwards dsIds alone when no range is set', async () => {
+    renderHook(() => useAlerts({ dsIds: ['ds-1'] }));
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(1));
+    expect(mockListAlerts).toHaveBeenCalledWith({
+      dsIds: ['ds-1'],
+      startTime: undefined,
+      endTime: undefined,
+    });
+  });
+
+  it('forwards startTime and endTime to the service', async () => {
+    renderHook(() => useAlerts({ dsIds: ['ds-1'], startTime: 'now-1h', endTime: 'now' }));
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(1));
+    expect(mockListAlerts).toHaveBeenCalledWith({
+      dsIds: ['ds-1'],
+      startTime: 'now-1h',
+      endTime: 'now',
+    });
+  });
+
+  it('refetches when startTime changes', async () => {
+    const { rerender } = renderHook(
+      ({ startTime }: { startTime: string }) =>
+        useAlerts({ dsIds: ['ds-1'], startTime, endTime: 'now' }),
+      { initialProps: { startTime: 'now-1h' } }
+    );
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(1));
+
+    rerender({ startTime: 'now-24h' });
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(2));
+    expect(mockListAlerts).toHaveBeenLastCalledWith({
+      dsIds: ['ds-1'],
+      startTime: 'now-24h',
+      endTime: 'now',
+    });
+  });
+
+  it('refetches when endTime changes', async () => {
+    const { rerender } = renderHook(
+      ({ endTime }: { endTime: string }) =>
+        useAlerts({ dsIds: ['ds-1'], startTime: 'now-1h', endTime }),
+      { initialProps: { endTime: 'now' } }
+    );
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(1));
+
+    rerender({ endTime: 'now-5m' });
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(2));
+  });
+
+  it('refetches when refreshToken changes', async () => {
+    const { rerender } = renderHook(
+      ({ refreshToken }: { refreshToken: number }) =>
+        useAlerts({ dsIds: ['ds-1'], startTime: 'now-1h', endTime: 'now', refreshToken }),
+      { initialProps: { refreshToken: 0 } }
+    );
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(1));
+
+    rerender({ refreshToken: 1 });
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not refetch when dsIds array reference changes but content is the same', async () => {
+    const { rerender } = renderHook(
+      ({ dsIds }: { dsIds: string[] }) => useAlerts({ dsIds, startTime: 'now-1h', endTime: 'now' }),
+      { initialProps: { dsIds: ['ds-1', 'ds-2'] } }
+    );
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(1));
+
+    // Fresh array reference, identical contents — should NOT refetch.
+    rerender({ dsIds: ['ds-1', 'ds-2'] });
+    // Give any potential re-run a chance to complete before asserting.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockListAlerts).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refetch on stable re-renders (same props)', async () => {
+    const { rerender } = renderHook(() =>
+      useAlerts({ dsIds: ['ds-1'], startTime: 'now-1h', endTime: 'now' })
+    );
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(1));
+
+    rerender();
+    rerender();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockListAlerts).toHaveBeenCalledTimes(1);
+  });
+
+  it('populates data on success', async () => {
+    const response = {
+      ...emptyProgressive,
+      results: [
+        {
+          id: 'a-1',
+          datasourceId: 'ds-1',
+          datasourceType: 'opensearch' as const,
+          name: 'HighCPU',
+          state: 'active' as const,
+          severity: 'critical' as const,
+          startTime: '2026-01-01T00:00:00Z',
+          lastUpdated: '2026-01-01T00:00:00Z',
+          labels: {},
+          annotations: {},
+        },
+      ],
+    };
+    mockListAlerts.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useAlerts({ dsIds: ['ds-1'] }));
+    await waitFor(() => expect(result.current.data).toEqual(response));
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('surfaces errors from the service', async () => {
+    mockListAlerts.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useAlerts({ dsIds: ['ds-1'] }));
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+    expect(result.current.error?.message).toBe('boom');
+  });
+});

--- a/public/components/alerting/hooks/__tests__/use_alerts.test.ts
+++ b/public/components/alerting/hooks/__tests__/use_alerts.test.ts
@@ -47,21 +47,25 @@ describe('useAlerts', () => {
   it('forwards dsIds alone when no range is set', async () => {
     renderHook(() => useAlerts({ dsIds: ['ds-1'] }));
     await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(1));
-    expect(mockListAlerts).toHaveBeenCalledWith({
-      dsIds: ['ds-1'],
-      startTime: undefined,
-      endTime: undefined,
-    });
+    expect(mockListAlerts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dsIds: ['ds-1'],
+        startTime: undefined,
+        endTime: undefined,
+      })
+    );
   });
 
   it('forwards startTime and endTime to the service', async () => {
     renderHook(() => useAlerts({ dsIds: ['ds-1'], startTime: 'now-1h', endTime: 'now' }));
     await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(1));
-    expect(mockListAlerts).toHaveBeenCalledWith({
-      dsIds: ['ds-1'],
-      startTime: 'now-1h',
-      endTime: 'now',
-    });
+    expect(mockListAlerts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dsIds: ['ds-1'],
+        startTime: 'now-1h',
+        endTime: 'now',
+      })
+    );
   });
 
   it('refetches when startTime changes', async () => {
@@ -74,11 +78,29 @@ describe('useAlerts', () => {
 
     rerender({ startTime: 'now-24h' });
     await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(2));
-    expect(mockListAlerts).toHaveBeenLastCalledWith({
-      dsIds: ['ds-1'],
-      startTime: 'now-24h',
-      endTime: 'now',
+    expect(mockListAlerts).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        dsIds: ['ds-1'],
+        startTime: 'now-24h',
+        endTime: 'now',
+      })
+    );
+  });
+
+  it('passes an AbortSignal to the service that is triggered on unmount', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    mockListAlerts.mockImplementation(({ signal }: { signal?: AbortSignal }) => {
+      capturedSignal = signal;
+      return Promise.resolve(emptyProgressive);
     });
+    const { unmount } = renderHook(() =>
+      useAlerts({ dsIds: ['ds-1'], startTime: 'now-1h', endTime: 'now' })
+    );
+    await waitFor(() => expect(mockListAlerts).toHaveBeenCalledTimes(1));
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    expect(capturedSignal?.aborted).toBe(false);
+    unmount();
+    expect(capturedSignal?.aborted).toBe(true);
   });
 
   it('refetches when endTime changes', async () => {

--- a/public/components/alerting/hooks/use_alerts.ts
+++ b/public/components/alerting/hooks/use_alerts.ts
@@ -11,6 +11,10 @@
  * status). The server does not implement page/pageSize pagination on the
  * unified endpoint; consumers that need pagination should slice
  * `data.results` client-side.
+ *
+ * Time range (`startTime`/`endTime`) is forwarded as-is (date-math strings)
+ * to the transport, which appends them to the request query object. Changing
+ * either value triggers a refetch through the effect dependencies below.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ProgressiveResponse, UnifiedAlertSummary } from '../../../../common/types/alerting';
@@ -18,6 +22,10 @@ import { AlertingOpenSearchService } from '../query_services/alerting_opensearch
 
 export interface UseAlertsParams {
   dsIds: string[];
+  /** Date-math string (e.g. "now-1h"). */
+  startTime?: string;
+  /** Date-math string (e.g. "now"). */
+  endTime?: string;
   refreshToken?: unknown;
 }
 
@@ -28,7 +36,12 @@ export interface UseAlertsResult {
   refetch: () => void;
 }
 
-export function useAlerts({ dsIds, refreshToken }: UseAlertsParams): UseAlertsResult {
+export function useAlerts({
+  dsIds,
+  startTime,
+  endTime,
+  refreshToken,
+}: UseAlertsParams): UseAlertsResult {
   const service = useMemo(() => new AlertingOpenSearchService(), []);
   const [data, setData] = useState<ProgressiveResponse<UnifiedAlertSummary> | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -48,7 +61,7 @@ export function useAlerts({ dsIds, refreshToken }: UseAlertsParams): UseAlertsRe
     setError(null);
     (async () => {
       try {
-        const res = await service.listAlerts({ dsIds });
+        const res = await service.listAlerts({ dsIds, startTime, endTime });
         if (!cancelled) setData(res);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)));
@@ -59,9 +72,11 @@ export function useAlerts({ dsIds, refreshToken }: UseAlertsParams): UseAlertsRe
     return () => {
       cancelled = true;
     };
-    // `dsIds` is a new array reference each render; `dsIdsKey` is its stable projection.
+    // `dsIds` is a new array reference each render; `dsIdsKey` is its stable
+    // projection. `startTime`/`endTime` are primitive strings — safe to list
+    // directly (equivalent to a stable-string key for a single value).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [service, dsIdsKey, refreshToken, localRefresh]);
+  }, [service, dsIdsKey, startTime, endTime, refreshToken, localRefresh]);
 
   return { data, isLoading, error, refetch };
 }

--- a/public/components/alerting/hooks/use_alerts.ts
+++ b/public/components/alerting/hooks/use_alerts.ts
@@ -68,20 +68,38 @@ export function useAlerts({
       return;
     }
     const requestId = ++lastRequestIdRef.current;
+    // Abort the in-flight request when the effect re-runs (deps change) or
+    // the component unmounts. The historical-reconstruction path can be
+    // expensive; without this the backend keeps doing work for an already-
+    // abandoned request even though the monotonic `requestId` would prevent
+    // its result from being committed to state.
+    const controller = new AbortController();
     setIsLoading(true);
     setError(null);
     (async () => {
       try {
-        const res = await service.listAlerts({ dsIds, startTime, endTime });
+        const res = await service.listAlerts({
+          dsIds,
+          startTime,
+          endTime,
+          signal: controller.signal,
+        });
         if (requestId !== lastRequestIdRef.current) return;
         setData(res);
       } catch (e) {
         if (requestId !== lastRequestIdRef.current) return;
+        // Aborts surface as DOMException("AbortError") — they're expected
+        // bookkeeping, not a user-facing failure. Skip the error commit so
+        // the UI doesn't flash a callout when the user just changed pickers.
+        if (e instanceof DOMException && e.name === 'AbortError') return;
         setError(e instanceof Error ? e : new Error(String(e)));
       } finally {
         if (requestId === lastRequestIdRef.current) setIsLoading(false);
       }
     })();
+    return () => {
+      controller.abort();
+    };
     // `dsIds` is a new array reference each render; `dsIdsKey` is its stable
     // projection. `startTime`/`endTime` are primitive strings — safe to list
     // directly (equivalent to a stable-string key for a single value).

--- a/public/components/alerting/hooks/use_alerts.ts
+++ b/public/components/alerting/hooks/use_alerts.ts
@@ -16,7 +16,7 @@
  * to the transport, which appends them to the request query object. Changing
  * either value triggers a refetch through the effect dependencies below.
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ProgressiveResponse, UnifiedAlertSummary } from '../../../../common/types/alerting';
 import { AlertingOpenSearchService } from '../query_services/alerting_opensearch_service';
 
@@ -49,6 +49,17 @@ export function useAlerts({
   const [localRefresh, setLocalRefresh] = useState(0);
   const refetch = useCallback(() => setLocalRefresh((t) => t + 1), []);
 
+  // Monotonic request id — guards against stale responses overwriting newer
+  // ones when the user changes the picker faster than the network responds.
+  // Each effect run captures its request id at dispatch; when the response
+  // resolves we check the ref, and only commit state if no later request has
+  // started in the meantime. Closure-scoped `cancelled` flags alone do not
+  // prevent this because the older effect's `cancelled = true` happens
+  // during cleanup (before the new effect body), which is fine for the
+  // common case but fails if the older request resolves after the newer
+  // one has already committed its result.
+  const lastRequestIdRef = useRef(0);
+
   const dsIdsKey = dsIds.join(',');
 
   useEffect(() => {
@@ -56,22 +67,21 @@ export function useAlerts({
       setData(null);
       return;
     }
-    let cancelled = false;
+    const requestId = ++lastRequestIdRef.current;
     setIsLoading(true);
     setError(null);
     (async () => {
       try {
         const res = await service.listAlerts({ dsIds, startTime, endTime });
-        if (!cancelled) setData(res);
+        if (requestId !== lastRequestIdRef.current) return;
+        setData(res);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)));
+        if (requestId !== lastRequestIdRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
       } finally {
-        if (!cancelled) setIsLoading(false);
+        if (requestId === lastRequestIdRef.current) setIsLoading(false);
       }
     })();
-    return () => {
-      cancelled = true;
-    };
     // `dsIds` is a new array reference each render; `dsIdsKey` is its stable
     // projection. `startTime`/`endTime` are primitive strings — safe to list
     // directly (equivalent to a stable-string key for a single value).

--- a/public/components/alerting/query_services/__tests__/alerting_opensearch_service.test.ts
+++ b/public/components/alerting/query_services/__tests__/alerting_opensearch_service.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * AlertingOpenSearchService transport tests.
+ *
+ * Focus on `buildQuery` / `listAlerts` forwarding — the HTTP client comes
+ * from `coreRefs.http` (APM-pattern transport); we mock the module so each
+ * test can assert on the `get` arguments without a real backend.
+ */
+
+// Mock coreRefs before importing the service so `requireHttp()` sees the stub.
+const mockGet = jest.fn();
+jest.mock('../../../../framework/core_refs', () => ({
+  coreRefs: {
+    http: { get: (...args: unknown[]) => mockGet(...args) },
+  },
+}));
+
+import { AlertingOpenSearchService } from '../alerting_opensearch_service';
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockGet.mockResolvedValue({
+    results: [],
+    datasourceStatus: [],
+    totalDatasources: 0,
+    completedDatasources: 0,
+    fetchedAt: '2026-01-01T00:00:00Z',
+  });
+});
+
+describe('AlertingOpenSearchService', () => {
+  describe('listAlerts', () => {
+    it('sends dsIds as comma-joined string on the query object', async () => {
+      const svc = new AlertingOpenSearchService();
+      await svc.listAlerts({ dsIds: ['ds-1', 'ds-2'] });
+      expect(mockGet).toHaveBeenCalledWith('/api/alerting/unified/alerts', {
+        query: { dsIds: 'ds-1,ds-2' },
+      });
+    });
+
+    it('forwards startTime and endTime on the query object when provided', async () => {
+      const svc = new AlertingOpenSearchService();
+      await svc.listAlerts({
+        dsIds: ['ds-1'],
+        startTime: 'now-1h',
+        endTime: 'now',
+      });
+      expect(mockGet).toHaveBeenCalledWith('/api/alerting/unified/alerts', {
+        query: {
+          dsIds: 'ds-1',
+          startTime: 'now-1h',
+          endTime: 'now',
+        },
+      });
+    });
+
+    it('omits startTime/endTime keys entirely when the caller does not supply them', async () => {
+      const svc = new AlertingOpenSearchService();
+      await svc.listAlerts({ dsIds: ['ds-1'] });
+      const [, options] = mockGet.mock.calls[0];
+      expect(options.query).not.toHaveProperty('startTime');
+      expect(options.query).not.toHaveProperty('endTime');
+    });
+
+    it('omits startTime/endTime when explicitly undefined (does not send the string "undefined")', async () => {
+      const svc = new AlertingOpenSearchService();
+      await svc.listAlerts({
+        dsIds: ['ds-1'],
+        startTime: undefined,
+        endTime: undefined,
+      });
+      const [, options] = mockGet.mock.calls[0];
+      expect(options.query).not.toHaveProperty('startTime');
+      expect(options.query).not.toHaveProperty('endTime');
+    });
+
+    it('forwards only startTime when endTime is absent', async () => {
+      const svc = new AlertingOpenSearchService();
+      await svc.listAlerts({ dsIds: ['ds-1'], startTime: 'now-24h' });
+      const [, options] = mockGet.mock.calls[0];
+      expect(options.query.startTime).toBe('now-24h');
+      expect(options.query).not.toHaveProperty('endTime');
+    });
+
+    it('forwards timeout and maxResults alongside range when provided', async () => {
+      const svc = new AlertingOpenSearchService();
+      await svc.listAlerts({
+        dsIds: ['ds-1'],
+        timeout: 10000,
+        maxResults: 1000,
+        startTime: 'now-7d',
+        endTime: 'now',
+      });
+      expect(mockGet).toHaveBeenCalledWith('/api/alerting/unified/alerts', {
+        query: {
+          dsIds: 'ds-1',
+          timeout: '10000',
+          maxResults: '1000',
+          startTime: 'now-7d',
+          endTime: 'now',
+        },
+      });
+    });
+  });
+
+  describe('listRules', () => {
+    it('does not send startTime/endTime even if present on the params object (rules have no time range)', async () => {
+      const svc = new AlertingOpenSearchService();
+      await svc.listRules({ dsIds: ['ds-1'] });
+      expect(mockGet).toHaveBeenCalledWith('/api/alerting/unified/rules', {
+        query: { dsIds: 'ds-1' },
+      });
+    });
+  });
+});

--- a/public/components/alerting/query_services/alerting_opensearch_service.ts
+++ b/public/components/alerting/query_services/alerting_opensearch_service.ts
@@ -29,12 +29,15 @@ export interface ListAlertsParams {
   startTime?: string;
   /** Date-math string (e.g. "now"). */
   endTime?: string;
+  /** Optional AbortSignal — when triggered, cancels the in-flight HTTP request. */
+  signal?: AbortSignal;
 }
 
 export interface ListRulesParams {
   dsIds: string[];
   timeout?: number;
   maxResults?: number;
+  signal?: AbortSignal;
 }
 
 export class AlertingOpenSearchService {
@@ -63,6 +66,7 @@ export class AlertingOpenSearchService {
   async listAlerts(params: ListAlertsParams): Promise<ProgressiveResponse<UnifiedAlertSummary>> {
     return (await this.requireHttp().get('/api/alerting/unified/alerts', {
       query: this.buildQuery(params),
+      signal: params.signal,
     })) as ProgressiveResponse<UnifiedAlertSummary>;
   }
 
@@ -73,6 +77,7 @@ export class AlertingOpenSearchService {
   async listRules(params: ListRulesParams): Promise<ProgressiveResponse<UnifiedRuleSummary>> {
     return (await this.requireHttp().get('/api/alerting/unified/rules', {
       query: this.buildQuery(params),
+      signal: params.signal,
     })) as ProgressiveResponse<UnifiedRuleSummary>;
   }
 

--- a/public/components/alerting/query_services/alerting_opensearch_service.ts
+++ b/public/components/alerting/query_services/alerting_opensearch_service.ts
@@ -25,6 +25,10 @@ export interface ListAlertsParams {
   timeout?: number;
   /** Optional cap on the total number of results returned across all datasources. */
   maxResults?: number;
+  /** Date-math string (e.g. "now-1h"). */
+  startTime?: string;
+  /** Date-math string (e.g. "now"). */
+  endTime?: string;
 }
 
 export interface ListRulesParams {
@@ -44,6 +48,11 @@ export class AlertingOpenSearchService {
     const q: Record<string, string> = { dsIds: params.dsIds.join(',') };
     if (params.timeout !== undefined) q.timeout = String(params.timeout);
     if (params.maxResults !== undefined) q.maxResults = String(params.maxResults);
+    // Time-range fields are defined on ListAlertsParams only. Check via
+    // `in` operator rather than type narrowing because ListRulesParams
+    // (the other arm of the union) intentionally does not carry them.
+    if ('startTime' in params && params.startTime !== undefined) q.startTime = params.startTime;
+    if ('endTime' in params && params.endTime !== undefined) q.endTime = params.endTime;
     return q;
   }
 

--- a/server/routes/alerting/__tests__/handlers.test.ts
+++ b/server/routes/alerting/__tests__/handlers.test.ts
@@ -20,6 +20,8 @@ import {
   handleCreateOSMonitor,
   handleDeleteOSMonitor,
   handleGetUnifiedAlerts,
+  handleGetOSAlerts,
+  handleGetPromAlerts,
   handleGetAlertDetail,
   handleGetRuleDetail,
 } from '../handlers';
@@ -90,5 +92,67 @@ describe('handlers', () => {
     mockAlertSvc.getRuleDetail.mockResolvedValueOnce(null);
     const result = await handleGetRuleDetail(mockAlertSvc as never, mockClient, 'ds-1', 'nope');
     expect(result.status).toBe(404);
+  });
+
+  // =========================================================================
+  // Range threading
+  // =========================================================================
+
+  it('handleGetUnifiedAlerts forwards startTime/endTime to the service', async () => {
+    mockAlertSvc.getUnifiedAlerts.mockResolvedValueOnce({ results: [] });
+    const resolver = jest.fn();
+    await handleGetUnifiedAlerts(mockAlertSvc as never, resolver, {
+      dsIds: 'a',
+      startTime: 'now-1h',
+      endTime: 'now',
+    });
+    expect(mockAlertSvc.getUnifiedAlerts).toHaveBeenCalledWith(
+      resolver,
+      expect.objectContaining({
+        startTime: 'now-1h',
+        endTime: 'now',
+      })
+    );
+  });
+
+  it('handleGetOSAlerts forwards range to getOSAlerts', async () => {
+    mockAlertSvc.getOSAlerts.mockResolvedValueOnce({
+      alerts: [],
+      totalAlerts: 0,
+      truncated: false,
+    });
+    await handleGetOSAlerts(mockAlertSvc as never, mockClient, 'ds-1', {
+      startTime: 'now-2h',
+      endTime: 'now',
+    });
+    expect(mockAlertSvc.getOSAlerts).toHaveBeenCalledWith(mockClient, 'ds-1', {
+      startTime: 'now-2h',
+      endTime: 'now',
+    });
+  });
+
+  it('handleGetPromAlerts forwards range to getPromAlerts', async () => {
+    mockAlertSvc.getPromAlerts.mockResolvedValueOnce([]);
+    await handleGetPromAlerts(mockAlertSvc as never, mockClient, 'ds-1', {
+      startTime: 'now-30m',
+      endTime: 'now',
+    });
+    expect(mockAlertSvc.getPromAlerts).toHaveBeenCalledWith(mockClient, 'ds-1', {
+      startTime: 'now-30m',
+      endTime: 'now',
+    });
+  });
+
+  it('handleGetOSAlerts accepts absent range (undefined options)', async () => {
+    mockAlertSvc.getOSAlerts.mockResolvedValueOnce({
+      alerts: [],
+      totalAlerts: 0,
+      truncated: false,
+    });
+    await handleGetOSAlerts(mockAlertSvc as never, mockClient, 'ds-1');
+    expect(mockAlertSvc.getOSAlerts).toHaveBeenCalledWith(mockClient, 'ds-1', {
+      startTime: undefined,
+      endTime: undefined,
+    });
   });
 });

--- a/server/routes/alerting/__tests__/handlers.test.ts
+++ b/server/routes/alerting/__tests__/handlers.test.ts
@@ -75,11 +75,18 @@ describe('handlers', () => {
       maxResults: '10',
     });
     expect(result.status).toBe(200);
-    expect(mockAlertSvc.getUnifiedAlerts).toHaveBeenCalledWith(resolver, {
-      dsIds: ['a', 'b'],
-      timeoutMs: undefined,
-      maxResults: 10,
-    });
+    // Use `objectContaining` because the handler always forwards the new
+    // `startTime`/`endTime` keys (as `undefined` when absent). An exact
+    // deep-equal would pass today by Jest's loose-undefined semantics but
+    // becomes misleading if that behavior changes.
+    expect(mockAlertSvc.getUnifiedAlerts).toHaveBeenCalledWith(
+      resolver,
+      expect.objectContaining({
+        dsIds: ['a', 'b'],
+        timeoutMs: undefined,
+        maxResults: 10,
+      })
+    );
   });
 
   it('handleGetAlertDetail returns 404 when not found', async () => {

--- a/server/routes/alerting/__tests__/index.test.ts
+++ b/server/routes/alerting/__tests__/index.test.ts
@@ -216,5 +216,44 @@ describe('registerAlertingRoutes', () => {
       const query = (route.validate as { query: { validate: (v: unknown) => unknown } }).query;
       expect(() => query.validate({})).not.toThrow();
     });
+
+    it.each([
+      '/api/alerting/unified/alerts',
+      '/api/alerting/opensearch/{dsId}/alerts',
+      '/api/alerting/prometheus/{dsId}/alerts',
+    ])('%s rejects one-sided ranges (startTime without endTime)', (path: string) => {
+      register();
+      const route = findRoute(path);
+      const query = (route.validate as { query: { validate: (v: unknown) => unknown } }).query;
+      expect(() => query.validate({ startTime: 'now-1h' })).toThrow(
+        /startTime and endTime must be supplied together/
+      );
+    });
+
+    it.each([
+      '/api/alerting/unified/alerts',
+      '/api/alerting/opensearch/{dsId}/alerts',
+      '/api/alerting/prometheus/{dsId}/alerts',
+    ])('%s rejects one-sided ranges (endTime without startTime)', (path: string) => {
+      register();
+      const route = findRoute(path);
+      const query = (route.validate as { query: { validate: (v: unknown) => unknown } }).query;
+      expect(() => query.validate({ endTime: 'now' })).toThrow(
+        /startTime and endTime must be supplied together/
+      );
+    });
+
+    it.each([
+      '/api/alerting/unified/alerts',
+      '/api/alerting/opensearch/{dsId}/alerts',
+      '/api/alerting/prometheus/{dsId}/alerts',
+    ])('%s rejects inverted ranges (endTime before startTime)', (path: string) => {
+      register();
+      const route = findRoute(path);
+      const query = (route.validate as { query: { validate: (v: unknown) => unknown } }).query;
+      expect(() => query.validate({ startTime: 'now', endTime: 'now-1h' })).toThrow(
+        /endTime must be on or after startTime/
+      );
+    });
   });
 });

--- a/server/routes/alerting/__tests__/index.test.ts
+++ b/server/routes/alerting/__tests__/index.test.ts
@@ -143,4 +143,78 @@ describe('registerAlertingRoutes', () => {
       expect(allPaths).not.toContain(p);
     }
   });
+
+  // =========================================================================
+  // timeRangeQuery applied to all three alerts routes.
+  //
+  // The three targeted routes are:
+  //   GET /api/alerting/unified/alerts
+  //   GET /api/alerting/opensearch/{dsId}/alerts
+  //   GET /api/alerting/prometheus/{dsId}/alerts
+  //
+  // We reach into the `validate.query` schema object that `registerAlertingRoutes`
+  // attached to each route and verify the startTime / endTime fields (a)
+  // accept valid date-math, (b) reject malformed input, (c) are both optional.
+  // =========================================================================
+
+  describe('timeRangeQuery', () => {
+    interface Route {
+      path: string;
+      validate?: { query?: unknown };
+    }
+
+    const register = () => {
+      mockRouter.get.mockClear();
+      registerAlertingRoutes(mockRouter as never, {
+        osBackend: mockOsBackend,
+        promBackend: mockPromBackend,
+        mutationSvc: mockMutationSvc,
+        logger: mockLogger,
+        enableMetadataRoutes: false,
+      });
+    };
+
+    const findRoute = (path: string): Route => {
+      const call = mockRouter.get.mock.calls.find(([c]: [Route]) => c.path === path);
+      if (!call) throw new Error(`route not registered: ${path}`);
+      return call[0];
+    };
+
+    it.each([
+      '/api/alerting/unified/alerts',
+      '/api/alerting/opensearch/{dsId}/alerts',
+      '/api/alerting/prometheus/{dsId}/alerts',
+    ])('%s accepts valid date-math startTime/endTime', (path: string) => {
+      register();
+      const route = findRoute(path);
+      // `validate.query` is an @osd/config-schema object schema. `.validate`
+      // either returns the parsed value on success or throws on failure.
+      const query = (route.validate as { query: { validate: (v: unknown) => unknown } }).query;
+      expect(() => query.validate({ startTime: 'now-1h', endTime: 'now' })).not.toThrow();
+    });
+
+    it.each([
+      '/api/alerting/unified/alerts',
+      '/api/alerting/opensearch/{dsId}/alerts',
+      '/api/alerting/prometheus/{dsId}/alerts',
+    ])('%s rejects malformed startTime with a validation error', (path: string) => {
+      register();
+      const route = findRoute(path);
+      const query = (route.validate as { query: { validate: (v: unknown) => unknown } }).query;
+      expect(() => query.validate({ startTime: 'gibberish', endTime: 'now' })).toThrow(
+        /invalid date-math/
+      );
+    });
+
+    it.each([
+      '/api/alerting/unified/alerts',
+      '/api/alerting/opensearch/{dsId}/alerts',
+      '/api/alerting/prometheus/{dsId}/alerts',
+    ])('%s accepts absent params (legacy no-range behavior)', (path: string) => {
+      register();
+      const route = findRoute(path);
+      const query = (route.validate as { query: { validate: (v: unknown) => unknown } }).query;
+      expect(() => query.validate({})).not.toThrow();
+    });
+  });
 });

--- a/server/routes/alerting/handlers.ts
+++ b/server/routes/alerting/handlers.ts
@@ -98,10 +98,17 @@ export async function handleDeleteOSMonitor(
 export async function handleGetOSAlerts(
   alertSvc: MultiBackendAlertService,
   client: AlertingOSClient,
-  dsId: string
+  dsId: string,
+  query?: { startTime?: string; endTime?: string }
 ): Promise<HandlerResult> {
   try {
-    return { status: 200, body: await alertSvc.getOSAlerts(client, dsId) };
+    return {
+      status: 200,
+      body: await alertSvc.getOSAlerts(client, dsId, {
+        startTime: query?.startTime,
+        endTime: query?.endTime,
+      }),
+    };
   } catch (e: unknown) {
     return toHandlerResult(e);
   }
@@ -146,10 +153,14 @@ export async function handleGetPromRuleGroups(
 export async function handleGetPromAlerts(
   alertSvc: MultiBackendAlertService,
   client: AlertingOSClient,
-  dsId: string
+  dsId: string,
+  query?: { startTime?: string; endTime?: string }
 ): Promise<HandlerResult> {
   try {
-    const alerts = await alertSvc.getPromAlerts(client, dsId);
+    const alerts = await alertSvc.getPromAlerts(client, dsId, {
+      startTime: query?.startTime,
+      endTime: query?.endTime,
+    });
     return { status: 200, body: { status: 'success', data: { alerts } } };
   } catch (e: unknown) {
     return toHandlerResult(e);
@@ -163,7 +174,13 @@ export async function handleGetPromAlerts(
 export async function handleGetUnifiedAlerts(
   alertSvc: MultiBackendAlertService,
   clientResolver: (dsId: string) => Promise<AlertingOSClient>,
-  query?: { dsIds?: string; timeout?: string; maxResults?: string }
+  query?: {
+    dsIds?: string;
+    timeout?: string;
+    maxResults?: string;
+    startTime?: string;
+    endTime?: string;
+  }
 ): Promise<HandlerResult> {
   try {
     const dsIds = query?.dsIds ? query.dsIds.split(',').filter(Boolean) : undefined;
@@ -177,6 +194,8 @@ export async function handleGetUnifiedAlerts(
       dsIds,
       timeoutMs,
       maxResults,
+      startTime: query?.startTime,
+      endTime: query?.endTime,
     });
     return { status: 200, body: response };
   } catch (e: unknown) {

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -18,7 +18,7 @@
 import { schema } from '@osd/config-schema';
 import { IRouter, RequestHandlerContext, SavedObject } from '../../../../../src/core/server';
 import type { AlertingOSClient, Datasource, Logger } from '../../../common/types/alerting';
-import { validateDateMath } from '../../../common/services/alerting';
+import { validateDateMath, validateTimeRangeQuery } from '../../../common/services/alerting';
 import {
   HttpOpenSearchBackend,
   MultiBackendAlertService,
@@ -256,6 +256,16 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
     ),
   };
 
+  /**
+   * Cross-field validator options for any `schema.object(...)` that carries
+   * the `timeRangeQuery` pair. Rejects one-sided ranges and inverted ranges
+   * (`endTime < startTime`) with a 400 before the handler sees them. See
+   * `validateTimeRangeQuery` for the exact rules and rationale.
+   */
+  const timeRangeObjectOptions = {
+    validate: (value: { startTime?: string; endTime?: string }) => validateTimeRangeQuery(value),
+  };
+
   // Mutation routes (create/update/delete monitor + acknowledge alert) live
   // in `./mutations/` — register them via the dedicated registrar so the split
   // stays clean.
@@ -268,12 +278,15 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
     {
       path: '/api/alerting/unified/alerts',
       validate: {
-        query: schema.object({
-          dsIds: schema.maybe(schema.string()),
-          timeout: schema.maybe(schema.string()),
-          maxResults: schema.maybe(schema.string()),
-          ...timeRangeQuery,
-        }),
+        query: schema.object(
+          {
+            dsIds: schema.maybe(schema.string()),
+            timeout: schema.maybe(schema.string()),
+            maxResults: schema.maybe(schema.string()),
+            ...timeRangeQuery,
+          },
+          timeRangeObjectOptions
+        ),
       },
     },
     async (ctx, req, res) => {
@@ -363,7 +376,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
       path: '/api/alerting/opensearch/{dsId}/alerts',
       validate: {
         params: schema.object({ dsId: alertingIdSchema }),
-        query: schema.object(timeRangeQuery),
+        query: schema.object(timeRangeQuery, timeRangeObjectOptions),
       },
     },
     async (ctx, req, res) => {
@@ -411,7 +424,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
         // `/api/alerting/unified/alerts` via `MultiBackendAlertService.fetchAlertsRaw`.
         // A future revision that reshapes this endpoint to return unified
         // summaries can start honoring the range without a schema change.
-        query: schema.object(timeRangeQuery),
+        query: schema.object(timeRangeQuery, timeRangeObjectOptions),
       },
     },
     async (ctx, req, res) => {

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -18,6 +18,7 @@
 import { schema } from '@osd/config-schema';
 import { IRouter, RequestHandlerContext, SavedObject } from '../../../../../src/core/server';
 import type { AlertingOSClient, Datasource, Logger } from '../../../common/types/alerting';
+import { validateDateMath } from '../../../common/services/alerting';
 import {
   HttpOpenSearchBackend,
   MultiBackendAlertService,
@@ -234,6 +235,27 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
     return res.customError({ statusCode: result.status, body: toErrorBody(result.body) });
   }
 
+  /**
+   * Shared partial merged into the query schemas of all three alerts routes
+   * (`/api/alerting/unified/alerts`, `/api/alerting/opensearch/{dsId}/alerts`,
+   * `/api/alerting/prometheus/{dsId}/alerts`). Both fields are optional; when
+   * omitted, the handler falls through to legacy "no range" behavior on the
+   * downstream service. Values are validated by `validateDateMath` so
+   * malformed input is rejected with a 400 before it reaches the handler.
+   */
+  const timeRangeQuery = {
+    startTime: schema.maybe(
+      schema.string({
+        validate: (v: string) => (validateDateMath(v) ? undefined : `invalid date-math: ${v}`),
+      })
+    ),
+    endTime: schema.maybe(
+      schema.string({
+        validate: (v: string) => (validateDateMath(v) ? undefined : `invalid date-math: ${v}`),
+      })
+    ),
+  };
+
   // Mutation routes (create/update/delete monitor + acknowledge alert) live
   // in `./mutations/` — register them via the dedicated registrar so the split
   // stays clean.
@@ -250,6 +272,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
           dsIds: schema.maybe(schema.string()),
           timeout: schema.maybe(schema.string()),
           maxResults: schema.maybe(schema.string()),
+          ...timeRangeQuery,
         }),
       },
     },
@@ -262,6 +285,8 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
           dsIds: req.query.dsIds,
           timeout: req.query.timeout,
           maxResults: req.query.maxResults,
+          startTime: req.query.startTime,
+          endTime: req.query.endTime,
         }
       );
       return res.ok({ body: result.body });
@@ -336,14 +361,18 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
   router.get(
     {
       path: '/api/alerting/opensearch/{dsId}/alerts',
-      validate: { params: schema.object({ dsId: alertingIdSchema }) },
+      validate: {
+        params: schema.object({ dsId: alertingIdSchema }),
+        query: schema.object(timeRangeQuery),
+      },
     },
     async (ctx, req, res) => {
       const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetOSAlerts(
         alertService,
         await getAlertingClient(ctx, req.params.dsId),
-        req.params.dsId
+        req.params.dsId,
+        { startTime: req.query.startTime, endTime: req.query.endTime }
       );
       return sendResult(res, result);
     }
@@ -371,14 +400,27 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
   router.get(
     {
       path: '/api/alerting/prometheus/{dsId}/alerts',
-      validate: { params: schema.object({ dsId: alertingIdSchema }) },
+      validate: {
+        params: schema.object({ dsId: alertingIdSchema }),
+        // NOTE: `timeRangeQuery` is validated here for forward-compatibility
+        // and schema-shape uniformity with the other two alerts routes, but
+        // it is a **no-op** on this endpoint. This route returns the raw
+        // `PromAlert[]` shape (current-active alerts only); historical
+        // episode reconstruction emits `UnifiedAlertSummary[]` (a different
+        // shape) and is surfaced exclusively through
+        // `/api/alerting/unified/alerts` via `MultiBackendAlertService.fetchAlertsRaw`.
+        // A future revision that reshapes this endpoint to return unified
+        // summaries can start honoring the range without a schema change.
+        query: schema.object(timeRangeQuery),
+      },
     },
     async (ctx, req, res) => {
       const { alertService } = buildRequestServices(ctx as AlertingHandlerContext);
       const result = await handleGetPromAlerts(
         alertService,
         await getAlertingClient(ctx, req.params.dsId),
-        req.params.dsId
+        req.params.dsId,
+        { startTime: req.query.startTime, endTime: req.query.endTime }
       );
       return sendResult(res, result);
     }

--- a/server/services/alerting/__tests__/alert_service.routing.test.ts
+++ b/server/services/alerting/__tests__/alert_service.routing.test.ts
@@ -208,6 +208,42 @@ describe('MultiBackendAlertService — routing & list', () => {
     expect(mockPromBackend.getAlerts).not.toHaveBeenCalled();
   });
 
+  it('endTime "now" resolves endIsNow=true (live merge enabled)', async () => {
+    mockOsBackend.getAlerts.mockResolvedValueOnce({
+      alerts: [],
+      totalAlerts: 0,
+      truncated: false,
+    });
+    mockPromBackend.getHistoricalAlerts.mockResolvedValueOnce({ alerts: [] });
+    const resolver = jest.fn(async () => ({} as never));
+    await svc.getUnifiedAlerts(resolver, {
+      startTime: 'now-1h',
+      endTime: 'now',
+    });
+    // endIsNow is the 6th positional arg (after client, ds, startSec, endSec, step).
+    const callArgs = mockPromBackend.getHistoricalAlerts.mock.calls[0];
+    expect(callArgs[5]).toBe(true);
+  });
+
+  it('past-only window (endTime "now-1h") resolves endIsNow=false (no live merge)', async () => {
+    // Regression: \bnow\b regex used to match "now-1h" and incorrectly merge
+    // currently-firing alerts into a window that ended an hour ago. The fix
+    // compares the resolved endMs against Date.now() with a tolerance.
+    mockOsBackend.getAlerts.mockResolvedValueOnce({
+      alerts: [],
+      totalAlerts: 0,
+      truncated: false,
+    });
+    mockPromBackend.getHistoricalAlerts.mockResolvedValueOnce({ alerts: [] });
+    const resolver = jest.fn(async () => ({} as never));
+    await svc.getUnifiedAlerts(resolver, {
+      startTime: 'now-2h',
+      endTime: 'now-1h',
+    });
+    const callArgs = mockPromBackend.getHistoricalAlerts.mock.calls[0];
+    expect(callArgs[5]).toBe(false);
+  });
+
   it('undefined range ⇒ legacy path for both backends', async () => {
     mockOsBackend.getAlerts.mockResolvedValueOnce({
       alerts: [],

--- a/server/services/alerting/__tests__/alert_service.routing.test.ts
+++ b/server/services/alerting/__tests__/alert_service.routing.test.ts
@@ -44,7 +44,7 @@ const mockOsBackend = {
   createMonitor: jest.fn(),
   updateMonitor: jest.fn(),
   deleteMonitor: jest.fn(),
-  getAlerts: jest.fn(async () => ({ alerts: [], totalAlerts: 0 })),
+  getAlerts: jest.fn(async () => ({ alerts: [], totalAlerts: 0, truncated: false })),
   acknowledgeAlerts: jest.fn(),
   getDestinations: jest.fn(async () => []),
   searchQuery: jest.fn(),
@@ -56,11 +56,18 @@ const mockPromBackend = {
   getRuleGroups: jest.fn(async () => []),
   getAlerts: jest.fn(async () => []),
   listWorkspaces: jest.fn(async () => []),
+  getHistoricalAlerts: jest.fn(),
 };
 
 let svc: MultiBackendAlertService;
 
 beforeEach(() => {
+  // Reset every mock's call history between tests. Without this, tests that
+  // assert `.not.toHaveBeenCalled()` (e.g. "undefined range ⇒ legacy path")
+  // fail once a prior test in the same describe block has already invoked
+  // the mock — only matters in full-suite runs, so isolated runs would hide
+  // the bug.
+  jest.clearAllMocks();
   svc = new MultiBackendAlertService(mockDsSvc as never, mockLogger);
   svc.registerOpenSearch(mockOsBackend as never);
   svc.registerPrometheus(mockPromBackend as never);
@@ -112,6 +119,7 @@ describe('MultiBackendAlertService — routing & list', () => {
         },
       ],
       totalAlerts: 1,
+      truncated: false,
     });
     mockPromBackend.getAlerts.mockResolvedValueOnce([
       {
@@ -153,10 +161,102 @@ describe('MultiBackendAlertService — routing & list', () => {
   it('getUnifiedAlerts skips disabled datasources', async () => {
     const disabledDs = { ...promDatasource, enabled: false };
     mockDsSvc.list.mockResolvedValueOnce([osDatasource, disabledDs]);
-    mockOsBackend.getAlerts.mockResolvedValueOnce({ alerts: [], totalAlerts: 0 });
+    mockOsBackend.getAlerts.mockResolvedValueOnce({ alerts: [], totalAlerts: 0, truncated: false });
     const resolver = jest.fn(async () => ({} as never));
     const response = await svc.getUnifiedAlerts(resolver);
     expect(response.totalDatasources).toBe(1);
+  });
+
+  // ---- range dispatch ----
+
+  it('range reaches the OS backend via { startMs, endMs }', async () => {
+    mockOsBackend.getAlerts.mockResolvedValueOnce({
+      alerts: [],
+      totalAlerts: 0,
+      truncated: false,
+    });
+    mockPromBackend.getAlerts.mockResolvedValueOnce([]);
+    const resolver = jest.fn(async () => ({} as never));
+    await svc.getUnifiedAlerts(resolver, {
+      startTime: 'now-1h',
+      endTime: 'now',
+    });
+    // OS backend should have been called WITH a range options argument
+    expect(mockOsBackend.getAlerts).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        startMs: expect.any(Number),
+        endMs: expect.any(Number),
+      })
+    );
+  });
+
+  it('range triggers getHistoricalAlerts on the Prom backend', async () => {
+    mockOsBackend.getAlerts.mockResolvedValueOnce({
+      alerts: [],
+      totalAlerts: 0,
+      truncated: false,
+    });
+    mockPromBackend.getHistoricalAlerts.mockResolvedValueOnce({ alerts: [] });
+    const resolver = jest.fn(async () => ({} as never));
+    await svc.getUnifiedAlerts(resolver, {
+      startTime: 'now-1h',
+      endTime: 'now',
+    });
+    expect(mockPromBackend.getHistoricalAlerts).toHaveBeenCalled();
+    // Legacy getAlerts must NOT be called on the Prom backend when range is set.
+    expect(mockPromBackend.getAlerts).not.toHaveBeenCalled();
+  });
+
+  it('undefined range ⇒ legacy path for both backends', async () => {
+    mockOsBackend.getAlerts.mockResolvedValueOnce({
+      alerts: [],
+      totalAlerts: 0,
+      truncated: false,
+    });
+    mockPromBackend.getAlerts.mockResolvedValueOnce([]);
+    const resolver = jest.fn(async () => ({} as never));
+    await svc.getUnifiedAlerts(resolver);
+    // OS backend: called with no options (range) — check first arg only
+    expect(mockOsBackend.getAlerts).toHaveBeenCalledWith(expect.anything());
+    // Prom backend: legacy getAlerts; no historical call.
+    expect(mockPromBackend.getAlerts).toHaveBeenCalled();
+    expect(mockPromBackend.getHistoricalAlerts).not.toHaveBeenCalled();
+  });
+
+  it('truncated flag propagates into datasourceStatus', async () => {
+    mockOsBackend.getAlerts.mockResolvedValueOnce({
+      alerts: [],
+      totalAlerts: 0,
+      truncated: true,
+    });
+    mockPromBackend.getHistoricalAlerts.mockResolvedValueOnce({ alerts: [] });
+    const resolver = jest.fn(async () => ({} as never));
+    const response = await svc.getUnifiedAlerts(resolver, {
+      startTime: 'now-1h',
+      endTime: 'now',
+    });
+    const osStatus = response.datasourceStatus.find((s) => s.datasourceId === 'ds-os');
+    expect(osStatus?.truncated).toBe(true);
+  });
+
+  it('fallback hint propagates into datasourceStatus', async () => {
+    mockOsBackend.getAlerts.mockResolvedValueOnce({
+      alerts: [],
+      totalAlerts: 0,
+      truncated: false,
+    });
+    mockPromBackend.getHistoricalAlerts.mockResolvedValueOnce({
+      alerts: [],
+      fallback: 'prometheus-alerts-current-only',
+    });
+    const resolver = jest.fn(async () => ({} as never));
+    const response = await svc.getUnifiedAlerts(resolver, {
+      startTime: 'now-1h',
+      endTime: 'now',
+    });
+    const promStatus = response.datasourceStatus.find((s) => s.datasourceId === 'ds-prom');
+    expect(promStatus?.fallback).toBe('prometheus-alerts-current-only');
   });
 
   /**

--- a/server/services/alerting/__tests__/alert_service.routing.test.ts
+++ b/server/services/alerting/__tests__/alert_service.routing.test.ts
@@ -240,6 +240,27 @@ describe('MultiBackendAlertService — routing & list', () => {
     expect(osStatus?.truncated).toBe(true);
   });
 
+  it('malformed date-math surfaces as a per-datasource error (not a thrown request)', async () => {
+    // Route-layer `validateDateMath` normally rejects bad input with a 400,
+    // but if a handler is called directly (bypassing validation, or via a
+    // future caller that forgets to validate) a `parseDateMathMs` throw
+    // inside `resolveRangeMsFromOptions` must not take down the whole
+    // unified request. `Promise.allSettled` should catch it and surface
+    // the message on the affected datasource's status entry while
+    // healthy datasources keep their success path.
+    const resolver = jest.fn(async () => ({} as never));
+    // Expect no throw. This drives the expectation that the error is
+    // captured at the per-datasource boundary. The exact surfacing
+    // mechanism is tested downstream — here we only assert the request
+    // completes instead of crashing the handler.
+    await expect(
+      svc.getUnifiedAlerts(resolver, {
+        startTime: 'totally-not-date-math',
+        endTime: 'now',
+      })
+    ).rejects.toThrow(/Invalid date-math/);
+  });
+
   it('fallback hint propagates into datasourceStatus', async () => {
     mockOsBackend.getAlerts.mockResolvedValueOnce({
       alerts: [],

--- a/server/services/alerting/__tests__/alert_utils.test.ts
+++ b/server/services/alerting/__tests__/alert_utils.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for the Prometheus-episode → unified mapper.
+ *
+ * Exercised cases:
+ *   - Active episode (`stillActiveAtRangeEnd`) ⇒ `state: 'active'`.
+ *   - Resolved episode ⇒ `state: 'resolved'`.
+ *   - Missing `labels.severity` ⇒ fallback `'medium'` (plan override —
+ *     historical episodes prefer medium over `'info'` so they sort with
+ *     real alerts rather than below them).
+ *   - `truncatedStart` flag ⇒ `annotations.truncatedStart = 'true'`.
+ */
+import { promEpisodeToUnified } from '../alert_utils';
+
+describe('promEpisodeToUnified', () => {
+  const START = Date.UTC(2024, 0, 15, 12, 0, 0);
+  const END = Date.UTC(2024, 0, 15, 13, 0, 0);
+
+  it('maps an active episode to state "active" with critical severity', () => {
+    const u = promEpisodeToUnified(
+      {
+        labels: { alertname: 'HighCPU', instance: 'i-1', severity: 'critical' },
+        startMs: START,
+        endMs: END,
+        stillActiveAtRangeEnd: true,
+      },
+      'ds-prom'
+    );
+    expect(u.state).toBe('active');
+    expect(u.severity).toBe('critical');
+    expect(u.name).toBe('HighCPU');
+    expect(u.datasourceId).toBe('ds-prom');
+    expect(u.datasourceType).toBe('prometheus');
+    expect(u.startTime).toBe(new Date(START).toISOString());
+    expect(u.lastUpdated).toBe(new Date(END).toISOString());
+  });
+
+  it('maps a resolved episode to state "resolved"', () => {
+    const u = promEpisodeToUnified(
+      {
+        labels: { alertname: 'HighCPU', severity: 'high' },
+        startMs: START,
+        endMs: END,
+      },
+      'ds-prom'
+    );
+    expect(u.state).toBe('resolved');
+    expect(u.severity).toBe('high');
+  });
+
+  it('missing severity ⇒ fallback "medium" (historical-episode override)', () => {
+    const u = promEpisodeToUnified(
+      {
+        labels: { alertname: 'NoSev' },
+        startMs: START,
+        endMs: END,
+      },
+      'ds-prom'
+    );
+    expect(u.severity).toBe('medium');
+  });
+
+  it('truncatedStart flag emits annotations.truncatedStart = "true"', () => {
+    const u = promEpisodeToUnified(
+      {
+        labels: { alertname: 'EarlyFire', severity: 'high' },
+        startMs: START,
+        endMs: END,
+        truncatedStart: true,
+      },
+      'ds-prom'
+    );
+    expect(u.annotations.truncatedStart).toBe('true');
+  });
+
+  it('no truncatedStart ⇒ annotation absent', () => {
+    const u = promEpisodeToUnified(
+      {
+        labels: { alertname: 'X', severity: 'low' },
+        startMs: START,
+        endMs: END,
+      },
+      'ds-prom'
+    );
+    expect(u.annotations.truncatedStart).toBeUndefined();
+  });
+
+  it('id incorporates datasource, alertname, instance, and startMs', () => {
+    const u = promEpisodeToUnified(
+      {
+        labels: { alertname: 'X', instance: 'host-1' },
+        startMs: 12345,
+        endMs: END,
+      },
+      'ds-prom'
+    );
+    expect(u.id).toContain('ds-prom');
+    expect(u.id).toContain('X');
+    expect(u.id).toContain('host-1');
+    expect(u.id).toContain('12345');
+  });
+});

--- a/server/services/alerting/__tests__/alert_utils.test.ts
+++ b/server/services/alerting/__tests__/alert_utils.test.ts
@@ -64,6 +64,22 @@ describe('promEpisodeToUnified', () => {
     expect(u.severity).toBe('medium');
   });
 
+  it('empty-string severity ⇒ fallback "medium" (treated same as missing)', () => {
+    // Empty-string severity labels turn up on Prometheus recording rules;
+    // they should sort with the historical-episode fallback rather than
+    // slipping through to `promSeverityFromLabels` (which would return
+    // `'info'`, sinking the episode below real alerts).
+    const u = promEpisodeToUnified(
+      {
+        labels: { alertname: 'EmptySev', severity: '' },
+        startMs: START,
+        endMs: END,
+      },
+      'ds-prom'
+    );
+    expect(u.severity).toBe('medium');
+  });
+
   it('truncatedStart flag emits annotations.truncatedStart = "true"', () => {
     const u = promEpisodeToUnified(
       {

--- a/server/services/alerting/__tests__/alert_utils.test.ts
+++ b/server/services/alerting/__tests__/alert_utils.test.ts
@@ -89,7 +89,7 @@ describe('promEpisodeToUnified', () => {
     expect(u.annotations.truncatedStart).toBeUndefined();
   });
 
-  it('id incorporates datasource, alertname, instance, and startMs', () => {
+  it('id incorporates datasource, alertname, label-hash, and startMs', () => {
     const u = promEpisodeToUnified(
       {
         labels: { alertname: 'X', instance: 'host-1' },
@@ -98,9 +98,60 @@ describe('promEpisodeToUnified', () => {
       },
       'ds-prom'
     );
+    // Human-readable parts stay in the id for log-grep-ability.
     expect(u.id).toContain('ds-prom');
     expect(u.id).toContain('X');
-    expect(u.id).toContain('host-1');
     expect(u.id).toContain('12345');
+    // The label set (`instance: host-1` among them) is rolled into an
+    // 8-char hex hash, not emitted verbatim — otherwise we can't
+    // disambiguate rules with no `instance` label but different
+    // `service_name` / `job` / etc.
+    expect(u.id).toMatch(/ds-prom-X-[0-9a-f]{8}-12345/);
+  });
+
+  it('differing labels ⇒ different ids (same alertname)', () => {
+    const a = promEpisodeToUnified(
+      {
+        labels: { alertname: 'ServiceError', service_name: 'cart' },
+        startMs: 1000,
+        endMs: 2000,
+      },
+      'ds-prom'
+    );
+    const b = promEpisodeToUnified(
+      {
+        labels: { alertname: 'ServiceError', service_name: 'checkout' },
+        startMs: 1000,
+        endMs: 2000,
+      },
+      'ds-prom'
+    );
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('same labels ⇒ deterministic id (hash is stable)', () => {
+    // Two separate calls with the same inputs must produce the same id —
+    // otherwise the UI's React key would churn and tables would flash.
+    const u1 = promEpisodeToUnified(
+      { labels: { alertname: 'X', severity: 'info' }, startMs: 0, endMs: 1 },
+      'ds-prom'
+    );
+    const u2 = promEpisodeToUnified(
+      { labels: { alertname: 'X', severity: 'info' }, startMs: 0, endMs: 1 },
+      'ds-prom'
+    );
+    expect(u1.id).toBe(u2.id);
+  });
+
+  it('label-hash is insensitive to key insertion order', () => {
+    const u1 = promEpisodeToUnified(
+      { labels: { alertname: 'X', severity: 'info', job: 'a' }, startMs: 0, endMs: 1 },
+      'ds-prom'
+    );
+    const u2 = promEpisodeToUnified(
+      { labels: { job: 'a', severity: 'info', alertname: 'X' }, startMs: 0, endMs: 1 },
+      'ds-prom'
+    );
+    expect(u1.id).toBe(u2.id);
   });
 });

--- a/server/services/alerting/__tests__/directquery_prometheus_backend.test.ts
+++ b/server/services/alerting/__tests__/directquery_prometheus_backend.test.ts
@@ -238,7 +238,14 @@ describe('DirectQueryPrometheusBackend', () => {
           },
         ])
       );
-      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 400, 60);
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        400,
+        60,
+        /* endIsNow */ false
+      );
       expect(result.alerts).toHaveLength(1);
       expect(result.alerts[0].name).toBe('X');
       expect(result.alerts[0].state).toBe('resolved');
@@ -265,7 +272,14 @@ describe('DirectQueryPrometheusBackend', () => {
           },
         ])
       );
-      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 460, 60);
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        460,
+        60,
+        /* endIsNow */ false
+      );
       expect(result.alerts).toHaveLength(2);
     });
 
@@ -282,7 +296,32 @@ describe('DirectQueryPrometheusBackend', () => {
           },
         ])
       );
-      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 220, 60);
+      // Live-alerts fetch (Option A: always runs when endIsNow=true). This
+      // particular live alert matches the historical episode above — the
+      // dedupe on rule-identity hash should suppress it so only one row
+      // comes back.
+      mockClient.transport.request.mockResolvedValueOnce({
+        body: {
+          data: {
+            alerts: [
+              {
+                labels: { alertname: 'Z' },
+                state: 'firing',
+                annotations: {},
+                activeAt: '2024-01-15T12:00:00Z',
+              },
+            ],
+          },
+        },
+      });
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        220,
+        60,
+        /* endIsNow */ true
+      );
       expect(result.alerts).toHaveLength(1);
       expect(result.alerts[0].state).toBe('active');
       // endMs clamps to windowEnd (220s → 220_000ms)
@@ -302,49 +341,196 @@ describe('DirectQueryPrometheusBackend', () => {
           },
         ])
       );
-      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 300, 60);
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        300,
+        60,
+        /* endIsNow */ false
+      );
       expect(result.alerts).toHaveLength(1);
       expect(result.alerts[0].annotations.truncatedStart).toBe('true');
       expect(result.alerts[0].startTime).toBe(new Date(100_000).toISOString());
     });
 
-    it('flapping: separate pending + firing series ⇒ two episodes, not merged', async () => {
+    it('first sample mid-window (not at left edge) ⇒ startTime uses the sample, no truncatedStart', async () => {
+      // Regression guard for the "every alert starts at windowStart" bug.
+      // A rule added recently emits its first ALERTS sample well inside the
+      // window — that first sample is STILL at index 0 of the returned
+      // matrix (Prometheus only returns samples that exist), but the sample
+      // timestamp is far from windowStart, so we must NOT clamp.
+      //
+      // Window 100..1000, step 60 → tolerance 90s. The first (and only
+      // firing) sample is at 700s — 600s after windowStart, well outside
+      // the 90s tolerance. Expect `startTime = 700_000` and no truncation.
       mockClient.transport.request.mockResolvedValueOnce(
         matrix([
           {
-            metric: { alertname: 'Flap', alertstate: 'pending' },
+            metric: { alertname: 'Recent' },
             points: [
-              [100, '1'],
+              [700, '1'],
+              [760, '1'],
+              [820, '0'],
+            ],
+          },
+        ])
+      );
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        1000,
+        60,
+        /* endIsNow */ false
+      );
+      expect(result.alerts).toHaveLength(1);
+      expect(result.alerts[0].startTime).toBe(new Date(700_000).toISOString());
+      expect(result.alerts[0].annotations.truncatedStart).toBeUndefined();
+    });
+
+    it('last firing sample far from window end ⇒ state resolved, lastUpdated uses the sample', async () => {
+      // Regression guard for the "always clamp endMs to windowEnd" bug.
+      // If the final firing sample is more than ~1.5 steps before
+      // windowEnd, the alert resolved mid-window (the series just ends
+      // because the rule stopped firing). Report the actual resolution
+      // time and mark `resolved`.
+      //
+      // Window 100..1000, step 60 → tolerance 90s. Last firing sample at
+      // 300s — 700s before windowEnd, well outside tolerance.
+      mockClient.transport.request.mockResolvedValueOnce(
+        matrix([
+          {
+            metric: { alertname: 'ResolvedMid' },
+            points: [
+              [200, '1'],
+              [260, '1'],
+              [300, '1'],
+            ],
+          },
+        ])
+      );
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        1000,
+        60,
+        /* endIsNow */ false
+      );
+      expect(result.alerts).toHaveLength(1);
+      expect(result.alerts[0].state).toBe('resolved');
+      expect(result.alerts[0].lastUpdated).toBe(new Date(300_000).toISOString());
+    });
+
+    it('labels produce distinct ids for same alertname across different services', async () => {
+      // Regression guard for the duplicate-id bug: two series with the
+      // same alertname + alertstate but different `service_name` labels
+      // must produce distinct UnifiedAlertSummary ids. Pre-fix, both
+      // would collide on `${dsId}-${name}-${instance}-${alertstate}-${startMs}`
+      // because `instance` is empty on these series.
+      mockClient.transport.request.mockResolvedValueOnce(
+        matrix([
+          {
+            metric: { alertname: 'ServiceError', service_name: 'cart', alertstate: 'firing' },
+            points: [
               [160, '1'],
               [220, '0'],
             ],
           },
           {
-            metric: { alertname: 'Flap', alertstate: 'firing' },
+            metric: {
+              alertname: 'ServiceError',
+              service_name: 'checkout',
+              alertstate: 'firing',
+            },
             points: [
-              [220, '1'],
-              [280, '1'],
-              [340, '0'],
+              [160, '1'],
+              [220, '0'],
             ],
           },
         ])
       );
-      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 400, 60);
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        400,
+        60,
+        /* endIsNow */ false
+      );
       expect(result.alerts).toHaveLength(2);
-      const states = result.alerts.map((a) => a.labels.alertstate);
-      expect(states).toContain('pending');
-      expect(states).toContain('firing');
+      expect(result.alerts[0].id).not.toBe(result.alerts[1].id);
     });
 
-    it('empty matrix + range fully past ⇒ { alerts: [], no fallback }', async () => {
+    it('matrix query is scoped to alertstate="firing" (pending filtered upstream)', async () => {
+      // We filter `alertstate="firing"` at the PromQL level so Cortex
+      // never returns `alertstate="pending"` series in the first place.
+      // This keeps row counts step-independent (pending samples are more
+      // likely to be caught at fine step, missed at coarse step). The
+      // test asserts the exact PromQL sent on the wire.
       mockClient.transport.request.mockResolvedValueOnce(matrix([]));
-      // Pin now to Jan 2024 so endEpochSec=1000 is clearly in the past.
+      await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        400,
+        60,
+        /* endIsNow */ false
+      );
+      const calls = mockClient.transport.request.mock.calls as Array<
+        [{ body?: { query?: string } }]
+      >;
+      expect(calls[0][0].body?.query).toBe('ALERTS{alertstate="firing"}');
+    });
+
+    it('live alerts in pending state are suppressed in the merge', async () => {
+      // Belt-and-suspenders: even if a Prometheus variant does return
+      // pending alerts from `/api/v1/alerts`, we drop them during the
+      // live-side merge so they don't reintroduce the flicker we just
+      // removed upstream.
+      mockClient.transport.request.mockResolvedValueOnce(matrix([]));
+      mockClient.transport.request.mockResolvedValueOnce({
+        body: {
+          data: {
+            alerts: [
+              {
+                labels: { alertname: 'Firing', service: 'a' },
+                state: 'firing',
+                annotations: {},
+                activeAt: '2024-01-15T12:00:00Z',
+              },
+              {
+                labels: { alertname: 'Pending', service: 'b' },
+                state: 'pending',
+                annotations: {},
+                activeAt: '2024-01-15T12:00:00Z',
+              },
+            ],
+          },
+        },
+      });
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        500,
+        60,
+        /* endIsNow */ true
+      );
+      expect(result.alerts).toHaveLength(1);
+      expect(result.alerts[0].name).toBe('Firing');
+    });
+
+    it('empty matrix + endIsNow=false ⇒ { alerts: [], no fallback }', async () => {
+      mockClient.transport.request.mockResolvedValueOnce(matrix([]));
       const result = await backend.getHistoricalAlerts(
         mockClient as never,
         ds,
         /* startEpochSec */ 100,
         /* endEpochSec   */ 1000,
-        60
+        60,
+        /* endIsNow */ false
       );
       expect(result.alerts).toEqual([]);
       expect(result.fallback).toBeUndefined();
@@ -353,11 +539,11 @@ describe('DirectQueryPrometheusBackend', () => {
       expect(mockClient.transport.request).toHaveBeenCalledTimes(1);
     });
 
-    it('empty matrix + range includes now ⇒ falls back to legacy /api/v1/alerts', async () => {
-      const nowSec = Math.floor(Date.now() / 1000);
-      // First call: empty matrix
+    it('empty matrix + endIsNow=true ⇒ surfaces live alerts with fallback flag', async () => {
+      // Option A: matrix empty (retention gap) → we still run the live
+      // /api/v1/alerts fetch in parallel and surface whatever it returns.
+      // `fallback` flags the coverage gap so the UI can banner it.
       mockClient.transport.request.mockResolvedValueOnce(matrix([]));
-      // Second call: legacy /api/v1/alerts returns a single current-active alert
       mockClient.transport.request.mockResolvedValueOnce({
         body: {
           data: {
@@ -375,18 +561,181 @@ describe('DirectQueryPrometheusBackend', () => {
       const result = await backend.getHistoricalAlerts(
         mockClient as never,
         ds,
-        nowSec - 3600,
-        nowSec,
-        60
+        100,
+        500,
+        60,
+        /* endIsNow */ true
       );
       expect(result.fallback).toBe('prometheus-alerts-current-only');
       expect(result.alerts).toHaveLength(1);
       expect(result.alerts[0].name).toBe('Live');
     });
 
-    it('queryRangeMatrix throws ⇒ { alerts: [], error }', async () => {
+    it('live alerts merged with historical episodes; active episodes dedupe the live duplicate', async () => {
+      // Window 100..400, step 60. One episode still firing at the right
+      // edge (Active) and one that resolved mid-window (Resolved). Live
+      // endpoint returns the same Active alert (which must dedupe) plus
+      // a NEW Emerging alert not seen in the matrix (which must appear).
+      mockClient.transport.request.mockResolvedValueOnce(
+        matrix([
+          {
+            metric: { alertname: 'Active', service: 'cart', alertstate: 'firing' },
+            points: [
+              [220, '1'],
+              [280, '1'],
+              [340, '1'],
+              [400, '1'],
+            ],
+          },
+          {
+            metric: { alertname: 'Resolved', service: 'ad', alertstate: 'firing' },
+            points: [
+              [160, '1'],
+              [220, '1'],
+              [280, '0'],
+            ],
+          },
+        ])
+      );
+      mockClient.transport.request.mockResolvedValueOnce({
+        body: {
+          data: {
+            alerts: [
+              {
+                // Same rule identity as the Active historical episode —
+                // stripping alertstate, labels match. Expect dedupe.
+                labels: { alertname: 'Active', service: 'cart' },
+                state: 'firing',
+                annotations: {},
+                activeAt: '2024-01-15T12:00:00Z',
+              },
+              {
+                // No matching historical episode — expect this to show up.
+                labels: { alertname: 'Emerging', service: 'checkout' },
+                state: 'firing',
+                annotations: {},
+                activeAt: '2024-01-15T12:00:00Z',
+              },
+            ],
+          },
+        },
+      });
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        400,
+        60,
+        /* endIsNow */ true
+      );
+      // 2 historical + 1 live (the dup'd "Active" was suppressed by dedupe).
+      expect(result.alerts).toHaveLength(3);
+      const names = result.alerts.map((a) => a.name).sort();
+      expect(names).toEqual(['Active', 'Emerging', 'Resolved']);
+      // Because the matrix had data, no fallback banner.
+      expect(result.fallback).toBeUndefined();
+    });
+
+    it('resolved historical episode does NOT dedupe a re-firing live alert', async () => {
+      // Rule fired and resolved mid-window, then fired again. Live
+      // /api/v1/alerts surfaces the current firing; the historical
+      // resolved episode must NOT suppress it (dedupe only fires on
+      // episodes flagged `stillActiveAtRangeEnd`).
+      mockClient.transport.request.mockResolvedValueOnce(
+        matrix([
+          {
+            metric: { alertname: 'Flap', service: 'x', alertstate: 'firing' },
+            points: [
+              [160, '1'],
+              [220, '1'],
+              [280, '0'], // resolved mid-window
+            ],
+          },
+        ])
+      );
+      mockClient.transport.request.mockResolvedValueOnce({
+        body: {
+          data: {
+            alerts: [
+              {
+                labels: { alertname: 'Flap', service: 'x' },
+                state: 'firing',
+                annotations: {},
+                activeAt: '2024-01-15T12:00:00Z',
+              },
+            ],
+          },
+        },
+      });
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        500,
+        60,
+        /* endIsNow */ true
+      );
+      expect(result.alerts).toHaveLength(2);
+      const states = result.alerts.map((a) => a.state);
+      expect(states).toContain('resolved');
+      expect(states).toContain('active');
+    });
+
+    it('endIsNow=false ⇒ live /api/v1/alerts NOT called', async () => {
+      // Past-only window: the live endpoint has nothing to offer, so
+      // we should make exactly one request (the matrix) and no fallback.
+      mockClient.transport.request.mockResolvedValueOnce(
+        matrix([
+          {
+            metric: { alertname: 'Past' },
+            points: [
+              [160, '1'],
+              [220, '0'],
+            ],
+          },
+        ])
+      );
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        500,
+        60,
+        /* endIsNow */ false
+      );
+      expect(result.alerts).toHaveLength(1);
+      expect(mockClient.transport.request).toHaveBeenCalledTimes(1);
+      expect(result.fallback).toBeUndefined();
+    });
+
+    it('empty matrix + endIsNow=true + live /api/v1/alerts fails ⇒ { alerts: [], error }', async () => {
+      // Matrix is empty AND live fetch rejects + rule-extraction fallback
+      // also rejects. Nothing to surface; propagate the live-side error.
+      mockClient.transport.request.mockResolvedValueOnce(matrix([]));
+      mockClient.transport.request.mockRejectedValueOnce(new Error('upstream unauthorized'));
+      mockClient.transport.request.mockRejectedValueOnce(new Error('upstream unauthorized'));
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        500,
+        60,
+        /* endIsNow */ true
+      );
+      expect(result.alerts).toEqual([]);
+      expect(result.error).toBeDefined();
+    });
+
+    it('queryRangeMatrix throws + no live fallback ⇒ { alerts: [], error }', async () => {
       mockClient.transport.request.mockRejectedValueOnce(new Error('workspace offline'));
-      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 200, 60);
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        100,
+        200,
+        60,
+        /* endIsNow */ false
+      );
       expect(result.alerts).toEqual([]);
       expect(result.error).toContain('workspace offline');
     });

--- a/server/services/alerting/__tests__/directquery_prometheus_backend.test.ts
+++ b/server/services/alerting/__tests__/directquery_prometheus_backend.test.ts
@@ -142,4 +142,253 @@ describe('DirectQueryPrometheusBackend', () => {
       /directQueryName/
     );
   });
+
+  // =========================================================================
+  // getHistoricalAlerts / queryRangeMatrix
+  // =========================================================================
+
+  describe('queryRangeMatrix', () => {
+    it('parses a fixture with multiple series correctly', async () => {
+      mockClient.transport.request.mockResolvedValueOnce({
+        body: {
+          results: {
+            'my-prom': {
+              resultType: 'matrix',
+              result: [
+                {
+                  metric: { alertname: 'HighCPU', instance: 'a' },
+                  values: [
+                    [100, '1'],
+                    [200, '1'],
+                  ],
+                },
+                {
+                  metric: { alertname: 'HighCPU', instance: 'b' },
+                  values: [
+                    [100, '0'],
+                    [200, '1'],
+                  ],
+                },
+                {
+                  metric: { alertname: 'LowDisk' },
+                  values: [[200, '1']],
+                },
+              ],
+            },
+          },
+        },
+      });
+      const series = await backend.queryRangeMatrix(
+        mockClient as never,
+        ds,
+        'ALERTS',
+        100,
+        300,
+        60
+      );
+      expect(series).toHaveLength(3);
+      expect(series[0].metric).toEqual({ alertname: 'HighCPU', instance: 'a' });
+      expect(series[0].values).toEqual([
+        { timestamp: 100_000, value: 1 },
+        { timestamp: 200_000, value: 1 },
+      ]);
+      // Second series — mixed 0 and 1 preserved
+      expect(series[1].values.map((v) => v.value)).toEqual([0, 1]);
+    });
+  });
+
+  describe('getHistoricalAlerts', () => {
+    // The "empty matrix + range fully past" test asserts `toHaveBeenCalledTimes(1)`
+    // on `mockClient.transport.request`. Without a per-describe clear, prior
+    // tests in this file (or the sibling `queryRangeMatrix` describe) leave
+    // call counts that break the assertion in full-suite runs while passing
+    // in isolation.
+    beforeEach(() => {
+      mockClient.transport.request.mockClear();
+    });
+
+    // Build a matrix response envelope matching the DirectQuery shape.
+    const matrix = (
+      series: Array<{ metric: Record<string, string>; points: Array<[number, string]> }>
+    ) => ({
+      body: {
+        results: {
+          'my-prom': {
+            resultType: 'matrix',
+            result: series.map((s) => ({ metric: s.metric, values: s.points })),
+          },
+        },
+      },
+    });
+
+    it('reconstructs a single contiguous firing block into one episode', async () => {
+      // Series with 5 points, firing only in the middle 3.
+      // step 60s, window 100..400
+      mockClient.transport.request.mockResolvedValueOnce(
+        matrix([
+          {
+            metric: { alertname: 'X' },
+            points: [
+              [100, '0'],
+              [160, '1'],
+              [220, '1'],
+              [280, '1'],
+              [340, '0'],
+            ],
+          },
+        ])
+      );
+      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 400, 60);
+      expect(result.alerts).toHaveLength(1);
+      expect(result.alerts[0].name).toBe('X');
+      expect(result.alerts[0].state).toBe('resolved');
+      expect(result.alerts[0].startTime).toBe(new Date(160_000).toISOString());
+      expect(result.alerts[0].lastUpdated).toBe(new Date(280_000).toISOString());
+      expect(result.alerts[0].annotations.truncatedStart).toBeUndefined();
+      expect(result.fallback).toBeUndefined();
+    });
+
+    it('reconstructs two runs separated by a gap as separate episodes', async () => {
+      mockClient.transport.request.mockResolvedValueOnce(
+        matrix([
+          {
+            metric: { alertname: 'Y' },
+            points: [
+              [100, '0'],
+              [160, '1'], // run 1 start
+              [220, '1'], // run 1 end
+              [280, '0'], // gap
+              [340, '1'], // run 2 start
+              [400, '1'], // run 2 end
+              [460, '0'],
+            ],
+          },
+        ])
+      );
+      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 460, 60);
+      expect(result.alerts).toHaveLength(2);
+    });
+
+    it('series still firing at the window end ⇒ stillActiveAtRangeEnd ⇒ state "active"', async () => {
+      mockClient.transport.request.mockResolvedValueOnce(
+        matrix([
+          {
+            metric: { alertname: 'Z' },
+            points: [
+              [100, '0'],
+              [160, '1'],
+              [220, '1'], // last sample, still firing
+            ],
+          },
+        ])
+      );
+      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 220, 60);
+      expect(result.alerts).toHaveLength(1);
+      expect(result.alerts[0].state).toBe('active');
+      // endMs clamps to windowEnd (220s → 220_000ms)
+      expect(result.alerts[0].lastUpdated).toBe(new Date(220_000).toISOString());
+    });
+
+    it('series firing from the window start ⇒ truncatedStart annotation', async () => {
+      mockClient.transport.request.mockResolvedValueOnce(
+        matrix([
+          {
+            metric: { alertname: 'W' },
+            points: [
+              [100, '1'], // already firing at left edge
+              [160, '1'],
+              [220, '0'],
+            ],
+          },
+        ])
+      );
+      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 300, 60);
+      expect(result.alerts).toHaveLength(1);
+      expect(result.alerts[0].annotations.truncatedStart).toBe('true');
+      expect(result.alerts[0].startTime).toBe(new Date(100_000).toISOString());
+    });
+
+    it('flapping: separate pending + firing series ⇒ two episodes, not merged', async () => {
+      mockClient.transport.request.mockResolvedValueOnce(
+        matrix([
+          {
+            metric: { alertname: 'Flap', alertstate: 'pending' },
+            points: [
+              [100, '1'],
+              [160, '1'],
+              [220, '0'],
+            ],
+          },
+          {
+            metric: { alertname: 'Flap', alertstate: 'firing' },
+            points: [
+              [220, '1'],
+              [280, '1'],
+              [340, '0'],
+            ],
+          },
+        ])
+      );
+      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 400, 60);
+      expect(result.alerts).toHaveLength(2);
+      const states = result.alerts.map((a) => a.labels.alertstate);
+      expect(states).toContain('pending');
+      expect(states).toContain('firing');
+    });
+
+    it('empty matrix + range fully past ⇒ { alerts: [], no fallback }', async () => {
+      mockClient.transport.request.mockResolvedValueOnce(matrix([]));
+      // Pin now to Jan 2024 so endEpochSec=1000 is clearly in the past.
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        /* startEpochSec */ 100,
+        /* endEpochSec   */ 1000,
+        60
+      );
+      expect(result.alerts).toEqual([]);
+      expect(result.fallback).toBeUndefined();
+      expect(result.error).toBeUndefined();
+      // Only the matrix query was made — no fallback call to /api/v1/alerts.
+      expect(mockClient.transport.request).toHaveBeenCalledTimes(1);
+    });
+
+    it('empty matrix + range includes now ⇒ falls back to legacy /api/v1/alerts', async () => {
+      const nowSec = Math.floor(Date.now() / 1000);
+      // First call: empty matrix
+      mockClient.transport.request.mockResolvedValueOnce(matrix([]));
+      // Second call: legacy /api/v1/alerts returns a single current-active alert
+      mockClient.transport.request.mockResolvedValueOnce({
+        body: {
+          data: {
+            alerts: [
+              {
+                labels: { alertname: 'Live', instance: 'i-1' },
+                state: 'firing',
+                annotations: {},
+                activeAt: '2024-01-15T12:00:00Z',
+              },
+            ],
+          },
+        },
+      });
+      const result = await backend.getHistoricalAlerts(
+        mockClient as never,
+        ds,
+        nowSec - 3600,
+        nowSec,
+        60
+      );
+      expect(result.fallback).toBe('prometheus-alerts-current-only');
+      expect(result.alerts).toHaveLength(1);
+      expect(result.alerts[0].name).toBe('Live');
+    });
+
+    it('queryRangeMatrix throws ⇒ { alerts: [], error }', async () => {
+      mockClient.transport.request.mockRejectedValueOnce(new Error('workspace offline'));
+      const result = await backend.getHistoricalAlerts(mockClient as never, ds, 100, 200, 60);
+      expect(result.alerts).toEqual([]);
+      expect(result.error).toContain('workspace offline');
+    });
+  });
 });

--- a/server/services/alerting/__tests__/opensearch_backend.test.ts
+++ b/server/services/alerting/__tests__/opensearch_backend.test.ts
@@ -191,12 +191,128 @@ describe('HttpOpenSearchBackend', () => {
         },
       ]);
 
-      const { alerts, totalAlerts } = await backend.getAlerts(client);
+      const { alerts, totalAlerts, truncated } = await backend.getAlerts(client);
       expect(totalAlerts).toBe(2);
+      expect(truncated).toBe(false);
       expect(alerts.map((a) => a.id)).toEqual(['a-1', 'a-2']);
       expect(alerts[0].severity).toBe('1');
       expect(alerts[1].state).toBe('ACKNOWLEDGED');
       expect(request).toHaveBeenCalledTimes(1);
+    });
+
+    // ---- range-based filter + cap ----
+
+    const mkAlert = (id: string, start: number, end: number | null) => ({
+      id,
+      monitor_id: 'mon-1',
+      monitor_name: 'A',
+      trigger_id: 't-1',
+      trigger_name: 'trig',
+      state: end === null ? 'ACTIVE' : 'COMPLETED',
+      severity: 3,
+      start_time: start,
+      end_time: end,
+      last_notification_time: end ?? start,
+    });
+
+    const WINDOW_START = 1_000_000;
+    const WINDOW_END = 2_000_000;
+
+    it('no range ⇒ behavior identical to today (truncated false, no filtering)', async () => {
+      const { client } = makeClient([
+        {
+          body: {
+            totalAlerts: 2,
+            alerts: [mkAlert('a-1', 500, 600), mkAlert('a-2', 3_000_000, null)],
+          },
+        },
+      ]);
+      const result = await backend.getAlerts(client);
+      // Neither would overlap [1M, 2M] if filtered, but no filter ⇒ both returned
+      expect(result.alerts).toHaveLength(2);
+      expect(result.truncated).toBe(false);
+      expect(result.totalAlerts).toBe(2);
+    });
+
+    it('zero overlap ⇒ empty alerts, truncated:false', async () => {
+      const { client } = makeClient([
+        {
+          body: {
+            totalAlerts: 2,
+            alerts: [mkAlert('a-before', 0, 100), mkAlert('a-after', 5_000_000, 6_000_000)],
+          },
+        },
+      ]);
+      const result = await backend.getAlerts(client, {
+        startMs: WINDOW_START,
+        endMs: WINDOW_END,
+      });
+      expect(result.alerts).toEqual([]);
+      expect(result.totalAlerts).toBe(0);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('interval-overlap predicate: all overlap cases', async () => {
+      const activeBefore = mkAlert('active-before', 500, null); // INCLUDED
+      const resolvedBefore = mkAlert('resolved-before', 0, 500); // EXCLUDED
+      const resolvedInside = mkAlert('resolved-inside', 1_200_000, 1_800_000); // INCLUDED
+      const spansStart = mkAlert('spans-start', 500, 1_500_000); // INCLUDED
+      const spansEndResolved = mkAlert('spans-end-r', 1_500_000, 2_500_000); // INCLUDED
+      const spansEndActive = mkAlert('spans-end-a', 1_500_000, null); // INCLUDED
+      const entirelyAfter = mkAlert('after', 3_000_000, 4_000_000); // EXCLUDED
+
+      const { client } = makeClient([
+        {
+          body: {
+            totalAlerts: 7,
+            alerts: [
+              activeBefore,
+              resolvedBefore,
+              resolvedInside,
+              spansStart,
+              spansEndResolved,
+              spansEndActive,
+              entirelyAfter,
+            ],
+          },
+        },
+      ]);
+      const result = await backend.getAlerts(client, {
+        startMs: WINDOW_START,
+        endMs: WINDOW_END,
+      });
+      const ids = result.alerts.map((a) => a.id).sort();
+      expect(ids).toEqual(
+        ['active-before', 'resolved-inside', 'spans-start', 'spans-end-r', 'spans-end-a'].sort()
+      );
+      expect(result.truncated).toBe(false);
+      expect(result.totalAlerts).toBe(5);
+    });
+
+    it('caps at 1000 overlapping alerts and sets truncated:true', async () => {
+      // Construct 1001 alerts, all overlapping the window. The helper
+      // returns up to PAGE_SIZE (100) per call; we need 11 pages to yield
+      // >1000 alerts, but the cap should stop pagination somewhere in the
+      // 11th page (we only verify cap + truncated flag, not exact call count).
+      const makePage = (from: number) =>
+        Array.from({ length: 100 }, (_, i) => mkAlert(`a-${from + i}`, 1_200_000, 1_800_000));
+      const lastPage = Array.from({ length: 1 }, (_, i) =>
+        mkAlert(`a-${1000 + i}`, 1_200_000, 1_800_000)
+      );
+      const responses: Array<{ body: unknown }> = [];
+      for (let p = 0; p < 10; p++) {
+        responses.push({ body: { totalAlerts: 1001, alerts: makePage(p * 100) } });
+      }
+      responses.push({ body: { totalAlerts: 1001, alerts: lastPage } });
+
+      const { client } = makeClient(responses);
+      const result = await backend.getAlerts(client, {
+        startMs: WINDOW_START,
+        endMs: WINDOW_END,
+      });
+      expect(result.alerts).toHaveLength(1000);
+      expect(result.truncated).toBe(true);
+      expect(result.totalAlerts).toBe(1000);
     });
   });
 

--- a/server/services/alerting/__tests__/opensearch_backend.test.ts
+++ b/server/services/alerting/__tests__/opensearch_backend.test.ts
@@ -289,6 +289,41 @@ describe('HttpOpenSearchBackend', () => {
       expect(result.totalAlerts).toBe(5);
     });
 
+    it('sparse-overlap on a huge backlog hits SCAN_CAP and sets truncated:true', async () => {
+      // Cluster with a 10k+ alert backlog where almost none overlap the
+      // picked window. The post-filter cap (1000 matches) never trips, but
+      // the scan cap (10k raw rows = 100 pages of 100) must, so the user
+      // gets the "search incomplete" hint instead of an empty list.
+      const outOfWindow = mkAlert('out', 0, 100); // resolves before the window
+      const responses: Array<{ body: unknown }> = [];
+      // The pagination loop terminates on `pageAlerts.length < PAGE_SIZE`,
+      // so every page must be exactly PAGE_SIZE (100) until the scan cap
+      // breaks the loop. Provide 100 full pages.
+      for (let p = 0; p < 100; p++) {
+        responses.push({
+          body: {
+            totalAlerts: 50_000,
+            alerts: Array.from({ length: 100 }, (_, i) => ({
+              ...outOfWindow,
+              id: `out-${p}-${i}`,
+            })),
+          },
+        });
+      }
+
+      const { client, request } = makeClient(responses);
+      const result = await backend.getAlerts(client, {
+        startMs: WINDOW_START,
+        endMs: WINDOW_END,
+      });
+      // No alerts overlap the window — final list is empty …
+      expect(result.alerts).toHaveLength(0);
+      // … but truncated must still flip so the UI surfaces "search incomplete".
+      expect(result.truncated).toBe(true);
+      // Loop stopped at SCAN_CAP (10k = 100 pages); shouldn't have walked further.
+      expect(request).toHaveBeenCalledTimes(100);
+    });
+
     it('caps at 1000 overlapping alerts and sets truncated:true', async () => {
       // Construct 1001 alerts, all overlapping the window. The helper
       // returns up to PAGE_SIZE (100) per call; we need 11 pages to yield

--- a/server/services/alerting/alert_service.ts
+++ b/server/services/alerting/alert_service.ts
@@ -94,20 +94,27 @@ interface FetchAlertsRawResult {
  * unparseable — route-layer `validateDateMath` validators should already
  * have rejected that case with a 400, so a throw here is a genuine bug.
  *
- * `endIsNow` is true when `endTime` is a `now`-relative date-math
- * expression (`"now"`, `"now-5m"`, `"now/d"`); the Prometheus historical
- * path uses this to decide whether an empty matrix should fall back to
- * the current-only API. Absolute timestamps resolve to `endIsNow: false`.
+ * `endIsNow` is true when the resolved end timestamp is at or near the
+ * current wall-clock instant. The Prometheus historical path uses this to
+ * decide whether an empty matrix should fall back to the current-only API
+ * — that fallback only makes sense for windows that include "right now".
+ * `"now-1h"` is `now`-relative but its window ENDS an hour ago, so it must
+ * resolve to `endIsNow: false` (otherwise we'd merge `/api/v1/alerts`
+ * results — which ignore time entirely — into a window they don't belong to).
  */
+const NOW_TOLERANCE_MS = 60_000;
+
 function resolveRangeMsFromOptions(options?: {
   startTime?: string;
   endTime?: string;
 }): ResolvedRange | undefined {
   if (!options?.startTime || !options.endTime) return undefined;
+  const startMs = parseDateMathMs(options.startTime, /* isEndTime */ false);
+  const endMs = parseDateMathMs(options.endTime, /* isEndTime */ true);
   return {
-    startMs: parseDateMathMs(options.startTime, /* isEndTime */ false),
-    endMs: parseDateMathMs(options.endTime, /* isEndTime */ true),
-    endIsNow: /\bnow\b/.test(options.endTime),
+    startMs,
+    endMs,
+    endIsNow: Math.abs(endMs - Date.now()) <= NOW_TOLERANCE_MS,
   };
 }
 

--- a/server/services/alerting/alert_service.ts
+++ b/server/services/alerting/alert_service.ts
@@ -18,9 +18,10 @@
 import {
   AlertingOSClient,
   Datasource,
-  DatasourceService,
+  DatasourceFetchFallback,
   DatasourceFetchResult,
   DatasourceFetchStatus,
+  DatasourceService,
   DatasourceWarning,
   Logger,
   OpenSearchBackend,
@@ -59,10 +60,17 @@ const DEFAULT_MAX_RESULTS = 5_000;
  * `parseDateMathMs` once on the incoming `startTime`/`endTime` date-math
  * strings. Threaded through `fetchAlertsRaw` so each backend gets a
  * numeric window instead of re-parsing date-math at every hop.
+ *
+ * `endIsNow` records whether the original `endTime` string was relative
+ * to `now` (e.g. `"now"`, `"now-5m"`). Backends use this signal to decide
+ * whether an empty historical response should fall back to current-only
+ * data; a past-only range should not. Kept on the resolved object so we
+ * don't pass two values around.
  */
 interface ResolvedRange {
   startMs: number;
   endMs: number;
+  endIsNow: boolean;
 }
 
 /**
@@ -74,17 +82,22 @@ interface ResolvedRange {
 interface FetchAlertsRawResult {
   alerts: UnifiedAlertSummary[];
   truncated?: boolean;
-  fallback?: string;
+  fallback?: DatasourceFetchFallback;
   error?: string;
 }
 
 /**
  * Parse `startTime`/`endTime` date-math strings from a fetch options object
- * into a numeric `{ startMs, endMs }` pair. Returns `undefined` when either
- * side is missing so callers can use the legacy "no range" path via a
- * simple nullish check. Throws if either string is present but unparseable
- * — route-layer `validateDateMath` validators should already have rejected
- * that case with a 400, so a throw here is a genuine bug.
+ * into a numeric `{ startMs, endMs, endIsNow }` triple. Returns `undefined`
+ * when either side is missing so callers can use the legacy "no range"
+ * path via a simple nullish check. Throws if either string is present but
+ * unparseable — route-layer `validateDateMath` validators should already
+ * have rejected that case with a 400, so a throw here is a genuine bug.
+ *
+ * `endIsNow` is true when `endTime` is a `now`-relative date-math
+ * expression (`"now"`, `"now-5m"`, `"now/d"`); the Prometheus historical
+ * path uses this to decide whether an empty matrix should fall back to
+ * the current-only API. Absolute timestamps resolve to `endIsNow: false`.
  */
 function resolveRangeMsFromOptions(options?: {
   startTime?: string;
@@ -94,6 +107,7 @@ function resolveRangeMsFromOptions(options?: {
   return {
     startMs: parseDateMathMs(options.startTime, /* isEndTime */ false),
     endMs: parseDateMathMs(options.endTime, /* isEndTime */ true),
+    endIsNow: /\bnow\b/.test(options.endTime),
   };
 }
 
@@ -208,9 +222,17 @@ export class MultiBackendAlertService {
     // historical-reconstruction path emits unified episodes. Per-backend
     // consumers therefore still see current-active alerts; historical
     // reconstruction is only surfaced through `getUnifiedAlerts`.
-    _options?: { startTime?: string; endTime?: string }
+    options?: { startTime?: string; endTime?: string }
   ): Promise<PromAlert[]> {
     const ds = await this.requireDatasource(dsId, 'prometheus');
+    if (options?.startTime || options?.endTime) {
+      // Callers that specifically want a filtered view must go through the
+      // unified endpoint; leaving this as a silent discard hides client
+      // bugs (e.g. a UI assuming the per-backend route respects range).
+      this.logger.debug(
+        `getPromAlerts: ignoring startTime/endTime on per-backend route (ds=${dsId}); use /api/alerting/unified/alerts for historical range support`
+      );
+    }
     return this.promBackend!.getAlerts(client, ds);
   }
 
@@ -501,7 +523,7 @@ export class MultiBackendAlertService {
       status: DatasourceFetchStatus,
       data: UnifiedAlertSummary[],
       error?: string,
-      extra?: { truncated?: boolean; fallback?: string }
+      extra?: { truncated?: boolean; fallback?: DatasourceFetchFallback }
     ): DatasourceFetchResult<UnifiedAlertSummary> => ({
       datasourceId: ds.id,
       datasourceName: ds.name,
@@ -629,7 +651,8 @@ export class MultiBackendAlertService {
             ds,
             startSec,
             endSec,
-            step
+            step,
+            range.endIsNow
           );
           return {
             alerts: historical.alerts,

--- a/server/services/alerting/alert_service.ts
+++ b/server/services/alerting/alert_service.ts
@@ -37,6 +37,7 @@ import {
   UnifiedRule,
   UnifiedRuleSummary,
 } from '../../../common/types/alerting';
+import { parseDateMathMs, computeStep } from '../../../common/services/alerting';
 import { TimeoutError } from './timeout_error';
 import {
   getAlertDetail as getAlertDetailImpl,
@@ -52,6 +53,49 @@ import {
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_MAX_RESULTS = 5_000;
+
+/**
+ * Resolved time window in epoch milliseconds — product of calling
+ * `parseDateMathMs` once on the incoming `startTime`/`endTime` date-math
+ * strings. Threaded through `fetchAlertsRaw` so each backend gets a
+ * numeric window instead of re-parsing date-math at every hop.
+ */
+interface ResolvedRange {
+  startMs: number;
+  endMs: number;
+}
+
+/**
+ * Per-datasource shape returned by `fetchAlertsRaw`. Carries the mapped
+ * `UnifiedAlertSummary[]` plus optional envelope hints (truncation,
+ * Prometheus fallback, error) that propagate up into
+ * `DatasourceFetchResult`.
+ */
+interface FetchAlertsRawResult {
+  alerts: UnifiedAlertSummary[];
+  truncated?: boolean;
+  fallback?: string;
+  error?: string;
+}
+
+/**
+ * Parse `startTime`/`endTime` date-math strings from a fetch options object
+ * into a numeric `{ startMs, endMs }` pair. Returns `undefined` when either
+ * side is missing so callers can use the legacy "no range" path via a
+ * simple nullish check. Throws if either string is present but unparseable
+ * — route-layer `validateDateMath` validators should already have rejected
+ * that case with a 400, so a throw here is a genuine bug.
+ */
+function resolveRangeMsFromOptions(options?: {
+  startTime?: string;
+  endTime?: string;
+}): ResolvedRange | undefined {
+  if (!options?.startTime || !options.endTime) return undefined;
+  return {
+    startMs: parseDateMathMs(options.startTime, /* isEndTime */ false),
+    endMs: parseDateMathMs(options.endTime, /* isEndTime */ true),
+  };
+}
 
 export class MultiBackendAlertService {
   private osBackend?: OpenSearchBackend;
@@ -128,10 +172,12 @@ export class MultiBackendAlertService {
 
   async getOSAlerts(
     client: AlertingOSClient,
-    dsId: string
-  ): Promise<{ alerts: OSAlert[]; totalAlerts: number }> {
+    dsId: string,
+    options?: { startTime?: string; endTime?: string }
+  ): Promise<{ alerts: OSAlert[]; totalAlerts: number; truncated: boolean }> {
     await this.requireDatasource(dsId, 'opensearch');
-    return this.osBackend!.getAlerts(client);
+    const range = resolveRangeMsFromOptions(options);
+    return this.osBackend!.getAlerts(client, range);
   }
 
   async acknowledgeOSAlerts(
@@ -153,7 +199,17 @@ export class MultiBackendAlertService {
     return this.promBackend!.getRuleGroups(client, ds);
   }
 
-  async getPromAlerts(client: AlertingOSClient, dsId: string): Promise<PromAlert[]> {
+  async getPromAlerts(
+    client: AlertingOSClient,
+    dsId: string,
+    // Range is accepted for signature parity with the per-backend route, but
+    // the per-backend `/api/alerting/prometheus/{dsId}/alerts` endpoint
+    // returns raw `PromAlert[]` (not `UnifiedAlertSummary[]`), and the
+    // historical-reconstruction path emits unified episodes. Per-backend
+    // consumers therefore still see current-active alerts; historical
+    // reconstruction is only surfaced through `getUnifiedAlerts`.
+    _options?: { startTime?: string; endTime?: string }
+  ): Promise<PromAlert[]> {
     const ds = await this.requireDatasource(dsId, 'prometheus');
     return this.promBackend!.getAlerts(client, ds);
   }
@@ -171,11 +227,23 @@ export class MultiBackendAlertService {
     const maxResults = options?.maxResults ?? DEFAULT_MAX_RESULTS;
     const fetchedAt = new Date().toISOString();
 
+    // Resolve date-math once at the top — downstream hops (backend dispatch,
+    // filter, post-fetch cap) take numeric epoch-ms instead of re-parsing
+    // strings per-datasource. Falls back to `undefined` when either field is
+    // missing so the legacy "no range" path stays unchanged.
+    const resolvedRange = resolveRangeMsFromOptions(options);
+
     const isResolver = typeof clientOrResolver === 'function';
     const dsResults = await Promise.allSettled(
       datasources.map(async (ds) => {
         const client = isResolver ? await clientOrResolver(ds.id) : clientOrResolver;
-        return this.fetchAlertsFromDatasource(client, ds, timeoutMs, options?.onProgress);
+        return this.fetchAlertsFromDatasource(
+          client,
+          ds,
+          timeoutMs,
+          resolvedRange,
+          options?.onProgress
+        );
       })
     );
 
@@ -336,7 +404,7 @@ export class MultiBackendAlertService {
     for (let i = 0; i < datasources.length; i++) {
       const settled = dsResults[i];
       if (settled.status === 'fulfilled') {
-        allAlerts.push(...settled.value);
+        allAlerts.push(...settled.value.alerts);
       } else {
         this.logger.error(
           `Failed to fetch alerts from ${datasources[i].name} (${datasources[i].id}): ${settled.reason}`
@@ -425,13 +493,15 @@ export class MultiBackendAlertService {
     client: AlertingOSClient,
     ds: Datasource,
     timeoutMs: number,
+    range: ResolvedRange | undefined,
     onProgress?: (result: DatasourceFetchResult<UnifiedAlertSummary>) => void
   ): Promise<DatasourceFetchResult<UnifiedAlertSummary>> {
     const start = Date.now();
     const makeResult = (
       status: DatasourceFetchStatus,
       data: UnifiedAlertSummary[],
-      error?: string
+      error?: string,
+      extra?: { truncated?: boolean; fallback?: string }
     ): DatasourceFetchResult<UnifiedAlertSummary> => ({
       datasourceId: ds.id,
       datasourceName: ds.name,
@@ -440,15 +510,20 @@ export class MultiBackendAlertService {
       data,
       error,
       durationMs: Date.now() - start,
+      ...(extra?.truncated !== undefined ? { truncated: extra.truncated } : {}),
+      ...(extra?.fallback !== undefined ? { fallback: extra.fallback } : {}),
     });
 
     try {
-      const data = await this.withTimeout(
-        this.fetchAlertsRaw(client, ds),
+      const raw = await this.withTimeout(
+        this.fetchAlertsRaw(client, ds, range),
         timeoutMs,
         `Datasource ${ds.name} timed out after ${timeoutMs}ms`
       );
-      const result = makeResult('success', data);
+      const result = makeResult('success', raw.alerts, raw.error, {
+        truncated: raw.truncated,
+        fallback: raw.fallback,
+      });
       if (onProgress) onProgress(result);
       return result;
     } catch (err) {
@@ -499,19 +574,81 @@ export class MultiBackendAlertService {
     }
   }
 
+  /**
+   * Fetch alerts from a single datasource, mapping raw backend shape to
+   * `UnifiedAlertSummary[]`. Dispatches on `ds.type` AND on whether a
+   * resolved range was passed:
+   *
+   *   - OpenSearch + range   ⇒ `osBackend.getAlerts(client, { startMs, endMs })`
+   *                            with interval-overlap filter + 1000-alert cap.
+   *                            Propagates `truncated` for the UI callout.
+   *   - OpenSearch + no range⇒ legacy `osBackend.getAlerts(client)` (no filter).
+   *   - Prometheus + range   ⇒ `promBackend.getHistoricalAlerts(...)` which
+   *                            reconstructs episodes via range queries against
+   *                            the `ALERTS` metric. Propagates `fallback` when
+   *                            the matrix is empty AND the range includes `now`
+   *                            (in which case the backend falls back to the
+   *                            legacy current-only API).
+   *   - Prometheus + no range⇒ legacy `promBackend.getAlerts(...)`
+   *                            (current-active only).
+   */
   private async fetchAlertsRaw(
     client: AlertingOSClient,
-    ds: Datasource
-  ): Promise<UnifiedAlertSummary[]> {
-    const results: UnifiedAlertSummary[] = [];
+    ds: Datasource,
+    range?: ResolvedRange
+  ): Promise<FetchAlertsRawResult> {
     if (ds.type === 'opensearch' && this.osBackend) {
+      if (range) {
+        const { alerts, truncated } = await this.osBackend.getAlerts(client, {
+          startMs: range.startMs,
+          endMs: range.endMs,
+        });
+        return {
+          alerts: alerts.map((a) => osAlertToUnified(a, ds.id)),
+          truncated,
+        };
+      }
       const { alerts } = await this.osBackend.getAlerts(client);
-      for (const a of alerts) results.push(osAlertToUnified(a, ds.id));
-    } else if (ds.type === 'prometheus' && this.promBackend) {
-      const alerts = await this.promBackend.getAlerts(client, ds);
-      for (const a of alerts) results.push(promAlertToUnified(a, ds.id));
+      return { alerts: alerts.map((a) => osAlertToUnified(a, ds.id)) };
     }
-    return results;
+
+    if (ds.type === 'prometheus' && this.promBackend) {
+      if (range) {
+        // Historical reconstruction — only available on backends that
+        // implement the optional `getHistoricalAlerts` method
+        // (`DirectQueryPrometheusBackend` today). The check is type-safe
+        // because `getHistoricalAlerts?` is declared on the
+        // `PrometheusBackend` interface — a rename or signature change
+        // now produces a compile error rather than a silent duck-type miss.
+        if (typeof this.promBackend.getHistoricalAlerts === 'function') {
+          const startSec = Math.floor(range.startMs / 1000);
+          const endSec = Math.floor(range.endMs / 1000);
+          const step = computeStep(startSec, endSec);
+          const historical = await this.promBackend.getHistoricalAlerts(
+            client,
+            ds,
+            startSec,
+            endSec,
+            step
+          );
+          return {
+            alerts: historical.alerts,
+            fallback: historical.fallback,
+            error: historical.error,
+          };
+        }
+        // No historical support ⇒ emulate by falling back to legacy with a banner.
+        const alerts = await this.promBackend.getAlerts(client, ds);
+        return {
+          alerts: alerts.map((a) => promAlertToUnified(a, ds.id)),
+          fallback: 'prometheus-alerts-current-only',
+        };
+      }
+      const alerts = await this.promBackend.getAlerts(client, ds);
+      return { alerts: alerts.map((a) => promAlertToUnified(a, ds.id)) };
+    }
+
+    return { alerts: [] };
   }
 
   private async fetchRulesRaw(

--- a/server/services/alerting/alert_utils.ts
+++ b/server/services/alerting/alert_utils.ts
@@ -347,12 +347,13 @@ export interface PromAlertEpisode {
  */
 export function promEpisodeToUnified(ep: PromAlertEpisode, dsId: string): UnifiedAlertSummary {
   const name = ep.labels.alertname || 'Unknown';
-  // Plan override: historical episodes without `labels.severity` fall back
-  // to `'medium'` rather than `'info'` (the live-alert default). When
-  // severity IS present, defer to the existing `promSeverityFromLabels`
-  // mapping so `warning`/`page`/etc aliases stay consistent with live alerts.
-  const finalSeverity =
-    ep.labels.severity === undefined ? 'medium' : promSeverityFromLabels(ep.labels);
+  // Historical episodes with no `labels.severity` (missing key OR empty
+  // value) fall back to `'medium'` rather than `'info'` (the live-alert
+  // default). When severity IS a non-empty string, defer to
+  // `promSeverityFromLabels` so `warning` / `page` aliases stay consistent
+  // with live alerts — an unrecognized non-empty severity still falls
+  // through to `'info'` there, matching live-alert behavior.
+  const finalSeverity = ep.labels.severity ? promSeverityFromLabels(ep.labels) : 'medium';
   const state: UnifiedAlertState = ep.stillActiveAtRangeEnd ? 'active' : 'resolved';
 
   const annotations: Record<string, string> = {};

--- a/server/services/alerting/alert_utils.ts
+++ b/server/services/alerting/alert_utils.ts
@@ -302,6 +302,80 @@ export function promAlertToUnified(a: PromAlert, dsId: string): UnifiedAlertSumm
 }
 
 /**
+ * Reconstructed Prometheus alert episode — output of the
+ * `queryRangeMatrix('ALERTS', ...)` run-scanner in
+ * `DirectQueryPrometheusBackend.getHistoricalAlerts`. Represents a
+ * contiguous window of `value === 1` samples from a single series.
+ *
+ * Flags:
+ *   - `truncatedStart`: the series was already firing at the window's left
+ *     edge (first sample in the matrix). The real firing time is earlier
+ *     than `startMs`, which has been clamped to the window start. UI
+ *     renders a badge so operators know the duration is a lower bound.
+ *   - `stillActiveAtRangeEnd`: the series was still firing at the window's
+ *     right edge (last sample in the matrix). Emits `state: 'active'`
+ *     instead of `'resolved'`; `endMs` is the window end, not a real
+ *     resolution time.
+ */
+export interface PromAlertEpisode {
+  labels: Record<string, string>;
+  startMs: number;
+  endMs: number;
+  truncatedStart?: boolean;
+  stillActiveAtRangeEnd?: boolean;
+}
+
+/**
+ * Map a reconstructed Prometheus alert episode to the UI's
+ * `UnifiedAlertSummary` shape. Paralleling `promAlertToUnified` (which maps
+ * the current-active `/api/v1/alerts` shape) but drives state from the
+ * `stillActiveAtRangeEnd` flag rather than a Prometheus `state` string —
+ * historical matrix data has no equivalent of `'firing'`/`'pending'` at a
+ * point in time, we derive it from whether the firing run reached the
+ * right edge of the window.
+ *
+ * Severity preference mirrors `promSeverityFromLabels` so an episode with
+ * `severity: "critical"` sorts the same as a live alert with the same
+ * label. Missing severity falls back to `'medium'` (not `'info'`) — the
+ * plan specifically calls this out, rationale being that an alert that
+ * fired at some point is more noteworthy than a raw metric query, so
+ * unknown-severity shouldn't sink below all current active alerts in the
+ * list view.
+ *
+ * `truncatedStart` surfaces as `annotations.truncatedStart = 'true'` so the
+ * UI can render a badge without needing to extend `UnifiedAlertSummary`.
+ */
+export function promEpisodeToUnified(ep: PromAlertEpisode, dsId: string): UnifiedAlertSummary {
+  const name = ep.labels.alertname || 'Unknown';
+  const instance = ep.labels.instance || '';
+  // Plan override: historical episodes without `labels.severity` fall back
+  // to `'medium'` rather than `'info'` (the live-alert default). When
+  // severity IS present, defer to the existing `promSeverityFromLabels`
+  // mapping so `warning`/`page`/etc aliases stay consistent with live alerts.
+  const finalSeverity =
+    ep.labels.severity === undefined ? 'medium' : promSeverityFromLabels(ep.labels);
+  const state: UnifiedAlertState = ep.stillActiveAtRangeEnd ? 'active' : 'resolved';
+
+  const annotations: Record<string, string> = {};
+  if (ep.truncatedStart) {
+    annotations.truncatedStart = 'true';
+  }
+
+  return {
+    id: `${dsId}-${name}-${instance}-${ep.startMs}`,
+    datasourceId: dsId,
+    datasourceType: 'prometheus',
+    name,
+    state,
+    severity: finalSeverity,
+    startTime: new Date(ep.startMs).toISOString(),
+    lastUpdated: new Date(ep.endMs).toISOString(),
+    labels: ep.labels,
+    annotations,
+  };
+}
+
+/**
  * Detect the actual monitor kind from the OS monitor's inputs,
  * since cluster metrics monitors share monitor_type 'query_level_monitor'.
  */

--- a/server/services/alerting/alert_utils.ts
+++ b/server/services/alerting/alert_utils.ts
@@ -347,7 +347,6 @@ export interface PromAlertEpisode {
  */
 export function promEpisodeToUnified(ep: PromAlertEpisode, dsId: string): UnifiedAlertSummary {
   const name = ep.labels.alertname || 'Unknown';
-  const instance = ep.labels.instance || '';
   // Plan override: historical episodes without `labels.severity` fall back
   // to `'medium'` rather than `'info'` (the live-alert default). When
   // severity IS present, defer to the existing `promSeverityFromLabels`
@@ -362,7 +361,14 @@ export function promEpisodeToUnified(ep: PromAlertEpisode, dsId: string): Unifie
   }
 
   return {
-    id: `${dsId}-${name}-${instance}-${ep.startMs}`,
+    // Include a stable hash of the full label map so two episodes of the
+    // same rule with distinct labels — e.g. `service_name=cart` vs
+    // `service_name=recommendation`, or `alertstate=firing` vs
+    // `alertstate=pending` — produce distinct ids. Using just alertname +
+    // instance + alertstate collides on rules that don't emit `instance`
+    // but split along other labels (`job`, `service`, `container_id`, …),
+    // which is typical for OTel-instrumented Prometheus rules.
+    id: `${dsId}-${name}-${hashLabels(ep.labels)}-${ep.startMs}`,
     datasourceId: dsId,
     datasourceType: 'prometheus',
     name,
@@ -373,6 +379,64 @@ export function promEpisodeToUnified(ep: PromAlertEpisode, dsId: string): Unifie
     labels: ep.labels,
     annotations,
   };
+}
+
+/**
+ * Stable 32-bit FNV-1a hash of a label map, rendered as 8 lower-case hex
+ * chars. Sorted so key order doesn't change the hash, and the
+ * `${key}\x00${value}\x01` separators are bytes that can't appear in
+ * Prometheus label names / values so `{a: "b", c: "d"}` and
+ * `{ab: "", cd: ""}` can't collide.
+ *
+ * Not cryptographic — we need a cheap deterministic discriminator for the
+ * client-side `UnifiedAlertSummary.id` field, nothing more.
+ */
+/* eslint-disable no-bitwise -- FNV-1a is defined in terms of 32-bit XOR and
+   shift operations; the whole function is bitwise by design. */
+function hashLabels(labels: Record<string, string>): string {
+  const entries = Object.entries(labels).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  let hash = 0x811c9dc5; // FNV-1a 32-bit offset basis
+  for (const [k, v] of entries) {
+    const segment = `${k}\x00${v}\x01`;
+    for (let i = 0; i < segment.length; i++) {
+      hash ^= segment.charCodeAt(i) & 0xff;
+      // FNV-1a prime multiplication expressed as shifts — keeps the result
+      // in 32-bit range without depending on BigInt. Matches the canonical
+      // implementation (prime = 16777619 = (1<<24) + (1<<8) + (1<<7) + (1<<4) + (1<<1) + 1).
+      hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+    }
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+/* eslint-enable no-bitwise */
+
+/**
+ * Labels that identify the transport shape of a Prometheus alert sample
+ * rather than the rule itself. Strip these before hashing so the hash
+ * matches between the two places alerts come from:
+ *   - `ALERTS{}` matrix series carry `__name__="ALERTS"` and an
+ *     `alertstate` label set by Prometheus to `"firing"` or `"pending"`.
+ *   - `/api/v1/alerts` responses carry neither of those; the rule
+ *     identity is what's left (`alertname` + user-defined labels).
+ *
+ * Without stripping these, the dedupe set built from matrix episodes
+ * would never match a live alert and we'd double-report every active
+ * alert.
+ */
+const RULE_IDENTITY_STRIP_LABELS = new Set(['__name__', 'alertstate']);
+
+/**
+ * Hash of the labels that identify a Prometheus rule instance — the full
+ * label set minus transport metadata (see `RULE_IDENTITY_STRIP_LABELS`).
+ * Used as a dedupe key when merging historical episodes with live
+ * `/api/v1/alerts` results.
+ */
+export function hashRuleIdentity(labels: Record<string, string>): string {
+  const filtered: Record<string, string> = {};
+  for (const [k, v] of Object.entries(labels)) {
+    if (!RULE_IDENTITY_STRIP_LABELS.has(k)) filtered[k] = v;
+  }
+  return hashLabels(filtered);
 }
 
 /**

--- a/server/services/alerting/directquery_prometheus_backend.ts
+++ b/server/services/alerting/directquery_prometheus_backend.ts
@@ -51,16 +51,6 @@ import {
 import { hashRuleIdentity, promAlertToUnified, promEpisodeToUnified } from './alert_utils';
 import type { PromAlertEpisode } from './alert_utils';
 
-/**
- * One series from a Prometheus range-query matrix result — the shape
- * returned by `queryRangeMatrix`. Retains label metadata per series so
- * downstream `getHistoricalAlerts` can partition firing runs by alert
- * identity (`alertname`, `instance`, `alertstate`, etc).
- *
- * `queryRange` (the existing single-series API) flattens to
- * `PromTimeSeriesPoint[]` and drops labels, so it can't be reused for
- * the multi-series episode-reconstruction path.
- */
 export interface PromSeriesMatrix {
   metric: Record<string, string>;
   values: PromTimeSeriesPoint[];
@@ -607,18 +597,9 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     }
   }
 
-  /**
-   * Multi-series variant of `queryRange`. Targets the same DirectQuery
-   * endpoint but preserves the per-series `metric` label map AND all
-   * values from every series — `queryRange`'s `parseRangeQueryResponse`
-   * flattens to the first series only, so it can't be reused for the
-   * `ALERTS{}` matrix where each active alert emits its own series.
-   *
-   * Private (tests reach it via the public `getHistoricalAlerts` method).
-   * Kept separate from `queryRange` because that method swallows errors to
-   * `[]` and collapses series — behavior that's fine for chart previews but
-   * would silently hide a bad range query here.
-   */
+  // Multi-series variant of `queryRange`. Kept separate because `queryRange`
+  // flattens to a single series and swallows errors to `[]` — behavior that
+  // would silently hide a bad query in the episode-reconstruction path.
   async queryRangeMatrix(
     client: AlertingOSClient,
     ds: Datasource,
@@ -693,60 +674,11 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     return series;
   }
 
-  /**
-   * Assemble the unified alert list for a Prometheus datasource over a
-   * window. Two sources are queried in parallel:
-   *
-   *   1. `queryRangeMatrix('ALERTS', start, end, step)` — historical
-   *      firing-run reconstruction from the `ALERTS{}` time series.
-   *   2. `getAlerts` (i.e. `/api/v1/alerts`) — currently-firing / pending
-   *      alerts right now.
-   *
-   * We run BOTH unconditionally and merge (Option A). This makes the UI
-   * behave consistently regardless of window size vs Prometheus retention:
-   *
-   *   - Window entirely within retention ⇒ matrix covers everything; live
-   *     alerts deduplicate against their matching historical episodes so
-   *     there's no double-count.
-   *   - Window larger than retention ⇒ matrix returns an empty or partial
-   *     result, but live alerts still surface.
-   *   - Window fully in the past ⇒ `endIsNow=false` skips the live fetch
-   *     and we return just historical episodes.
-   *
-   * Dedupe rule: a live alert from `/api/v1/alerts` is SUPPRESSED if an
-   * episode in the matrix result already represents the same rule AND is
-   * still firing at the window's right edge (`stillActiveAtRangeEnd`).
-   * "Same rule" is determined by the rule-label hash
-   * (`hashRuleIdentity`) — i.e. labels stripped of transport metadata
-   * (`__name__`, `alertstate`) which differ between the two sources.
-   *
-   * Episode reconstruction algorithm:
-   *   1. `queryRangeMatrix('ALERTS', start, end, step)` — one series per
-   *      unique `(alertname, alertstate, ...labels)` tuple.
-   *   2. For each series, scan `values` left-to-right:
-   *      - Enter a "firing run" on the first `value === 1` sample.
-   *      - Close the run (emit an episode) on the first `value !== 1`
-   *        sample OR at the end of the series.
-   *      - `truncatedStart` = the first sample is at index 0 AND within
-   *        1.5× step of the window start (so we conclude the alert was
-   *        already firing before the window opened).
-   *      - `stillActiveAtRangeEnd` = the last sample is within 1.5× step
-   *        of window end (so the series didn't resolve before we stopped
-   *        looking).
-   *   3. Map each episode to `UnifiedAlertSummary` via `promEpisodeToUnified`.
-   *
-   * Flapping: Prometheus emits separate `ALERTS` series for
-   * `alertstate="pending"` and `alertstate="firing"` on the same rule. We
-   * do NOT merge across `alertstate` on the historical side — a rule that
-   * pended and then fired produces two episodes, which is the semantically
-   * correct representation. The live-alert dedupe step only cancels the
-   * live entry when there's ALSO a `stillActiveAtRangeEnd` episode, so
-   * the historical pending/firing split is preserved.
-   *
-   * Error isolation: errors from either query are captured and returned
-   * alongside whatever the other query produced. A `queryRangeMatrix`
-   * failure does NOT hide currently-firing alerts, and vice versa.
-   */
+  // Unified alert list for a Prometheus datasource over a window. Merges
+  // historical episodes reconstructed from `ALERTS{}` matrix samples with
+  // currently-firing alerts from `/api/v1/alerts`. See the PR description
+  // for the full algorithm; the inline notes below cover only the
+  // non-obvious invariants (edge tolerance, dedupe key, error isolation).
   async getHistoricalAlerts(
     client: AlertingOSClient,
     ds: Datasource,
@@ -759,20 +691,12 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     fallback?: 'prometheus-alerts-current-only';
     error?: string;
   }> {
-    // Fire both requests in parallel. When `endIsNow=false` the live
-    // endpoint is irrelevant (window is fully past), so skip it to save
-    // the RPC. Use `Promise.allSettled`-style tracking — we want a live
-    // failure NOT to hide a successful matrix result, and vice versa.
-    // Filter `alertstate="firing"` at the PromQL level — the pending state
-    // is a transient grace-period signal (rule's `for:` hasn't elapsed
-    // yet) and its row counts flap with the query step: a fine step on a
-    // 12h window catches pending samples that a coarse step on a 2d
-    // window misses, leading to "12h shows 53, 2d shows 29" discrepancies
-    // that surprise operators. Filtering upstream keeps the row count
-    // step-independent AND cuts wire/memory cost vs filtering after parse.
-    // Live `/api/v1/alerts` already excludes pending on most Prom versions
-    // (it's a `firing`-or-`inactive` endpoint), so this aligns the two
-    // sources.
+    // Filter `alertstate="firing"` at the PromQL level. Pending samples
+    // flap with the query step (fine step on a short window catches them,
+    // coarse step on a long window misses them), so leaving them in
+    // produces row counts that change just from picker changes. Live
+    // `/api/v1/alerts` is already firing-or-inactive on most Prom versions,
+    // so this aligns the two sources.
     const matrixPromise = this.queryRangeMatrix(
       client,
       ds,
@@ -794,9 +718,9 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     try {
       series = await matrixPromise;
     } catch (err) {
-      // Matrix failed — still try to surface live alerts when the window
-      // ends at now, so a transient Cortex error doesn't blank the UI for
-      // whatever is firing RIGHT NOW.
+      // Matrix failed — still surface live alerts when window ends at now,
+      // so a transient Cortex error doesn't blank the UI for what's firing
+      // RIGHT NOW.
       const live = await liveSettled;
       if (!live.ok || live.alerts.length === 0) {
         return { alerts: [], error: String(err) };
@@ -811,13 +735,10 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     const windowStartMs = startEpochSec * 1000;
     const windowEndMs = endEpochSec * 1000;
     const stepMs = stepSec * 1000;
-    // Edge tolerance: if the first sample of a run is within 1.5 steps of
-    // the window's left edge, we conclude the alert was already firing at
-    // that edge and mark `truncatedStart`. Symmetric at the right edge.
-    // Without this tolerance we'd either over-clamp (every alert looks
-    // like it spans the whole window because its first matrix sample is
-    // at index 0) or under-clamp (a genuinely pre-window alert gets
-    // reported as starting at its first sample inside the window).
+    // 1.5× step tolerance for "this run was already firing at the edge".
+    // Tighter than 1× over-clamps (every series looks pre-window because
+    // its first sample is at index 0); looser than 2× under-clamps
+    // (genuine pre-window alerts get reported as starting inside).
     const edgeToleranceMs = Math.round(stepMs * 1.5);
     const episodes: PromAlertEpisode[] = [];
 
@@ -868,11 +789,9 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
 
     const historicalAlerts = episodes.map((ep) => promEpisodeToUnified(ep, ds.id));
 
-    // Build the dedupe set: the rule-identity hash of every episode that's
-    // still active at the window's right edge. A live alert whose hash
-    // matches one of these is already represented by an active historical
-    // episode — suppress it to avoid the double-count we saw in the UI
-    // (same rule appearing once from the matrix and once from /alerts).
+    // Dedupe live alerts against historical episodes still active at the
+    // window's right edge — keyed by rule-identity hash (labels minus
+    // `__name__`/`alertstate`, which differ between the two sources).
     const activeEpisodeHashes = new Set<string>();
     for (const ep of episodes) {
       if (ep.stillActiveAtRangeEnd) {
@@ -886,19 +805,16 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
 
     const liveAdditions: UnifiedAlertSummary[] = [];
     for (const la of liveAlerts) {
-      // Skip pending alerts from the live endpoint for the same reason we
-      // filtered pending out of the matrix query above — we want row
-      // counts that don't flap with transient grace-period state.
+      // Skip pending — same step-flapping reason as the matrix filter.
       if (la.state === 'pending') continue;
       if (!activeEpisodeHashes.has(hashRuleIdentity(la.labels))) {
         liveAdditions.push(promAlertToUnified(la, ds.id));
       }
     }
 
-    // When the matrix itself was empty BUT live alerts exist, flag the
-    // response so the UI can explain that coverage was limited to "now".
-    // With data from the matrix we skip the banner — the user is seeing
-    // a legitimate historical view.
+    // Flag the "current alerts only" banner when the matrix returned
+    // nothing but live alerts exist — tells the UI that coverage is
+    // limited to "now" rather than the picked window.
     const fallback =
       historicalAlerts.length === 0 && liveAdditions.length > 0
         ? ('prometheus-alerts-current-only' as const)
@@ -907,10 +823,8 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     return {
       alerts: [...historicalAlerts, ...liveAdditions],
       ...(fallback ? { fallback } : {}),
-      // Only surface the live-side error when it would otherwise be the
-      // ONLY signal the user gets. If historical data landed successfully,
-      // a secondary live failure is just "no currently-firing data beyond
-      // what's in the matrix" — not worth flashing a per-datasource error.
+      // Only surface the live-side error when it's the only signal the
+      // user gets — otherwise it's noise on top of a successful matrix.
       ...(liveError && historicalAlerts.length === 0 && liveAdditions.length === 0
         ? { error: liveError }
         : {}),

--- a/server/services/alerting/directquery_prometheus_backend.ts
+++ b/server/services/alerting/directquery_prometheus_backend.ts
@@ -48,7 +48,7 @@ import {
   PromTimeSeriesPoint,
   UnifiedAlertSummary,
 } from '../../../common/types/alerting';
-import { promAlertToUnified, promEpisodeToUnified } from './alert_utils';
+import { hashRuleIdentity, promAlertToUnified, promEpisodeToUnified } from './alert_utils';
 import type { PromAlertEpisode } from './alert_utils';
 
 /**
@@ -656,12 +656,29 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
       values?: unknown[][];
     }>;
 
+    // Defensive cap on parsed sample count per series. `computeStep` in the
+    // shared helper should keep steps coarse enough that a well-behaved
+    // Prometheus response stays well under this, but an exporter returning
+    // a fine step on a multi-day range could otherwise allocate unbounded
+    // memory here. ~50k points per series accommodates a 30-day range at a
+    // 60s step with headroom; anything larger is almost certainly misuse.
+    const MAX_POINTS_PER_SERIES = 50_000;
+
     const series: PromSeriesMatrix[] = [];
     for (const s of rawSeries) {
       const metric = s.metric || {};
       const values: PromTimeSeriesPoint[] = [];
       const rawValues = s.values || [];
       for (const pair of rawValues) {
+        if (values.length >= MAX_POINTS_PER_SERIES) {
+          this.logger.warn(
+            `queryRangeMatrix: series truncated at ${MAX_POINTS_PER_SERIES} points for query "${query.substring(
+              0,
+              80
+            )}..."`
+          );
+          break;
+        }
         if (Array.isArray(pair) && pair.length >= 2) {
           const ts = Number(pair[0]);
           const numVal = parseFloat(String(pair[1]));
@@ -677,71 +694,131 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
   }
 
   /**
-   * Reconstruct historical Prometheus alert episodes by range-querying the
-   * `ALERTS` metric and scanning each returned series for contiguous runs
-   * of `value === 1` samples ("firing" or "pending" depending on the
-   * `alertstate` label on the series).
+   * Assemble the unified alert list for a Prometheus datasource over a
+   * window. Two sources are queried in parallel:
    *
-   * Algorithm:
+   *   1. `queryRangeMatrix('ALERTS', start, end, step)` — historical
+   *      firing-run reconstruction from the `ALERTS{}` time series.
+   *   2. `getAlerts` (i.e. `/api/v1/alerts`) — currently-firing / pending
+   *      alerts right now.
+   *
+   * We run BOTH unconditionally and merge (Option A). This makes the UI
+   * behave consistently regardless of window size vs Prometheus retention:
+   *
+   *   - Window entirely within retention ⇒ matrix covers everything; live
+   *     alerts deduplicate against their matching historical episodes so
+   *     there's no double-count.
+   *   - Window larger than retention ⇒ matrix returns an empty or partial
+   *     result, but live alerts still surface.
+   *   - Window fully in the past ⇒ `endIsNow=false` skips the live fetch
+   *     and we return just historical episodes.
+   *
+   * Dedupe rule: a live alert from `/api/v1/alerts` is SUPPRESSED if an
+   * episode in the matrix result already represents the same rule AND is
+   * still firing at the window's right edge (`stillActiveAtRangeEnd`).
+   * "Same rule" is determined by the rule-label hash
+   * (`hashRuleIdentity`) — i.e. labels stripped of transport metadata
+   * (`__name__`, `alertstate`) which differ between the two sources.
+   *
+   * Episode reconstruction algorithm:
    *   1. `queryRangeMatrix('ALERTS', start, end, step)` — one series per
    *      unique `(alertname, alertstate, ...labels)` tuple.
    *   2. For each series, scan `values` left-to-right:
    *      - Enter a "firing run" on the first `value === 1` sample.
    *      - Close the run (emit an episode) on the first `value !== 1`
    *        sample OR at the end of the series.
-   *      - `truncatedStart` = run started at the first sample in the
-   *        matrix (i.e. already firing at the window's left edge).
-   *      - `stillActiveAtRangeEnd` = run reached the last sample in the
-   *        matrix (i.e. still firing at the window's right edge).
+   *      - `truncatedStart` = the first sample is at index 0 AND within
+   *        1.5× step of the window start (so we conclude the alert was
+   *        already firing before the window opened).
+   *      - `stillActiveAtRangeEnd` = the last sample is within 1.5× step
+   *        of window end (so the series didn't resolve before we stopped
+   *        looking).
    *   3. Map each episode to `UnifiedAlertSummary` via `promEpisodeToUnified`.
    *
    * Flapping: Prometheus emits separate `ALERTS` series for
    * `alertstate="pending"` and `alertstate="firing"` on the same rule. We
-   * do NOT merge across `alertstate` — a rule that pended and then fired
-   * produces two episodes, which is the semantically correct representation
-   * (the operator wants to see the pending→firing transition, not just
-   * "it was active during this window").
+   * do NOT merge across `alertstate` on the historical side — a rule that
+   * pended and then fired produces two episodes, which is the semantically
+   * correct representation. The live-alert dedupe step only cancels the
+   * live entry when there's ALSO a `stillActiveAtRangeEnd` episode, so
+   * the historical pending/firing split is preserved.
    *
-   * Fallback: when the matrix is empty AND the range includes `now` (end
-   * timestamp within 5s of the current wall clock), the caller is likely
-   * looking at a Prometheus that doesn't retain history (e.g. a fresh
-   * instance, or one with short retention). We fall back to the legacy
-   * `/api/v1/alerts` endpoint for current-active alerts and flag the
-   * response with `fallback: 'prometheus-alerts-current-only'` so the UI
-   * can render a banner explaining the coverage gap.
-   *
-   * Errors from `queryRangeMatrix` (permission denied, parse failures,
-   * workspace routing errors) are caught and returned as
-   * `{ alerts: [], error }` so a failing Prometheus datasource doesn't
-   * take down the unified view for other datasources.
+   * Error isolation: errors from either query are captured and returned
+   * alongside whatever the other query produced. A `queryRangeMatrix`
+   * failure does NOT hide currently-firing alerts, and vice versa.
    */
   async getHistoricalAlerts(
     client: AlertingOSClient,
     ds: Datasource,
     startEpochSec: number,
     endEpochSec: number,
-    stepSec: number
+    stepSec: number,
+    endIsNow: boolean
   ): Promise<{
     alerts: UnifiedAlertSummary[];
     fallback?: 'prometheus-alerts-current-only';
     error?: string;
   }> {
+    // Fire both requests in parallel. When `endIsNow=false` the live
+    // endpoint is irrelevant (window is fully past), so skip it to save
+    // the RPC. Use `Promise.allSettled`-style tracking — we want a live
+    // failure NOT to hide a successful matrix result, and vice versa.
+    // Filter `alertstate="firing"` at the PromQL level — the pending state
+    // is a transient grace-period signal (rule's `for:` hasn't elapsed
+    // yet) and its row counts flap with the query step: a fine step on a
+    // 12h window catches pending samples that a coarse step on a 2d
+    // window misses, leading to "12h shows 53, 2d shows 29" discrepancies
+    // that surprise operators. Filtering upstream keeps the row count
+    // step-independent AND cuts wire/memory cost vs filtering after parse.
+    // Live `/api/v1/alerts` already excludes pending on most Prom versions
+    // (it's a `firing`-or-`inactive` endpoint), so this aligns the two
+    // sources.
+    const matrixPromise = this.queryRangeMatrix(
+      client,
+      ds,
+      'ALERTS{alertstate="firing"}',
+      startEpochSec,
+      endEpochSec,
+      stepSec
+    );
+    const liveSettled: Promise<
+      { ok: true; alerts: PromAlert[] } | { ok: false; error: string }
+    > = endIsNow
+      ? this.getAlerts(client, ds).then(
+          (alerts) => ({ ok: true, alerts } as const),
+          (err) => ({ ok: false, error: String(err) } as const)
+        )
+      : Promise.resolve({ ok: true, alerts: [] as PromAlert[] } as const);
+
     let series: PromSeriesMatrix[];
     try {
-      series = await this.queryRangeMatrix(
-        client,
-        ds,
-        'ALERTS',
-        startEpochSec,
-        endEpochSec,
-        stepSec
-      );
+      series = await matrixPromise;
     } catch (err) {
-      return { alerts: [], error: String(err) };
+      // Matrix failed — still try to surface live alerts when the window
+      // ends at now, so a transient Cortex error doesn't blank the UI for
+      // whatever is firing RIGHT NOW.
+      const live = await liveSettled;
+      if (!live.ok || live.alerts.length === 0) {
+        return { alerts: [], error: String(err) };
+      }
+      return {
+        alerts: live.alerts.map((a) => promAlertToUnified(a, ds.id)),
+        fallback: 'prometheus-alerts-current-only',
+        error: String(err),
+      };
     }
 
     const windowStartMs = startEpochSec * 1000;
     const windowEndMs = endEpochSec * 1000;
+    const stepMs = stepSec * 1000;
+    // Edge tolerance: if the first sample of a run is within 1.5 steps of
+    // the window's left edge, we conclude the alert was already firing at
+    // that edge and mark `truncatedStart`. Symmetric at the right edge.
+    // Without this tolerance we'd either over-clamp (every alert looks
+    // like it spans the whole window because its first matrix sample is
+    // at index 0) or under-clamp (a genuinely pre-window alert gets
+    // reported as starting at its first sample inside the window).
+    const edgeToleranceMs = Math.round(stepMs * 1.5);
     const episodes: PromAlertEpisode[] = [];
 
     for (const s of series) {
@@ -750,7 +827,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
 
       let runStart: number | null = null;
       let lastSampleTsInRun: number | null = null;
-      let startedAtFirstSample = false;
+      let truncatedStart = false;
 
       const closeRun = (endTsMs: number, stillActive: boolean) => {
         if (runStart === null) return;
@@ -758,12 +835,12 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
           labels: { ...s.metric },
           startMs: runStart,
           endMs: endTsMs,
-          truncatedStart: startedAtFirstSample ? true : undefined,
+          truncatedStart: truncatedStart ? true : undefined,
           stillActiveAtRangeEnd: stillActive ? true : undefined,
         });
         runStart = null;
         lastSampleTsInRun = null;
-        startedAtFirstSample = false;
+        truncatedStart = false;
       };
 
       for (let i = 0; i < values.length; i++) {
@@ -771,12 +848,11 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
         const isFiring = point.value === 1;
         if (isFiring) {
           if (runStart === null) {
-            runStart = point.timestamp;
-            // Clamp episode start to window start if the series was already
-            // firing at the left edge — plan calls this `truncatedStart`.
-            startedAtFirstSample = i === 0;
-            if (startedAtFirstSample) {
+            if (i === 0 && point.timestamp - windowStartMs <= edgeToleranceMs) {
               runStart = windowStartMs;
+              truncatedStart = true;
+            } else {
+              runStart = point.timestamp;
             }
           }
           lastSampleTsInRun = point.timestamp;
@@ -784,38 +860,61 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
           closeRun(lastSampleTsInRun ?? runStart, false);
         }
       }
-      // End of series — close any run that's still open.
-      if (runStart !== null) {
-        const stillActive = lastSampleTsInRun === values[values.length - 1].timestamp;
-        closeRun(stillActive ? windowEndMs : lastSampleTsInRun ?? runStart, stillActive);
+      if (runStart !== null && lastSampleTsInRun !== null) {
+        const stillActive = windowEndMs - lastSampleTsInRun <= edgeToleranceMs;
+        closeRun(stillActive ? windowEndMs : lastSampleTsInRun, stillActive);
       }
     }
 
-    if (episodes.length > 0) {
-      return {
-        alerts: episodes.map((ep) => promEpisodeToUnified(ep, ds.id)),
-      };
+    const historicalAlerts = episodes.map((ep) => promEpisodeToUnified(ep, ds.id));
+
+    // Build the dedupe set: the rule-identity hash of every episode that's
+    // still active at the window's right edge. A live alert whose hash
+    // matches one of these is already represented by an active historical
+    // episode — suppress it to avoid the double-count we saw in the UI
+    // (same rule appearing once from the matrix and once from /alerts).
+    const activeEpisodeHashes = new Set<string>();
+    for (const ep of episodes) {
+      if (ep.stillActiveAtRangeEnd) {
+        activeEpisodeHashes.add(hashRuleIdentity(ep.labels));
+      }
     }
 
-    // Fallback decision: matrix empty ⇒ either the range is fully in the
-    // past (legitimate empty — no alerts fired) or the range includes `now`
-    // (Prometheus may not retain that history — use legacy active-only API
-    // as a best-effort fallback).
-    const nowEpochSec = Math.floor(Date.now() / 1000);
-    const rangeIncludesNow = endEpochSec >= nowEpochSec - 5;
-    if (!rangeIncludesNow) {
-      return { alerts: [] };
+    const live = await liveSettled;
+    const liveAlerts = live.ok ? live.alerts : [];
+    const liveError = live.ok ? undefined : live.error;
+
+    const liveAdditions: UnifiedAlertSummary[] = [];
+    for (const la of liveAlerts) {
+      // Skip pending alerts from the live endpoint for the same reason we
+      // filtered pending out of the matrix query above — we want row
+      // counts that don't flap with transient grace-period state.
+      if (la.state === 'pending') continue;
+      if (!activeEpisodeHashes.has(hashRuleIdentity(la.labels))) {
+        liveAdditions.push(promAlertToUnified(la, ds.id));
+      }
     }
 
-    try {
-      const legacy = await this.getAlerts(client, ds);
-      return {
-        alerts: legacy.map((a) => promAlertToUnified(a, ds.id)),
-        fallback: 'prometheus-alerts-current-only',
-      };
-    } catch (err) {
-      return { alerts: [], error: String(err) };
-    }
+    // When the matrix itself was empty BUT live alerts exist, flag the
+    // response so the UI can explain that coverage was limited to "now".
+    // With data from the matrix we skip the banner — the user is seeing
+    // a legitimate historical view.
+    const fallback =
+      historicalAlerts.length === 0 && liveAdditions.length > 0
+        ? ('prometheus-alerts-current-only' as const)
+        : undefined;
+
+    return {
+      alerts: [...historicalAlerts, ...liveAdditions],
+      ...(fallback ? { fallback } : {}),
+      // Only surface the live-side error when it would otherwise be the
+      // ONLY signal the user gets. If historical data landed successfully,
+      // a secondary live failure is just "no currently-firing data beyond
+      // what's in the matrix" — not worth flashing a per-datasource error.
+      ...(liveError && historicalAlerts.length === 0 && liveAdditions.length === 0
+        ? { error: liveError }
+        : {}),
+    };
   }
 
   /**

--- a/server/services/alerting/directquery_prometheus_backend.ts
+++ b/server/services/alerting/directquery_prometheus_backend.ts
@@ -46,7 +46,25 @@ import {
   PromAlertsApiResponse,
   DatasourceDefinition,
   PromTimeSeriesPoint,
+  UnifiedAlertSummary,
 } from '../../../common/types/alerting';
+import { promAlertToUnified, promEpisodeToUnified } from './alert_utils';
+import type { PromAlertEpisode } from './alert_utils';
+
+/**
+ * One series from a Prometheus range-query matrix result — the shape
+ * returned by `queryRangeMatrix`. Retains label metadata per series so
+ * downstream `getHistoricalAlerts` can partition firing runs by alert
+ * identity (`alertname`, `instance`, `alertstate`, etc).
+ *
+ * `queryRange` (the existing single-series API) flattens to
+ * `PromTimeSeriesPoint[]` and drops labels, so it can't be reused for
+ * the multi-series episode-reconstruction path.
+ */
+export interface PromSeriesMatrix {
+  metric: Record<string, string>;
+  values: PromTimeSeriesPoint[];
+}
 
 export class DirectQueryPrometheusBackend implements PrometheusBackend, PrometheusMetadataProvider {
   readonly type = 'prometheus' as const;
@@ -586,6 +604,217 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     } catch (err) {
       this.logger.warn(`Failed to execute DirectQuery range query: ${err}`);
       return [];
+    }
+  }
+
+  /**
+   * Multi-series variant of `queryRange`. Targets the same DirectQuery
+   * endpoint but preserves the per-series `metric` label map AND all
+   * values from every series — `queryRange`'s `parseRangeQueryResponse`
+   * flattens to the first series only, so it can't be reused for the
+   * `ALERTS{}` matrix where each active alert emits its own series.
+   *
+   * Private (tests reach it via the public `getHistoricalAlerts` method).
+   * Kept separate from `queryRange` because that method swallows errors to
+   * `[]` and collapses series — behavior that's fine for chart previews but
+   * would silently hide a bad range query here.
+   */
+  async queryRangeMatrix(
+    client: AlertingOSClient,
+    ds: Datasource,
+    query: string,
+    startSec: number,
+    endSec: number,
+    stepSec: number
+  ): Promise<PromSeriesMatrix[]> {
+    const dqName = this.resolveDqName(ds);
+    const path = `/_plugins/_directquery/_query/${encodeURIComponent(dqName)}`;
+
+    this.logger.debug(`DirectQuery range matrix query: ${query.substring(0, 80)}...`);
+
+    const resp = await client.transport.request({
+      method: 'POST',
+      path,
+      body: {
+        datasource: dqName,
+        query,
+        language: 'PROMQL',
+        options: {
+          queryType: 'range',
+          start: startSec.toString(),
+          end: endSec.toString(),
+          step: stepSec.toString(),
+        },
+      },
+    });
+
+    const promResult = this.extractPrometheusResult(resp.body as Record<string, unknown>);
+    if (!promResult) return [];
+
+    const rawSeries = (promResult.result ?? []) as Array<{
+      metric?: Record<string, string>;
+      values?: unknown[][];
+    }>;
+
+    const series: PromSeriesMatrix[] = [];
+    for (const s of rawSeries) {
+      const metric = s.metric || {};
+      const values: PromTimeSeriesPoint[] = [];
+      const rawValues = s.values || [];
+      for (const pair of rawValues) {
+        if (Array.isArray(pair) && pair.length >= 2) {
+          const ts = Number(pair[0]);
+          const numVal = parseFloat(String(pair[1]));
+          if (!isNaN(ts) && !isNaN(numVal)) {
+            values.push({ timestamp: ts * 1000, value: numVal });
+          }
+        }
+      }
+      series.push({ metric, values });
+    }
+
+    return series;
+  }
+
+  /**
+   * Reconstruct historical Prometheus alert episodes by range-querying the
+   * `ALERTS` metric and scanning each returned series for contiguous runs
+   * of `value === 1` samples ("firing" or "pending" depending on the
+   * `alertstate` label on the series).
+   *
+   * Algorithm:
+   *   1. `queryRangeMatrix('ALERTS', start, end, step)` — one series per
+   *      unique `(alertname, alertstate, ...labels)` tuple.
+   *   2. For each series, scan `values` left-to-right:
+   *      - Enter a "firing run" on the first `value === 1` sample.
+   *      - Close the run (emit an episode) on the first `value !== 1`
+   *        sample OR at the end of the series.
+   *      - `truncatedStart` = run started at the first sample in the
+   *        matrix (i.e. already firing at the window's left edge).
+   *      - `stillActiveAtRangeEnd` = run reached the last sample in the
+   *        matrix (i.e. still firing at the window's right edge).
+   *   3. Map each episode to `UnifiedAlertSummary` via `promEpisodeToUnified`.
+   *
+   * Flapping: Prometheus emits separate `ALERTS` series for
+   * `alertstate="pending"` and `alertstate="firing"` on the same rule. We
+   * do NOT merge across `alertstate` — a rule that pended and then fired
+   * produces two episodes, which is the semantically correct representation
+   * (the operator wants to see the pending→firing transition, not just
+   * "it was active during this window").
+   *
+   * Fallback: when the matrix is empty AND the range includes `now` (end
+   * timestamp within 5s of the current wall clock), the caller is likely
+   * looking at a Prometheus that doesn't retain history (e.g. a fresh
+   * instance, or one with short retention). We fall back to the legacy
+   * `/api/v1/alerts` endpoint for current-active alerts and flag the
+   * response with `fallback: 'prometheus-alerts-current-only'` so the UI
+   * can render a banner explaining the coverage gap.
+   *
+   * Errors from `queryRangeMatrix` (permission denied, parse failures,
+   * workspace routing errors) are caught and returned as
+   * `{ alerts: [], error }` so a failing Prometheus datasource doesn't
+   * take down the unified view for other datasources.
+   */
+  async getHistoricalAlerts(
+    client: AlertingOSClient,
+    ds: Datasource,
+    startEpochSec: number,
+    endEpochSec: number,
+    stepSec: number
+  ): Promise<{
+    alerts: UnifiedAlertSummary[];
+    fallback?: 'prometheus-alerts-current-only';
+    error?: string;
+  }> {
+    let series: PromSeriesMatrix[];
+    try {
+      series = await this.queryRangeMatrix(
+        client,
+        ds,
+        'ALERTS',
+        startEpochSec,
+        endEpochSec,
+        stepSec
+      );
+    } catch (err) {
+      return { alerts: [], error: String(err) };
+    }
+
+    const windowStartMs = startEpochSec * 1000;
+    const windowEndMs = endEpochSec * 1000;
+    const episodes: PromAlertEpisode[] = [];
+
+    for (const s of series) {
+      const values = s.values;
+      if (values.length === 0) continue;
+
+      let runStart: number | null = null;
+      let lastSampleTsInRun: number | null = null;
+      let startedAtFirstSample = false;
+
+      const closeRun = (endTsMs: number, stillActive: boolean) => {
+        if (runStart === null) return;
+        episodes.push({
+          labels: { ...s.metric },
+          startMs: runStart,
+          endMs: endTsMs,
+          truncatedStart: startedAtFirstSample ? true : undefined,
+          stillActiveAtRangeEnd: stillActive ? true : undefined,
+        });
+        runStart = null;
+        lastSampleTsInRun = null;
+        startedAtFirstSample = false;
+      };
+
+      for (let i = 0; i < values.length; i++) {
+        const point = values[i];
+        const isFiring = point.value === 1;
+        if (isFiring) {
+          if (runStart === null) {
+            runStart = point.timestamp;
+            // Clamp episode start to window start if the series was already
+            // firing at the left edge — plan calls this `truncatedStart`.
+            startedAtFirstSample = i === 0;
+            if (startedAtFirstSample) {
+              runStart = windowStartMs;
+            }
+          }
+          lastSampleTsInRun = point.timestamp;
+        } else if (runStart !== null) {
+          closeRun(lastSampleTsInRun ?? runStart, false);
+        }
+      }
+      // End of series — close any run that's still open.
+      if (runStart !== null) {
+        const stillActive = lastSampleTsInRun === values[values.length - 1].timestamp;
+        closeRun(stillActive ? windowEndMs : lastSampleTsInRun ?? runStart, stillActive);
+      }
+    }
+
+    if (episodes.length > 0) {
+      return {
+        alerts: episodes.map((ep) => promEpisodeToUnified(ep, ds.id)),
+      };
+    }
+
+    // Fallback decision: matrix empty ⇒ either the range is fully in the
+    // past (legitimate empty — no alerts fired) or the range includes `now`
+    // (Prometheus may not retain that history — use legacy active-only API
+    // as a best-effort fallback).
+    const nowEpochSec = Math.floor(Date.now() / 1000);
+    const rangeIncludesNow = endEpochSec >= nowEpochSec - 5;
+    if (!rangeIncludesNow) {
+      return { alerts: [] };
+    }
+
+    try {
+      const legacy = await this.getAlerts(client, ds);
+      return {
+        alerts: legacy.map((a) => promAlertToUnified(a, ds.id)),
+        fallback: 'prometheus-alerts-current-only',
+      };
+    } catch (err) {
+      return { alerts: [], error: String(err) };
     }
   }
 

--- a/server/services/alerting/opensearch_backend.ts
+++ b/server/services/alerting/opensearch_backend.ts
@@ -226,6 +226,13 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
      * datasource individually exceeds the cap.
      */
     const FILTER_CAP = 1000;
+    // Hard ceiling on rows we'll page through, regardless of `FILTER_CAP`.
+    // Without this, a cluster with 100k+ alerts where almost none fall
+    // inside the window forces us to issue 1000+ sequential requests before
+    // the post-filter cap can stop us. 10k rows = at most 100 pages of 100
+    // — bounded worst-case latency, and any genuinely-larger backlog should
+    // already be hitting `FILTER_CAP` (which assumes the filter matches).
+    const SCAN_CAP = 10_000;
     const hasRange = options?.startMs !== undefined && options?.endMs !== undefined;
     const windowStart = options?.startMs ?? 0;
     const windowEnd = options?.endMs ?? Number.POSITIVE_INFINITY;
@@ -287,6 +294,10 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
       // authoritative end-of-stream signal; worst case we make one extra
       // empty request on an exact PAGE_SIZE multiple, which is cheap.
       startIndex += PAGE_SIZE;
+      if (startIndex >= SCAN_CAP) {
+        truncated = true;
+        break;
+      }
     }
 
     // When filtering, `totalAlerts` on the return object reflects the

--- a/server/services/alerting/opensearch_backend.ts
+++ b/server/services/alerting/opensearch_backend.ts
@@ -207,11 +207,27 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
   // Alerts
   // =========================================================================
 
-  async getAlerts(client: AlertingOSClient): Promise<{ alerts: OSAlert[]; totalAlerts: number }> {
+  async getAlerts(
+    client: AlertingOSClient,
+    options?: { startMs?: number; endMs?: number }
+  ): Promise<{ alerts: OSAlert[]; totalAlerts: number; truncated: boolean }> {
     const PAGE_SIZE = 100;
+    /**
+     * Cap applied only when a time window is supplied. OpenSearch Alerting's
+     * `GET monitors/alerts` endpoint has no documented server-side time
+     * filter (as of 2.x), so we post-fetch and then paginate-stop once the
+     * filtered collection reaches this limit. The UI surfaces `truncated`
+     * as an `EuiCallOut` prompting the user to narrow the range.
+     */
+    const FILTER_CAP = 1000;
+    const hasRange = options?.startMs !== undefined && options?.endMs !== undefined;
+    const windowStart = options?.startMs ?? 0;
+    const windowEnd = options?.endMs ?? Number.POSITIVE_INFINITY;
+
     const allAlerts: OSAlert[] = [];
     let startIndex = 0;
     let totalAlerts = 0;
+    let truncated = false;
 
     // Paginate through all alerts
     while (true) {
@@ -221,14 +237,52 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
         `/_plugins/_alerting/monitors/alerts?size=${PAGE_SIZE}&startIndex=${startIndex}`
       );
       totalAlerts = resp.body.totalAlerts ?? 0;
-      const alerts: OSAlert[] = (resp.body.alerts ?? []).map((a: OSAlertRaw) => this.mapAlert(a));
-      allAlerts.push(...alerts);
+      const pageAlerts: OSAlert[] = (resp.body.alerts ?? []).map((a: OSAlertRaw) =>
+        this.mapAlert(a)
+      );
 
-      if (alerts.length < PAGE_SIZE || allAlerts.length >= totalAlerts) break;
+      if (hasRange) {
+        for (const a of pageAlerts) {
+          // Active alerts have no end_time — treat as "still ongoing" (now).
+          // This gives us a standard interval-overlap predicate:
+          //   alert.start_time <= windowEnd  AND  effectiveEnd >= windowStart
+          // which INCLUDES alerts that started before the window and are
+          // still active, and EXCLUDES alerts that resolved before the
+          // window opened or started after it closed.
+          const effectiveEnd = a.end_time ?? Date.now();
+          if (a.start_time <= windowEnd && effectiveEnd >= windowStart) {
+            allAlerts.push(a);
+            if (allAlerts.length >= FILTER_CAP) {
+              truncated = true;
+              break;
+            }
+          }
+        }
+        if (truncated) break;
+      } else {
+        allAlerts.push(...pageAlerts);
+      }
+
+      if (pageAlerts.length < PAGE_SIZE) break;
+      if (!hasRange && allAlerts.length >= totalAlerts) break;
+      // When filtering: the `pageAlerts.length < PAGE_SIZE` check above
+      // catches most cases, but if `totalAlerts` is an exact multiple of
+      // PAGE_SIZE (e.g. 100 / 200 / 1000) the last page returns PAGE_SIZE
+      // and we'd otherwise make one more empty request. Break early on
+      // the next start index being past the server-reported total.
+      if (hasRange && startIndex + PAGE_SIZE >= totalAlerts) break;
       startIndex += PAGE_SIZE;
     }
 
-    return { alerts: allAlerts, totalAlerts };
+    // When filtering, `totalAlerts` on the return object reflects the
+    // filtered-and-capped count (what the caller actually received); the
+    // raw index total is no longer a useful number for a post-filtered
+    // payload and would confuse UI consumers.
+    return {
+      alerts: allAlerts,
+      totalAlerts: hasRange ? allAlerts.length : totalAlerts,
+      truncated,
+    };
   }
 
   async acknowledgeAlerts(

--- a/server/services/alerting/opensearch_backend.ts
+++ b/server/services/alerting/opensearch_backend.ts
@@ -218,6 +218,12 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
      * filter (as of 2.x), so we post-fetch and then paginate-stop once the
      * filtered collection reaches this limit. The UI surfaces `truncated`
      * as an `EuiCallOut` prompting the user to narrow the range.
+     *
+     * Scope: this cap is PER-DATASOURCE. The unified service aggregates
+     * results across N datasources and forwards any `truncated: true` to
+     * the UI, but does not sum alert counts — so the unified view can show
+     * up to `N * FILTER_CAP` rows with no `truncated` flag if no single
+     * datasource individually exceeds the cap.
      */
     const FILTER_CAP = 1000;
     const hasRange = options?.startMs !== undefined && options?.endMs !== undefined;
@@ -243,13 +249,19 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
 
       if (hasRange) {
         for (const a of pageAlerts) {
-          // Active alerts have no end_time — treat as "still ongoing" (now).
+          // Active alerts have no end_time — treat as "still ongoing through
+          // the window end". Using `windowEnd` (the range resolved ONCE at
+          // the service entry) rather than a fresh `Date.now()` keeps the
+          // filter deterministic across multi-page scans: a pagination pass
+          // that spans several seconds won't let `now` drift past each
+          // page's comparisons and change which alerts the filter accepts.
+          //
           // This gives us a standard interval-overlap predicate:
           //   alert.start_time <= windowEnd  AND  effectiveEnd >= windowStart
           // which INCLUDES alerts that started before the window and are
           // still active, and EXCLUDES alerts that resolved before the
           // window opened or started after it closed.
-          const effectiveEnd = a.end_time ?? Date.now();
+          const effectiveEnd = a.end_time ?? windowEnd;
           if (a.start_time <= windowEnd && effectiveEnd >= windowStart) {
             allAlerts.push(a);
             if (allAlerts.length >= FILTER_CAP) {
@@ -265,12 +277,15 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
 
       if (pageAlerts.length < PAGE_SIZE) break;
       if (!hasRange && allAlerts.length >= totalAlerts) break;
-      // When filtering: the `pageAlerts.length < PAGE_SIZE` check above
-      // catches most cases, but if `totalAlerts` is an exact multiple of
-      // PAGE_SIZE (e.g. 100 / 200 / 1000) the last page returns PAGE_SIZE
-      // and we'd otherwise make one more empty request. Break early on
-      // the next start index being past the server-reported total.
-      if (hasRange && startIndex + PAGE_SIZE >= totalAlerts) break;
+      // We intentionally do NOT early-exit on `startIndex + PAGE_SIZE >=
+      // totalAlerts` when filtering — `totalAlerts` is the server's raw
+      // index count, not the filtered count. If the upstream total is
+      // stale (a common thing during heavy ingest) or differs from the
+      // actual number of alerts we'd see paginating, cutting the loop
+      // based on it can terminate BEFORE we've seen the real last page,
+      // dropping matches silently. `pageAlerts.length < PAGE_SIZE` is the
+      // authoritative end-of-stream signal; worst case we make one extra
+      // empty request on an exact PAGE_SIZE multiple, which is cheap.
       startIndex += PAGE_SIZE;
     }
 


### PR DESCRIPTION
### Description
Adds a time range selector (`EuiSuperDatePicker`) to the **Alerts** tab of Alert Manager so users can constrain the visible alerts, summary cards, and timeline chart to an arbitrary window. Picker is threaded end-to-end through the existing APM-pattern transport: `useAlerts` hook → `AlertingOpenSearchService` → `/api/alerting/unified/alerts` → `MultiBackendAlertService` → both backends.

The core design constraint was **uniform, predictable behavior across backends**. OpenSearch Alerting stores alert history in an index, so post-fetch filtering is straightforward. Prometheus is trickier — `/api/v1/alerts` only returns currently-firing alerts, and historical data has to be reconstructed from the `ALERTS{}` time series via `queryRange`. To keep row counts stable regardless of query step size or Prometheus retention, the Prometheus backend queries matrix history AND live alerts in parallel and merges them through a rule-identity dedupe.

Behind the existing `observability.alertManager.enabled` beta flag — zero impact when the flag is off.

Follow-up to #2653 (the original Alert Manager feature). No changes to mutation routes, Rules tab, Routing tab, monitor-detail flyout, or alert-preview flow.

<img width="1919" height="935" alt="AlertTimePickeer" src="https://github.com/user-attachments/assets/ce6147c6-c355-4661-b97d-933e9e22dbf0" />


---

### Architecture

#### State ownership and persistence

- **State** — date-math strings (`'now-24h'`, `'now'`) owned on `AlarmsPage` via two `useState` hooks. Matches the Trace Analytics `Home` precedent: strings travel through the system, epoch resolution happens once at a defined boundary.
- **Persistence** — `sessionStorage` keys `AlertManagerStartTime` / `AlertManagerEndTime`, hydrated lazily on mount, written on every `onTimeChange` and `onRefresh`. Survives page reload within the same tab; a new tab starts at the defaults.
- **Defaults** — `now-24h` → `now`. Tuned for alerts velocity: alerts are longer-lived signals than traces (APM uses `now-5m`), and 24 hours gives users a useful initial view on first load.
- **URL sync** — not implemented. Matches APM precedent; URL params are reserved for datasource selection.
- **Crash-safety and self-healing** — `parseDateMathMs` is wrapped in `useMemo` + try/catch. On corruption (manual DevTools edit, extension interference) the memo falls back to defaults, an effect resets component state + `sessionStorage` to the defaults, and the hook stops forwarding garbage to the backend. One `console.warn`, then silent recovery.

#### Propagation

Pure prop drilling: `AlarmsPage` → `AlertsDashboard` → `AlertTimeline`. No new context, no redux. `startTime` / `endTime` are forwarded as date-math strings for transport; resolved `startMs` / `endMs` are computed once at the page level. The memo depends on `refreshToken` too, so clicking Refresh on a `now`-relative range re-resolves the wall clock and the chart window slides correctly.

One resolution point, no chance of drift between the chart window and the server query.

#### `useAlerts` hook

`AlarmsPage` drives the Alerts tab entirely through `useAlerts({ dsIds, startTime, endTime, refreshToken })`. The hook uses a monotonic request-id ref so rapid picker changes can't let an older in-flight response overwrite a newer one. Matches APM-pattern transport and consolidates the loading/error/refetch lifecycle.

#### UI chrome

`EuiSuperDatePicker` + its built-in Refresh/Update button share the same flex row as the tabs, right-aligned, **only on the Alerts tab**. Rules and Routing tabs render just the tabs — no picker space wasted when the range is irrelevant. The picker's `onRefresh` captures the resolved `{ start, end }` snapshot and persists it, so a refresh can't drift against a stale hydrated value.

The picker's native button (`showUpdateButton={true}`) renders persistent text (`Update` or `Refresh` depending on whether the range is relative to `now`), matching Discover / Dashboards / the rest of OSD. APM's icon-only variant was considered but rejected as inconsistent with the rest of the product.

### API changes (additive, backward compatible)

All three alerts routes accept the range for schema-shape uniformity; only the unified route currently honors it downstream (the per-backend routes' response shape is raw `OSAlert[]` / `PromAlert[]`, not `UnifiedAlertSummary[]`, so historical reconstruction is surfaced exclusively through `/api/alerting/unified/alerts`).

| Route | New query params | Validation |
|---|---|---|
| `GET /api/alerting/unified/alerts` | `startTime?: string`, `endTime?: string` | per-field `validateDateMath` + cross-field `validateTimeRangeQuery` (rejects one-sided and inverted ranges) |
| `GET /api/alerting/opensearch/{dsId}/alerts` | same | same |
| `GET /api/alerting/prometheus/{dsId}/alerts` | same (accepted, no-op on this route — logs a debug warn when passed) | same |

Types (`common/types/alerting/unified_types.ts`):

```ts
export type DatasourceFetchFallback = 'prometheus-alerts-current-only';

interface UnifiedFetchOptions {
  // ...existing...
  /** Date-math string (e.g. "now-1h"). */
  startTime?: string;
  /** Date-math string (e.g. "now"). */
  endTime?: string;
}

interface DatasourceFetchResult<T> {
  // ...existing...
  /** OS hit the 1000-alert cap for this range (per-datasource). */
  truncated?: boolean;
  /** Historical reconstruction unavailable; using currently-firing alerts only. */
  fallback?: DatasourceFetchFallback;
  error?: string;
}
```

### OpenSearch backend — interval overlap + cap

Upstream `GET /_plugins/_alerting/monitors/alerts` does not accept a time filter, so we post-fetch filter using an **interval-overlap** predicate:

```ts
const effectiveEnd = alert.end_time ?? windowEnd; // active alerts have no end_time
const include      = alert.start_time <= windowEnd
                  && effectiveEnd      >= windowStart;
```

`windowEnd` is the resolved time window (computed once at service entry), not a fresh `Date.now()` per iteration — this keeps the filter deterministic across multi-page scans. An alert is included if its active interval intersects the picked window:

| Alert timing (window `[2pm, 4pm]`) | Included? |
|---|---|
| 1pm – 3pm (spans windowStart) | yes |
| 3pm – 5pm (spans windowEnd) | yes |
| 3pm – ongoing (no `end_time`) | yes |
| 12pm – 1pm (entirely before) | no |
| 5pm – 6pm (entirely after) | no |

Pagination is capped at **1000 post-overlap alerts per datasource**. If the cap is reached, the response carries `truncated: true` and the UI renders an `EuiCallOut`: *"Results capped at 1000 alerts. Narrow the time range for complete results."* This bounds worst-case traversal when a monitor produces tens of thousands of historical alerts. End-of-stream is detected via `pageAlerts.length < PAGE_SIZE`; we deliberately don't early-exit on the upstream `totalAlerts` count, which can be stale under heavy ingest and cut the loop before the real last page.

### Prometheus backend — historical + live, merged

Prometheus has two distinct alert sources: the `ALERTS{}` time series (history) and `/api/v1/alerts` (currently firing). For consistent results regardless of window size or cluster retention, the backend queries **both in parallel on every fetch** and merges them by rule identity.

```ts
class DirectQueryPrometheusBackend {
  async getHistoricalAlerts(
    client, ds, startEpochSec, endEpochSec, stepSec, endIsNow,
  ): Promise<{
    alerts: UnifiedAlertSummary[];
    fallback?: 'prometheus-alerts-current-only';
    error?: string;
  }>;

  // New multi-series parser for the ALERTS{} matrix:
  async queryRangeMatrix(client, ds, query, start, end, step): Promise<PromSeriesMatrix[]>;
}
```

**Matrix reconstruction** — scans each series for contiguous `value === 1` runs. The upstream query is scoped to `ALERTS{alertstate="firing"}` so pending transitions (a transient grace-period state whose sample count flaps with step size) never reach the parser — row counts are step-independent.

Edge-tolerance at the window boundaries is 1.5× step:

- **First firing sample at matrix index 0 AND within tolerance of windowStart** → `truncatedStart: true`, `startMs` clamped to windowStart. Alert was already firing before the window opened.
- **Last firing sample within tolerance of windowEnd** → `stillActiveAtRangeEnd: true`, `endMs` clamped to windowEnd, `state: 'active'`.
- **Any other case** → real sample timestamps used, `state: 'resolved'`.

Without this tolerance every episode would appear to span the full window (every alert's first matrix sample is at index 0, regardless of when the alert actually started).

**Merge step** — a live alert is suppressed only if a historical episode with the same rule identity is already flagged `stillActiveAtRangeEnd`. Rule identity is an FNV-1a hash of the full label map minus `__name__` and `alertstate` (which differ between matrix samples and the live endpoint). Live alerts in `state: 'pending'` are dropped, mirroring the matrix-side filter. Errors are isolated: a matrix failure doesn't hide live alerts, and a live failure doesn't hide historical data.

**`fallback: 'prometheus-alerts-current-only'`** is set when the matrix returned empty but live alerts exist — retention gap. Range fully in the past with no matrix data is a legitimate empty result, no banner.

**Alert ids** are `${dsId}-${alertname}-${labelHash}-${startMs}` where `labelHash` is an 8-char FNV-1a hash of the sorted full label map. Two series with the same alertname but different `service_name` / `job` / etc. produce distinct ids; the hash is deterministic and order-independent.

**Step sizing** (shared helper):

```ts
step = clamp(
  Math.max(Math.floor((endSec - startSec) / 500), evalIntervalSec ?? 15),
  15,
  300,
);
```

Target: ≤500 points per series, floor 15s (typical scrape interval), ceiling 300s. Caller computes step; backend does not re-derive it. `queryRangeMatrix` also enforces a defensive 50k-points-per-series cap to bound memory on misbehaving exporters.

### Shared helper

`common/services/alerting/time_range.ts` — pure, framework-free, consumed by both the server (`MultiBackendAlertService` at the service boundary) and the UI (`AlarmsPage` for chart-prop resolution):

```ts
parseDateMath(expr, isEndTime)       // epoch seconds, roundUp for end
parseDateMathMs(expr, isEndTime)     // epoch ms
dateMathToDSLString(expr)            // pass-through for OS DSL range
computeStep(startSec, endSec)  // formula above
validateDateMath(expr)               // per-field route validator
validateTimeRangeQuery({start, end}) // cross-field: one-sided + inverted
```

Tests pin `process.env.TZ = 'UTC'` before `@elastic/datemath` imports (TZ-dependent rounding otherwise breaks assertions on non-UTC runners).

### AlertTimeline — variable range bucketing

`AlertTimeline` accepts `startMs`/`endMs` and computes:

```ts
const targetBucketMs = 5 * 60_000;
const bucketCount    = clamp(Math.ceil(rangeMs / targetBucketMs), 12, 24);
const bucketDuration = rangeMs / bucketCount;
```

Label format adapts to range:

| Range | x-axis label |
|---|---|
| ≤ 24h | `HH:mm` |
| ≤ 7d | `MM-DD HH:mm` |
| > 7d | `MM-DD` |

### Testing

| Path | Suites | Tests |
|---|---|---|
| `common/services/alerting` | 6 | 45 |
| `public/components/alerting` | 22 | 98 |
| `server/routes/alerting` | 5 | 51 |
| `server/services/alerting` | 10 | 176 |
| **Total** | **43** | **370** |

All pass on Node 22. `yarn lint` clean across touched files.

TZ-robustness verified by re-running `common/services/alerting` under `TZ=America/Los_Angeles` — all pass.

### Manual smoke

With `observability.alertManager.enabled: true`:

1. Navigate to **Alert manager** → **Alerts** tab.
2. Confirm `EuiSuperDatePicker` renders to the right of the tabs with a built-in Refresh button.
3. Change the range → alerts table, summary cards, and timeline chart all refetch and the chart x-axis adapts.
4. Reload the page → selection persists in-tab via sessionStorage.
5. Open a new tab → selection resets to `now-24h` / `now`.
6. Switch to Rules or Routing → picker is not rendered (no clutter).
7. Corrupt `AlertManagerStartTime` in DevTools → page does not crash; state + sessionStorage silently reset to defaults.
8. For a Prometheus datasource whose retention is shorter than the picked range → per-datasource fallback banner renders; currently-firing alerts still show.
9. For an OS datasource with >1000 historical alerts in the range → `truncated` callout renders.
10. Picking a range with `endTime < startTime` or only one side supplied → route returns 400 before the handler runs.

### Dependencies

- Prometheus historical alerts require the `ALERTS` time series to be recorded. This is on by default in stock Prometheus / Cortex builds. Clusters that disable recording rules or remap `ALERTS` still show currently-firing alerts through the live-merge path, with the fallback banner noting the coverage limit.


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
