### PR TITLE
Cypress fix Panels

### DIFF
--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -45,6 +45,8 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
   describe('Creating visualizations', () => {
     beforeEach(() => {
       moveToEventsHome();
+      cy.reload(true);
+      cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     });
 
     it('Create first visualization in event analytics', () => {

--- a/.cypress/integration/panels_test/panels.spec.ts
+++ b/.cypress/integration/panels_test/panels.spec.ts
@@ -45,6 +45,10 @@ describe('Panels testing with Sample Data', { defaultCommandTimeout: 10000 }, ()
   describe('Creating visualizations', () => {
     beforeEach(() => {
       moveToEventsHome();
+      // Explorer persists savedObjectId in sessionStorage via redux-persist; clear it
+      // so the second test creates a new visualization instead of trying to PUT-update
+      // the previous test's visualization (which the outer beforeEach has just deleted).
+      cy.window().then((win) => win.sessionStorage.clear());
       cy.reload(true);
       cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
     });


### PR DESCRIPTION
### Description
  The Create second visualization in event analytics test in panels.spec.ts was consistently failing in CI but passing locally. The failure manifested as:

  AssertionError: Timed out retrying after 10000ms: Expected to find content: 'successfully'
  within the element: <span.euiToastHeader__title> but never did.

  Root cause

  The Cypress run video showed a PUT 404 against /api/saved_objects/observability-visualization/<id> immediately followed by a Cannot update Visualization 'Average flight delay minutes' — Not Found error toast.

  The flow that caused it:

  1. Test 1 creates a visualization with id X and saves it.
  2. The outer beforeEach calls eraseSavedVisualizations(), which deletes X from the backend.
  3. Test 2 starts. Because cypress.config.js sets testIsolation: false, the browser tab is reused between tests. The explorer's Redux
  store is wrapped in redux-persist backed by sessionStorage (public/framework/redux/store/index.ts:7), and sessionStorage survives within a single tab. So SAVED_OBJECT_ID = X is still present — both in the live Redux store and in sessionStorage.
  4. When test 2 hits Save, handleSavingObject in explorer.tsx:832 sees isTabHasObjID && isObjTypeMatchVis and dispatches SaveAsCurrentVisualization, which issues PUT /saved_objects/observability-visualization/X (update) instead of POST (create). The server returns 404 because X was just deleted, the error toast fires, the successfully toast never appears, and the assertion times out.

  The reason it usually passes locally is purely timing-dependent: slower local typing/interactions sometimes give the explorer enough time to drop the stale savedObjectId before save is clicked.

  Fix

  Force a clean explorer state at the start of each Creating visualizations test by clearing the persisted Redux state and reloading:
```
  describe('Creating visualizations', () => {
    beforeEach(() => {
      moveToEventsHome();
      // Explorer persists savedObjectId in sessionStorage via redux-persist; clear it
      // so the second test creates a new visualization instead of trying to PUT-update
      // the previous test's visualization (which the outer beforeEach has just deleted).
      cy.window().then((win) => win.sessionStorage.clear());
      cy.reload(true);
      cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
    });
    ...
  });
```
  Why all three lines are needed, in order:

  1. moveToEventsHome() — cy.window() requires a page to be loaded, so we have to visit first. This rehydrates the stale state from sessionStorage into the live Redux store.
  2. cy.window().then((win) => win.sessionStorage.clear()) — wipes the persisted state so the next rehydrate starts clean. This alone isn't enough because the running tab still has the stale id in its live store.
  3. cy.reload(true) — hard reload, forcing rehydrate from the now-empty sessionStorage. This is what actually drops the stale savedObjectId from the running app.

  The subsequent save now correctly POSTs a new visualization instead of PUT-ing onto a deleted id.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
