### PR TITLE
Update uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "ws": "^8.18.0",
     "nanoid": "3.3.8",
     "serialize-javascript": "^7.0.3",
-    "@babel/runtime": "^7.26.10"
+    "@babel/runtime": "^7.26.10",
+    "uuid": "^3.4.0"
   },
   "eslintIgnore": [
     "common/query_manager/antlr/output/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,10 +2405,10 @@ utf8-byte-length@^1.0.1:
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz#f9f63910d15536ee2b2d5dd4665389715eac5c1e"
   integrity sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==
 
-uuid@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-  integrity sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg==
+uuid@^2.0.1, uuid@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 vfile-location@^2.0.0:
   version "2.0.6"


### PR DESCRIPTION
### Description
  Fixes #2657 — Mend-flagged uuid-2.0.3 (CVE-2026-41907) pulled in transitively by react-graph-vis@1.0.7.

  Why a resolutions pin instead of upgrading react-graph-vis

  react-graph-vis@1.0.7 is the latest published version (last release 2020) and depends on uuid@^2.0.1, which resolves to the flagged 2.0.3.
  There is no upstream upgrade available.

  Why pin to uuid@^3.4.0 and not the "patched" 11.1.1

  The advisory's vulnerable range is uuid >= 11.0.0 — the buggy v3/v5/v6 external-buffer code paths only exist in 11.x+. uuid@3.4.0:

  - is outside the advisory's vulnerable range (no v3/v5/v6 external-buffer API)
  - preserves the legacy default-export shape (module.exports = v4; v4.v4 = v4) that react-graph-vis/lib/index.js:57 relies on
  (_uuid2.default.v4()); jumping to 11.x dropped that and would crash the service map at runtime
  - matches what the parent OpenSearch-Dashboards workspace already pins (uuid@3.3.2)

  Change

  A single entry added to package.json resolutions:

  "uuid": "^3.4.0"

  yarn install rewrote yarn.lock so the transitive uuid@^2.0.1 now resolves to 3.4.0. Diff is one block in yarn.lock, no source code changes.

  Blast radius

  react-graph-vis is imported in exactly one source file: public/components/trace_analytics/components/common/plots/service_map.tsx. That component renders the Service Map panel (Trace Analytics) and the Application Composition Map panel (Applications).

  Verification

  - node -e "require('uuid').v4()" → returns valid UUID against 3.4.0
  - Simulated babel _interopRequireDefault(require('uuid')).default.v4() (the exact call shape react-graph-vis uses) → returns valid UUID
  - Service map renders nodes/edges and focus search works on Trace Analytics → Services and Applications → Composition Map
  - yarn test:jest public/components/trace_analytics/components/common/plots/__tests__/service_map.test.tsx passes

  Issues Resolved

  Closes #2657

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
