### PR TITLE
feat(slo): PR 2 — workspace id + acting user + wizard completeness

### DIFF
--- a/.cypress/integration/slo_test/slo_crud_smoke.spec.js
+++ b/.cypress/integration/slo_test/slo_crud_smoke.spec.js
@@ -6,7 +6,11 @@
 /// <reference types="cypress" />
 
 /*
- * PR-1 SLO CRUD smoke — create → detail → listing row → delete → row gone.
+ * SLO CRUD smoke — create → detail → listing row → delete → row gone.
+ *
+ * The wizard surface targeted here is the PR 2 multi-section wizard. Test-subj
+ * naming follows the `slos*` convention introduced in PR 2 (vs. PR 1's
+ * `sloWizard*` names which the wizard rewrite replaced).
  *
  * Prereqs:
  *   - Dev stack running with `observability.slo.enabled: true` in
@@ -19,8 +23,6 @@
  *   yarn cypress:run \
  *     --spec .cypress/integration/slo_test/slo_crud_smoke.spec.js \
  *     --env workspaceId=<WS_ID>,sloDatasourceId=<DS_ID>,baseUrl=http://localhost:5602
- *
- * The baseUrl env overrides `cypress.config.js` for dev servers on :5602.
  */
 
 const WORKSPACE_ID = Cypress.env('workspaceId');
@@ -37,7 +39,7 @@ const sloApp = `${prefix}/app/observability-apm-slo`;
 // doesn't have the stack up without failing the whole suite.
 const SLO_ENABLED = Cypress.env('sloEnabled') !== false;
 
-describe('SLO — CRUD smoke (PR 1)', () => {
+describe('SLO — CRUD smoke', () => {
   before(function () {
     if (!SLO_ENABLED) this.skip();
   });
@@ -48,21 +50,23 @@ describe('SLO — CRUD smoke (PR 1)', () => {
 
     // Land on the listing page.
     cy.visit(`${sloApp}#/slos`);
-    // Wait for the listing to render — either an empty prompt or the table.
     cy.get(
       '[data-test-subj="sloCreateBtn"], [data-test-subj="sloCreateBtnEmpty"]'
     )
       .first()
       .click();
 
-    // Fill the wizard.
-    cy.get('[data-test-subj="sloWizardName"]').type(name);
-    cy.get('[data-test-subj="sloWizardService"]').type(service);
-    cy.get('[data-test-subj="sloWizardTeam"]').type('platform');
-    cy.get('[data-test-subj="sloWizardDatasource"]').type(DATASOURCE_ID);
-    cy.get('[data-test-subj="sloWizardMetric"]').clear().type('http_requests_total');
-    cy.get('[data-test-subj="sloWizardTarget"]').clear().type('99.9');
-    cy.get('[data-test-subj="sloWizardSubmit"]').click();
+    // Pick a template (HTTP availability — single objective, no probe path).
+    cy.get('[data-test-subj="slosTemplate-http-availability"]', { timeout: 10000 }).click();
+
+    // Fill the wizard fields. Identity, owner, datasource — single objective
+    // suffices for the smoke path.
+    cy.get('[data-test-subj="slosWizardDatasourceId"]').clear().type(DATASOURCE_ID);
+    cy.get('[data-test-subj="slosWizardName"]').type(name);
+    cy.get('[data-test-subj="slosWizardService"]').type(service);
+    cy.get('[data-test-subj="slosWizardOwnerTeam"]').type('platform');
+
+    cy.get('[data-test-subj="slosWizardSubmit"]').click();
 
     // After create the wizard redirects to the detail page for the new SLO.
     cy.location('hash', { timeout: 15000 }).should('match', /#\/slos\/[0-9a-f-]{36}/);

--- a/.cypress/integration/slo_test/slo_wizard_multi_objective.spec.js
+++ b/.cypress/integration/slo_test/slo_wizard_multi_objective.spec.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="cypress" />
+
+/*
+ * PR 2 wizard — multi-objective happy path + validation summary.
+ *
+ * Adds a second objective row, fills both, submits, and verifies the SLO is
+ * persisted with two objectives. Then exercises the validation-summary flow:
+ * clear a required field, submit, the summary banner appears with one error.
+ *
+ * Prereqs:
+ *   - `observability.slo.enabled: true` in opensearch_dashboards.yml.
+ *   - A registered Prometheus-backed DirectQuery datasource.
+ *
+ * Run with (from plugin dir):
+ *   yarn cypress:run \
+ *     --spec .cypress/integration/slo_test/slo_wizard_multi_objective.spec.js \
+ *     --env workspaceId=<WS_ID>,sloDatasourceId=<DS_ID>,baseUrl=http://localhost:5602
+ */
+
+const WORKSPACE_ID = Cypress.env('workspaceId');
+const DATASOURCE_ID = Cypress.env('sloDatasourceId') || 'prom';
+
+const uniqueSuffix = () => Math.random().toString(36).slice(2, 8);
+const prefix = WORKSPACE_ID ? `/w/${WORKSPACE_ID}` : '';
+const sloApp = `${prefix}/app/observability-apm-slo`;
+
+const SLO_ENABLED = Cypress.env('sloEnabled') !== false;
+
+describe('SLO wizard — multi-objective', () => {
+  before(function () {
+    if (!SLO_ENABLED) this.skip();
+  });
+
+  it('creates an SLO with two objectives and renders the rule preview', () => {
+    const name = `Multi-Obj SLO ${uniqueSuffix()}`;
+    const service = `multi-obj-svc-${uniqueSuffix()}`;
+
+    cy.visit(`${sloApp}#/slos/create`);
+    cy.get('[data-test-subj="slosTemplate-http-availability"]', { timeout: 10000 }).click();
+
+    // Identity / owner / datasource.
+    cy.get('[data-test-subj="slosWizardDatasourceId"]').clear().type(DATASOURCE_ID);
+    cy.get('[data-test-subj="slosWizardName"]').type(name);
+    cy.get('[data-test-subj="slosWizardService"]').type(service);
+    cy.get('[data-test-subj="slosWizardOwnerTeam"]').type('platform');
+
+    // Default objective is "availability-99-9". Add a second.
+    cy.get('[data-test-subj="slosWizardObjectiveAdd"]').click();
+    cy.get('[data-test-subj="slosWizardObjectiveName-1"]').clear().type('availability-99-0');
+    cy.get('[data-test-subj="slosWizardObjectiveTarget-1"]').clear().type('99');
+
+    // Live downtime preview surfaces under the target.
+    cy.get('[data-test-subj="slosWizardObjectiveTargetDowntime-0"]').should('be.visible');
+    cy.get('[data-test-subj="slosWizardObjectiveTargetDowntime-1"]').should('be.visible');
+
+    // Rule-preview panel renders once form is valid (debounce ~500ms).
+    cy.get('[data-test-subj="slosWizardPreviewSuccess"]', { timeout: 15000 }).should('be.visible');
+
+    cy.get('[data-test-subj="slosWizardSubmit"]').click();
+    cy.location('hash', { timeout: 15000 }).should('match', /#\/slos\/[0-9a-f-]{36}/);
+
+    // Detail page surfaces both objectives in the spec JSON view.
+    cy.contains(name).should('be.visible');
+    cy.contains('availability-99-0').should('be.visible');
+  });
+
+  it('surfaces a top-level validation summary when a required field is missing', () => {
+    cy.visit(`${sloApp}#/slos/create`);
+    cy.get('[data-test-subj="slosTemplate-http-availability"]', { timeout: 10000 }).click();
+
+    // Skip the Name field — but fill the rest so this is a single-error flow.
+    cy.get('[data-test-subj="slosWizardDatasourceId"]').clear().type(DATASOURCE_ID);
+    cy.get('[data-test-subj="slosWizardService"]').type(`svc-${uniqueSuffix()}`);
+    cy.get('[data-test-subj="slosWizardOwnerTeam"]').type('platform');
+
+    cy.get('[data-test-subj="slosWizardSubmit"]').click();
+    cy.get('[data-test-subj="slosWizardValidationSummary"]', { timeout: 5000 }).should('be.visible');
+    cy.get('[data-test-subj="slosWizardValidationSummaryItem-spec.name"]').should('be.visible');
+
+    // Filling the name clears the corresponding row from the summary on next
+    // submit attempt (the user sees progress, not a stale red banner).
+    cy.get('[data-test-subj="slosWizardName"]').type(`Recovered ${uniqueSuffix()}`);
+    cy.get('[data-test-subj="slosWizardSubmit"]').click();
+    cy.get('[data-test-subj="slosWizardValidationSummaryItem-spec.name"]').should('not.exist');
+  });
+});

--- a/.cypress/integration/slo_test/slo_workspace_isolation.spec.js
+++ b/.cypress/integration/slo_test/slo_workspace_isolation.spec.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="cypress" />
+
+/*
+ * Workspace-scoped create — confirms PR 2's request-layer plumbing routes the
+ * workspace id from `getWorkspaceState(req)` into `sloRulerNamespaceFor(...)`.
+ * An SLO created under a non-default workspace lands in
+ * `slo-generated-<wsId>` on the ruler and is visible only from the same
+ * workspace's listing.
+ *
+ * Prereqs:
+ *   - `observability.slo.enabled: true` in opensearch_dashboards.yml.
+ *   - A non-default workspace `<WS_ID>` with the APM + SLO apps visible.
+ *   - A registered Prometheus-backed DirectQuery datasource visible in that
+ *     workspace.
+ *
+ * Run with (from plugin dir):
+ *   yarn cypress:run \
+ *     --spec .cypress/integration/slo_test/slo_workspace_isolation.spec.js \
+ *     --env workspaceId=<WS_ID>,sloDatasourceId=<DS_ID>,baseUrl=http://localhost:5602
+ *
+ * The spec NO-OPs (skips) when no workspaceId is supplied — single-workspace
+ * deployments don't have a "non-default" path to exercise.
+ */
+
+const WORKSPACE_ID = Cypress.env('workspaceId');
+const DATASOURCE_ID = Cypress.env('sloDatasourceId') || 'prom';
+
+const uniqueSuffix = () => Math.random().toString(36).slice(2, 8);
+const sloApp = (prefix) => `${prefix}/app/observability-apm-slo`;
+
+const SLO_ENABLED = Cypress.env('sloEnabled') !== false;
+
+describe('SLO — workspace-scoped create', () => {
+  before(function () {
+    if (!SLO_ENABLED) this.skip();
+    if (!WORKSPACE_ID) this.skip();
+  });
+
+  it('creates an SLO under a non-default workspace and lists it only there', () => {
+    const name = `WS Iso SLO ${uniqueSuffix()}`;
+    const service = `ws-iso-svc-${uniqueSuffix()}`;
+    const wsPrefix = `/w/${WORKSPACE_ID}`;
+
+    // Create from the workspace-scoped app surface.
+    cy.visit(`${sloApp(wsPrefix)}#/slos`);
+    cy.get(
+      '[data-test-subj="sloCreateBtn"], [data-test-subj="sloCreateBtnEmpty"]'
+    )
+      .first()
+      .click();
+
+    cy.get('[data-test-subj="slosTemplate-http-availability"]', { timeout: 10000 }).click();
+    cy.get('[data-test-subj="slosWizardDatasourceId"]').clear().type(DATASOURCE_ID);
+    cy.get('[data-test-subj="slosWizardName"]').type(name);
+    cy.get('[data-test-subj="slosWizardService"]').type(service);
+    cy.get('[data-test-subj="slosWizardOwnerTeam"]').type('platform');
+    cy.get('[data-test-subj="slosWizardSubmit"]').click();
+
+    cy.location('hash', { timeout: 15000 }).should('match', /#\/slos\/[0-9a-f-]{36}/);
+    cy.contains('h1', name, { timeout: 15000 }).should('be.visible');
+
+    // Listing shows the row inside this workspace.
+    cy.visit(`${sloApp(wsPrefix)}#/slos`);
+    cy.get('[data-test-subj="tablePaginationPopoverButton"]').click();
+    cy.get('.euiContextMenuItem').contains('100 rows').click();
+    cy.contains('[data-test-subj="sloRowName"]', name, { timeout: 15000 }).should('be.visible');
+
+    // Listing in the default workspace must NOT show the row — workspace
+    // isolation at the saved-objects layer plus the ruler-namespace gate
+    // means the SLO is genuinely scoped to the creating workspace.
+    cy.visit(sloApp('') + '#/slos');
+    cy.get('[data-test-subj="tablePaginationPopoverButton"]', { timeout: 10000 }).click();
+    cy.get('.euiContextMenuItem').contains('100 rows').click();
+    cy.contains('[data-test-subj="sloRowName"]', name).should('not.exist');
+
+    // Clean up — go back to the workspace-scoped listing and delete.
+    cy.visit(`${sloApp(wsPrefix)}#/slos`);
+    cy.get('[data-test-subj="tablePaginationPopoverButton"]').click();
+    cy.get('.euiContextMenuItem').contains('100 rows').click();
+    cy.contains('[data-test-subj="sloRowName"]', name)
+      .closest('tr')
+      .find('[data-test-subj="sloRowDelete"]')
+      .click();
+    cy.get('[data-test-subj="sloDeleteConfirm"]').find('button.euiButton--danger').click();
+    cy.contains('[data-test-subj="sloRowName"]', name).should('not.exist');
+  });
+});

--- a/common/slo/__tests__/slo_rule_provenance.test.ts
+++ b/common/slo/__tests__/slo_rule_provenance.test.ts
@@ -64,6 +64,7 @@ function ruleStub(name: string, type: 'alerting' | 'recording' = 'alerting'): Ge
 function groupStub(name: string, rules: GeneratedRule[]): GeneratedRuleGroup {
   return {
     groupName: name,
+    rulerNamespace: 'slo-generated-default',
     interval: 60,
     rules,
     yaml: '',

--- a/common/slo/__tests__/slo_ruler_namespace.test.ts
+++ b/common/slo/__tests__/slo_ruler_namespace.test.ts
@@ -9,11 +9,12 @@
  * writes to `slo-generated-<W>`") holds iff every caller goes through this
  * helper with a validated workspace id.
  *
- * Today PR 1 hard-codes `workspaceId: 'default'` at the route layer; PR 2
- * will plumb real workspace ids from request scope. The shape check here
- * makes sure a caller that forgets to normalize trips a server-side error
- * rather than silently landing a namespace with `..` or `%`-encoded bytes
- * in a ruler URL.
+ * As of PR 2, the route layer pulls real workspace ids from request scope
+ * via `getWorkspaceState(req).requestWorkspaceId`, falling back to
+ * `'default'` when OSD workspaces are disabled. The shape check here makes
+ * sure a caller that forgets to normalize trips a server-side error rather
+ * than silently landing a namespace with `..` or `%`-encoded bytes in a
+ * ruler URL.
  */
 
 import { sloRulerNamespaceFor } from '../slo_service';

--- a/common/slo/slo_promql_generator.ts
+++ b/common/slo/slo_promql_generator.ts
@@ -48,6 +48,22 @@ const DEFAULT_INTERVAL_SECONDS = 60;
 export const SLO_RULER_NAMESPACE = 'slo-generated';
 
 /**
+ * Compose the workspace-suffixed ruler namespace from a workspace id.
+ *
+ * Generator-local helper used to stamp `GeneratedRuleGroup.rulerNamespace`
+ * for previews / fallbacks where the doc's `status.provisioning.rulerNamespace`
+ * isn't set. The single source of truth for live writes is
+ * `sloRulerNamespaceFor` in `slo_service.ts`, which validates the workspace
+ * id against the path-safe regex; this helper deliberately stays
+ * dependency-free to keep `slo_promql_generator.ts` free of cycles. The
+ * service-layer boundary is the only place untrusted workspace ids enter
+ * the system, so the validation lives there, not here.
+ */
+function composeRulerNamespace(workspaceId: string): string {
+  return `${SLO_RULER_NAMESPACE}-${workspaceId}`;
+}
+
+/**
  * Default MWMBR tiers per the Google SRE Workbook Ch. 5 Table 5-8 and Sloth's
  * google-30d.yaml. Consumers can override per-SLO.
  */
@@ -646,11 +662,17 @@ export function generateSloRuleGroup(
 ): GeneratedRuleGroup {
   const { spec, id } = doc;
   const workspaceId = opts.workspaceId ?? 'default';
+  // Prefer the persisted namespace from the doc — it was stamped at create
+  // time by `sloRulerNamespaceFor` and stays durable across deployments. Only
+  // fall through for previews where `status.provisioning` may be a stub.
+  const rulerNamespace =
+    doc.status?.provisioning?.rulerNamespace ?? composeRulerNamespace(workspaceId);
   const rules: GeneratedRule[] = [];
 
   if (spec.sli.type !== 'single') {
     return {
       groupName: `slo:${id}`,
+      rulerNamespace,
       interval: DEFAULT_INTERVAL_SECONDS,
       rules: [],
       yaml: `# composite SLOs are reserved for P2\n`,
@@ -679,6 +701,7 @@ export function generateSloRuleGroup(
 
   return {
     groupName,
+    rulerNamespace,
     interval: DEFAULT_INTERVAL_SECONDS,
     rules,
     yaml: rulesToYaml(groupName, DEFAULT_INTERVAL_SECONDS, rules),
@@ -757,6 +780,13 @@ export function generateRecordingGroupForFingerprint(input: {
   sli: SingleSli;
   /** Required only when the SLI is a `latency_threshold` type. */
   objectiveLatencyThreshold?: number;
+  /**
+   * Workspace this recording group is being built for. Used to stamp
+   * `GeneratedRuleGroup.rulerNamespace` so the wizard preview / reconciler
+   * can render the namespace without re-deriving it. Defaults to `'default'`
+   * for callers that haven't been threaded yet (preview path falls back).
+   */
+  workspaceId?: string;
 }): GeneratedRuleGroup | null {
   const def = input.sli.definition;
   if (def.backend !== 'prometheus') return null;
@@ -788,6 +818,7 @@ export function generateRecordingGroupForFingerprint(input: {
   const groupName = dedupRecordingGroupName(fingerprint);
   return {
     groupName,
+    rulerNamespace: composeRulerNamespace(input.workspaceId ?? 'default'),
     interval: DEFAULT_INTERVAL_SECONDS,
     rules,
     yaml: rulesToYaml(groupName, DEFAULT_INTERVAL_SECONDS, rules),
@@ -811,6 +842,11 @@ export function generateAlertGroupFor(
 ): GeneratedRuleGroup {
   const { spec, id } = doc;
   const workspaceId = opts.workspaceId ?? 'default';
+  // Same prefer-doc-then-fall-through pattern as `generateSloRuleGroup`. The
+  // alert group lives in the same namespace as the recording groups it
+  // references, since the AMP invariant is "one workspace = one namespace".
+  const rulerNamespace =
+    doc.status?.provisioning?.rulerNamespace ?? composeRulerNamespace(workspaceId);
   const groupSlug = slugifySloObjective(spec.name, 'group');
   const firstSuffix = ruleSuffix(workspaceId, id, 'group');
   const groupName = `slo:alerts:${groupSlug}_${firstSuffix}`;
@@ -819,6 +855,7 @@ export function generateAlertGroupFor(
   if (spec.sli.type !== 'single') {
     return {
       groupName,
+      rulerNamespace,
       interval: DEFAULT_INTERVAL_SECONDS,
       rules: [],
       yaml: rulesToYaml(groupName, DEFAULT_INTERVAL_SECONDS, rules),
@@ -847,6 +884,7 @@ export function generateAlertGroupFor(
 
   return {
     groupName,
+    rulerNamespace,
     interval: DEFAULT_INTERVAL_SECONDS,
     rules,
     yaml: rulesToYaml(groupName, DEFAULT_INTERVAL_SECONDS, rules),

--- a/common/slo/slo_service.ts
+++ b/common/slo/slo_service.ts
@@ -724,6 +724,7 @@ export class SloService {
           fingerprint: fp,
           sli: representative.sli,
           objectiveLatencyThreshold: representative.latencyThreshold,
+          workspaceId: deploy.workspaceId,
         });
         if (recGroup) {
           try {
@@ -1013,6 +1014,7 @@ export class SloService {
           fingerprint: fp,
           sli: representative.sli,
           objectiveLatencyThreshold: representative.latencyThreshold,
+          workspaceId: deploy.workspaceId,
         });
         if (recGroup) {
           try {
@@ -1390,6 +1392,7 @@ export class SloService {
         fingerprint: fp,
         sli: representative.sli,
         objectiveLatencyThreshold: representative.latencyThreshold,
+        workspaceId: ctx.deploy.workspaceId,
       });
       if (recGroup) {
         await ctx.deploy.ruler.upsertRuleGroup(

--- a/common/slo/slo_types.ts
+++ b/common/slo/slo_types.ts
@@ -431,6 +431,15 @@ export interface GeneratedRule {
 
 export interface GeneratedRuleGroup {
   groupName: string;
+  /**
+   * The Prometheus / Cortex rule namespace this group will land in
+   * (`slo-generated-<workspaceId>`). Stamped by the generator from the
+   * doc's `status.provisioning.rulerNamespace` (or composed from
+   * `opts.workspaceId` for previews where the doc isn't persisted yet).
+   * Surfaced so the wizard preview chip matches the saved doc's
+   * `status.provisioning.rulerNamespace` byte-for-byte.
+   */
+  rulerNamespace: string;
   /** Evaluation interval in seconds. */
   interval: number;
   rules: GeneratedRule[];

--- a/public/components/apm/pages/slos/__tests__/burn_rate_presets.test.ts
+++ b/public/components/apm/pages/slos/__tests__/burn_rate_presets.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BURN_RATE_PRESETS, getBurnRatePreset, isPresetApplied } from '../burn_rate_presets';
+
+describe('burn-rate presets', () => {
+  it('exposes the documented three presets', () => {
+    expect(BURN_RATE_PRESETS.map((p) => p.id).sort()).toEqual(
+      ['balanced', 'page-heavy', 'ticket-heavy'].sort()
+    );
+  });
+
+  it('each preset has at least one tier', () => {
+    for (const p of BURN_RATE_PRESETS) {
+      expect(p.tiers.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('isPresetApplied returns true on a freshly cloned preset', () => {
+    const p = getBurnRatePreset('balanced');
+    expect(
+      isPresetApplied(
+        p,
+        p.tiers.map((t) => ({ ...t }))
+      )
+    ).toBe(true);
+  });
+
+  it('isPresetApplied returns false when the user edits any field', () => {
+    const p = getBurnRatePreset('balanced');
+    const tiers = p.tiers.map((t) => ({ ...t }));
+    tiers[0].burnRateMultiplier = tiers[0].burnRateMultiplier + 0.1;
+    expect(isPresetApplied(p, tiers)).toBe(false);
+  });
+
+  it('isPresetApplied returns false when the user adds a tier', () => {
+    const p = getBurnRatePreset('balanced');
+    const tiers = p.tiers.map((t) => ({ ...t }));
+    tiers.push({ ...tiers[0] });
+    expect(isPresetApplied(p, tiers)).toBe(false);
+  });
+
+  it('getBurnRatePreset throws on an unknown id', () => {
+    // Cast to bypass the union — the runtime guard is the point of the test.
+    expect(() => getBurnRatePreset('made-up' as 'balanced')).toThrow(/Unknown burn-rate preset/);
+  });
+});

--- a/public/components/apm/pages/slos/__tests__/generated_rules_preview.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/generated_rules_preview.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Asserts the wizard preview chip renders the workspace-scoped namespace
+ * the server returned (e.g. `slo-generated-ws-alpha`) — not the bare
+ * `SLO_RULER_NAMESPACE` constant. Bug-1 regression guard:
+ * pre-fix the chip read from the imported constant and would always show
+ * `slo-generated`, regardless of which workspace the saved doc landed in.
+ */
+
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+
+import { GeneratedRulesPreview, PREVIEW_DEBOUNCE_MS } from '../generated_rules_preview';
+import type { GeneratedRuleGroup, SloCreateInput } from '../../../../../../common/slo/slo_types';
+
+function dummyInput(): SloCreateInput {
+  // The component only round-trips the input through JSON.stringify before
+  // handing it to the mocked apiClient — it is never validated client-side
+  // here, so a partial spec is fine for this test's purposes. We assert
+  // the rendered chip from the apiClient response, not from the input.
+  return ({ id: 'slo-1', spec: { name: 'demo' } } as unknown) as SloCreateInput;
+}
+
+function ruleGroupFor(rulerNamespace: string): GeneratedRuleGroup {
+  return {
+    groupName: 'slo:demo_abcd1234',
+    rulerNamespace,
+    interval: 60,
+    rules: [
+      {
+        type: 'recording',
+        name: 'slo:sli_error:ratio_rate_5m:demo_abcd1234',
+        expr: 'vector(0)',
+        labels: {},
+        description: 'rec',
+      },
+    ],
+    yaml: 'name: slo:demo_abcd1234\n',
+  };
+}
+
+describe('GeneratedRulesPreview — namespace chip', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  async function flushDebounceAndPromises(): Promise<void> {
+    // The component debounces serialized input, then issues the preview
+    // request. Step the timer, then let microtasks settle so the promise
+    // resolves and re-render lands.
+    await act(async () => {
+      jest.advanceTimersByTime(PREVIEW_DEBOUNCE_MS + 1);
+    });
+    await act(async () => {
+      // microtask flush
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('renders the rulerNamespace returned by the server (workspace-suffixed)', async () => {
+    const apiClient = {
+      preview: jest.fn().mockResolvedValue(ruleGroupFor('slo-generated-ws-alpha')),
+    };
+    const { getByTestId } = render(
+      <GeneratedRulesPreview apiClient={apiClient as never} input={dummyInput()} />
+    );
+
+    await flushDebounceAndPromises();
+
+    await waitFor(() => expect(getByTestId('slosWizardPreviewSuccess')).toBeInTheDocument());
+    expect(getByTestId('slosWizardPreviewNamespace').textContent).toContain(
+      'slo-generated-ws-alpha'
+    );
+    // Pre-fix regression guard: the bare constant must not show up.
+    expect(getByTestId('slosWizardPreviewNamespace').textContent).not.toMatch(
+      /\bslo-generated\b(?!-)/
+    );
+  });
+
+  it('renders the default workspace suffix when the server stamps slo-generated-default', async () => {
+    const apiClient = {
+      preview: jest.fn().mockResolvedValue(ruleGroupFor('slo-generated-default')),
+    };
+    const { getByTestId } = render(
+      <GeneratedRulesPreview apiClient={apiClient as never} input={dummyInput()} />
+    );
+
+    await flushDebounceAndPromises();
+
+    await waitFor(() => expect(getByTestId('slosWizardPreviewSuccess')).toBeInTheDocument());
+    expect(getByTestId('slosWizardPreviewNamespace').textContent).toContain(
+      'slo-generated-default'
+    );
+  });
+});

--- a/public/components/apm/pages/slos/__tests__/objectives_section.test.ts
+++ b/public/components/apm/pages/slos/__tests__/objectives_section.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Allowed-downtime formatter sanity. The formatter is the visible
+ * "99.9% over 28d → 40m 20s of error budget" preview — getting it wrong
+ * pushes users towards picking targets without seeing the actual budget.
+ */
+
+import { formatAllowedDowntime } from '../objectives_section';
+
+describe('formatAllowedDowntime', () => {
+  it('renders the two-largest non-zero units', () => {
+    expect(formatAllowedDowntime(2 * 86_400_000 + 3 * 3_600_000)).toBe('2d 3h');
+    expect(formatAllowedDowntime(83 * 60_000 + 19_000)).toBe('1h 23m');
+    expect(formatAllowedDowntime(60_000 + 5_000)).toBe('1m 5s');
+  });
+
+  it('drops zero-valued leading units', () => {
+    expect(formatAllowedDowntime(45_000)).toBe('45s');
+    expect(formatAllowedDowntime(60_000)).toBe('1m');
+  });
+
+  it('renders 0s for zero or sub-second durations', () => {
+    expect(formatAllowedDowntime(0)).toBe('0s');
+    expect(formatAllowedDowntime(400)).toBe('0s');
+  });
+
+  it('returns empty string for invalid inputs (no NaN%, no negatives)', () => {
+    expect(formatAllowedDowntime(NaN)).toBe('');
+    expect(formatAllowedDowntime(-1)).toBe('');
+    expect(formatAllowedDowntime(Infinity)).toBe('');
+  });
+
+  it("rounds the ms→sec boundary so IEEE-754 noise doesn't flip the seconds digit", () => {
+    // 99.9% over 30d. Without rounding, `Math.floor` would tick this back to
+    // 43m 11s (one second short).
+    const ms = (1 - 99.9 / 100) * 30 * 86_400_000;
+    expect(formatAllowedDowntime(ms)).toBe('43m 12s');
+  });
+
+  it('preserves seconds precision for tight targets (the cases most worth scrutinizing)', () => {
+    // 99.99% over 28d → 4m 1.92s of budget. Round to 4m 2s.
+    const ms = (1 - 99.99 / 100) * 28 * 86_400_000;
+    expect(formatAllowedDowntime(ms)).toBe('4m 2s');
+  });
+});

--- a/public/components/apm/pages/slos/__tests__/slo_api_client.test.ts
+++ b/public/components/apm/pages/slos/__tests__/slo_api_client.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for the toast-message extractors that drive the wizard,
+ * listing, and detail-page error toasts. The extractors must:
+ *
+ *   - Prefer `body.message` over `err.message` so OSD's HTTP-status
+ *     reason ("Bad Request", "Not Found") does not eclipse the route's
+ *     actionable diagnostic.
+ *
+ *   - Surface `body.attributes.errors` from the route's validation
+ *     envelope. The single-error case (the canonical typo'd-datasource
+ *     flow) renders inline; the multi-error case appends a count and
+ *     defers to the wizard's inline summary.
+ */
+
+import { extractRulerErrorEnvelope, extractServerMessage } from '../slo_api_client';
+
+function osdHttpError(body: unknown, message = 'Bad Request'): unknown {
+  // Mirrors the IHttpFetchError shape OSD attaches `.body` to.
+  const err = new Error(message) as Error & { body?: unknown };
+  err.body = body;
+  return err;
+}
+
+describe('extractServerMessage', () => {
+  it('prefers body.message when the OSD envelope is present', () => {
+    const err = osdHttpError({ message: 'Workspace id is malformed' }, 'Bad Request');
+    expect(extractServerMessage(err)).toBe('Workspace id is malformed');
+  });
+
+  it('falls back to err.message when body is absent', () => {
+    expect(extractServerMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('returns String(err) for non-Error inputs without a message', () => {
+    expect(extractServerMessage(42)).toBe('42');
+    expect(extractServerMessage(null)).toBe('null');
+  });
+
+  describe('attributes.errors envelope (route validation 400)', () => {
+    it('renders single field errors inline as "head\\nfield: msg"', () => {
+      const err = osdHttpError({
+        message: 'Validation failed',
+        attributes: {
+          errors: {
+            'spec.datasourceId':
+              'Datasource "does-not-exist-pr2" is not registered. Pick one from /api/alerting/datasources.',
+          },
+        },
+      });
+      expect(extractServerMessage(err)).toBe(
+        'Validation failed\n' +
+          'spec.datasourceId: Datasource "does-not-exist-pr2" is not registered. ' +
+          'Pick one from /api/alerting/datasources.'
+      );
+    });
+
+    it('falls back to "Validation failed" head when body.message is absent', () => {
+      const err = osdHttpError({
+        attributes: {
+          errors: { 'spec.name': 'Required' },
+        },
+      });
+      expect(extractServerMessage(err)).toBe('Validation failed\nspec.name: Required');
+    });
+
+    it('renders multi-field errors as "head (N field errors)" — defers detail to inline summary', () => {
+      const err = osdHttpError({
+        message: 'Validation failed',
+        attributes: {
+          errors: {
+            'spec.datasourceId': 'Datasource "X" is not registered',
+            'spec.objectives[0].target': 'Target must be between 0 and 1',
+            'spec.window.duration': 'Unsupported window',
+          },
+        },
+      });
+      expect(extractServerMessage(err)).toBe('Validation failed (3 field errors)');
+    });
+
+    it('ignores non-string error values and falls through to body.message when none survive', () => {
+      const err = osdHttpError({
+        message: 'Validation failed',
+        attributes: {
+          errors: {
+            'spec.objectives': { foo: 'bar' }, // not a string
+            'spec.window': null,
+            'spec.x': '', // empty
+          },
+        },
+      });
+      expect(extractServerMessage(err)).toBe('Validation failed');
+    });
+
+    it('ignores non-object errors fields and falls through to body.message', () => {
+      const err = osdHttpError({
+        message: 'Validation failed',
+        attributes: { errors: 'not-an-object' },
+      });
+      expect(extractServerMessage(err)).toBe('Validation failed');
+    });
+  });
+});
+
+describe('extractRulerErrorEnvelope', () => {
+  it('returns null when the body has no ruler attributes', () => {
+    expect(extractRulerErrorEnvelope(osdHttpError({ message: 'Bad Request' }))).toBeNull();
+  });
+
+  it('extracts a RULER_VALIDATION_FAILED envelope', () => {
+    const env = extractRulerErrorEnvelope(
+      osdHttpError({
+        message: 'Ruler dual-write failed',
+        attributes: {
+          error: 'invalid PromQL',
+          code: 'RULER_VALIDATION_FAILED',
+          httpStatus: 400,
+          rawBody: 'parse error at char 42',
+        },
+      })
+    );
+    expect(env).toEqual({
+      error: 'invalid PromQL',
+      code: 'RULER_VALIDATION_FAILED',
+      httpStatus: 400,
+      rawBody: 'parse error at char 42',
+    });
+  });
+
+  it('returns null for unrelated attribute envelopes (e.g. validation 400)', () => {
+    expect(
+      extractRulerErrorEnvelope(
+        osdHttpError({
+          message: 'Validation failed',
+          attributes: { errors: { 'spec.name': 'Required' } },
+        })
+      )
+    ).toBeNull();
+  });
+});

--- a/public/components/apm/pages/slos/__tests__/wizard_builders.test.ts
+++ b/public/components/apm/pages/slos/__tests__/wizard_builders.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for the form-state → SloCreateInput builder. Most of the wizard's
+ * complexity is shape: percent → decimal target, key=value rows → flat
+ * record, custom-PromQL mode routing, latency-only `latencyThreshold` field.
+ */
+
+import { SLO_TEMPLATES } from '../../../../../../common/slo/slo_templates';
+import type { SloTemplate } from '../../../../../../common/slo/slo_templates';
+import { buildCreateInput, entriesToRecord, parseKeyValueBlock } from '../wizard_builders';
+import { initialState, reducer } from '../wizard_state';
+import type { FormState } from '../wizard_state';
+
+function pickTemplate(id: string): SloTemplate {
+  const t = SLO_TEMPLATES.find((x) => x.id === id);
+  if (!t) throw new Error(`expected fixture template "${id}" to exist`);
+  return t;
+}
+
+function statePopulated(): FormState {
+  let s = initialState();
+  s = reducer(s, { kind: 'setField', field: 'datasourceId', value: 'ds-1' });
+  s = reducer(s, { kind: 'setField', field: 'name', value: 'checkout-availability' });
+  s = reducer(s, { kind: 'setField', field: 'service', value: 'checkout' });
+  s = reducer(s, { kind: 'setField', field: 'ownerTeam', value: 'storefront' });
+  s = reducer(s, { kind: 'setObjectiveField', index: 0, field: 'target', value: '99.5' });
+  return s;
+}
+
+describe('buildCreateInput', () => {
+  it('converts target % into a decimal ratio', () => {
+    const t = pickTemplate('apm-service-availability');
+    const input = buildCreateInput(statePopulated(), t);
+    expect(input.spec.objectives[0].target).toBeCloseTo(0.995, 5);
+  });
+
+  it('emits one objective per wizard row (multi-objective)', () => {
+    let s = statePopulated();
+    s = reducer(s, { kind: 'addObjective' });
+    s = reducer(s, { kind: 'setObjectiveField', index: 1, field: 'target', value: '99.0' });
+    const input = buildCreateInput(s, pickTemplate('apm-service-availability'));
+    expect(input.spec.objectives.map((o) => o.target)).toEqual([
+      expect.closeTo(0.995, 5),
+      expect.closeTo(0.99, 5),
+    ]);
+  });
+
+  it('only carries latencyThreshold for latency_threshold templates', () => {
+    const availability = buildCreateInput(
+      statePopulated(),
+      pickTemplate('apm-service-availability')
+    );
+    expect(availability.spec.objectives[0].latencyThreshold).toBeUndefined();
+
+    const latencyTemplate = SLO_TEMPLATES.find((t) => t.sli.type === 'latency_threshold');
+    if (!latencyTemplate) {
+      throw new Error('expected at least one latency_threshold template fixture');
+    }
+    let s = statePopulated();
+    s = reducer(s, {
+      kind: 'setObjectiveField',
+      index: 0,
+      field: 'latencyThreshold',
+      value: '0.4',
+    });
+    const latency = buildCreateInput(s, latencyTemplate);
+    expect(latency.spec.objectives[0].latencyThreshold).toBeCloseTo(0.4, 5);
+  });
+
+  it('routes events-mode custom PromQL into customExpr.goodQuery / totalQuery', () => {
+    const customTemplate = SLO_TEMPLATES.find((t) => t.sli.type === 'custom');
+    if (!customTemplate) throw new Error('expected a custom template fixture');
+    let s = statePopulated();
+    s = reducer(s, {
+      kind: 'setCustomPromql',
+      patch: { mode: 'events', goodQuery: 'g', totalQuery: 't' },
+    });
+    const input = buildCreateInput(s, customTemplate);
+    expect(input.spec.sli.type).toBe('single');
+    const sli = input.spec.sli as { type: 'single'; definition?: { customExpr?: unknown } };
+    expect(sli.definition?.customExpr).toEqual({
+      mode: 'events',
+      goodQuery: 'g',
+      totalQuery: 't',
+    });
+  });
+
+  it('routes raw-mode custom PromQL into customExpr.errorRatioQuery', () => {
+    const customTemplate = SLO_TEMPLATES.find((t) => t.sli.type === 'custom');
+    if (!customTemplate) throw new Error('expected a custom template fixture');
+    let s = statePopulated();
+    s = reducer(s, {
+      kind: 'setCustomPromql',
+      patch: { mode: 'raw', errorRatioQuery: 'rate(errors[5m])' },
+    });
+    const input = buildCreateInput(s, customTemplate);
+    expect(input.spec.sli.type).toBe('single');
+    const sli = input.spec.sli as { type: 'single'; definition?: { customExpr?: unknown } };
+    expect(sli.definition?.customExpr).toEqual({
+      mode: 'raw',
+      errorRatioQuery: 'rate(errors[5m])',
+    });
+  });
+
+  it('flattens the labels grid into Record<string,string>, dropping empty-key rows', () => {
+    let s = statePopulated();
+    s = reducer(s, { kind: 'addLabelEntry' });
+    s = reducer(s, { kind: 'setLabelEntry', index: 0, field: 'key', value: 'compliance' });
+    s = reducer(s, { kind: 'setLabelEntry', index: 0, field: 'value', value: 'pci' });
+    s = reducer(s, { kind: 'addLabelEntry' });
+    s = reducer(s, { kind: 'setLabelEntry', index: 1, field: 'key', value: '' });
+    s = reducer(s, { kind: 'setLabelEntry', index: 1, field: 'value', value: 'orphan' });
+    const input = buildCreateInput(s, pickTemplate('apm-service-availability'));
+    expect(input.spec.labels).toEqual({ compliance: 'pci' });
+  });
+
+  it('drops empty dimensions but keeps entered ones', () => {
+    let s = statePopulated();
+    s = reducer(s, { kind: 'setDimension', index: 0, dim: { name: 'service', value: 'checkout' } });
+    s = reducer(s, { kind: 'addDimension' });
+    s = reducer(s, { kind: 'setDimension', index: 1, dim: { name: '', value: 'orphan' } });
+    const input = buildCreateInput(s, pickTemplate('apm-service-availability'));
+    expect(input.spec.sli.type).toBe('single');
+    const sli = input.spec.sli as {
+      type: 'single';
+      dimensions?: Array<{ name: string; value: string }>;
+    };
+    expect(sli.dimensions).toEqual([{ name: 'service', value: 'checkout' }]);
+  });
+});
+
+describe('entriesToRecord', () => {
+  it('drops rows with empty keys', () => {
+    expect(
+      entriesToRecord([
+        { key: 'a', value: '1' },
+        { key: '', value: 'orphan' },
+        { key: 'b', value: '' },
+      ])
+    ).toEqual({ a: '1', b: '' });
+  });
+});
+
+describe('parseKeyValueBlock', () => {
+  it('parses a multi-line key=value block, tolerating whitespace', () => {
+    const block = `
+      compliance = pci
+      runbook=https://wiki/slo
+      ignored without equals
+    `;
+    expect(parseKeyValueBlock(block)).toEqual({
+      compliance: 'pci',
+      runbook: 'https://wiki/slo',
+    });
+  });
+});

--- a/public/components/apm/pages/slos/__tests__/wizard_builders.test.ts
+++ b/public/components/apm/pages/slos/__tests__/wizard_builders.test.ts
@@ -11,7 +11,7 @@
 
 import { SLO_TEMPLATES } from '../../../../../../common/slo/slo_templates';
 import type { SloTemplate } from '../../../../../../common/slo/slo_templates';
-import { buildCreateInput, entriesToRecord, parseKeyValueBlock } from '../wizard_builders';
+import { buildCreateInput, entriesToRecord } from '../wizard_builders';
 import { initialState, reducer } from '../wizard_state';
 import type { FormState } from '../wizard_state';
 
@@ -142,19 +142,5 @@ describe('entriesToRecord', () => {
         { key: 'b', value: '' },
       ])
     ).toEqual({ a: '1', b: '' });
-  });
-});
-
-describe('parseKeyValueBlock', () => {
-  it('parses a multi-line key=value block, tolerating whitespace', () => {
-    const block = `
-      compliance = pci
-      runbook=https://wiki/slo
-      ignored without equals
-    `;
-    expect(parseKeyValueBlock(block)).toEqual({
-      compliance: 'pci',
-      runbook: 'https://wiki/slo',
-    });
   });
 });

--- a/public/components/apm/pages/slos/__tests__/wizard_sections.test.ts
+++ b/public/components/apm/pages/slos/__tests__/wizard_sections.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Drift-guard for `WIZARD_SECTIONS`. The order and shape of this list is
+ * load-bearing — it drives:
+ *   - the visual order of the wizard panels (wizard_page);
+ *   - the anchor nav (wizard_nav);
+ *   - the validation summary grouping (wizard_validation_summary);
+ *   - the rule-preview empty state's missing-fields list.
+ *
+ * Pinning the order here means a future refactor can't silently shuffle
+ * the user-facing layout without updating the test.
+ */
+
+import {
+  WIZARD_SECTIONS,
+  WizardSectionId,
+  findSectionForKey,
+  sectionsWithErrors,
+} from '../wizard_sections';
+
+describe('WIZARD_SECTIONS — drift guard', () => {
+  it('preserves the canonical visual order', () => {
+    const ids = WIZARD_SECTIONS.map((s) => s.id);
+    expect(ids).toEqual<WizardSectionId[]>([
+      'identity',
+      'window',
+      'owner',
+      'sli',
+      'promql',
+      'objectives',
+      'advanced',
+      'exclusions',
+      'labels',
+      'rulesPreview',
+    ]);
+  });
+
+  it('every section has a unique anchor id (anchor-id collisions break scrollIntoView)', () => {
+    const anchors = WIZARD_SECTIONS.map((s) => s.anchorId);
+    expect(new Set(anchors).size).toBe(anchors.length);
+  });
+
+  it('every section has a non-empty label', () => {
+    for (const section of WIZARD_SECTIONS) {
+      expect(section.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('errorPrefixes do not overlap shorter prefixes (longest-prefix match relies on this)', () => {
+    // Specifically: the SLI prefix `spec.sli` is a prefix of the PromQL
+    // section's `spec.sli.definition.customExpr`. The longest-prefix match
+    // in `findSectionForKey` is what keeps these from clashing — pin the
+    // expected resolution.
+    const sliKey = 'spec.sli.dimensions';
+    const promqlKey = 'spec.sli.definition.customExpr.goodQuery';
+    expect(findSectionForKey(sliKey)?.id).toBe('sli');
+    expect(findSectionForKey(promqlKey)?.id).toBe('promql');
+  });
+});
+
+describe('findSectionForKey', () => {
+  it('returns undefined for keys with no matching prefix', () => {
+    expect(findSectionForKey('totally.unrelated.key')).toBeUndefined();
+  });
+
+  it('matches indexed errors (`spec.objectives[0].name`)', () => {
+    expect(findSectionForKey('spec.objectives[0].name')?.id).toBe('objectives');
+    expect(findSectionForKey('spec.alerting.burnRates[2].shortWindow')?.id).toBe('advanced');
+  });
+
+  it('matches an exact-equal prefix (`spec.name`)', () => {
+    expect(findSectionForKey('spec.name')?.id).toBe('identity');
+  });
+});
+
+describe('sectionsWithErrors', () => {
+  it('returns an empty set for no errors', () => {
+    expect(sectionsWithErrors({})).toEqual(new Set());
+  });
+
+  it('groups errors by their owning section', () => {
+    const errors = {
+      'spec.name': 'required',
+      'spec.objectives[0].target': 'out of range',
+      'spec.alerting.burnRates[0].shortWindow': 'invalid duration',
+    };
+    expect(sectionsWithErrors(errors)).toEqual(new Set(['identity', 'objectives', 'advanced']));
+  });
+});

--- a/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
+++ b/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Reducer-shape sanity checks. The wizard reducer is small but its array
+ * mutations (objectives, dimensions, burn rates, exclusion windows,
+ * labels/annotations) are easy to break: forgetting to slice() leaks state
+ * mutation; forgetting to clamp `removeObjective` lets the user delete the
+ * sole remaining objective and submit with `objectives.length === 0`.
+ */
+
+import { initialState, reducer } from '../wizard_state';
+
+describe('reducer — multi-objective edits', () => {
+  it('starts with one objective row', () => {
+    const s = initialState();
+    expect(s.objectives).toHaveLength(1);
+  });
+
+  it("addObjective appends a new row carrying the first row's defaults", () => {
+    const s0 = initialState();
+    const s1 = reducer(s0, { kind: 'addObjective' });
+    expect(s1.objectives).toHaveLength(2);
+    expect(s1.objectives[1].name).toBe('objective-2');
+    expect(s1.objectives[1].target).toBe(s0.objectives[0].target);
+  });
+
+  it('removeObjective drops the targeted row but never the last one', () => {
+    let s = initialState();
+    s = reducer(s, { kind: 'addObjective' });
+    s = reducer(s, { kind: 'addObjective' });
+    expect(s.objectives).toHaveLength(3);
+    s = reducer(s, { kind: 'removeObjective', index: 1 });
+    expect(s.objectives).toHaveLength(2);
+
+    // Remove down to one — can't go further.
+    s = reducer(s, { kind: 'removeObjective', index: 0 });
+    s = reducer(s, { kind: 'removeObjective', index: 0 });
+    expect(s.objectives).toHaveLength(1);
+  });
+
+  it('setObjectiveField updates only the targeted row', () => {
+    let s = initialState();
+    s = reducer(s, { kind: 'addObjective' });
+    s = reducer(s, { kind: 'setObjectiveField', index: 1, field: 'target', value: '99.5' });
+    expect(s.objectives[0].target).toBe('99.9');
+    expect(s.objectives[1].target).toBe('99.5');
+  });
+});
+
+describe('reducer — burn-rate presets', () => {
+  it('applyBurnRatePreset overwrites the burn-rate tiers', () => {
+    let s = initialState();
+    expect(s.burnRates.length).toBe(4); // balanced default
+    s = reducer(s, { kind: 'applyBurnRatePreset', preset: 'page-heavy' });
+    expect(s.burnRates.length).toBe(3);
+    expect(s.burnRates.every((t) => t.severity === 'critical')).toBe(true);
+    s = reducer(s, { kind: 'applyBurnRatePreset', preset: 'ticket-heavy' });
+    expect(s.burnRates.every((t) => t.severity === 'warning')).toBe(true);
+  });
+
+  it('addBurnRate adds a fresh tier', () => {
+    let s = initialState();
+    const before = s.burnRates.length;
+    s = reducer(s, { kind: 'addBurnRate' });
+    expect(s.burnRates.length).toBe(before + 1);
+  });
+});
+
+describe('reducer — labels / annotations grids', () => {
+  it('addLabelEntry appends an empty row', () => {
+    let s = initialState();
+    s = reducer(s, { kind: 'addLabelEntry' });
+    expect(s.labels).toEqual([{ key: '', value: '' }]);
+  });
+
+  it('setLabelEntry edits the targeted row', () => {
+    let s = initialState();
+    s = reducer(s, { kind: 'addLabelEntry' });
+    s = reducer(s, { kind: 'setLabelEntry', index: 0, field: 'key', value: 'compliance' });
+    s = reducer(s, { kind: 'setLabelEntry', index: 0, field: 'value', value: 'pci' });
+    expect(s.labels[0]).toEqual({ key: 'compliance', value: 'pci' });
+  });
+
+  it('annotation grid is independent of label grid', () => {
+    let s = initialState();
+    s = reducer(s, { kind: 'addLabelEntry' });
+    s = reducer(s, { kind: 'addAnnotationEntry' });
+    s = reducer(s, { kind: 'setAnnotationEntry', index: 0, field: 'key', value: 'runbook' });
+    expect(s.labels[0]).toEqual({ key: '', value: '' });
+    expect(s.annotations[0]).toEqual({ key: 'runbook', value: '' });
+  });
+});
+
+describe('reducer — supplemental alarm toggles', () => {
+  it('preserves noData.forDuration when toggling enabled', () => {
+    let s = initialState();
+    s = reducer(s, { kind: 'setNoDataDuration', forDuration: '15m' });
+    expect(s.alarms.noData).toEqual({ enabled: false, forDuration: '15m' });
+    s = reducer(s, { kind: 'setAlarmToggle', alarm: 'noData', enabled: true });
+    expect(s.alarms.noData).toEqual({ enabled: true, forDuration: '15m' });
+  });
+
+  it('toggles other alarm types without disturbing the rest', () => {
+    let s = initialState();
+    s = reducer(s, { kind: 'setAlarmToggle', alarm: 'sliHealth', enabled: true });
+    expect(s.alarms.sliHealth.enabled).toBe(true);
+    expect(s.alarms.budgetWarning.enabled).toBe(true); // unchanged
+    expect(s.alarms.attainmentBreach.enabled).toBe(false); // unchanged
+  });
+});
+
+describe('reducer — submit gate', () => {
+  it('markSubmitAttempted is idempotent', () => {
+    const s0 = initialState();
+    const s1 = reducer(s0, { kind: 'markSubmitAttempted' });
+    expect(s1.submitAttempted).toBe(true);
+    const s2 = reducer(s1, { kind: 'markSubmitAttempted' });
+    expect(s2).toBe(s1); // same object: no-op when already attempted
+  });
+});
+
+describe('reducer — exclusion windows', () => {
+  it('addExclusionWindow seeds a default cron schedule', () => {
+    let s = initialState();
+    s = reducer(s, { kind: 'addExclusionWindow' });
+    expect(s.exclusionWindows).toHaveLength(1);
+    expect(s.exclusionWindows[0].schedule.type).toBe('cron');
+  });
+
+  it('flipping schedule type to oneoff replaces the schedule shape', () => {
+    let s = initialState();
+    s = reducer(s, { kind: 'addExclusionWindow' });
+    s = reducer(s, { kind: 'setExclusionWindowScheduleType', index: 0, type: 'oneoff' });
+    expect(s.exclusionWindows[0].schedule.type).toBe('oneoff');
+  });
+});

--- a/public/components/apm/pages/slos/advanced_section.tsx
+++ b/public/components/apm/pages/slos/advanced_section.tsx
@@ -9,8 +9,10 @@
  *
  *   1. MWMBR burn-rate tiers — short/long windows, multiplier, severity.
  *   2. Budget-warning thresholds — fraction remaining + severity.
- *   3. Supplemental alarm toggles — sliHealth, attainmentBreach, noData,
- *      resolved. budgetWarning is covered by the thresholds editor above.
+ *   3. Supplemental alarm toggles — sliHealth, attainmentBreach,
+ *      budgetWarning, noData, resolved. The budgetWarning toggle gates
+ *      *alert emission*; the thresholds editor above edits the threshold
+ *      *values*. Both surfaces are needed.
  *
  * Progressive disclosure: defaults match the hardcoded values
  * (google-30d.yaml burn rates, 50%/20% budget warnings, alarms off-by-default

--- a/public/components/apm/pages/slos/advanced_section.tsx
+++ b/public/components/apm/pages/slos/advanced_section.tsx
@@ -1,0 +1,449 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Advanced section. Collapsed by default so the common path stays
+ * minimal. Exposes the three knobs that were previously hard-coded:
+ *
+ *   1. MWMBR burn-rate tiers — short/long windows, multiplier, severity.
+ *   2. Budget-warning thresholds — fraction remaining + severity.
+ *   3. Supplemental alarm toggles — sliHealth, attainmentBreach, noData,
+ *      resolved. budgetWarning is covered by the thresholds editor above.
+ *
+ * Progressive disclosure: defaults match the hardcoded values
+ * (google-30d.yaml burn rates, 50%/20% budget warnings, alarms off-by-default
+ * except budgetWarning). Users who don't open the accordion get exactly what
+ * the wizard produced before this PR.
+ */
+
+import React, { useMemo } from 'react';
+import {
+  EuiAccordion,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCheckbox,
+  EuiFieldNumber,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiPanel,
+  EuiSelect,
+  EuiSpacer,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
+import type { BudgetWarningThreshold, BurnRateConfig } from '../../../../../common/slo/slo_types';
+import type { Action, FormState, ToggleableAlarm } from './wizard_state';
+import { BURN_RATE_PRESETS, isPresetApplied } from './burn_rate_presets';
+
+export interface AdvancedSectionProps {
+  burnRates: BurnRateConfig[];
+  budgetWarnings: BudgetWarningThreshold[];
+  alarms: FormState['alarms'];
+  errors: Record<string, string>;
+  dispatch: React.Dispatch<Action>;
+}
+
+const SEVERITY_OPTIONS = [
+  { value: 'critical', text: 'critical' },
+  { value: 'warning', text: 'warning' },
+  { value: 'info', text: 'info' },
+];
+
+export const AdvancedSection: React.FC<AdvancedSectionProps> = ({
+  burnRates,
+  budgetWarnings,
+  alarms,
+  errors,
+  dispatch,
+}) => (
+  <EuiPanel>
+    <EuiAccordion
+      id="slosWizardAdvanced"
+      buttonContent="Advanced — burn rates, budget warnings, supplemental alarms"
+      paddingSize="s"
+      data-test-subj="slosWizardAdvancedToggle"
+    >
+      <BurnRatesEditor burnRates={burnRates} errors={errors} dispatch={dispatch} />
+      <EuiSpacer size="m" />
+      <BudgetWarningsEditor budgetWarnings={budgetWarnings} errors={errors} dispatch={dispatch} />
+      <EuiSpacer size="m" />
+      <AlarmsEditor alarms={alarms} dispatch={dispatch} />
+    </EuiAccordion>
+  </EuiPanel>
+);
+
+// ---- Burn rates --------------------------------------------------------
+
+const BurnRatesEditor: React.FC<{
+  burnRates: BurnRateConfig[];
+  errors: Record<string, string>;
+  dispatch: React.Dispatch<Action>;
+}> = ({ burnRates, errors, dispatch }) => {
+  const activePresetId = useMemo(
+    () => BURN_RATE_PRESETS.find((p) => isPresetApplied(p, burnRates))?.id ?? null,
+    [burnRates]
+  );
+  return (
+    <div data-test-subj="slosWizardBurnrates">
+      <EuiText size="s">
+        <h5>Burn-rate tiers (MWMBR)</h5>
+      </EuiText>
+      <EuiText size="xs" color="subdued">
+        Pick a preset, or edit the table below for a custom configuration. Presets overwrite the
+        existing tiers.
+      </EuiText>
+      <EuiSpacer size="xs" />
+      <EuiFlexGroup gutterSize="s" responsive={false} wrap>
+        {BURN_RATE_PRESETS.map((preset) => (
+          <EuiFlexItem grow={false} key={preset.id}>
+            <EuiToolTip content={preset.summary}>
+              <EuiButton
+                size="s"
+                fill={activePresetId === preset.id}
+                onClick={() => dispatch({ kind: 'applyBurnRatePreset', preset: preset.id })}
+                data-test-subj={`slosBurnRatePreset-${preset.id}`}
+              >
+                {preset.label}
+              </EuiButton>
+            </EuiToolTip>
+          </EuiFlexItem>
+        ))}
+        {activePresetId === null && (
+          <EuiFlexItem grow={false}>
+            <EuiText size="xs" color="subdued" data-test-subj="slosBurnRatePresetCustom">
+              Custom configuration
+            </EuiText>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+      <EuiSpacer size="s" />
+      {burnRates.map((tier, i) => {
+        const prefix = `spec.alerting.burnRates[${i}]`;
+        return (
+          <EuiFlexGroup
+            key={i}
+            gutterSize="s"
+            alignItems="flexEnd"
+            style={{ marginBottom: 6 }}
+            data-test-subj={`slosWizardBurnrateRow-${i}`}
+            wrap
+          >
+            <EuiFlexItem>
+              <EuiFormRow
+                label="Short window"
+                isInvalid={!!errors[`${prefix}.shortWindow`]}
+                error={errors[`${prefix}.shortWindow`]}
+              >
+                <EuiFieldText
+                  value={tier.shortWindow}
+                  onChange={(e) =>
+                    dispatch({
+                      kind: 'setBurnRateField',
+                      index: i,
+                      field: 'shortWindow',
+                      value: e.target.value,
+                    })
+                  }
+                  compressed
+                  data-test-subj={`slosWizardBurnrateShort-${i}`}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow
+                label="Long window"
+                isInvalid={!!errors[`${prefix}.longWindow`]}
+                error={errors[`${prefix}.longWindow`]}
+              >
+                <EuiFieldText
+                  value={tier.longWindow}
+                  onChange={(e) =>
+                    dispatch({
+                      kind: 'setBurnRateField',
+                      index: i,
+                      field: 'longWindow',
+                      value: e.target.value,
+                    })
+                  }
+                  compressed
+                  data-test-subj={`slosWizardBurnrateLong-${i}`}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow
+                label="Multiplier"
+                isInvalid={!!errors[`${prefix}.burnRateMultiplier`]}
+                error={errors[`${prefix}.burnRateMultiplier`]}
+              >
+                <EuiFieldNumber
+                  value={tier.burnRateMultiplier}
+                  step={0.1}
+                  min={0.001}
+                  onChange={(e) =>
+                    dispatch({
+                      kind: 'setBurnRateField',
+                      index: i,
+                      field: 'burnRateMultiplier',
+                      value: Number(e.target.value),
+                    })
+                  }
+                  compressed
+                  data-test-subj={`slosWizardBurnrateMultiplier-${i}`}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow label="For">
+                <EuiFieldText
+                  value={tier.forDuration}
+                  onChange={(e) =>
+                    dispatch({
+                      kind: 'setBurnRateField',
+                      index: i,
+                      field: 'forDuration',
+                      value: e.target.value,
+                    })
+                  }
+                  compressed
+                  data-test-subj={`slosWizardBurnrateFor-${i}`}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow label="Severity">
+                <EuiSelect
+                  value={tier.severity}
+                  onChange={(e) =>
+                    dispatch({
+                      kind: 'setBurnRateField',
+                      index: i,
+                      field: 'severity',
+                      value: e.target.value,
+                    })
+                  }
+                  options={SEVERITY_OPTIONS}
+                  compressed
+                  data-test-subj={`slosWizardBurnrateSeverity-${i}`}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiCheckbox
+                id={`slosWizardBurnrateAlarm-${i}`}
+                label="Alarm"
+                checked={tier.createAlarm}
+                onChange={(e) =>
+                  dispatch({
+                    kind: 'setBurnRateField',
+                    index: i,
+                    field: 'createAlarm',
+                    value: e.target.checked,
+                  })
+                }
+                data-test-subj={`slosWizardBurnrateAlarm-${i}`}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                color="danger"
+                onClick={() => dispatch({ kind: 'removeBurnRate', index: i })}
+                iconType="trash"
+                aria-label={`Remove burn-rate tier ${i}`}
+                size="s"
+                data-test-subj={`slosWizardBurnrateRemove-${i}`}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        );
+      })}
+      <EuiButtonEmpty
+        iconType="plusInCircle"
+        size="s"
+        onClick={() => dispatch({ kind: 'addBurnRate' })}
+        data-test-subj="slosWizardBurnrateAdd"
+      >
+        Add burn-rate tier
+      </EuiButtonEmpty>
+    </div>
+  );
+};
+
+// ---- Budget warnings ---------------------------------------------------
+
+const BudgetWarningsEditor: React.FC<{
+  budgetWarnings: BudgetWarningThreshold[];
+  errors: Record<string, string>;
+  dispatch: React.Dispatch<Action>;
+}> = ({ budgetWarnings, errors, dispatch }) => (
+  <div data-test-subj="slosWizardBudgetWarnings">
+    <EuiText size="s">
+      <h5>Budget-warning thresholds</h5>
+    </EuiText>
+    <EuiText size="xs" color="subdued">
+      Fires when the remaining error budget drops below <code>threshold</code>. Values are fractions
+      of the total budget.
+    </EuiText>
+    <EuiSpacer size="xs" />
+    {budgetWarnings.map((bw, i) => {
+      const prefix = `spec.budgetWarningThresholds[${i}]`;
+      return (
+        <EuiFlexGroup
+          key={i}
+          gutterSize="s"
+          alignItems="flexEnd"
+          style={{ marginBottom: 6 }}
+          data-test-subj={`slosWizardBudgetWarningRow-${i}`}
+        >
+          <EuiFlexItem>
+            <EuiFormRow
+              label="Threshold (fraction remaining)"
+              isInvalid={!!errors[`${prefix}.threshold`]}
+              error={errors[`${prefix}.threshold`]}
+            >
+              <EuiFieldNumber
+                value={bw.threshold}
+                step={0.05}
+                min={0.01}
+                max={0.99}
+                onChange={(e) =>
+                  dispatch({
+                    kind: 'setBudgetWarningField',
+                    index: i,
+                    field: 'threshold',
+                    value: Number(e.target.value),
+                  })
+                }
+                compressed
+                data-test-subj={`slosWizardBudgetWarningThreshold-${i}`}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow label="Severity">
+              <EuiSelect
+                value={bw.severity}
+                onChange={(e) =>
+                  dispatch({
+                    kind: 'setBudgetWarningField',
+                    index: i,
+                    field: 'severity',
+                    value: e.target.value,
+                  })
+                }
+                options={SEVERITY_OPTIONS}
+                compressed
+                data-test-subj={`slosWizardBudgetWarningSeverity-${i}`}
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              color="danger"
+              onClick={() => dispatch({ kind: 'removeBudgetWarning', index: i })}
+              iconType="trash"
+              aria-label={`Remove budget warning ${i}`}
+              size="s"
+              data-test-subj={`slosWizardBudgetWarningRemove-${i}`}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    })}
+    <EuiButtonEmpty
+      iconType="plusInCircle"
+      size="s"
+      onClick={() => dispatch({ kind: 'addBudgetWarning' })}
+      data-test-subj="slosWizardBudgetWarningAdd"
+    >
+      Add budget-warning threshold
+    </EuiButtonEmpty>
+  </div>
+);
+
+// ---- Alarms ------------------------------------------------------------
+
+interface AlarmToggle {
+  id: ToggleableAlarm;
+  label: string;
+  caption: string;
+}
+
+const ALARM_TOGGLES: AlarmToggle[] = [
+  {
+    id: 'sliHealth',
+    label: 'SLI health',
+    caption: 'Overlaps the page-quick tier; default OFF to avoid duplicate pages.',
+  },
+  {
+    id: 'attainmentBreach',
+    label: 'Attainment breach',
+    caption: 'Fires when attainment falls below the objective target for the whole window.',
+  },
+  {
+    id: 'budgetWarning',
+    label: 'Budget-warning alerts',
+    caption: 'Emits one alert per (objective × threshold) defined above.',
+  },
+  {
+    id: 'resolved',
+    label: 'Resolved notifications',
+    caption: 'Recovery notification when any firing SLO alert clears.',
+  },
+];
+
+const AlarmsEditor: React.FC<{
+  alarms: FormState['alarms'];
+  dispatch: React.Dispatch<Action>;
+}> = ({ alarms, dispatch }) => (
+  <div data-test-subj="slosWizardSupplementalAlarms">
+    <EuiText size="s">
+      <h5>Supplemental alarms</h5>
+    </EuiText>
+    <EuiSpacer size="xs" />
+    {ALARM_TOGGLES.map((a) => (
+      <div key={a.id} style={{ marginBottom: 8 }}>
+        <EuiCheckbox
+          id={`slosWizardAlarm-${a.id}`}
+          label={a.label}
+          checked={alarms[a.id].enabled}
+          onChange={(e) =>
+            dispatch({ kind: 'setAlarmToggle', alarm: a.id, enabled: e.target.checked })
+          }
+          data-test-subj={`slosWizardAlarm-${a.id}`}
+        />
+        <EuiText size="xs" color="subdued">
+          {a.caption}
+        </EuiText>
+      </div>
+    ))}
+    <EuiFlexGroup gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiCheckbox
+          id="slosWizardAlarmNoData"
+          label="No-data alert"
+          checked={alarms.noData.enabled}
+          onChange={(e) =>
+            dispatch({ kind: 'setAlarmToggle', alarm: 'noData', enabled: e.target.checked })
+          }
+          data-test-subj="slosWizardAlarmNoData"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFormRow label="For">
+          <EuiFieldText
+            value={alarms.noData.forDuration}
+            onChange={(e) => dispatch({ kind: 'setNoDataDuration', forDuration: e.target.value })}
+            disabled={!alarms.noData.enabled}
+            compressed
+            data-test-subj="slosWizardAlarmNoDataDuration"
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+);

--- a/public/components/apm/pages/slos/advanced_section.tsx
+++ b/public/components/apm/pages/slos/advanced_section.tsx
@@ -21,6 +21,7 @@
  */
 
 import React, { useMemo } from 'react';
+import { i18n } from '@osd/i18n';
 import {
   EuiAccordion,
   EuiButton,
@@ -49,10 +50,127 @@ export interface AdvancedSectionProps {
   dispatch: React.Dispatch<Action>;
 }
 
+const I18N = {
+  severityCritical: i18n.translate('observability.slo.advanced.severityCritical', {
+    defaultMessage: 'critical',
+  }),
+  severityWarning: i18n.translate('observability.slo.advanced.severityWarning', {
+    defaultMessage: 'warning',
+  }),
+  severityInfo: i18n.translate('observability.slo.advanced.severityInfo', {
+    defaultMessage: 'info',
+  }),
+  accordionLabel: i18n.translate('observability.slo.advanced.accordionLabel', {
+    defaultMessage: 'Advanced — burn rates, budget warnings, supplemental alarms',
+  }),
+  burnRatesHeading: i18n.translate('observability.slo.advanced.burnRatesHeading', {
+    defaultMessage: 'Burn-rate tiers (MWMBR)',
+  }),
+  burnRatesDescription: i18n.translate('observability.slo.advanced.burnRatesDescription', {
+    defaultMessage:
+      'Pick a preset, or edit the table below for a custom configuration. Presets overwrite the existing tiers.',
+  }),
+  customConfiguration: i18n.translate('observability.slo.advanced.customConfiguration', {
+    defaultMessage: 'Custom configuration',
+  }),
+  shortWindow: i18n.translate('observability.slo.advanced.shortWindow', {
+    defaultMessage: 'Short window',
+  }),
+  longWindow: i18n.translate('observability.slo.advanced.longWindow', {
+    defaultMessage: 'Long window',
+  }),
+  multiplier: i18n.translate('observability.slo.advanced.multiplier', {
+    defaultMessage: 'Multiplier',
+  }),
+  forLabel: i18n.translate('observability.slo.advanced.forLabel', {
+    defaultMessage: 'For',
+  }),
+  severity: i18n.translate('observability.slo.advanced.severity', {
+    defaultMessage: 'Severity',
+  }),
+  alarm: i18n.translate('observability.slo.advanced.alarm', {
+    defaultMessage: 'Alarm',
+  }),
+  removeBurnRateAria: (index: number) =>
+    i18n.translate('observability.slo.advanced.removeBurnRateAria', {
+      defaultMessage: 'Remove burn-rate tier {index}',
+      values: { index },
+    }),
+  addBurnRate: i18n.translate('observability.slo.advanced.addBurnRate', {
+    defaultMessage: 'Add burn-rate tier',
+  }),
+  budgetWarningsHeading: i18n.translate('observability.slo.advanced.budgetWarningsHeading', {
+    defaultMessage: 'Budget-warning thresholds',
+  }),
+  budgetWarningsDescriptionPrefix: i18n.translate(
+    'observability.slo.advanced.budgetWarningsDescriptionPrefix',
+    {
+      defaultMessage: 'Fires when the remaining error budget drops below',
+    }
+  ),
+  budgetWarningsDescriptionSuffix: i18n.translate(
+    'observability.slo.advanced.budgetWarningsDescriptionSuffix',
+    {
+      defaultMessage: '. Values are fractions of the total budget.',
+    }
+  ),
+  thresholdLabel: i18n.translate('observability.slo.advanced.thresholdLabel', {
+    defaultMessage: 'Threshold (fraction remaining)',
+  }),
+  removeBudgetWarningAria: (index: number) =>
+    i18n.translate('observability.slo.advanced.removeBudgetWarningAria', {
+      defaultMessage: 'Remove budget warning {index}',
+      values: { index },
+    }),
+  addBudgetWarning: i18n.translate('observability.slo.advanced.addBudgetWarning', {
+    defaultMessage: 'Add budget-warning threshold',
+  }),
+  alarmsHeading: i18n.translate('observability.slo.advanced.alarmsHeading', {
+    defaultMessage: 'Supplemental alarms',
+  }),
+  noDataAlert: i18n.translate('observability.slo.advanced.noDataAlert', {
+    defaultMessage: 'No-data alert',
+  }),
+  alarmSliHealthLabel: i18n.translate('observability.slo.advanced.alarmSliHealthLabel', {
+    defaultMessage: 'SLI health',
+  }),
+  alarmSliHealthCaption: i18n.translate('observability.slo.advanced.alarmSliHealthCaption', {
+    defaultMessage: 'Overlaps the page-quick tier; default OFF to avoid duplicate pages.',
+  }),
+  alarmAttainmentBreachLabel: i18n.translate(
+    'observability.slo.advanced.alarmAttainmentBreachLabel',
+    {
+      defaultMessage: 'Attainment breach',
+    }
+  ),
+  alarmAttainmentBreachCaption: i18n.translate(
+    'observability.slo.advanced.alarmAttainmentBreachCaption',
+    {
+      defaultMessage:
+        'Fires when attainment falls below the objective target for the whole window.',
+    }
+  ),
+  alarmBudgetWarningLabel: i18n.translate('observability.slo.advanced.alarmBudgetWarningLabel', {
+    defaultMessage: 'Budget-warning alerts',
+  }),
+  alarmBudgetWarningCaption: i18n.translate(
+    'observability.slo.advanced.alarmBudgetWarningCaption',
+    {
+      defaultMessage: 'Emits one alert per (objective × threshold) defined above.',
+    }
+  ),
+  alarmResolvedLabel: i18n.translate('observability.slo.advanced.alarmResolvedLabel', {
+    defaultMessage: 'Resolved notifications',
+  }),
+  alarmResolvedCaption: i18n.translate('observability.slo.advanced.alarmResolvedCaption', {
+    defaultMessage: 'Recovery notification when any firing SLO alert clears.',
+  }),
+};
+
 const SEVERITY_OPTIONS = [
-  { value: 'critical', text: 'critical' },
-  { value: 'warning', text: 'warning' },
-  { value: 'info', text: 'info' },
+  { value: 'critical', text: I18N.severityCritical },
+  { value: 'warning', text: I18N.severityWarning },
+  { value: 'info', text: I18N.severityInfo },
 ];
 
 export const AdvancedSection: React.FC<AdvancedSectionProps> = ({
@@ -65,7 +183,7 @@ export const AdvancedSection: React.FC<AdvancedSectionProps> = ({
   <EuiPanel>
     <EuiAccordion
       id="slosWizardAdvanced"
-      buttonContent="Advanced — burn rates, budget warnings, supplemental alarms"
+      buttonContent={I18N.accordionLabel}
       paddingSize="s"
       data-test-subj="slosWizardAdvancedToggle"
     >
@@ -92,11 +210,10 @@ const BurnRatesEditor: React.FC<{
   return (
     <div data-test-subj="slosWizardBurnrates">
       <EuiText size="s">
-        <h5>Burn-rate tiers (MWMBR)</h5>
+        <h5>{I18N.burnRatesHeading}</h5>
       </EuiText>
       <EuiText size="xs" color="subdued">
-        Pick a preset, or edit the table below for a custom configuration. Presets overwrite the
-        existing tiers.
+        {I18N.burnRatesDescription}
       </EuiText>
       <EuiSpacer size="xs" />
       <EuiFlexGroup gutterSize="s" responsive={false} wrap>
@@ -117,7 +234,7 @@ const BurnRatesEditor: React.FC<{
         {activePresetId === null && (
           <EuiFlexItem grow={false}>
             <EuiText size="xs" color="subdued" data-test-subj="slosBurnRatePresetCustom">
-              Custom configuration
+              {I18N.customConfiguration}
             </EuiText>
           </EuiFlexItem>
         )}
@@ -136,7 +253,7 @@ const BurnRatesEditor: React.FC<{
           >
             <EuiFlexItem>
               <EuiFormRow
-                label="Short window"
+                label={I18N.shortWindow}
                 isInvalid={!!errors[`${prefix}.shortWindow`]}
                 error={errors[`${prefix}.shortWindow`]}
               >
@@ -157,7 +274,7 @@ const BurnRatesEditor: React.FC<{
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiFormRow
-                label="Long window"
+                label={I18N.longWindow}
                 isInvalid={!!errors[`${prefix}.longWindow`]}
                 error={errors[`${prefix}.longWindow`]}
               >
@@ -178,7 +295,7 @@ const BurnRatesEditor: React.FC<{
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiFormRow
-                label="Multiplier"
+                label={I18N.multiplier}
                 isInvalid={!!errors[`${prefix}.burnRateMultiplier`]}
                 error={errors[`${prefix}.burnRateMultiplier`]}
               >
@@ -200,7 +317,7 @@ const BurnRatesEditor: React.FC<{
               </EuiFormRow>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiFormRow label="For">
+              <EuiFormRow label={I18N.forLabel}>
                 <EuiFieldText
                   value={tier.forDuration}
                   onChange={(e) =>
@@ -217,7 +334,7 @@ const BurnRatesEditor: React.FC<{
               </EuiFormRow>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiFormRow label="Severity">
+              <EuiFormRow label={I18N.severity}>
                 <EuiSelect
                   value={tier.severity}
                   onChange={(e) =>
@@ -237,7 +354,7 @@ const BurnRatesEditor: React.FC<{
             <EuiFlexItem grow={false}>
               <EuiCheckbox
                 id={`slosWizardBurnrateAlarm-${i}`}
-                label="Alarm"
+                label={I18N.alarm}
                 checked={tier.createAlarm}
                 onChange={(e) =>
                   dispatch({
@@ -255,7 +372,7 @@ const BurnRatesEditor: React.FC<{
                 color="danger"
                 onClick={() => dispatch({ kind: 'removeBurnRate', index: i })}
                 iconType="trash"
-                aria-label={`Remove burn-rate tier ${i}`}
+                aria-label={I18N.removeBurnRateAria(i)}
                 size="s"
                 data-test-subj={`slosWizardBurnrateRemove-${i}`}
               />
@@ -269,7 +386,7 @@ const BurnRatesEditor: React.FC<{
         onClick={() => dispatch({ kind: 'addBurnRate' })}
         data-test-subj="slosWizardBurnrateAdd"
       >
-        Add burn-rate tier
+        {I18N.addBurnRate}
       </EuiButtonEmpty>
     </div>
   );
@@ -284,11 +401,11 @@ const BudgetWarningsEditor: React.FC<{
 }> = ({ budgetWarnings, errors, dispatch }) => (
   <div data-test-subj="slosWizardBudgetWarnings">
     <EuiText size="s">
-      <h5>Budget-warning thresholds</h5>
+      <h5>{I18N.budgetWarningsHeading}</h5>
     </EuiText>
     <EuiText size="xs" color="subdued">
-      Fires when the remaining error budget drops below <code>threshold</code>. Values are fractions
-      of the total budget.
+      {I18N.budgetWarningsDescriptionPrefix} <code>threshold</code>
+      {I18N.budgetWarningsDescriptionSuffix}
     </EuiText>
     <EuiSpacer size="xs" />
     {budgetWarnings.map((bw, i) => {
@@ -303,7 +420,7 @@ const BudgetWarningsEditor: React.FC<{
         >
           <EuiFlexItem>
             <EuiFormRow
-              label="Threshold (fraction remaining)"
+              label={I18N.thresholdLabel}
               isInvalid={!!errors[`${prefix}.threshold`]}
               error={errors[`${prefix}.threshold`]}
             >
@@ -326,7 +443,7 @@ const BudgetWarningsEditor: React.FC<{
             </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiFormRow label="Severity">
+            <EuiFormRow label={I18N.severity}>
               <EuiSelect
                 value={bw.severity}
                 onChange={(e) =>
@@ -348,7 +465,7 @@ const BudgetWarningsEditor: React.FC<{
               color="danger"
               onClick={() => dispatch({ kind: 'removeBudgetWarning', index: i })}
               iconType="trash"
-              aria-label={`Remove budget warning ${i}`}
+              aria-label={I18N.removeBudgetWarningAria(i)}
               size="s"
               data-test-subj={`slosWizardBudgetWarningRemove-${i}`}
             />
@@ -362,7 +479,7 @@ const BudgetWarningsEditor: React.FC<{
       onClick={() => dispatch({ kind: 'addBudgetWarning' })}
       data-test-subj="slosWizardBudgetWarningAdd"
     >
-      Add budget-warning threshold
+      {I18N.addBudgetWarning}
     </EuiButtonEmpty>
   </div>
 );
@@ -378,23 +495,23 @@ interface AlarmToggle {
 const ALARM_TOGGLES: AlarmToggle[] = [
   {
     id: 'sliHealth',
-    label: 'SLI health',
-    caption: 'Overlaps the page-quick tier; default OFF to avoid duplicate pages.',
+    label: I18N.alarmSliHealthLabel,
+    caption: I18N.alarmSliHealthCaption,
   },
   {
     id: 'attainmentBreach',
-    label: 'Attainment breach',
-    caption: 'Fires when attainment falls below the objective target for the whole window.',
+    label: I18N.alarmAttainmentBreachLabel,
+    caption: I18N.alarmAttainmentBreachCaption,
   },
   {
     id: 'budgetWarning',
-    label: 'Budget-warning alerts',
-    caption: 'Emits one alert per (objective × threshold) defined above.',
+    label: I18N.alarmBudgetWarningLabel,
+    caption: I18N.alarmBudgetWarningCaption,
   },
   {
     id: 'resolved',
-    label: 'Resolved notifications',
-    caption: 'Recovery notification when any firing SLO alert clears.',
+    label: I18N.alarmResolvedLabel,
+    caption: I18N.alarmResolvedCaption,
   },
 ];
 
@@ -404,7 +521,7 @@ const AlarmsEditor: React.FC<{
 }> = ({ alarms, dispatch }) => (
   <div data-test-subj="slosWizardSupplementalAlarms">
     <EuiText size="s">
-      <h5>Supplemental alarms</h5>
+      <h5>{I18N.alarmsHeading}</h5>
     </EuiText>
     <EuiSpacer size="xs" />
     {ALARM_TOGGLES.map((a) => (
@@ -427,7 +544,7 @@ const AlarmsEditor: React.FC<{
       <EuiFlexItem grow={false}>
         <EuiCheckbox
           id="slosWizardAlarmNoData"
-          label="No-data alert"
+          label={I18N.noDataAlert}
           checked={alarms.noData.enabled}
           onChange={(e) =>
             dispatch({ kind: 'setAlarmToggle', alarm: 'noData', enabled: e.target.checked })
@@ -436,7 +553,7 @@ const AlarmsEditor: React.FC<{
         />
       </EuiFlexItem>
       <EuiFlexItem>
-        <EuiFormRow label="For">
+        <EuiFormRow label={I18N.forLabel}>
           <EuiFieldText
             value={alarms.noData.forDuration}
             onChange={(e) => dispatch({ kind: 'setNoDataDuration', forDuration: e.target.value })}

--- a/public/components/apm/pages/slos/burn_rate_presets.ts
+++ b/public/components/apm/pages/slos/burn_rate_presets.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Burn-rate tier presets surfaced in the Advanced section. Three options
+ * progressively trade page urgency for ticket cadence:
+ *
+ *   balanced     — Google SRE Workbook Ch.5 (matches DEFAULT_MWMBR_TIERS)
+ *   page-heavy   — immediate critical paging only; drops warning tiers
+ *   ticket-heavy — warning cadence only; drops immediate paging
+ *
+ * `isPresetApplied` compares deep-equal against the live state so the UI
+ * can highlight the matching button (or none, meaning the user has a
+ * custom configuration).
+ */
+
+import type { BurnRateConfig } from '../../../../../common/slo/slo_types';
+
+export type BurnRatePresetId = 'balanced' | 'page-heavy' | 'ticket-heavy';
+
+export interface BurnRatePreset {
+  id: BurnRatePresetId;
+  label: string;
+  summary: string;
+  tiers: BurnRateConfig[];
+}
+
+const balancedTiers: BurnRateConfig[] = [
+  {
+    shortWindow: '5m',
+    longWindow: '1h',
+    burnRateMultiplier: 14.4,
+    severity: 'critical',
+    createAlarm: true,
+    forDuration: '2m',
+  },
+  {
+    shortWindow: '30m',
+    longWindow: '6h',
+    burnRateMultiplier: 6,
+    severity: 'critical',
+    createAlarm: true,
+    forDuration: '5m',
+  },
+  {
+    shortWindow: '2h',
+    longWindow: '1d',
+    burnRateMultiplier: 3,
+    severity: 'warning',
+    createAlarm: true,
+    forDuration: '10m',
+  },
+  {
+    shortWindow: '6h',
+    longWindow: '3d',
+    burnRateMultiplier: 1,
+    severity: 'warning',
+    createAlarm: true,
+    forDuration: '30m',
+  },
+];
+
+const pageHeavyTiers: BurnRateConfig[] = [
+  {
+    shortWindow: '2m',
+    longWindow: '30m',
+    burnRateMultiplier: 28.8,
+    severity: 'critical',
+    createAlarm: true,
+    forDuration: '1m',
+  },
+  {
+    shortWindow: '5m',
+    longWindow: '1h',
+    burnRateMultiplier: 14.4,
+    severity: 'critical',
+    createAlarm: true,
+    forDuration: '2m',
+  },
+  {
+    shortWindow: '30m',
+    longWindow: '6h',
+    burnRateMultiplier: 6,
+    severity: 'critical',
+    createAlarm: true,
+    forDuration: '5m',
+  },
+];
+
+const ticketHeavyTiers: BurnRateConfig[] = [
+  {
+    shortWindow: '2h',
+    longWindow: '1d',
+    burnRateMultiplier: 3,
+    severity: 'warning',
+    createAlarm: true,
+    forDuration: '10m',
+  },
+  {
+    shortWindow: '6h',
+    longWindow: '3d',
+    burnRateMultiplier: 1,
+    severity: 'warning',
+    createAlarm: true,
+    forDuration: '30m',
+  },
+  {
+    shortWindow: '1d',
+    longWindow: '7d',
+    burnRateMultiplier: 0.5,
+    severity: 'warning',
+    createAlarm: true,
+    forDuration: '2h',
+  },
+];
+
+export const BURN_RATE_PRESETS: readonly BurnRatePreset[] = [
+  {
+    id: 'page-heavy',
+    label: 'Page-heavy',
+    summary:
+      '3 tiers, all critical. Adds an immediate 2m/30m guardrail; drops the slow warning tiers.',
+    tiers: pageHeavyTiers,
+  },
+  {
+    id: 'balanced',
+    label: 'Balanced',
+    summary:
+      '4 tiers (2 critical + 2 warning). Matches the Google SRE Workbook table — the wizard default.',
+    tiers: balancedTiers,
+  },
+  {
+    id: 'ticket-heavy',
+    label: 'Ticket-heavy',
+    summary:
+      '3 warning tiers, no immediate paging. Adds a slow 1d/7d ticket tier for chronic drift.',
+    tiers: ticketHeavyTiers,
+  },
+];
+
+export function getBurnRatePreset(id: BurnRatePresetId): BurnRatePreset {
+  const found = BURN_RATE_PRESETS.find((p) => p.id === id);
+  if (!found) throw new Error(`Unknown burn-rate preset: ${id}`);
+  return found;
+}
+
+/**
+ * Deep-equal comparison against a preset's tiers, respecting order. Used by
+ * the UI to render the matching preset button as `fill={true}`.
+ */
+export function isPresetApplied(preset: BurnRatePreset, tiers: BurnRateConfig[]): boolean {
+  if (tiers.length !== preset.tiers.length) return false;
+  for (let i = 0; i < tiers.length; i++) {
+    const a = tiers[i];
+    const b = preset.tiers[i];
+    if (
+      a.shortWindow !== b.shortWindow ||
+      a.longWindow !== b.longWindow ||
+      a.burnRateMultiplier !== b.burnRateMultiplier ||
+      a.severity !== b.severity ||
+      a.createAlarm !== b.createAlarm ||
+      a.forDuration !== b.forDuration
+    ) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/public/components/apm/pages/slos/burn_rate_presets.ts
+++ b/public/components/apm/pages/slos/burn_rate_presets.ts
@@ -16,9 +16,34 @@
  * custom configuration).
  */
 
+import { i18n } from '@osd/i18n';
 import type { BurnRateConfig } from '../../../../../common/slo/slo_types';
 
 export type BurnRatePresetId = 'balanced' | 'page-heavy' | 'ticket-heavy';
+
+const I18N = {
+  pageHeavyLabel: i18n.translate('observability.slo.burnRatePresets.pageHeavyLabel', {
+    defaultMessage: 'Page-heavy',
+  }),
+  pageHeavySummary: i18n.translate('observability.slo.burnRatePresets.pageHeavySummary', {
+    defaultMessage:
+      '3 tiers, all critical. Adds an immediate 2m/30m guardrail; drops the slow warning tiers.',
+  }),
+  balancedLabel: i18n.translate('observability.slo.burnRatePresets.balancedLabel', {
+    defaultMessage: 'Balanced',
+  }),
+  balancedSummary: i18n.translate('observability.slo.burnRatePresets.balancedSummary', {
+    defaultMessage:
+      '4 tiers (2 critical + 2 warning). Matches the Google SRE Workbook table — the wizard default.',
+  }),
+  ticketHeavyLabel: i18n.translate('observability.slo.burnRatePresets.ticketHeavyLabel', {
+    defaultMessage: 'Ticket-heavy',
+  }),
+  ticketHeavySummary: i18n.translate('observability.slo.burnRatePresets.ticketHeavySummary', {
+    defaultMessage:
+      '3 warning tiers, no immediate paging. Adds a slow 1d/7d ticket tier for chronic drift.',
+  }),
+};
 
 export interface BurnRatePreset {
   id: BurnRatePresetId;
@@ -119,23 +144,20 @@ const ticketHeavyTiers: BurnRateConfig[] = [
 export const BURN_RATE_PRESETS: readonly BurnRatePreset[] = [
   {
     id: 'page-heavy',
-    label: 'Page-heavy',
-    summary:
-      '3 tiers, all critical. Adds an immediate 2m/30m guardrail; drops the slow warning tiers.',
+    label: I18N.pageHeavyLabel,
+    summary: I18N.pageHeavySummary,
     tiers: pageHeavyTiers,
   },
   {
     id: 'balanced',
-    label: 'Balanced',
-    summary:
-      '4 tiers (2 critical + 2 warning). Matches the Google SRE Workbook table — the wizard default.',
+    label: I18N.balancedLabel,
+    summary: I18N.balancedSummary,
     tiers: balancedTiers,
   },
   {
     id: 'ticket-heavy',
-    label: 'Ticket-heavy',
-    summary:
-      '3 warning tiers, no immediate paging. Adds a slow 1d/7d ticket tier for chronic drift.',
+    label: I18N.ticketHeavyLabel,
+    summary: I18N.ticketHeavySummary,
     tiers: ticketHeavyTiers,
   },
 ];

--- a/public/components/apm/pages/slos/custom_promql_editor.tsx
+++ b/public/components/apm/pages/slos/custom_promql_editor.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Custom PromQL editor. Only rendered when the wizard is on the
+ * `custom` template. Two modes:
+ *
+ *   events  → user supplies `goodQuery` + `totalQuery`; generator derives
+ *             the error ratio as `1 - (goodQuery / totalQuery)`.
+ *   raw     → user supplies a pre-computed error-ratio `errorRatioQuery`;
+ *             generator uses it as-is (must already be in [0, 1]).
+ *
+ * Validation is `validateCustomPromQL` from `slo_validators.ts` (already
+ * wired via `validateSloSpec`). The wizard surfaces the field-level errors
+ * inline and the top-level summary picks them up via `WIZARD_SECTIONS`.
+ *
+ * OUI first: EuiTextArea with monospaced styling. A full Monaco/PromQL
+ * editor is listed as a follow-up — OSD ships one, but wiring it adds a
+ * cross-plugin dependency that this PR doesn't need.
+ */
+
+import React from 'react';
+import {
+  EuiButtonGroup,
+  EuiCallOut,
+  EuiFormRow,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTextArea,
+} from '@elastic/eui';
+import type { Action, FormState } from './wizard_state';
+
+export interface CustomPromqlEditorProps {
+  value: FormState['customPromql'];
+  errors: Record<string, string>;
+  dispatch: React.Dispatch<Action>;
+}
+
+const MODE_OPTIONS = [
+  { id: 'events', label: 'Events (good + total)' },
+  { id: 'raw', label: 'Raw error-ratio' },
+];
+
+const MONO_STYLE: React.CSSProperties = { fontFamily: 'monospace' };
+
+export const CustomPromqlEditor: React.FC<CustomPromqlEditorProps> = ({
+  value,
+  errors,
+  dispatch,
+}) => {
+  const goodError = errors['spec.sli.definition.customExpr.goodQuery'];
+  const totalError = errors['spec.sli.definition.customExpr.totalQuery'];
+  const rawError = errors['spec.sli.definition.customExpr.errorRatioQuery'];
+  const anyCustomExprError = errors['spec.sli.definition.customExpr'];
+
+  return (
+    <EuiPanel data-test-subj="slosWizardCustomPromql">
+      <EuiText size="m">
+        <h4>Custom PromQL</h4>
+      </EuiText>
+      <EuiText size="s" color="subdued">
+        Supply your own PromQL. Preview below shows the exact rule group that will be deployed.
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiButtonGroup
+        legend="PromQL mode"
+        idSelected={value.mode}
+        onChange={(id) =>
+          dispatch({
+            kind: 'setCustomPromql',
+            patch: { mode: id === 'raw' ? 'raw' : 'events' },
+          })
+        }
+        options={MODE_OPTIONS}
+        data-test-subj="slosWizardCustomPromqlMode"
+      />
+      <EuiSpacer size="s" />
+      {anyCustomExprError && (
+        <>
+          <EuiCallOut
+            color="warning"
+            size="s"
+            title={anyCustomExprError}
+            data-test-subj="slosWizardCustomPromqlMissing"
+          />
+          <EuiSpacer size="s" />
+        </>
+      )}
+      {value.mode === 'events' ? (
+        <>
+          <EuiFormRow
+            label="Good events query"
+            isInvalid={!!goodError}
+            error={goodError}
+            helpText="PromQL returning the count of good events (non-errors)."
+            fullWidth
+          >
+            <EuiTextArea
+              rows={3}
+              value={value.goodQuery}
+              onChange={(e) =>
+                dispatch({ kind: 'setCustomPromql', patch: { goodQuery: e.target.value } })
+              }
+              style={MONO_STYLE}
+              fullWidth
+              placeholder={`sum(rate(http_requests_total{status_code!~"5.."}[5m]))`}
+              data-test-subj="slosWizardCustomPromqlGood"
+            />
+          </EuiFormRow>
+          <EuiFormRow
+            label="Total events query"
+            isInvalid={!!totalError}
+            error={totalError}
+            helpText="PromQL returning the count of total events."
+            fullWidth
+          >
+            <EuiTextArea
+              rows={3}
+              value={value.totalQuery}
+              onChange={(e) =>
+                dispatch({ kind: 'setCustomPromql', patch: { totalQuery: e.target.value } })
+              }
+              style={MONO_STYLE}
+              fullWidth
+              placeholder={`sum(rate(http_requests_total[5m]))`}
+              data-test-subj="slosWizardCustomPromqlTotal"
+            />
+          </EuiFormRow>
+        </>
+      ) : (
+        <EuiFormRow
+          label="Error-ratio query"
+          isInvalid={!!rawError}
+          error={rawError}
+          helpText="PromQL returning a pre-computed error ratio in [0, 1]."
+          fullWidth
+        >
+          <EuiTextArea
+            rows={3}
+            value={value.errorRatioQuery}
+            onChange={(e) =>
+              dispatch({ kind: 'setCustomPromql', patch: { errorRatioQuery: e.target.value } })
+            }
+            style={MONO_STYLE}
+            fullWidth
+            placeholder={`(sum(rate(errors[5m])) / sum(rate(requests[5m])))`}
+            data-test-subj="slosWizardCustomPromqlRaw"
+          />
+        </EuiFormRow>
+      )}
+    </EuiPanel>
+  );
+};

--- a/public/components/apm/pages/slos/custom_promql_editor.tsx
+++ b/public/components/apm/pages/slos/custom_promql_editor.tsx
@@ -22,6 +22,7 @@
  */
 
 import React from 'react';
+import { i18n } from '@osd/i18n';
 import {
   EuiButtonGroup,
   EuiCallOut,
@@ -39,9 +40,46 @@ export interface CustomPromqlEditorProps {
   dispatch: React.Dispatch<Action>;
 }
 
+const I18N = {
+  modeEvents: i18n.translate('observability.slo.customPromql.modeEvents', {
+    defaultMessage: 'Events (good + total)',
+  }),
+  modeRaw: i18n.translate('observability.slo.customPromql.modeRaw', {
+    defaultMessage: 'Raw error-ratio',
+  }),
+  heading: i18n.translate('observability.slo.customPromql.heading', {
+    defaultMessage: 'Custom PromQL',
+  }),
+  description: i18n.translate('observability.slo.customPromql.description', {
+    defaultMessage:
+      'Supply your own PromQL. Preview below shows the exact rule group that will be deployed.',
+  }),
+  modeLegend: i18n.translate('observability.slo.customPromql.modeLegend', {
+    defaultMessage: 'PromQL mode',
+  }),
+  goodLabel: i18n.translate('observability.slo.customPromql.goodLabel', {
+    defaultMessage: 'Good events query',
+  }),
+  goodHelp: i18n.translate('observability.slo.customPromql.goodHelp', {
+    defaultMessage: 'PromQL returning the count of good events (non-errors).',
+  }),
+  totalLabel: i18n.translate('observability.slo.customPromql.totalLabel', {
+    defaultMessage: 'Total events query',
+  }),
+  totalHelp: i18n.translate('observability.slo.customPromql.totalHelp', {
+    defaultMessage: 'PromQL returning the count of total events.',
+  }),
+  rawLabel: i18n.translate('observability.slo.customPromql.rawLabel', {
+    defaultMessage: 'Error-ratio query',
+  }),
+  rawHelp: i18n.translate('observability.slo.customPromql.rawHelp', {
+    defaultMessage: 'PromQL returning a pre-computed error ratio in [0, 1].',
+  }),
+};
+
 const MODE_OPTIONS = [
-  { id: 'events', label: 'Events (good + total)' },
-  { id: 'raw', label: 'Raw error-ratio' },
+  { id: 'events', label: I18N.modeEvents },
+  { id: 'raw', label: I18N.modeRaw },
 ];
 
 const MONO_STYLE: React.CSSProperties = { fontFamily: 'monospace' };
@@ -59,14 +97,14 @@ export const CustomPromqlEditor: React.FC<CustomPromqlEditorProps> = ({
   return (
     <EuiPanel data-test-subj="slosWizardCustomPromql">
       <EuiText size="m">
-        <h4>Custom PromQL</h4>
+        <h4>{I18N.heading}</h4>
       </EuiText>
       <EuiText size="s" color="subdued">
-        Supply your own PromQL. Preview below shows the exact rule group that will be deployed.
+        {I18N.description}
       </EuiText>
       <EuiSpacer size="s" />
       <EuiButtonGroup
-        legend="PromQL mode"
+        legend={I18N.modeLegend}
         idSelected={value.mode}
         onChange={(id) =>
           dispatch({
@@ -92,10 +130,10 @@ export const CustomPromqlEditor: React.FC<CustomPromqlEditorProps> = ({
       {value.mode === 'events' ? (
         <>
           <EuiFormRow
-            label="Good events query"
+            label={I18N.goodLabel}
             isInvalid={!!goodError}
             error={goodError}
-            helpText="PromQL returning the count of good events (non-errors)."
+            helpText={I18N.goodHelp}
             fullWidth
           >
             <EuiTextArea
@@ -111,10 +149,10 @@ export const CustomPromqlEditor: React.FC<CustomPromqlEditorProps> = ({
             />
           </EuiFormRow>
           <EuiFormRow
-            label="Total events query"
+            label={I18N.totalLabel}
             isInvalid={!!totalError}
             error={totalError}
-            helpText="PromQL returning the count of total events."
+            helpText={I18N.totalHelp}
             fullWidth
           >
             <EuiTextArea
@@ -132,10 +170,10 @@ export const CustomPromqlEditor: React.FC<CustomPromqlEditorProps> = ({
         </>
       ) : (
         <EuiFormRow
-          label="Error-ratio query"
+          label={I18N.rawLabel}
           isInvalid={!!rawError}
           error={rawError}
-          helpText="PromQL returning a pre-computed error ratio in [0, 1]."
+          helpText={I18N.rawHelp}
           fullWidth
         >
           <EuiTextArea

--- a/public/components/apm/pages/slos/exclusion_windows_editor.tsx
+++ b/public/components/apm/pages/slos/exclusion_windows_editor.tsx
@@ -1,0 +1,234 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Exclusion-window editor. Shape-only: the definition is persisted on the
+ * SLO document but attainment exclusion enforcement is deferred. The editor
+ * captures the spec so data-gathering can start before enforcement ships.
+ *
+ * Two schedule modes:
+ *   cron    — recurring (expression + timezone + duration-per-occurrence)
+ *   oneoff  — start + end ISO timestamps
+ */
+
+import React from 'react';
+import {
+  EuiAccordion,
+  EuiButtonEmpty,
+  EuiButtonGroup,
+  EuiCallOut,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import type { ExclusionWindow } from '../../../../../common/slo/slo_types';
+import type { Action } from './wizard_state';
+
+export interface ExclusionWindowsEditorProps {
+  exclusionWindows: ExclusionWindow[];
+  dispatch: React.Dispatch<Action>;
+}
+
+const SCHEDULE_OPTIONS = [
+  { id: 'cron', label: 'Recurring (cron)' },
+  { id: 'oneoff', label: 'One-off window' },
+];
+
+export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
+  exclusionWindows,
+  dispatch,
+}) => (
+  <EuiPanel>
+    <EuiAccordion
+      id="slosWizardExclusionWindows"
+      buttonContent="Exclusion windows (maintenance / deploy freezes)"
+      paddingSize="s"
+      data-test-subj="slosWizardExclusionWindowsToggle"
+    >
+      <EuiCallOut
+        color="primary"
+        size="s"
+        iconType="iInCircle"
+        title="Saved with the SLO; attainment exclusion enforcement ships post-GA."
+        data-test-subj="slosWizardExclusionWindowsNotice"
+      />
+      <EuiSpacer size="s" />
+      {exclusionWindows.length === 0 && (
+        <EuiText size="s" color="subdued" data-test-subj="slosWizardExclusionWindowsEmpty">
+          No exclusion windows configured.
+        </EuiText>
+      )}
+      {exclusionWindows.map((ew, i) => (
+        <div key={i} style={{ marginBottom: 12 }} data-test-subj={`slosWizardExclusionRow-${i}`}>
+          <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
+            <EuiFlexItem>
+              <EuiFormRow label="Name">
+                <EuiFieldText
+                  value={ew.name}
+                  onChange={(e) =>
+                    dispatch({
+                      kind: 'setExclusionWindowField',
+                      index: i,
+                      field: 'name',
+                      value: e.target.value,
+                    })
+                  }
+                  compressed
+                  data-test-subj={`slosWizardExclusionName-${i}`}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow label="Reason (optional)">
+                <EuiFieldText
+                  value={ew.reason ?? ''}
+                  onChange={(e) =>
+                    dispatch({
+                      kind: 'setExclusionWindowField',
+                      index: i,
+                      field: 'reason',
+                      value: e.target.value,
+                    })
+                  }
+                  compressed
+                  data-test-subj={`slosWizardExclusionReason-${i}`}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                color="danger"
+                onClick={() => dispatch({ kind: 'removeExclusionWindow', index: i })}
+                iconType="trash"
+                aria-label={`Remove exclusion window ${i}`}
+                size="s"
+                data-test-subj={`slosWizardExclusionRemove-${i}`}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="xs" />
+          <EuiButtonGroup
+            legend="Schedule type"
+            idSelected={ew.schedule.type}
+            onChange={(id) =>
+              dispatch({
+                kind: 'setExclusionWindowScheduleType',
+                index: i,
+                type: id === 'oneoff' ? 'oneoff' : 'cron',
+              })
+            }
+            options={SCHEDULE_OPTIONS}
+            data-test-subj={`slosWizardExclusionScheduleType-${i}`}
+          />
+          <EuiSpacer size="xs" />
+          {ew.schedule.type === 'cron' ? (
+            <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
+              <EuiFlexItem>
+                <EuiFormRow label="Cron expression">
+                  <EuiFieldText
+                    value={ew.schedule.expression}
+                    onChange={(e) =>
+                      dispatch({
+                        kind: 'setExclusionWindowField',
+                        index: i,
+                        field: 'cronExpression',
+                        value: e.target.value,
+                      })
+                    }
+                    compressed
+                    data-test-subj={`slosWizardExclusionCronExpression-${i}`}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFormRow label="Timezone">
+                  <EuiFieldText
+                    value={ew.schedule.timezone}
+                    onChange={(e) =>
+                      dispatch({
+                        kind: 'setExclusionWindowField',
+                        index: i,
+                        field: 'cronTimezone',
+                        value: e.target.value,
+                      })
+                    }
+                    compressed
+                    data-test-subj={`slosWizardExclusionCronTimezone-${i}`}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFormRow label="Duration (per occurrence)">
+                  <EuiFieldText
+                    value={ew.schedule.duration}
+                    onChange={(e) =>
+                      dispatch({
+                        kind: 'setExclusionWindowField',
+                        index: i,
+                        field: 'cronDuration',
+                        value: e.target.value,
+                      })
+                    }
+                    compressed
+                    data-test-subj={`slosWizardExclusionCronDuration-${i}`}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
+              <EuiFlexItem>
+                <EuiFormRow label="Start (ISO-8601)">
+                  <EuiFieldText
+                    value={ew.schedule.start}
+                    onChange={(e) =>
+                      dispatch({
+                        kind: 'setExclusionWindowField',
+                        index: i,
+                        field: 'oneoffStart',
+                        value: e.target.value,
+                      })
+                    }
+                    compressed
+                    data-test-subj={`slosWizardExclusionOneoffStart-${i}`}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFormRow label="End (ISO-8601)">
+                  <EuiFieldText
+                    value={ew.schedule.end}
+                    onChange={(e) =>
+                      dispatch({
+                        kind: 'setExclusionWindowField',
+                        index: i,
+                        field: 'oneoffEnd',
+                        value: e.target.value,
+                      })
+                    }
+                    compressed
+                    data-test-subj={`slosWizardExclusionOneoffEnd-${i}`}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
+        </div>
+      ))}
+      <EuiButtonEmpty
+        iconType="plusInCircle"
+        size="s"
+        onClick={() => dispatch({ kind: 'addExclusionWindow' })}
+        data-test-subj="slosWizardExclusionAdd"
+      >
+        Add exclusion window
+      </EuiButtonEmpty>
+    </EuiAccordion>
+  </EuiPanel>
+);

--- a/public/components/apm/pages/slos/exclusion_windows_editor.tsx
+++ b/public/components/apm/pages/slos/exclusion_windows_editor.tsx
@@ -14,6 +14,7 @@
  */
 
 import React from 'react';
+import { i18n } from '@osd/i18n';
 import {
   EuiAccordion,
   EuiButtonEmpty,
@@ -35,9 +36,59 @@ export interface ExclusionWindowsEditorProps {
   dispatch: React.Dispatch<Action>;
 }
 
+const I18N = {
+  scheduleCron: i18n.translate('observability.slo.exclusionWindows.scheduleCron', {
+    defaultMessage: 'Recurring (cron)',
+  }),
+  scheduleOneoff: i18n.translate('observability.slo.exclusionWindows.scheduleOneoff', {
+    defaultMessage: 'One-off window',
+  }),
+  accordionLabel: i18n.translate('observability.slo.exclusionWindows.accordionLabel', {
+    defaultMessage: 'Exclusion windows (maintenance / deploy freezes)',
+  }),
+  noticeTitle: i18n.translate('observability.slo.exclusionWindows.noticeTitle', {
+    defaultMessage: 'Saved with the SLO; attainment exclusion enforcement ships post-GA.',
+  }),
+  empty: i18n.translate('observability.slo.exclusionWindows.empty', {
+    defaultMessage: 'No exclusion windows configured.',
+  }),
+  nameLabel: i18n.translate('observability.slo.exclusionWindows.nameLabel', {
+    defaultMessage: 'Name',
+  }),
+  reasonLabel: i18n.translate('observability.slo.exclusionWindows.reasonLabel', {
+    defaultMessage: 'Reason (optional)',
+  }),
+  removeAria: (index: number) =>
+    i18n.translate('observability.slo.exclusionWindows.removeAria', {
+      defaultMessage: 'Remove exclusion window {index}',
+      values: { index },
+    }),
+  scheduleLegend: i18n.translate('observability.slo.exclusionWindows.scheduleLegend', {
+    defaultMessage: 'Schedule type',
+  }),
+  cronExpression: i18n.translate('observability.slo.exclusionWindows.cronExpression', {
+    defaultMessage: 'Cron expression',
+  }),
+  timezone: i18n.translate('observability.slo.exclusionWindows.timezone', {
+    defaultMessage: 'Timezone',
+  }),
+  duration: i18n.translate('observability.slo.exclusionWindows.duration', {
+    defaultMessage: 'Duration (per occurrence)',
+  }),
+  startIso: i18n.translate('observability.slo.exclusionWindows.startIso', {
+    defaultMessage: 'Start (ISO-8601)',
+  }),
+  endIso: i18n.translate('observability.slo.exclusionWindows.endIso', {
+    defaultMessage: 'End (ISO-8601)',
+  }),
+  addButton: i18n.translate('observability.slo.exclusionWindows.addButton', {
+    defaultMessage: 'Add exclusion window',
+  }),
+};
+
 const SCHEDULE_OPTIONS = [
-  { id: 'cron', label: 'Recurring (cron)' },
-  { id: 'oneoff', label: 'One-off window' },
+  { id: 'cron', label: I18N.scheduleCron },
+  { id: 'oneoff', label: I18N.scheduleOneoff },
 ];
 
 export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
@@ -47,7 +98,7 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
   <EuiPanel>
     <EuiAccordion
       id="slosWizardExclusionWindows"
-      buttonContent="Exclusion windows (maintenance / deploy freezes)"
+      buttonContent={I18N.accordionLabel}
       paddingSize="s"
       data-test-subj="slosWizardExclusionWindowsToggle"
     >
@@ -55,20 +106,20 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
         color="primary"
         size="s"
         iconType="iInCircle"
-        title="Saved with the SLO; attainment exclusion enforcement ships post-GA."
+        title={I18N.noticeTitle}
         data-test-subj="slosWizardExclusionWindowsNotice"
       />
       <EuiSpacer size="s" />
       {exclusionWindows.length === 0 && (
         <EuiText size="s" color="subdued" data-test-subj="slosWizardExclusionWindowsEmpty">
-          No exclusion windows configured.
+          {I18N.empty}
         </EuiText>
       )}
       {exclusionWindows.map((ew, i) => (
         <div key={i} style={{ marginBottom: 12 }} data-test-subj={`slosWizardExclusionRow-${i}`}>
           <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
             <EuiFlexItem>
-              <EuiFormRow label="Name">
+              <EuiFormRow label={I18N.nameLabel}>
                 <EuiFieldText
                   value={ew.name}
                   onChange={(e) =>
@@ -85,7 +136,7 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
               </EuiFormRow>
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiFormRow label="Reason (optional)">
+              <EuiFormRow label={I18N.reasonLabel}>
                 <EuiFieldText
                   value={ew.reason ?? ''}
                   onChange={(e) =>
@@ -106,7 +157,7 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
                 color="danger"
                 onClick={() => dispatch({ kind: 'removeExclusionWindow', index: i })}
                 iconType="trash"
-                aria-label={`Remove exclusion window ${i}`}
+                aria-label={I18N.removeAria(i)}
                 size="s"
                 data-test-subj={`slosWizardExclusionRemove-${i}`}
               />
@@ -114,7 +165,7 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
           </EuiFlexGroup>
           <EuiSpacer size="xs" />
           <EuiButtonGroup
-            legend="Schedule type"
+            legend={I18N.scheduleLegend}
             idSelected={ew.schedule.type}
             onChange={(id) =>
               dispatch({
@@ -130,7 +181,7 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
           {ew.schedule.type === 'cron' ? (
             <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
               <EuiFlexItem>
-                <EuiFormRow label="Cron expression">
+                <EuiFormRow label={I18N.cronExpression}>
                   <EuiFieldText
                     value={ew.schedule.expression}
                     onChange={(e) =>
@@ -147,7 +198,7 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
                 </EuiFormRow>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiFormRow label="Timezone">
+                <EuiFormRow label={I18N.timezone}>
                   <EuiFieldText
                     value={ew.schedule.timezone}
                     onChange={(e) =>
@@ -164,7 +215,7 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
                 </EuiFormRow>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiFormRow label="Duration (per occurrence)">
+                <EuiFormRow label={I18N.duration}>
                   <EuiFieldText
                     value={ew.schedule.duration}
                     onChange={(e) =>
@@ -184,7 +235,7 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
           ) : (
             <EuiFlexGroup gutterSize="s" alignItems="flexEnd">
               <EuiFlexItem>
-                <EuiFormRow label="Start (ISO-8601)">
+                <EuiFormRow label={I18N.startIso}>
                   <EuiFieldText
                     value={ew.schedule.start}
                     onChange={(e) =>
@@ -201,7 +252,7 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
                 </EuiFormRow>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiFormRow label="End (ISO-8601)">
+                <EuiFormRow label={I18N.endIso}>
                   <EuiFieldText
                     value={ew.schedule.end}
                     onChange={(e) =>
@@ -227,7 +278,7 @@ export const ExclusionWindowsEditor: React.FC<ExclusionWindowsEditorProps> = ({
         onClick={() => dispatch({ kind: 'addExclusionWindow' })}
         data-test-subj="slosWizardExclusionAdd"
       >
-        Add exclusion window
+        {I18N.addButton}
       </EuiButtonEmpty>
     </EuiAccordion>
   </EuiPanel>

--- a/public/components/apm/pages/slos/generated_rules_preview.tsx
+++ b/public/components/apm/pages/slos/generated_rules_preview.tsx
@@ -144,21 +144,26 @@ export const GeneratedRulesPreview: React.FC<GeneratedRulesPreviewProps> = ({
       setState(INITIAL);
       return;
     }
-    let cancelled = false;
+    // AbortController over a `cancelled` flag: aborts the fetch itself when
+    // the input changes mid-flight or the component unmounts, so we don't
+    // hold a network slot open just to discard the response. The catch
+    // branch still has to filter out the resulting AbortError so it doesn't
+    // surface as a preview error toast.
+    const ac = new AbortController();
     setState({ status: 'loading' });
     apiClient
-      .preview(JSON.parse(debouncedSerialized) as SloCreateInput)
+      .preview(JSON.parse(debouncedSerialized) as SloCreateInput, ac.signal)
       .then((group) => {
-        if (cancelled) return;
+        if (ac.signal.aborted) return;
         setState({ status: 'success', group });
       })
       .catch((e) => {
-        if (cancelled) return;
+        if (ac.signal.aborted) return;
         const message = e instanceof Error ? e.message : String(e);
         setState({ status: 'error', error: message });
       });
     return () => {
-      cancelled = true;
+      ac.abort();
     };
   }, [apiClient, debouncedSerialized]);
 

--- a/public/components/apm/pages/slos/generated_rules_preview.tsx
+++ b/public/components/apm/pages/slos/generated_rules_preview.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
+import { i18n } from '@osd/i18n';
 import {
   EuiAccordion,
   EuiBadge,
@@ -34,6 +35,63 @@ import type { GeneratedRuleGroup, SloCreateInput } from '../../../../../common/s
 import { SLO_RULER_NAMESPACE } from '../../../../../common/slo/slo_promql_generator';
 import type { SloApiClient } from './slo_api_client';
 import { findSectionForKey, scrollToErrorKey } from './wizard_sections';
+
+const I18N = {
+  heading: i18n.translate('observability.slo.rulesPreview.heading', {
+    defaultMessage: 'Rule preview',
+  }),
+  description: i18n.translate('observability.slo.rulesPreview.description', {
+    defaultMessage: 'The Prometheus rule group that will be deployed when you click Create.',
+  }),
+  generating: i18n.translate('observability.slo.rulesPreview.generating', {
+    defaultMessage: 'Generating preview…',
+  }),
+  errorTitle: i18n.translate('observability.slo.rulesPreview.errorTitle', {
+    defaultMessage: 'Preview unavailable',
+  }),
+  errorFallback: i18n.translate('observability.slo.rulesPreview.errorFallback', {
+    defaultMessage: 'Unable to generate preview.',
+  }),
+  ruleSingular: i18n.translate('observability.slo.rulesPreview.ruleSingular', {
+    defaultMessage: 'rule',
+  }),
+  rulePlural: i18n.translate('observability.slo.rulesPreview.rulePlural', {
+    defaultMessage: 'rules',
+  }),
+  ruleCount: (count: number, ruleWord: string) =>
+    i18n.translate('observability.slo.rulesPreview.ruleCount', {
+      defaultMessage: '{count} {ruleWord}',
+      values: { count, ruleWord },
+    }),
+  namespacePrefix: i18n.translate('observability.slo.rulesPreview.namespacePrefix', {
+    defaultMessage: 'namespace',
+  }),
+  evalInterval: (interval: number) =>
+    i18n.translate('observability.slo.rulesPreview.evalInterval', {
+      defaultMessage: 'eval interval {interval}s',
+      values: { interval },
+    }),
+  yamlToggle: i18n.translate('observability.slo.rulesPreview.yamlToggle', {
+    defaultMessage: 'Show rule-group YAML',
+  }),
+  emptyTitle: i18n.translate('observability.slo.rulesPreview.emptyTitle', {
+    defaultMessage: 'Preview renders once the form is valid',
+  }),
+  missingHeader: i18n.translate('observability.slo.rulesPreview.missingHeader', {
+    defaultMessage: 'Missing or invalid fields:',
+  }),
+  pickTemplate: i18n.translate('observability.slo.rulesPreview.pickTemplate', {
+    defaultMessage: 'Pick a template to start building the rule set.',
+  }),
+  fillRequired: i18n.translate('observability.slo.rulesPreview.fillRequired', {
+    defaultMessage: 'Fill in the required fields to see the generated rules.',
+  }),
+  serverMessage: (serverMessage: string) =>
+    i18n.translate('observability.slo.rulesPreview.serverMessage', {
+      defaultMessage: 'Server message: {serverMessage}',
+      values: { serverMessage },
+    }),
+};
 
 export const PREVIEW_DEBOUNCE_MS = 500;
 
@@ -108,10 +166,10 @@ export const GeneratedRulesPreview: React.FC<GeneratedRulesPreviewProps> = ({
   return (
     <EuiPanel data-test-subj="slosWizardPreview">
       <EuiText size="m">
-        <h4>Rule preview</h4>
+        <h4>{I18N.heading}</h4>
       </EuiText>
       <EuiText size="s" color="subdued">
-        The Prometheus rule group that will be deployed when you click Create.
+        {I18N.description}
       </EuiText>
       <EuiSpacer size="s" />
       {renderBody(state, input, errors ?? {})}
@@ -135,7 +193,7 @@ function renderBody(
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="s" color="subdued">
-            Generating preview…
+            {I18N.generating}
           </EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -150,13 +208,13 @@ function renderBody(
     }
     return (
       <EuiCallOut
-        title="Preview unavailable"
+        title={I18N.errorTitle}
         color="warning"
         iconType="alert"
         size="s"
         data-test-subj="slosWizardPreviewError"
       >
-        <EuiText size="s">{state.error ?? 'Unable to generate preview.'}</EuiText>
+        <EuiText size="s">{state.error ?? I18N.errorFallback}</EuiText>
       </EuiCallOut>
     );
   }
@@ -166,7 +224,10 @@ function renderBody(
       <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
         <EuiFlexItem grow={false}>
           <EuiBadge color="primary" data-test-subj="slosWizardPreviewRuleCount">
-            {group.rules.length} {group.rules.length === 1 ? 'rule' : 'rules'}
+            {I18N.ruleCount(
+              group.rules.length,
+              group.rules.length === 1 ? I18N.ruleSingular : I18N.rulePlural
+            )}
           </EuiBadge>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
@@ -176,19 +237,19 @@ function renderBody(
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="xs" color="subdued" data-test-subj="slosWizardPreviewNamespace">
-            namespace <code>{SLO_RULER_NAMESPACE}</code>
+            {I18N.namespacePrefix} <code>{SLO_RULER_NAMESPACE}</code>
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="xs" color="subdued">
-            eval interval {group.interval}s
+            {I18N.evalInterval(group.interval)}
           </EuiText>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="s" />
       <EuiAccordion
         id="slosWizardPreviewYaml"
-        buttonContent="Show rule-group YAML"
+        buttonContent={I18N.yamlToggle}
         paddingSize="s"
         data-test-subj="slosWizardPreviewYamlToggle"
       >
@@ -221,7 +282,7 @@ function renderEmptyPrompt(
     missingEntries.length > 0 ? (
       <>
         <EuiText size="s" color="subdued">
-          Missing or invalid fields:
+          {I18N.missingHeader}
         </EuiText>
         <ul data-test-subj="slosWizardPreviewMissingList">
           {missingEntries.map(([key, msg]) => {
@@ -241,16 +302,14 @@ function renderEmptyPrompt(
       </>
     ) : (
       <EuiText size="s" color="subdued">
-        {input === null
-          ? 'Pick a template to start building the rule set.'
-          : 'Fill in the required fields to see the generated rules.'}
+        {input === null ? I18N.pickTemplate : I18N.fillRequired}
       </EuiText>
     );
   return (
     <EuiEmptyPrompt
       iconType="inspect"
       titleSize="xs"
-      title={<h4>Preview renders once the form is valid</h4>}
+      title={<h4>{I18N.emptyTitle}</h4>}
       body={
         <>
           {body}
@@ -258,7 +317,7 @@ function renderEmptyPrompt(
             <>
               <EuiSpacer size="s" />
               <EuiText size="xs" color="subdued" data-test-subj="slosWizardPreviewServerMsg">
-                Server message: {serverMessage}
+                {I18N.serverMessage(serverMessage)}
               </EuiText>
             </>
           )}

--- a/public/components/apm/pages/slos/generated_rules_preview.tsx
+++ b/public/components/apm/pages/slos/generated_rules_preview.tsx
@@ -1,0 +1,270 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Wizard-side preview of the Prometheus rule group that will be deployed.
+ *
+ * Calls the server `/preview` endpoint with a debounced input so typing in the
+ * wizard doesn't generate a request per keystroke. The server runs the same
+ * `generateSloRuleGroup` as the deploy path — what the preview shows is what
+ * will land in the ruler.
+ *
+ * The server response carries the rendered YAML on `yaml`; this component
+ * renders it verbatim rather than recomputing client-side.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  EuiAccordion,
+  EuiBadge,
+  EuiCallOut,
+  EuiCodeBlock,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiLoadingSpinner,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import type { GeneratedRuleGroup, SloCreateInput } from '../../../../../common/slo/slo_types';
+import { SLO_RULER_NAMESPACE } from '../../../../../common/slo/slo_promql_generator';
+import type { SloApiClient } from './slo_api_client';
+import { findSectionForKey, scrollToErrorKey } from './wizard_sections';
+
+export const PREVIEW_DEBOUNCE_MS = 500;
+
+export interface GeneratedRulesPreviewProps {
+  apiClient: Pick<SloApiClient, 'preview'>;
+  /**
+   * Current wizard input. Pass `null` when the form isn't yet ready for
+   * preview (e.g. no template selected); the component will render a hint.
+   */
+  input: SloCreateInput | null;
+  /**
+   * Live client-side validation errors keyed by validator path. When set,
+   * the empty-state prompt lists the missing fields as clickable links that
+   * scroll the user to the right section.
+   */
+  errors?: Record<string, string>;
+}
+
+interface PreviewState {
+  status: 'idle' | 'loading' | 'success' | 'error';
+  group?: GeneratedRuleGroup;
+  error?: string;
+}
+
+const INITIAL: PreviewState = { status: 'idle' };
+
+export const GeneratedRulesPreview: React.FC<GeneratedRulesPreviewProps> = ({
+  apiClient,
+  input,
+  errors,
+}) => {
+  // Debounce on the serialized input so equivalent objects don't retrigger
+  // fetches (stable JSON → stable effect dep). Unlike useDebouncedValue, we
+  // never seed the debounced value from the initial prop — the first preview
+  // request should wait out the debounce window just like subsequent ones.
+  const serialized = useMemo(() => (input ? JSON.stringify(input) : null), [input]);
+  const [debouncedSerialized, setDebouncedSerialized] = useState<string | null>(null);
+  const [state, setState] = useState<PreviewState>(INITIAL);
+
+  useEffect(() => {
+    if (serialized === null) {
+      setDebouncedSerialized(null);
+      return;
+    }
+    const t = setTimeout(() => setDebouncedSerialized(serialized), PREVIEW_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [serialized]);
+
+  useEffect(() => {
+    if (!debouncedSerialized) {
+      setState(INITIAL);
+      return;
+    }
+    let cancelled = false;
+    setState({ status: 'loading' });
+    apiClient
+      .preview(JSON.parse(debouncedSerialized) as SloCreateInput)
+      .then((group) => {
+        if (cancelled) return;
+        setState({ status: 'success', group });
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        const message = e instanceof Error ? e.message : String(e);
+        setState({ status: 'error', error: message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apiClient, debouncedSerialized]);
+
+  return (
+    <EuiPanel data-test-subj="slosWizardPreview">
+      <EuiText size="m">
+        <h4>Rule preview</h4>
+      </EuiText>
+      <EuiText size="s" color="subdued">
+        The Prometheus rule group that will be deployed when you click Create.
+      </EuiText>
+      <EuiSpacer size="s" />
+      {renderBody(state, input, errors ?? {})}
+    </EuiPanel>
+  );
+};
+
+function renderBody(
+  state: PreviewState,
+  input: SloCreateInput | null,
+  errors: Record<string, string>
+): JSX.Element {
+  if (state.status === 'idle') {
+    return renderEmptyPrompt(input, errors);
+  }
+  if (state.status === 'loading') {
+    return (
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner size="m" data-test-subj="slosWizardPreviewLoading" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="s" color="subdued">
+            Generating preview…
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+  if (state.status === 'error') {
+    // Server-side validation failures (400-class) route to the same empty-state
+    // prompt so the fix path is consistent with "form isn't valid yet". Genuine
+    // upstream failures (ruler unreachable, 5xx) keep the warning callout.
+    if (isValidationStyleError(state.error)) {
+      return renderEmptyPrompt(input, errors, state.error);
+    }
+    return (
+      <EuiCallOut
+        title="Preview unavailable"
+        color="warning"
+        iconType="alert"
+        size="s"
+        data-test-subj="slosWizardPreviewError"
+      >
+        <EuiText size="s">{state.error ?? 'Unable to generate preview.'}</EuiText>
+      </EuiCallOut>
+    );
+  }
+  const group = state.group!;
+  return (
+    <div data-test-subj="slosWizardPreviewSuccess">
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+        <EuiFlexItem grow={false}>
+          <EuiBadge color="primary" data-test-subj="slosWizardPreviewRuleCount">
+            {group.rules.length} {group.rules.length === 1 ? 'rule' : 'rules'}
+          </EuiBadge>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="s" data-test-subj="slosWizardPreviewGroupName">
+            <code>{group.groupName}</code>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued" data-test-subj="slosWizardPreviewNamespace">
+            namespace <code>{SLO_RULER_NAMESPACE}</code>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiText size="xs" color="subdued">
+            eval interval {group.interval}s
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="s" />
+      <EuiAccordion
+        id="slosWizardPreviewYaml"
+        buttonContent="Show rule-group YAML"
+        paddingSize="s"
+        data-test-subj="slosWizardPreviewYamlToggle"
+      >
+        <EuiCodeBlock
+          language="yaml"
+          paddingSize="s"
+          isCopyable
+          overflowHeight={320}
+          data-test-subj="slosWizardPreviewYaml"
+        >
+          {group.yaml}
+        </EuiCodeBlock>
+      </EuiAccordion>
+    </div>
+  );
+}
+
+function isValidationStyleError(msg: string | undefined): boolean {
+  if (!msg) return false;
+  return /bad request|400|validation/i.test(msg);
+}
+
+function renderEmptyPrompt(
+  input: SloCreateInput | null,
+  errors: Record<string, string>,
+  serverMessage?: string
+): JSX.Element {
+  const missingEntries = Object.entries(errors);
+  const body =
+    missingEntries.length > 0 ? (
+      <>
+        <EuiText size="s" color="subdued">
+          Missing or invalid fields:
+        </EuiText>
+        <ul data-test-subj="slosWizardPreviewMissingList">
+          {missingEntries.map(([key, msg]) => {
+            const section = findSectionForKey(key);
+            return (
+              <li key={key}>
+                <EuiLink
+                  onClick={() => scrollToErrorKey(key)}
+                  data-test-subj={`slosWizardPreviewMissing-${key}`}
+                >
+                  <strong>{section?.label ?? key}:</strong> {msg}
+                </EuiLink>
+              </li>
+            );
+          })}
+        </ul>
+      </>
+    ) : (
+      <EuiText size="s" color="subdued">
+        {input === null
+          ? 'Pick a template to start building the rule set.'
+          : 'Fill in the required fields to see the generated rules.'}
+      </EuiText>
+    );
+  return (
+    <EuiEmptyPrompt
+      iconType="inspect"
+      titleSize="xs"
+      title={<h4>Preview renders once the form is valid</h4>}
+      body={
+        <>
+          {body}
+          {serverMessage && (
+            <>
+              <EuiSpacer size="s" />
+              <EuiText size="xs" color="subdued" data-test-subj="slosWizardPreviewServerMsg">
+                Server message: {serverMessage}
+              </EuiText>
+            </>
+          )}
+        </>
+      }
+      data-test-subj="slosWizardPreviewEmpty"
+    />
+  );
+}

--- a/public/components/apm/pages/slos/generated_rules_preview.tsx
+++ b/public/components/apm/pages/slos/generated_rules_preview.tsx
@@ -32,7 +32,6 @@ import {
   EuiText,
 } from '@elastic/eui';
 import type { GeneratedRuleGroup, SloCreateInput } from '../../../../../common/slo/slo_types';
-import { SLO_RULER_NAMESPACE } from '../../../../../common/slo/slo_promql_generator';
 import type { SloApiClient } from './slo_api_client';
 import { findSectionForKey, scrollToErrorKey } from './wizard_sections';
 
@@ -237,7 +236,7 @@ function renderBody(
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiText size="xs" color="subdued" data-test-subj="slosWizardPreviewNamespace">
-            {I18N.namespacePrefix} <code>{SLO_RULER_NAMESPACE}</code>
+            {I18N.namespacePrefix} <code>{group.rulerNamespace}</code>
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/public/components/apm/pages/slos/objectives_section.tsx
+++ b/public/components/apm/pages/slos/objectives_section.tsx
@@ -1,0 +1,254 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Multi-objective editor. N rows; each row is {name, target%, latency
+ * threshold if the template is latency_threshold}. The validator already
+ * supports N objectives; the generator emits one rule-set per objective.
+ *
+ * The target row carries a live preview of the allowed downtime over the
+ * selected window — `99.9% over 28d → 40m 20s of error budget` — so the
+ * user picks an objective with eyes open. A high-target callout fires above
+ * 99.99% (Google's stated cap, citing GCP SLO defaults) so very-tight
+ * targets don't get rubber-stamped.
+ */
+
+import React from 'react';
+import {
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFieldNumber,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import type { SloTemplate } from '../../../../../common/slo/slo_templates';
+import type { Action, FormState } from './wizard_state';
+
+export interface ObjectivesSectionProps {
+  objectives: FormState['objectives'];
+  latencyThresholdUnit: FormState['latencyThresholdUnit'];
+  windowDuration: FormState['windowDuration'];
+  template: SloTemplate;
+  errors: Record<string, string>;
+  dispatch: React.Dispatch<Action>;
+}
+
+const HIGH_TARGET_THRESHOLD = 99.99;
+
+function windowDurationToMs(w: FormState['windowDuration']): number {
+  switch (w) {
+    case '7d':
+      return 7 * 86_400_000;
+    case '14d':
+      return 14 * 86_400_000;
+    case '28d':
+      return 28 * 86_400_000;
+    case '30d':
+      return 30 * 86_400_000;
+  }
+}
+
+// Two-largest-non-zero-units formatter: "1h 23m", "4m 19s", "12s". Seconds
+// precision matters here — at 99.99% over 28d the budget is ~4 minutes, and
+// chopping everything smaller than a minute would collapse the preview for
+// exactly the targets most in need of sober scrutiny. Rounds the ms→sec
+// boundary (rather than flooring) to absorb the IEEE-754 error from
+// `1 - Number('99.9')/100`, which otherwise ticks "43m 12s" down to "43m 11s"
+// on the 30d window.
+export function formatAllowedDowntime(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  const totalSec = Math.round(ms / 1000);
+  const d = Math.floor(totalSec / 86_400);
+  const h = Math.floor((totalSec % 86_400) / 3_600);
+  const m = Math.floor((totalSec % 3_600) / 60);
+  const s = totalSec % 60;
+  const parts: Array<[number, string]> = [
+    [d, 'd'],
+    [h, 'h'],
+    [m, 'm'],
+    [s, 's'],
+  ];
+  const nonzero = parts.filter(([v]) => v > 0).slice(0, 2);
+  if (nonzero.length === 0) return '0s';
+  return nonzero.map(([v, u]) => `${v}${u}`).join(' ');
+}
+
+function computePreview(
+  rawTarget: string,
+  windowDuration: FormState['windowDuration']
+): { downtime: string; highTarget: boolean } | null {
+  if (rawTarget.trim() === '') return null;
+  const parsed = Number(rawTarget);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) return null;
+  const windowMs = windowDurationToMs(windowDuration);
+  const allowedMs = (1 - parsed / 100) * windowMs;
+  return {
+    downtime: formatAllowedDowntime(allowedMs),
+    highTarget: parsed >= HIGH_TARGET_THRESHOLD,
+  };
+}
+
+export const ObjectivesSection: React.FC<ObjectivesSectionProps> = ({
+  objectives,
+  latencyThresholdUnit,
+  windowDuration,
+  template,
+  errors,
+  dispatch,
+}) => {
+  const showLatency = template.sli.type === 'latency_threshold';
+  return (
+    <EuiPanel data-test-subj="slosWizardObjectives">
+      <EuiText size="m">
+        <h4>Objectives</h4>
+      </EuiText>
+      <EuiText size="s" color="subdued">
+        Each objective produces its own set of recording and alerting rules. Common pattern: a
+        strict page target (p99) plus a looser ticket target (p90).
+      </EuiText>
+      <EuiSpacer size="s" />
+      {objectives.map((row, i) => {
+        const nameError = errors[`spec.objectives[${i}].name`];
+        const targetError = errors[`spec.objectives[${i}].target`];
+        const latencyError = errors[`spec.objectives[${i}].latencyThreshold`];
+        const preview = computePreview(row.target, windowDuration);
+        const targetHelpText = (
+          <>
+            <span>99.9% = 0.999 decimal</span>
+            {preview && (
+              <>
+                <br />
+                <span
+                  style={{ color: '#69707D' }}
+                  data-test-subj={`slosWizardObjectiveTargetDowntime-${i}`}
+                >
+                  {row.target}% over {windowDuration} &rarr; {preview.downtime} of error budget
+                </span>
+              </>
+            )}
+          </>
+        );
+        return (
+          <React.Fragment key={i}>
+            <EuiFlexGroup
+              gutterSize="s"
+              alignItems="flexEnd"
+              style={{ marginBottom: 8 }}
+              data-test-subj={`slosWizardObjectiveRow-${i}`}
+            >
+              <EuiFlexItem>
+                <EuiFormRow label="Objective name" isInvalid={!!nameError} error={nameError}>
+                  <EuiFieldText
+                    value={row.name}
+                    onChange={(e) =>
+                      dispatch({
+                        kind: 'setObjectiveField',
+                        index: i,
+                        field: 'name',
+                        value: e.target.value,
+                      })
+                    }
+                    compressed
+                    data-test-subj={`slosWizardObjectiveName-${i}`}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFormRow
+                  label="Target (%)"
+                  isInvalid={!!targetError}
+                  error={targetError}
+                  helpText={targetHelpText}
+                >
+                  <EuiFieldNumber
+                    value={row.target}
+                    min={50}
+                    max={99.999}
+                    step={0.001}
+                    onChange={(e) =>
+                      dispatch({
+                        kind: 'setObjectiveField',
+                        index: i,
+                        field: 'target',
+                        value: e.target.value,
+                      })
+                    }
+                    compressed
+                    data-test-subj={`slosWizardObjectiveTarget-${i}`}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              {showLatency && (
+                <EuiFlexItem>
+                  <EuiFormRow
+                    label={`Latency (${latencyThresholdUnit})`}
+                    isInvalid={!!latencyError}
+                    error={latencyError}
+                  >
+                    <EuiFieldNumber
+                      value={row.latencyThreshold}
+                      min={0}
+                      step={0.01}
+                      onChange={(e) =>
+                        dispatch({
+                          kind: 'setObjectiveField',
+                          index: i,
+                          field: 'latencyThreshold',
+                          value: e.target.value,
+                        })
+                      }
+                      compressed
+                      data-test-subj={`slosWizardObjectiveLatency-${i}`}
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+              )}
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  color="danger"
+                  onClick={() => dispatch({ kind: 'removeObjective', index: i })}
+                  disabled={objectives.length <= 1}
+                  iconType="trash"
+                  aria-label={`Remove objective ${i}`}
+                  size="s"
+                  data-test-subj={`slosWizardObjectiveRemove-${i}`}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            {preview?.highTarget && (
+              <>
+                <EuiCallOut
+                  size="s"
+                  color="warning"
+                  iconType="alert"
+                  data-test-subj={`slosWizardObjectiveTargetHighCallout-${i}`}
+                >
+                  <EuiText size="s">
+                    A target above 99.99% leaves almost no error budget. GCP caps SLO targets at
+                    99.9%; consider whether your users can actually distinguish 99.99% from 99.9%.
+                  </EuiText>
+                </EuiCallOut>
+                <EuiSpacer size="s" />
+              </>
+            )}
+          </React.Fragment>
+        );
+      })}
+      <EuiButtonEmpty
+        iconType="plusInCircle"
+        size="s"
+        onClick={() => dispatch({ kind: 'addObjective' })}
+        data-test-subj="slosWizardObjectiveAdd"
+      >
+        Add objective
+      </EuiButtonEmpty>
+    </EuiPanel>
+  );
+};

--- a/public/components/apm/pages/slos/objectives_section.tsx
+++ b/public/components/apm/pages/slos/objectives_section.tsx
@@ -16,6 +16,7 @@
  */
 
 import React from 'react';
+import { i18n } from '@osd/i18n';
 import {
   EuiButtonEmpty,
   EuiCallOut,
@@ -30,6 +31,47 @@ import {
 } from '@elastic/eui';
 import type { SloTemplate } from '../../../../../common/slo/slo_templates';
 import type { Action, FormState } from './wizard_state';
+
+const I18N = {
+  heading: i18n.translate('observability.slo.objectives.heading', {
+    defaultMessage: 'Objectives',
+  }),
+  description: i18n.translate('observability.slo.objectives.description', {
+    defaultMessage:
+      'Each objective produces its own set of recording and alerting rules. Common pattern: a strict page target (p99) plus a looser ticket target (p90).',
+  }),
+  helpDecimal: i18n.translate('observability.slo.objectives.helpDecimal', {
+    defaultMessage: '99.9% = 0.999 decimal',
+  }),
+  downtimePreview: (target: string, windowDuration: string, downtime: string) =>
+    i18n.translate('observability.slo.objectives.downtimePreview', {
+      defaultMessage: '{target}% over {windowDuration} → {downtime} of error budget',
+      values: { target, windowDuration, downtime },
+    }),
+  nameLabel: i18n.translate('observability.slo.objectives.nameLabel', {
+    defaultMessage: 'Objective name',
+  }),
+  targetLabel: i18n.translate('observability.slo.objectives.targetLabel', {
+    defaultMessage: 'Target (%)',
+  }),
+  latencyLabel: (unit: string) =>
+    i18n.translate('observability.slo.objectives.latencyLabel', {
+      defaultMessage: 'Latency ({unit})',
+      values: { unit },
+    }),
+  removeAria: (index: number) =>
+    i18n.translate('observability.slo.objectives.removeAria', {
+      defaultMessage: 'Remove objective {index}',
+      values: { index },
+    }),
+  highTargetWarning: i18n.translate('observability.slo.objectives.highTargetWarning', {
+    defaultMessage:
+      'A target above 99.99% leaves almost no error budget. GCP caps SLO targets at 99.9%; consider whether your users can actually distinguish 99.99% from 99.9%.',
+  }),
+  addButton: i18n.translate('observability.slo.objectives.addButton', {
+    defaultMessage: 'Add objective',
+  }),
+};
 
 export interface ObjectivesSectionProps {
   objectives: FormState['objectives'];
@@ -107,11 +149,10 @@ export const ObjectivesSection: React.FC<ObjectivesSectionProps> = ({
   return (
     <EuiPanel data-test-subj="slosWizardObjectives">
       <EuiText size="m">
-        <h4>Objectives</h4>
+        <h4>{I18N.heading}</h4>
       </EuiText>
       <EuiText size="s" color="subdued">
-        Each objective produces its own set of recording and alerting rules. Common pattern: a
-        strict page target (p99) plus a looser ticket target (p90).
+        {I18N.description}
       </EuiText>
       <EuiSpacer size="s" />
       {objectives.map((row, i) => {
@@ -121,7 +162,7 @@ export const ObjectivesSection: React.FC<ObjectivesSectionProps> = ({
         const preview = computePreview(row.target, windowDuration);
         const targetHelpText = (
           <>
-            <span>99.9% = 0.999 decimal</span>
+            <span>{I18N.helpDecimal}</span>
             {preview && (
               <>
                 <br />
@@ -129,7 +170,7 @@ export const ObjectivesSection: React.FC<ObjectivesSectionProps> = ({
                   style={{ color: '#69707D' }}
                   data-test-subj={`slosWizardObjectiveTargetDowntime-${i}`}
                 >
-                  {row.target}% over {windowDuration} &rarr; {preview.downtime} of error budget
+                  {I18N.downtimePreview(row.target, windowDuration, preview.downtime)}
                 </span>
               </>
             )}
@@ -144,7 +185,7 @@ export const ObjectivesSection: React.FC<ObjectivesSectionProps> = ({
               data-test-subj={`slosWizardObjectiveRow-${i}`}
             >
               <EuiFlexItem>
-                <EuiFormRow label="Objective name" isInvalid={!!nameError} error={nameError}>
+                <EuiFormRow label={I18N.nameLabel} isInvalid={!!nameError} error={nameError}>
                   <EuiFieldText
                     value={row.name}
                     onChange={(e) =>
@@ -162,7 +203,7 @@ export const ObjectivesSection: React.FC<ObjectivesSectionProps> = ({
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiFormRow
-                  label="Target (%)"
+                  label={I18N.targetLabel}
                   isInvalid={!!targetError}
                   error={targetError}
                   helpText={targetHelpText}
@@ -188,7 +229,7 @@ export const ObjectivesSection: React.FC<ObjectivesSectionProps> = ({
               {showLatency && (
                 <EuiFlexItem>
                   <EuiFormRow
-                    label={`Latency (${latencyThresholdUnit})`}
+                    label={I18N.latencyLabel(latencyThresholdUnit)}
                     isInvalid={!!latencyError}
                     error={latencyError}
                   >
@@ -216,7 +257,7 @@ export const ObjectivesSection: React.FC<ObjectivesSectionProps> = ({
                   onClick={() => dispatch({ kind: 'removeObjective', index: i })}
                   disabled={objectives.length <= 1}
                   iconType="trash"
-                  aria-label={`Remove objective ${i}`}
+                  aria-label={I18N.removeAria(i)}
                   size="s"
                   data-test-subj={`slosWizardObjectiveRemove-${i}`}
                 />
@@ -230,10 +271,7 @@ export const ObjectivesSection: React.FC<ObjectivesSectionProps> = ({
                   iconType="alert"
                   data-test-subj={`slosWizardObjectiveTargetHighCallout-${i}`}
                 >
-                  <EuiText size="s">
-                    A target above 99.99% leaves almost no error budget. GCP caps SLO targets at
-                    99.9%; consider whether your users can actually distinguish 99.99% from 99.9%.
-                  </EuiText>
+                  <EuiText size="s">{I18N.highTargetWarning}</EuiText>
                 </EuiCallOut>
                 <EuiSpacer size="s" />
               </>
@@ -247,7 +285,7 @@ export const ObjectivesSection: React.FC<ObjectivesSectionProps> = ({
         onClick={() => dispatch({ kind: 'addObjective' })}
         data-test-subj="slosWizardObjectiveAdd"
       >
-        Add objective
+        {I18N.addButton}
       </EuiButtonEmpty>
     </EuiPanel>
   );

--- a/public/components/apm/pages/slos/slo_api_client.ts
+++ b/public/components/apm/pages/slos/slo_api_client.ts
@@ -158,7 +158,7 @@ export class SloApiClient {
     return this.http.delete(`${SLO_BASE}/${encodeURIComponent(id)}`);
   }
 
-  preview(input: SloCreateInput): Promise<GeneratedRuleGroup> {
-    return this.http.post(`${SLO_BASE}/preview`, { body: JSON.stringify(input) });
+  preview(input: SloCreateInput, signal?: AbortSignal): Promise<GeneratedRuleGroup> {
+    return this.http.post(`${SLO_BASE}/preview`, { body: JSON.stringify(input), signal });
   }
 }

--- a/public/components/apm/pages/slos/slo_api_client.ts
+++ b/public/components/apm/pages/slos/slo_api_client.ts
@@ -47,13 +47,40 @@ export interface SloRulerErrorEnvelope {
  * a richer `body.message`. Falls back to `err.message` when the envelope
  * is absent. Symmetric with how the wizard surfaces ruler diagnostics via
  * `extractRulerErrorEnvelope` — extends the same unwrap to generic errors.
+ *
+ * For 400 responses with `body.attributes.errors: Record<string, string>`
+ * (the route layer's per-field validation envelope), the single-error case
+ * is rendered inline as `${body.message}\n${field}: ${msg}` so a typo'd
+ * datasource id surfaces actionably in the toast. The multi-error case
+ * appends `(N field errors)` and lets the wizard's inline
+ * `WizardValidationSummary` carry the per-field detail (PR 8 will merge
+ * those into the summary so toasts don't have to grow).
  */
 export function extractServerMessage(err: unknown): string {
   if (err && typeof err === 'object') {
     const body = (err as { body?: unknown }).body;
     if (body && typeof body === 'object') {
-      const msg = (body as { message?: unknown }).message;
-      if (typeof msg === 'string' && msg.length > 0) return msg;
+      const b = body as { message?: unknown; attributes?: unknown };
+      const headRaw = b.message;
+      const head =
+        typeof headRaw === 'string' && headRaw.length > 0 ? headRaw : 'Validation failed';
+      const attrs = b.attributes as { errors?: unknown } | undefined;
+      const errs = attrs?.errors;
+      if (errs && typeof errs === 'object' && !Array.isArray(errs)) {
+        // Only consume string-valued entries; the route shape is
+        // `Record<string, string>` but we defensively skip anything else.
+        const entries = Object.entries(errs as Record<string, unknown>).filter(
+          ([, v]) => typeof v === 'string' && v.length > 0
+        ) as Array<[string, string]>;
+        if (entries.length === 1) {
+          const [field, msg] = entries[0];
+          return `${head}\n${field}: ${msg}`;
+        }
+        if (entries.length > 1) {
+          return `${head} (${entries.length} field errors)`;
+        }
+      }
+      if (typeof headRaw === 'string' && headRaw.length > 0) return headRaw;
     }
     const msg = (err as { message?: unknown }).message;
     if (typeof msg === 'string' && msg.length > 0) return msg;

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
+import { i18n } from '@osd/i18n';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -40,7 +41,7 @@ import {
 } from '@elastic/eui';
 import { Prompt, useHistory, useParams } from 'react-router-dom';
 import type { ChromeStart, NotificationsStart } from '../../../../../../../src/core/public';
-import { extractRulerErrorEnvelope } from './slo_api_client';
+import { extractRulerErrorEnvelope, extractServerMessage } from './slo_api_client';
 import type { SloApiClient, SloRulerErrorEnvelope } from './slo_api_client';
 import { GeneratedRulesPreview } from './generated_rules_preview';
 import { ObjectivesSection } from './objectives_section';
@@ -73,17 +74,213 @@ export interface SloWizardPageProps {
   parentBreadcrumb: { text: string; href: string };
 }
 
-const UNSAVED_PROMPT =
-  'You have unsaved changes. Are you sure you want to leave this page? Your form will be lost.';
+const I18N = {
+  unsavedPrompt: i18n.translate('observability.slo.wizard.unsavedPrompt', {
+    defaultMessage:
+      'You have unsaved changes. Are you sure you want to leave this page? Your form will be lost.',
+  }),
+  breadcrumbSloSli: i18n.translate('observability.slo.wizard.breadcrumbSloSli', {
+    defaultMessage: 'SLO/SLI',
+  }),
+  breadcrumbCreate: i18n.translate('observability.slo.wizard.breadcrumbCreate', {
+    defaultMessage: 'Create',
+  }),
+  toastFixValidationTitle: i18n.translate('observability.slo.wizard.toastFixValidationTitle', {
+    defaultMessage: 'Fix validation errors',
+  }),
+  toastFixValidationText: i18n.translate('observability.slo.wizard.toastFixValidationText', {
+    defaultMessage: 'Some required fields are missing or invalid.',
+  }),
+  toastCreatedTitle: i18n.translate('observability.slo.wizard.toastCreatedTitle', {
+    defaultMessage: 'SLO created',
+  }),
+  toastCreatedText: (name: string) =>
+    i18n.translate('observability.slo.wizard.toastCreatedText', {
+      defaultMessage: '{name} is now provisioned.',
+      values: { name },
+    }),
+  toastCreateFailedTitle: i18n.translate('observability.slo.wizard.toastCreateFailedTitle', {
+    defaultMessage: 'Failed to create SLO',
+  }),
+  backToSlos: i18n.translate('observability.slo.wizard.backToSlos', {
+    defaultMessage: 'Back to SLOs',
+  }),
+  changeTemplate: i18n.translate('observability.slo.wizard.changeTemplate', {
+    defaultMessage: 'Change template',
+  }),
+  cancel: i18n.translate('observability.slo.wizard.cancel', {
+    defaultMessage: 'Cancel',
+  }),
+  createSlo: i18n.translate('observability.slo.wizard.createSlo', {
+    defaultMessage: 'Create SLO',
+  }),
+  rulerCodeUpstreamHttpPrefix: i18n.translate(
+    'observability.slo.wizard.rulerCodeUpstreamHttpPrefix',
+    {
+      defaultMessage: 'Code:',
+    }
+  ),
+  rulerUpstreamHttp: (httpStatus: number) =>
+    i18n.translate('observability.slo.wizard.rulerUpstreamHttp', {
+      defaultMessage: 'upstream HTTP {httpStatus}',
+      values: { httpStatus },
+    }),
+  pickTemplateHeading: i18n.translate('observability.slo.wizard.pickTemplateHeading', {
+    defaultMessage: 'Pick a template',
+  }),
+  pickTemplateDescription: i18n.translate('observability.slo.wizard.pickTemplateDescription', {
+    defaultMessage:
+      'APM templates build SLIs from the span-derived RED metrics Data Prepper produces for every traced service. OTel templates target direct semconv metrics (HTTP, RPC, DB, messaging, GenAI). Custom starts from blank PromQL.',
+  }),
+  categoryApm: i18n.translate('observability.slo.wizard.categoryApm', {
+    defaultMessage: 'APM service SLOs (span-derived)',
+  }),
+  categoryOtel: i18n.translate('observability.slo.wizard.categoryOtel', {
+    defaultMessage: 'OTel semconv metrics',
+  }),
+  categoryCustom: i18n.translate('observability.slo.wizard.categoryCustom', {
+    defaultMessage: 'Custom',
+  }),
+  identityHeading: (template: string) =>
+    i18n.translate('observability.slo.wizard.identityHeading', {
+      defaultMessage: '{template} — identity',
+      values: { template },
+    }),
+  datasourceLabel: i18n.translate('observability.slo.wizard.datasourceLabel', {
+    defaultMessage: 'Datasource ID',
+  }),
+  datasourcePlaceholder: i18n.translate('observability.slo.wizard.datasourcePlaceholder', {
+    defaultMessage: 'ds-2',
+  }),
+  nameLabel: i18n.translate('observability.slo.wizard.nameLabel', {
+    defaultMessage: 'Name',
+  }),
+  descriptionLabel: i18n.translate('observability.slo.wizard.descriptionLabel', {
+    defaultMessage: 'Description',
+  }),
+  ownerHeading: i18n.translate('observability.slo.wizard.ownerHeading', {
+    defaultMessage: 'Service & owner',
+  }),
+  serviceLabel: i18n.translate('observability.slo.wizard.serviceLabel', {
+    defaultMessage: 'Service',
+  }),
+  primaryTeamLabel: i18n.translate('observability.slo.wizard.primaryTeamLabel', {
+    defaultMessage: 'Primary team',
+  }),
+  primaryUserLabel: i18n.translate('observability.slo.wizard.primaryUserLabel', {
+    defaultMessage: 'Primary user (optional)',
+  }),
+  tierLabel: i18n.translate('observability.slo.wizard.tierLabel', {
+    defaultMessage: 'Tier (optional)',
+  }),
+  sliHeading: i18n.translate('observability.slo.wizard.sliHeading', {
+    defaultMessage: 'SLI',
+  }),
+  goodEventsLabel: i18n.translate('observability.slo.wizard.goodEventsLabel', {
+    defaultMessage: 'Good events filter',
+  }),
+  goodEventsHelpText: (defaultFilter: string) =>
+    i18n.translate('observability.slo.wizard.goodEventsHelpText', {
+      defaultMessage: 'Default: {defaultFilter}',
+      values: { defaultFilter },
+    }),
+  dimensionsLabel: i18n.translate('observability.slo.wizard.dimensionsLabel', {
+    defaultMessage: 'Dimensions',
+  }),
+  dimensionsLabelOptional: i18n.translate('observability.slo.wizard.dimensionsLabelOptional', {
+    defaultMessage: 'Dimensions (optional)',
+  }),
+  dimensionNamePlaceholder: i18n.translate('observability.slo.wizard.dimensionNamePlaceholder', {
+    defaultMessage: 'label name',
+  }),
+  dimensionValuePlaceholder: i18n.translate('observability.slo.wizard.dimensionValuePlaceholder', {
+    defaultMessage: 'label value',
+  }),
+  removeDimensionAria: i18n.translate('observability.slo.wizard.removeDimensionAria', {
+    defaultMessage: 'Remove dimension',
+  }),
+  addDimension: i18n.translate('observability.slo.wizard.addDimension', {
+    defaultMessage: 'Add dimension',
+  }),
+  windowHeading: i18n.translate('observability.slo.wizard.windowHeading', {
+    defaultMessage: 'Window & mode',
+  }),
+  rollingWindowLabel: i18n.translate('observability.slo.wizard.rollingWindowLabel', {
+    defaultMessage: 'Rolling window',
+  }),
+  window7d: i18n.translate('observability.slo.wizard.window7d', {
+    defaultMessage: '7 days',
+  }),
+  window14d: i18n.translate('observability.slo.wizard.window14d', {
+    defaultMessage: '14 days',
+  }),
+  window28d: i18n.translate('observability.slo.wizard.window28d', {
+    defaultMessage: '28 days (recommended)',
+  }),
+  window30d: i18n.translate('observability.slo.wizard.window30d', {
+    defaultMessage: '30 days',
+  }),
+  windowApproximationTitle: i18n.translate('observability.slo.wizard.windowApproximationTitle', {
+    defaultMessage: 'Window approximation',
+  }),
+  shadowModeLabel: i18n.translate('observability.slo.wizard.shadowModeLabel', {
+    defaultMessage: 'Shadow mode (deploy recording rules only; suppress alerts)',
+  }),
+  labelsHeading: i18n.translate('observability.slo.wizard.labelsHeading', {
+    defaultMessage: 'Labels & annotations (optional)',
+  }),
+  labelsDescriptionPrefix: i18n.translate('observability.slo.wizard.labelsDescriptionPrefix', {
+    defaultMessage: 'Labels propagate to rules as',
+  }),
+  labelsDescriptionSuffix: i18n.translate('observability.slo.wizard.labelsDescriptionSuffix', {
+    defaultMessage: '. Annotations stay on the document (e.g., runbook URLs).',
+  }),
+  labelsLabel: i18n.translate('observability.slo.wizard.labelsLabel', {
+    defaultMessage: 'Labels',
+  }),
+  annotationsLabel: i18n.translate('observability.slo.wizard.annotationsLabel', {
+    defaultMessage: 'Annotations',
+  }),
+  addLabel: i18n.translate('observability.slo.wizard.addLabel', {
+    defaultMessage: 'Add label',
+  }),
+  addAnnotation: i18n.translate('observability.slo.wizard.addAnnotation', {
+    defaultMessage: 'Add annotation',
+  }),
+  labelKeyPlaceholder: i18n.translate('observability.slo.wizard.labelKeyPlaceholder', {
+    defaultMessage: 'compliance',
+  }),
+  labelValuePlaceholder: i18n.translate('observability.slo.wizard.labelValuePlaceholder', {
+    defaultMessage: 'pci',
+  }),
+  annotationKeyPlaceholder: i18n.translate('observability.slo.wizard.annotationKeyPlaceholder', {
+    defaultMessage: 'runbook',
+  }),
+  annotationValuePlaceholder: i18n.translate(
+    'observability.slo.wizard.annotationValuePlaceholder',
+    {
+      defaultMessage: 'https://wiki/slo/...',
+    }
+  ),
+  rulerErrorValidation: i18n.translate('observability.slo.wizard.rulerErrorValidation', {
+    defaultMessage: 'Ruler rejected the rule group',
+  }),
+  rulerErrorAuth: i18n.translate('observability.slo.wizard.rulerErrorAuth', {
+    defaultMessage: 'Ruler authentication failed',
+  }),
+  rulerErrorUnreachable: i18n.translate('observability.slo.wizard.rulerErrorUnreachable', {
+    defaultMessage: 'Ruler is unreachable',
+  }),
+};
 
 // ============================================================================
 // Template selector
 // ============================================================================
 
 const CATEGORY_TITLES: Record<string, string> = {
-  apm: 'APM service SLOs (span-derived)',
-  otel: 'OTel semconv metrics',
-  custom: 'Custom',
+  apm: I18N.categoryApm,
+  otel: I18N.categoryOtel,
+  custom: I18N.categoryCustom,
 };
 
 const CATEGORY_ORDER: ReadonlyArray<'apm' | 'otel' | 'custom'> = ['apm', 'otel', 'custom'];
@@ -91,12 +288,10 @@ const CATEGORY_ORDER: ReadonlyArray<'apm' | 'otel' | 'custom'> = ['apm', 'otel',
 const TemplateSelector: React.FC<{ onPick: (id: string) => void }> = ({ onPick }) => (
   <EuiPanel>
     <EuiText size="m">
-      <h4>Pick a template</h4>
+      <h4>{I18N.pickTemplateHeading}</h4>
     </EuiText>
     <EuiText size="s" color="subdued">
-      APM templates build SLIs from the span-derived RED metrics Data Prepper produces for every
-      traced service. OTel templates target direct semconv metrics (HTTP, RPC, DB, messaging,
-      GenAI). Custom starts from blank PromQL.
+      {I18N.pickTemplateDescription}
     </EuiText>
     {CATEGORY_ORDER.map((category) => {
       const templates = SLO_TEMPLATES.filter((t) => t.category === category);
@@ -156,8 +351,8 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   useEffect(() => {
     chrome.setBreadcrumbs([
       parentBreadcrumb,
-      { text: 'SLO/SLI', href: '#/slos' },
-      { text: 'Create' },
+      { text: I18N.breadcrumbSloSli, href: '#/slos' },
+      { text: I18N.breadcrumbCreate },
     ]);
   }, [chrome, parentBreadcrumb]);
 
@@ -221,8 +416,8 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
     if (Object.keys(specErrors).length > 0) {
       setErrors(specErrors);
       notifications.toasts.addWarning({
-        title: 'Fix validation errors',
-        text: 'Some required fields are missing or invalid.',
+        title: I18N.toastFixValidationTitle,
+        text: I18N.toastFixValidationText,
       });
       return;
     }
@@ -235,8 +430,8 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
       // prompt firing on the navigation away.
       setCreatedSuccessfully(true);
       notifications.toasts.addSuccess({
-        title: 'SLO created',
-        text: `${doc.spec.name} is now provisioned.`,
+        title: I18N.toastCreatedTitle,
+        text: I18N.toastCreatedText(doc.spec.name),
       });
       history.push(`/slos/${encodeURIComponent(doc.id)}`);
     } catch (e) {
@@ -247,10 +442,12 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
       if (envelope) {
         setRulerError(envelope);
       } else {
-        const err = e instanceof Error ? e : new Error(String(e));
+        // Use the OSD http-error envelope's `body.message` (richer) when
+        // available; falling back to `err.message` collapses route-layer
+        // 400s like "Datasource X is not registered" to "Bad Request".
         notifications.toasts.addDanger({
-          title: 'Failed to create SLO',
-          text: err.message,
+          title: I18N.toastCreateFailedTitle,
+          text: extractServerMessage(e),
         });
       }
     } finally {
@@ -272,7 +469,7 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
                     size="s"
                     data-test-subj="slosCancel"
                   >
-                    Back to SLOs
+                    {I18N.backToSlos}
                   </EuiButtonEmpty>
                 </EuiFlexItem>
               </EuiFlexGroup>
@@ -304,7 +501,7 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
         {/* Block in-app navigation when the form is dirty and we haven't
             successfully submitted yet. `submitting` is allowed through so the
             post-create `history.push('/slos/<id>')` redirect lands. */}
-        <Prompt when={dirty && !createdSuccessfully && !submitting} message={UNSAVED_PROMPT} />
+        <Prompt when={dirty && !createdSuccessfully && !submitting} message={I18N.unsavedPrompt} />
         <EuiPageContent color="transparent" hasBorder={false} paddingSize="none">
           <EuiPageContentBody>
             <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" responsive={false}>
@@ -315,12 +512,12 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
                   size="s"
                   data-test-subj="slosTemplateBack"
                 >
-                  Change template
+                  {I18N.changeTemplate}
                 </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiButtonEmpty href="#/slos" size="s" data-test-subj="slosWizardCancel">
-                  Cancel
+                  {I18N.cancel}
                 </EuiButtonEmpty>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
@@ -331,7 +528,7 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
                   onClick={onSubmit}
                   data-test-subj="slosWizardSubmit"
                 >
-                  Create SLO
+                  {I18N.createSlo}
                 </EuiButton>
               </EuiFlexItem>
             </EuiFlexGroup>
@@ -465,8 +662,8 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
                           <p data-test-subj="slosWizardRulerErrorBody">{rulerError.rawBody}</p>
                           <p>
                             <small>
-                              Code: <code>{rulerError.code}</code> · upstream HTTP{' '}
-                              {rulerError.httpStatus}
+                              {I18N.rulerCodeUpstreamHttpPrefix} <code>{rulerError.code}</code> ·{' '}
+                              {I18N.rulerUpstreamHttp(rulerError.httpStatus)}
                             </small>
                           </p>
                         </EuiText>
@@ -505,11 +702,11 @@ const IdentityPanel: React.FC<PanelProps & { template: string }> = ({
 }) => (
   <EuiPanel>
     <EuiText size="m">
-      <h4>{template} — identity</h4>
+      <h4>{I18N.identityHeading(template)}</h4>
     </EuiText>
     <EuiSpacer size="s" />
     <EuiFormRow
-      label="Datasource ID"
+      label={I18N.datasourceLabel}
       isInvalid={!!errors['spec.datasourceId']}
       error={errors['spec.datasourceId']}
     >
@@ -519,17 +716,21 @@ const IdentityPanel: React.FC<PanelProps & { template: string }> = ({
           dispatch({ kind: 'setField', field: 'datasourceId', value: e.target.value })
         }
         data-test-subj="slosWizardDatasourceId"
-        placeholder="ds-2"
+        placeholder={I18N.datasourcePlaceholder}
       />
     </EuiFormRow>
-    <EuiFormRow label="Name" isInvalid={!!errors['spec.name']} error={errors['spec.name']}>
+    <EuiFormRow
+      label={I18N.nameLabel}
+      isInvalid={!!errors['spec.name']}
+      error={errors['spec.name']}
+    >
       <EuiFieldText
         value={state.name}
         onChange={(e) => dispatch({ kind: 'setField', field: 'name', value: e.target.value })}
         data-test-subj="slosWizardName"
       />
     </EuiFormRow>
-    <EuiFormRow label="Description">
+    <EuiFormRow label={I18N.descriptionLabel}>
       <EuiTextArea
         rows={2}
         value={state.description}
@@ -545,10 +746,14 @@ const IdentityPanel: React.FC<PanelProps & { template: string }> = ({
 const OwnerPanel: React.FC<PanelProps> = ({ state, errors, dispatch }) => (
   <EuiPanel>
     <EuiText size="m">
-      <h4>Service &amp; owner</h4>
+      <h4>{I18N.ownerHeading}</h4>
     </EuiText>
     <EuiSpacer size="s" />
-    <EuiFormRow label="Service" isInvalid={!!errors['spec.service']} error={errors['spec.service']}>
+    <EuiFormRow
+      label={I18N.serviceLabel}
+      isInvalid={!!errors['spec.service']}
+      error={errors['spec.service']}
+    >
       <EuiFieldText
         value={state.service}
         onChange={(e) => dispatch({ kind: 'setField', field: 'service', value: e.target.value })}
@@ -556,7 +761,7 @@ const OwnerPanel: React.FC<PanelProps> = ({ state, errors, dispatch }) => (
       />
     </EuiFormRow>
     <EuiFormRow
-      label="Primary team"
+      label={I18N.primaryTeamLabel}
       isInvalid={!!errors['spec.owner.teams']}
       error={errors['spec.owner.teams']}
     >
@@ -566,7 +771,7 @@ const OwnerPanel: React.FC<PanelProps> = ({ state, errors, dispatch }) => (
         data-test-subj="slosWizardOwnerTeam"
       />
     </EuiFormRow>
-    <EuiFormRow label="Primary user (optional)">
+    <EuiFormRow label={I18N.primaryUserLabel}>
       <EuiFieldText
         value={state.ownerPrimaryUser}
         onChange={(e) =>
@@ -575,7 +780,7 @@ const OwnerPanel: React.FC<PanelProps> = ({ state, errors, dispatch }) => (
         data-test-subj="slosWizardOwnerPrimaryUser"
       />
     </EuiFormRow>
-    <EuiFormRow label="Tier (optional)">
+    <EuiFormRow label={I18N.tierLabel}>
       <EuiFieldText
         value={state.tier}
         onChange={(e) => dispatch({ kind: 'setField', field: 'tier', value: e.target.value })}
@@ -593,13 +798,13 @@ const SliPanel: React.FC<PanelProps & { template: SloTemplate }> = ({
 }) => (
   <EuiPanel>
     <EuiText size="m">
-      <h4>SLI</h4>
+      <h4>{I18N.sliHeading}</h4>
     </EuiText>
     <EuiSpacer size="s" />
     {template.sli.type === 'availability' && (
       <EuiFormRow
-        label="Good events filter"
-        helpText={`Default: ${template.sli.goodEventsFilter ?? ''}`}
+        label={I18N.goodEventsLabel}
+        helpText={I18N.goodEventsHelpText(template.sli.goodEventsFilter ?? '')}
       >
         <EuiFieldText
           value={state.goodEventsFilter}
@@ -611,7 +816,7 @@ const SliPanel: React.FC<PanelProps & { template: SloTemplate }> = ({
       </EuiFormRow>
     )}
     <EuiFormRow
-      label={template.sli.type === 'custom' ? 'Dimensions (optional)' : 'Dimensions'}
+      label={template.sli.type === 'custom' ? I18N.dimensionsLabelOptional : I18N.dimensionsLabel}
       isInvalid={!!errors['spec.sli.dimensions']}
       error={errors['spec.sli.dimensions']}
       fullWidth
@@ -621,7 +826,7 @@ const SliPanel: React.FC<PanelProps & { template: SloTemplate }> = ({
           <EuiFlexGroup key={i} gutterSize="s" alignItems="flexEnd" style={{ marginBottom: 4 }}>
             <EuiFlexItem>
               <EuiFieldText
-                placeholder="label name"
+                placeholder={I18N.dimensionNamePlaceholder}
                 value={dim.name}
                 onChange={(e) =>
                   dispatch({
@@ -636,7 +841,7 @@ const SliPanel: React.FC<PanelProps & { template: SloTemplate }> = ({
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiFieldText
-                placeholder="label value"
+                placeholder={I18N.dimensionValuePlaceholder}
                 value={dim.value}
                 onChange={(e) =>
                   dispatch({
@@ -655,7 +860,7 @@ const SliPanel: React.FC<PanelProps & { template: SloTemplate }> = ({
                 onClick={() => dispatch({ kind: 'removeDimension', index: i })}
                 disabled={state.dimensions.length <= 1}
                 iconType="trash"
-                aria-label="Remove dimension"
+                aria-label={I18N.removeDimensionAria}
                 size="s"
                 data-test-subj={`slosWizardDimRemove-${i}`}
               />
@@ -668,7 +873,7 @@ const SliPanel: React.FC<PanelProps & { template: SloTemplate }> = ({
           onClick={() => dispatch({ kind: 'addDimension' })}
           data-test-subj="slosWizardDimAdd"
         >
-          Add dimension
+          {I18N.addDimension}
         </EuiButtonEmpty>
       </div>
     </EuiFormRow>
@@ -682,10 +887,10 @@ const WindowPanel: React.FC<{
 }> = ({ state, warnings, dispatch }) => (
   <EuiPanel>
     <EuiText size="m">
-      <h4>Window &amp; mode</h4>
+      <h4>{I18N.windowHeading}</h4>
     </EuiText>
     <EuiSpacer size="s" />
-    <EuiFormRow label="Rolling window">
+    <EuiFormRow label={I18N.rollingWindowLabel}>
       <EuiSelect
         value={state.windowDuration}
         onChange={(e) =>
@@ -696,10 +901,10 @@ const WindowPanel: React.FC<{
           })
         }
         options={[
-          { value: '7d', text: '7 days' },
-          { value: '14d', text: '14 days' },
-          { value: '28d', text: '28 days (recommended)' },
-          { value: '30d', text: '30 days' },
+          { value: '7d', text: I18N.window7d },
+          { value: '14d', text: I18N.window14d },
+          { value: '28d', text: I18N.window28d },
+          { value: '30d', text: I18N.window30d },
         ]}
         data-test-subj="slosWizardWindow"
       />
@@ -708,7 +913,7 @@ const WindowPanel: React.FC<{
       <>
         <EuiSpacer size="s" />
         <EuiCallOut
-          title="Window approximation"
+          title={I18N.windowApproximationTitle}
           color="warning"
           iconType="iInCircle"
           size="s"
@@ -720,7 +925,7 @@ const WindowPanel: React.FC<{
     )}
     <EuiCheckbox
       id="slosWizardShadow"
-      label="Shadow mode (deploy recording rules only; suppress alerts)"
+      label={I18N.shadowModeLabel}
       checked={state.shadow}
       onChange={(e) => dispatch({ kind: 'setField', field: 'shadow', value: e.target.checked })}
       data-test-subj="slosWizardShadow"
@@ -745,15 +950,15 @@ const LabelsAnnotationsPanel: React.FC<PanelProps> = ({ state, errors, dispatch 
   return (
     <EuiPanel>
       <EuiText size="m">
-        <h4>Labels &amp; annotations (optional)</h4>
+        <h4>{I18N.labelsHeading}</h4>
       </EuiText>
       <EuiText size="xs" color="subdued">
-        Labels propagate to rules as <code>slo_label_&lt;key&gt;</code>. Annotations stay on the
-        document (e.g., runbook URLs).
+        {I18N.labelsDescriptionPrefix} <code>slo_label_&lt;key&gt;</code>
+        {I18N.labelsDescriptionSuffix}
       </EuiText>
       <EuiSpacer size="s" />
       <EuiFormRow
-        label="Labels"
+        label={I18N.labelsLabel}
         fullWidth
         data-test-subj="slosWizardLabelsRow"
         display="rowCompressed"
@@ -767,14 +972,14 @@ const LabelsAnnotationsPanel: React.FC<PanelProps> = ({ state, errors, dispatch 
           onAdd={() => dispatch({ kind: 'addLabelEntry' })}
           onRemove={(index) => dispatch({ kind: 'removeLabelEntry', index })}
           testSubjPrefix="slosWizardLabel"
-          addLabel="Add label"
-          keyPlaceholder="compliance"
-          valuePlaceholder="pci"
+          addLabel={I18N.addLabel}
+          keyPlaceholder={I18N.labelKeyPlaceholder}
+          valuePlaceholder={I18N.labelValuePlaceholder}
         />
       </EuiFormRow>
       <EuiSpacer size="s" />
       <EuiFormRow
-        label="Annotations"
+        label={I18N.annotationsLabel}
         fullWidth
         isInvalid={!!annotationScalarError}
         error={annotationScalarError}
@@ -790,9 +995,9 @@ const LabelsAnnotationsPanel: React.FC<PanelProps> = ({ state, errors, dispatch 
           onAdd={() => dispatch({ kind: 'addAnnotationEntry' })}
           onRemove={(index) => dispatch({ kind: 'removeAnnotationEntry', index })}
           testSubjPrefix="slosWizardAnnotation"
-          addLabel="Add annotation"
-          keyPlaceholder="runbook"
-          valuePlaceholder="https://wiki/slo/..."
+          addLabel={I18N.addAnnotation}
+          keyPlaceholder={I18N.annotationKeyPlaceholder}
+          valuePlaceholder={I18N.annotationValuePlaceholder}
         />
       </EuiFormRow>
     </EuiPanel>
@@ -802,10 +1007,10 @@ const LabelsAnnotationsPanel: React.FC<PanelProps> = ({ state, errors, dispatch 
 function rulerErrorTitle(envelope: SloRulerErrorEnvelope): string {
   switch (envelope.code) {
     case 'RULER_VALIDATION_FAILED':
-      return 'Ruler rejected the rule group';
+      return I18N.rulerErrorValidation;
     case 'RULER_AUTH_FAILED':
-      return 'Ruler authentication failed';
+      return I18N.rulerErrorAuth;
     case 'RULER_UNREACHABLE':
-      return 'Ruler is unreachable';
+      return I18N.rulerErrorUnreachable;
   }
 }

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -56,7 +56,7 @@ import { initialState, reducer } from './wizard_state';
 import type { Action, FormState } from './wizard_state';
 import { buildCreateInput } from './wizard_builders';
 import { WizardNav } from './wizard_nav';
-import { WIZARD_SECTIONS } from './wizard_sections';
+import { WIZARD_SECTIONS, scrollToErrorKey } from './wizard_sections';
 import type { WizardSectionId } from './wizard_sections';
 import { WizardValidationSummary } from './wizard_validation_summary';
 import { WizardKeyValueGrid } from './wizard_key_value_grid';
@@ -409,12 +409,22 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   );
 
   const onSubmit = useCallback(async () => {
-    if (!template) return;
+    // Guard against rapid double-submit (programmatic clicks, keyboard
+    // accelerator while the EuiButton is still in `isLoading` state). The
+    // button itself disables on `isLoading`, but a stray Enter on a focused
+    // form control would otherwise re-enter onSubmit and fire a second
+    // POST while the first is in flight.
+    if (!template || submitting) return;
     dispatch({ kind: 'markSubmitAttempted' });
     const input = buildCreateInput(state, template);
     const { errors: specErrors } = validateSloSpec(input.spec);
     if (Object.keys(specErrors).length > 0) {
       setErrors(specErrors);
+      // Auto-scroll to the first failing field so users focused on a
+      // lower section see why their submit didn't land. The toast is a
+      // backup signal; the inline anchor is the actionable one.
+      const firstErrorKey = Object.keys(specErrors)[0];
+      if (firstErrorKey) scrollToErrorKey(firstErrorKey);
       notifications.toasts.addWarning({
         title: I18N.toastFixValidationTitle,
         text: I18N.toastFixValidationText,
@@ -453,7 +463,7 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
     } finally {
       setSubmitting(false);
     }
-  }, [apiClient, history, notifications, state, template]);
+  }, [apiClient, history, notifications, state, submitting, template]);
 
   if (!template) {
     return (

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -141,7 +141,6 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   const { templateId: urlTemplateId } = useParams<{ templateId?: string }>();
   const [state, dispatch] = useReducer(reducer, undefined, initialState);
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const [warnings, setWarnings] = useState<Record<string, string>>({});
   const [rulerError, setRulerError] = useState<SloRulerErrorEnvelope | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [createdSuccessfully, setCreatedSuccessfully] = useState(false);
@@ -174,20 +173,19 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
     () => (template ? buildCreateInput(state, template) : null),
     [state, template]
   );
-  const liveWarnings = useMemo<Record<string, string>>(
-    () => (liveInput ? validateSloSpec(liveInput.spec).warnings : {}),
-    [liveInput]
-  );
-  // Live errors drive the rule-preview empty-state list — *before* the user
-  // has clicked submit. Distinct from the `errors` state variable which only
-  // populates after submit (and gates the top-level summary).
-  const liveErrors = useMemo<Record<string, string>>(
-    () => (liveInput ? validateSloSpec(liveInput.spec).errors : {}),
-    [liveInput]
-  );
-  useEffect(() => {
-    setWarnings(liveWarnings);
-  }, [liveWarnings]);
+  // Live warnings + errors are derived from the live input. Warnings render
+  // unconditionally (advisory). Errors drive the rule-preview empty-state
+  // list — *before* the user has clicked submit. Distinct from the `errors`
+  // state variable which only populates after submit (and gates the top-
+  // level summary).
+  const { liveErrors, warnings } = useMemo<{
+    liveErrors: Record<string, string>;
+    warnings: Record<string, string>;
+  }>(() => {
+    if (!liveInput) return { liveErrors: {}, warnings: {} };
+    const result = validateSloSpec(liveInput.spec);
+    return { liveErrors: result.errors, warnings: result.warnings };
+  }, [liveInput]);
 
   // Track dirty state for the unsaved-changes prompt. The wizard becomes
   // dirty once the user types anything beyond the template default — we use
@@ -219,8 +217,7 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
     if (!template) return;
     dispatch({ kind: 'markSubmitAttempted' });
     const input = buildCreateInput(state, template);
-    const { errors: specErrors, warnings: specWarnings } = validateSloSpec(input.spec);
-    setWarnings(specWarnings);
+    const { errors: specErrors } = validateSloSpec(input.spec);
     if (Object.keys(specErrors).length > 0) {
       setErrors(specErrors);
       notifications.toasts.addWarning({

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -4,31 +4,67 @@
  */
 
 /**
- * Minimal create-SLO wizard — one template (HTTP availability), one
- * objective. Fuller multi-section wizard with probe-SLI, advanced section,
- * and exclusion windows lands in later PRs.
+ * SLO creation wizard — template-driven, orchestrates section components.
+ * Produces a correct SloCreateInput ({ id?, spec: SloSpec }) and submits.
+ *
+ * State + reducer live in wizard_state.ts; state → SloCreateInput in
+ * wizard_builders.ts. This file is the orchestrator + top-level layout.
+ *
+ * Probe-SLI button is intentionally NOT wired here — it lands with the
+ * rule-health probe in PR 4.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Prompt, useHistory } from 'react-router-dom';
-import { i18n } from '@osd/i18n';
+import React, { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
-  EuiFieldNumber,
+  EuiCallOut,
+  EuiCard,
+  EuiCheckbox,
   EuiFieldText,
+  EuiFlexGrid,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiForm,
   EuiFormRow,
+  EuiIcon,
   EuiPage,
   EuiPageBody,
   EuiPageContent,
+  EuiPageContentBody,
+  EuiPanel,
+  EuiSelect,
   EuiSpacer,
+  EuiText,
   EuiTextArea,
 } from '@elastic/eui';
+import { Prompt, useHistory, useParams } from 'react-router-dom';
 import type { ChromeStart, NotificationsStart } from '../../../../../../../src/core/public';
-import type { SloCreateInput, SloSpec } from '../../../../../common/slo/slo_types';
-import { DEFAULT_MWMBR_TIERS } from '../../../../../common/slo/slo_promql_generator';
-import { SloApiClient, extractRulerErrorEnvelope, extractServerMessage } from './slo_api_client';
+import { extractRulerErrorEnvelope } from './slo_api_client';
+import type { SloApiClient, SloRulerErrorEnvelope } from './slo_api_client';
+import { GeneratedRulesPreview } from './generated_rules_preview';
+import { ObjectivesSection } from './objectives_section';
+import { CustomPromqlEditor } from './custom_promql_editor';
+import { AdvancedSection } from './advanced_section';
+import { ExclusionWindowsEditor } from './exclusion_windows_editor';
+import type { SloCreateInput } from '../../../../../common/slo/slo_types';
+import { SLO_TEMPLATES } from '../../../../../common/slo/slo_templates';
+import type { SloTemplate } from '../../../../../common/slo/slo_templates';
+import { validateSloSpec } from '../../../../../common/slo/slo_validators';
+import { initialState, reducer } from './wizard_state';
+import type { Action, FormState } from './wizard_state';
+import { buildCreateInput } from './wizard_builders';
+import { WizardNav } from './wizard_nav';
+import { WIZARD_SECTIONS } from './wizard_sections';
+import type { WizardSectionId } from './wizard_sections';
+import { WizardValidationSummary } from './wizard_validation_summary';
+import { WizardKeyValueGrid } from './wizard_key_value_grid';
+
+function sectionAnchorId(id: WizardSectionId): string {
+  const found = WIZARD_SECTIONS.find((s) => s.id === id);
+  if (!found) throw new Error(`unknown wizard section id: ${id}`);
+  return found.anchorId;
+}
 
 export interface SloWizardPageProps {
   apiClient: SloApiClient;
@@ -37,139 +73,63 @@ export interface SloWizardPageProps {
   parentBreadcrumb: { text: string; href: string };
 }
 
-const I18N = {
-  breadcrumbSlos: i18n.translate('observability.slo.wizard.breadcrumbSlos', {
-    defaultMessage: 'SLOs',
-  }),
-  breadcrumbCreate: i18n.translate('observability.slo.wizard.breadcrumbCreate', {
-    defaultMessage: 'Create',
-  }),
-  labelName: i18n.translate('observability.slo.wizard.labelName', {
-    defaultMessage: 'Name',
-  }),
-  labelService: i18n.translate('observability.slo.wizard.labelService', {
-    defaultMessage: 'Service',
-  }),
-  labelTeam: i18n.translate('observability.slo.wizard.labelTeam', {
-    defaultMessage: 'Owner team',
-  }),
-  labelDatasource: i18n.translate('observability.slo.wizard.labelDatasource', {
-    defaultMessage: 'Datasource ID',
-  }),
-  helpDatasource: i18n.translate('observability.slo.wizard.helpDatasource', {
-    defaultMessage: 'The registered Prometheus / AMP DirectQuery connection.',
-  }),
-  labelMetric: i18n.translate('observability.slo.wizard.labelMetric', {
-    defaultMessage: 'Metric',
-  }),
-  helpMetric: i18n.translate('observability.slo.wizard.helpMetric', {
-    defaultMessage: 'Prometheus counter metric used to compute availability.',
-  }),
-  labelTarget: i18n.translate('observability.slo.wizard.labelTarget', {
-    defaultMessage: 'Target (%)',
-  }),
-  helpTarget: i18n.translate('observability.slo.wizard.helpTarget', {
-    defaultMessage: 'Between 50 and 99.999.',
-  }),
-  labelDescription: i18n.translate('observability.slo.wizard.labelDescription', {
-    defaultMessage: 'Description',
-  }),
-  cancel: i18n.translate('observability.slo.wizard.cancel', {
-    defaultMessage: 'Cancel',
-  }),
-  create: i18n.translate('observability.slo.wizard.create', {
-    defaultMessage: 'Create',
-  }),
-  toastCreated: (name: string) =>
-    i18n.translate('observability.slo.wizard.toastCreated', {
-      defaultMessage: 'Created SLO "{name}"',
-      values: { name },
-    }),
-  toastRulerRejected: (code: string) =>
-    i18n.translate('observability.slo.wizard.toastRulerRejected', {
-      defaultMessage: 'Ruler rejected the rule group ({code})',
-      values: { code },
-    }),
-  toastCreateFailed: i18n.translate('observability.slo.wizard.toastCreateFailed', {
-    defaultMessage: 'Failed to create SLO',
-  }),
-  unsavedChangesPrompt: i18n.translate('observability.slo.wizard.unsavedChangesPrompt', {
-    defaultMessage:
-      'You have unsaved changes. Are you sure you want to leave this page? Your form will be lost.',
-  }),
-  errorRequired: i18n.translate('observability.slo.wizard.errorRequired', {
-    defaultMessage: 'Required',
-  }),
-  errorTargetRange: i18n.translate('observability.slo.wizard.errorTargetRange', {
-    defaultMessage: 'Target must be between 50 and 99.999',
-  }),
+const UNSAVED_PROMPT =
+  'You have unsaved changes. Are you sure you want to leave this page? Your form will be lost.';
+
+// ============================================================================
+// Template selector
+// ============================================================================
+
+const CATEGORY_TITLES: Record<string, string> = {
+  apm: 'APM service SLOs (span-derived)',
+  otel: 'OTel semconv metrics',
+  custom: 'Custom',
 };
 
-interface FormState {
-  name: string;
-  service: string;
-  team: string;
-  datasourceId: string;
-  metric: string;
-  // `target` is the raw text from `EuiFieldNumber` so an empty input
-  // doesn't collapse to `0` mid-edit. Parsed at validation/submit time.
-  target: string;
-  description: string;
-}
+const CATEGORY_ORDER: ReadonlyArray<'apm' | 'otel' | 'custom'> = ['apm', 'otel', 'custom'];
 
-const INITIAL: FormState = {
-  name: '',
-  service: '',
-  team: '',
-  datasourceId: '',
-  metric: 'http_requests_total',
-  target: '99.9',
-  description: '',
-};
+const TemplateSelector: React.FC<{ onPick: (id: string) => void }> = ({ onPick }) => (
+  <EuiPanel>
+    <EuiText size="m">
+      <h4>Pick a template</h4>
+    </EuiText>
+    <EuiText size="s" color="subdued">
+      APM templates build SLIs from the span-derived RED metrics Data Prepper produces for every
+      traced service. OTel templates target direct semconv metrics (HTTP, RPC, DB, messaging,
+      GenAI). Custom starts from blank PromQL.
+    </EuiText>
+    {CATEGORY_ORDER.map((category) => {
+      const templates = SLO_TEMPLATES.filter((t) => t.category === category);
+      if (templates.length === 0) return null;
+      return (
+        <React.Fragment key={category}>
+          <EuiSpacer size="m" />
+          <EuiText size="xs" color="subdued">
+            <strong>{CATEGORY_TITLES[category] ?? category}</strong>
+          </EuiText>
+          <EuiSpacer size="s" />
+          <EuiFlexGrid columns={3}>
+            {templates.map((t) => (
+              <EuiFlexItem key={t.id}>
+                <EuiCard
+                  icon={<EuiIcon size="xl" type={t.icon} />}
+                  title={t.name}
+                  description={t.description}
+                  onClick={() => onPick(t.id)}
+                  data-test-subj={`slosTemplate-${t.id}`}
+                />
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGrid>
+        </React.Fragment>
+      );
+    })}
+  </EuiPanel>
+);
 
-function parseTarget(raw: string): number {
-  const n = Number(raw);
-  return Number.isFinite(n) ? n : NaN;
-}
-
-function buildSpec(form: FormState): SloSpec {
-  // Clamp target from percentage input (99.9) to the ratio the server stores (0.999).
-  const targetPct = parseTarget(form.target);
-  const target = Math.min(0.99999, Math.max(0.5, targetPct / 100));
-  return {
-    datasourceId: form.datasourceId.trim(),
-    name: form.name.trim(),
-    description: form.description.trim() || undefined,
-    enabled: true,
-    mode: 'active',
-    service: form.service.trim(),
-    owner: { teams: [form.team.trim()] },
-    sli: {
-      type: 'single',
-      definition: {
-        backend: 'prometheus',
-        type: 'availability',
-        calcMethod: 'events',
-        metric: form.metric.trim(),
-      },
-      dimensions: [{ name: 'service', value: form.service.trim() }],
-    },
-    objectives: [{ name: 'availability', target }],
-    budgetWarningThresholds: [{ threshold: 0.5, severity: 'warning' }],
-    window: { type: 'rolling', duration: '28d' },
-    alerting: { strategy: 'mwmbr', burnRates: DEFAULT_MWMBR_TIERS.map((t) => ({ ...t })) },
-    alarms: {
-      sliHealth: { enabled: false },
-      attainmentBreach: { enabled: false },
-      budgetWarning: { enabled: true },
-      noData: { enabled: false, forDuration: '10m' },
-      resolved: { enabled: false },
-    },
-    exclusionWindows: [],
-    labels: {},
-    annotations: {},
-  };
-}
+// ============================================================================
+// Main wizard
+// ============================================================================
 
 export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   apiClient,
@@ -178,233 +138,677 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   parentBreadcrumb,
 }) => {
   const history = useHistory();
-  const [form, setForm] = useState<FormState>(INITIAL);
+  const { templateId: urlTemplateId } = useParams<{ templateId?: string }>();
+  const [state, dispatch] = useReducer(reducer, undefined, initialState);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [warnings, setWarnings] = useState<Record<string, string>>({});
+  const [rulerError, setRulerError] = useState<SloRulerErrorEnvelope | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [submitted, setSubmitted] = useState(false);
-  // Mirrors the `generationRef` cancellation pattern from the listing page:
-  // submit completes asynchronously, and a parent unmount (browser back,
-  // breadcrumb click) before the response lands would otherwise call
-  // setState on an unmounted component. Tick this on unmount to drop late
-  // resolutions silently.
-  const submitGenerationRef = useRef(0);
+  const [createdSuccessfully, setCreatedSuccessfully] = useState(false);
 
+  // Initialize from URL template on mount.
   useEffect(() => {
-    return () => {
-      submitGenerationRef.current++;
-    };
-  }, []);
+    if (urlTemplateId && state.templateId !== urlTemplateId) {
+      dispatch({ kind: 'setTemplate', templateId: urlTemplateId });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlTemplateId]);
 
   useEffect(() => {
     chrome.setBreadcrumbs([
       parentBreadcrumb,
-      { text: I18N.breadcrumbSlos, href: '#/slos' },
-      { text: I18N.breadcrumbCreate, href: '#/slos/create' },
+      { text: 'SLO/SLI', href: '#/slos' },
+      { text: 'Create' },
     ]);
   }, [chrome, parentBreadcrumb]);
 
-  const onField = <K extends keyof FormState>(k: K) => (v: FormState[K]) => {
-    setForm((prev) => ({ ...prev, [k]: v }));
-  };
+  const template = useMemo(() => SLO_TEMPLATES.find((t) => t.id === state.templateId) ?? null, [
+    state.templateId,
+  ]);
 
-  const targetPct = parseTarget(form.target);
-  const validations = useMemo(
-    () => ({
-      name: form.name.trim().length > 0,
-      service: form.service.trim().length > 0,
-      team: form.team.trim().length > 0,
-      datasource: form.datasourceId.trim().length > 0,
-      metric: form.metric.trim().length > 0,
-      target: Number.isFinite(targetPct) && targetPct >= 50 && targetPct <= 99.999,
-    }),
-    [form, targetPct]
+  // Build the current input + live warnings. Preview uses the input; warnings
+  // surface advisories (e.g. rolling-window >3d approximation) without
+  // gating submit. Errors remain submit-gated so typing doesn't produce a
+  // sea of red before the user has finished a field.
+  const liveInput = useMemo<SloCreateInput | null>(
+    () => (template ? buildCreateInput(state, template) : null),
+    [state, template]
   );
-  const valid = Object.values(validations).every(Boolean);
+  const liveWarnings = useMemo<Record<string, string>>(
+    () => (liveInput ? validateSloSpec(liveInput.spec).warnings : {}),
+    [liveInput]
+  );
+  // Live errors drive the rule-preview empty-state list — *before* the user
+  // has clicked submit. Distinct from the `errors` state variable which only
+  // populates after submit (and gates the top-level summary).
+  const liveErrors = useMemo<Record<string, string>>(
+    () => (liveInput ? validateSloSpec(liveInput.spec).errors : {}),
+    [liveInput]
+  );
+  useEffect(() => {
+    setWarnings(liveWarnings);
+  }, [liveWarnings]);
 
+  // Track dirty state for the unsaved-changes prompt. The wizard becomes
+  // dirty once the user types anything beyond the template default — we use
+  // "submitted at least one field's first character" as the proxy here.
   const dirty = useMemo(() => {
     return (
-      form.name !== INITIAL.name ||
-      form.service !== INITIAL.service ||
-      form.team !== INITIAL.team ||
-      form.datasourceId !== INITIAL.datasourceId ||
-      form.metric !== INITIAL.metric ||
-      form.target !== INITIAL.target ||
-      form.description !== INITIAL.description
+      state.name !== '' ||
+      state.description !== '' ||
+      state.service !== '' ||
+      state.ownerTeam !== '' ||
+      state.ownerPrimaryUser !== '' ||
+      state.tier !== '' ||
+      state.datasourceId !== '' ||
+      state.labels.length > 0 ||
+      state.annotations.length > 0 ||
+      state.exclusionWindows.length > 0
     );
-  }, [form]);
+  }, [state]);
+
+  const onPickTemplate = useCallback(
+    (id: string) => {
+      history.replace(`/slos/create/${encodeURIComponent(id)}`);
+      dispatch({ kind: 'setTemplate', templateId: id });
+    },
+    [history]
+  );
 
   const onSubmit = useCallback(async () => {
-    if (!valid) {
-      setSubmitted(true);
+    if (!template) return;
+    dispatch({ kind: 'markSubmitAttempted' });
+    const input = buildCreateInput(state, template);
+    const { errors: specErrors, warnings: specWarnings } = validateSloSpec(input.spec);
+    setWarnings(specWarnings);
+    if (Object.keys(specErrors).length > 0) {
+      setErrors(specErrors);
+      notifications.toasts.addWarning({
+        title: 'Fix validation errors',
+        text: 'Some required fields are missing or invalid.',
+      });
       return;
     }
-    const myGen = ++submitGenerationRef.current;
+    setErrors({});
+    setRulerError(null);
     setSubmitting(true);
-    setSubmitted(true);
     try {
-      const input: SloCreateInput = { spec: buildSpec(form) };
       const doc = await apiClient.create(input);
-      if (myGen !== submitGenerationRef.current) return;
-      notifications.toasts.addSuccess(I18N.toastCreated(doc.spec.name));
-      // Redirect to the detail page so the user sees the spec they authored
-      // and so a new SLO on page 2 of a paginated listing doesn't "disappear".
+      // Allow the post-create redirect to land without the unsaved-changes
+      // prompt firing on the navigation away.
+      setCreatedSuccessfully(true);
+      notifications.toasts.addSuccess({
+        title: 'SLO created',
+        text: `${doc.spec.name} is now provisioned.`,
+      });
       history.push(`/slos/${encodeURIComponent(doc.id)}`);
-    } catch (err) {
-      if (myGen !== submitGenerationRef.current) return;
-      const ruler = extractRulerErrorEnvelope(err);
-      if (ruler) {
-        notifications.toasts.addDanger({
-          title: I18N.toastRulerRejected(ruler.code),
-          text: ruler.rawBody || ruler.error,
-        });
+    } catch (e) {
+      // Ruler dual-write envelope: surface the raw upstream message inline.
+      // `rawBody` is the user-actionable diagnostic (e.g. "invalid PromQL:
+      // parse error at char 42"); a generic toast would hide it.
+      const envelope = extractRulerErrorEnvelope(e);
+      if (envelope) {
+        setRulerError(envelope);
       } else {
+        const err = e instanceof Error ? e : new Error(String(e));
         notifications.toasts.addDanger({
-          title: I18N.toastCreateFailed,
-          text: extractServerMessage(err),
+          title: 'Failed to create SLO',
+          text: err.message,
         });
       }
     } finally {
-      if (myGen === submitGenerationRef.current) setSubmitting(false);
+      setSubmitting(false);
     }
-  }, [apiClient, form, history, notifications, valid]);
+  }, [apiClient, history, notifications, state, template]);
 
-  // Show field errors only after the user attempted submit OR after they
-  // touched the field — avoids blasting the form red on first render.
-  const showError = submitted;
+  if (!template) {
+    return (
+      <EuiPage data-test-subj="sloWizardPage">
+        <EuiPageBody component="main">
+          <EuiPageContent color="transparent" hasBorder={false} paddingSize="none">
+            <EuiPageContentBody>
+              <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    iconType="arrowLeft"
+                    href="#/slos"
+                    size="s"
+                    data-test-subj="slosCancel"
+                  >
+                    Back to SLOs
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+              <EuiSpacer size="m" />
+              <TemplateSelector onPick={onPickTemplate} />
+            </EuiPageContentBody>
+          </EuiPageContent>
+        </EuiPageBody>
+      </EuiPage>
+    );
+  }
+
+  const visibleSectionIds: WizardSectionId[] = [
+    'identity',
+    'window',
+    'owner',
+    'sli',
+    ...(template.sli.type === 'custom' ? (['promql'] as WizardSectionId[]) : []),
+    'objectives',
+    'advanced',
+    'exclusions',
+    'labels',
+    'rulesPreview',
+  ];
+
   return (
-    <EuiPage>
-      <EuiPageBody>
-        <EuiPageContent>
-          {/*
-            Block in-app navigation when the form is dirty and we haven't
-            successfully submitted yet. `submitting` is allowed through so
-            the post-create `history.push('/slos/<id>')` redirect lands.
-          */}
-          <Prompt when={dirty && !submitting} message={I18N.unsavedChangesPrompt} />
-          <EuiForm
-            component="form"
-            onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
-              // Default form submit reloads the page when the form has no
-              // explicit `action` — which the wizard doesn't, since submit
-              // is handled by the create button below.
-              e.preventDefault();
-              if (!submitting) onSubmit();
-            }}
-          >
-            <EuiFormRow
-              label={I18N.labelName}
-              fullWidth
-              isInvalid={showError && !validations.name}
-              error={showError && !validations.name ? I18N.errorRequired : undefined}
-            >
-              <EuiFieldText
-                value={form.name}
-                onChange={(e) => onField('name')(e.target.value)}
-                isInvalid={showError && !validations.name}
-                data-test-subj="sloWizardName"
-                fullWidth
-              />
-            </EuiFormRow>
-            <EuiFormRow
-              label={I18N.labelService}
-              fullWidth
-              isInvalid={showError && !validations.service}
-              error={showError && !validations.service ? I18N.errorRequired : undefined}
-            >
-              <EuiFieldText
-                value={form.service}
-                onChange={(e) => onField('service')(e.target.value)}
-                isInvalid={showError && !validations.service}
-                data-test-subj="sloWizardService"
-                fullWidth
-              />
-            </EuiFormRow>
-            <EuiFormRow
-              label={I18N.labelTeam}
-              fullWidth
-              isInvalid={showError && !validations.team}
-              error={showError && !validations.team ? I18N.errorRequired : undefined}
-            >
-              <EuiFieldText
-                value={form.team}
-                onChange={(e) => onField('team')(e.target.value)}
-                isInvalid={showError && !validations.team}
-                data-test-subj="sloWizardTeam"
-                fullWidth
-              />
-            </EuiFormRow>
-            <EuiFormRow
-              label={I18N.labelDatasource}
-              helpText={I18N.helpDatasource}
-              fullWidth
-              isInvalid={showError && !validations.datasource}
-              error={showError && !validations.datasource ? I18N.errorRequired : undefined}
-            >
-              <EuiFieldText
-                value={form.datasourceId}
-                onChange={(e) => onField('datasourceId')(e.target.value)}
-                isInvalid={showError && !validations.datasource}
-                data-test-subj="sloWizardDatasource"
-                fullWidth
-              />
-            </EuiFormRow>
-            <EuiFormRow
-              label={I18N.labelMetric}
-              helpText={I18N.helpMetric}
-              fullWidth
-              isInvalid={showError && !validations.metric}
-              error={showError && !validations.metric ? I18N.errorRequired : undefined}
-            >
-              <EuiFieldText
-                value={form.metric}
-                onChange={(e) => onField('metric')(e.target.value)}
-                isInvalid={showError && !validations.metric}
-                data-test-subj="sloWizardMetric"
-                fullWidth
-              />
-            </EuiFormRow>
-            <EuiFormRow
-              label={I18N.labelTarget}
-              helpText={I18N.helpTarget}
-              fullWidth
-              isInvalid={showError && !validations.target}
-              error={showError && !validations.target ? I18N.errorTargetRange : undefined}
-            >
-              <EuiFieldNumber
-                // Store the raw text in form state — `Number('')` collapses
-                // to `0`, which would silently overwrite the user's edit
-                // when they clear the field to retype.
-                value={form.target}
-                onChange={(e) => onField('target')(e.target.value)}
-                min={50}
-                max={99.999}
-                step={0.001}
-                isInvalid={showError && !validations.target}
-                data-test-subj="sloWizardTarget"
-                fullWidth
-              />
-            </EuiFormRow>
-            <EuiFormRow label={I18N.labelDescription} fullWidth>
-              <EuiTextArea
-                value={form.description}
-                onChange={(e) => onField('description')(e.target.value)}
-                data-test-subj="sloWizardDescription"
-                fullWidth
-              />
-            </EuiFormRow>
-            <EuiSpacer />
-            <EuiButtonEmpty onClick={() => history.push('/slos')}>{I18N.cancel}</EuiButtonEmpty>
-            <EuiButton
-              fill
-              type="submit"
-              isDisabled={submitting}
-              isLoading={submitting}
-              data-test-subj="sloWizardSubmit"
-            >
-              {I18N.create}
-            </EuiButton>
-          </EuiForm>
+    <EuiPage data-test-subj="sloWizardPage">
+      <EuiPageBody component="main">
+        {/* Block in-app navigation when the form is dirty and we haven't
+            successfully submitted yet. `submitting` is allowed through so the
+            post-create `history.push('/slos/<id>')` redirect lands. */}
+        <Prompt when={dirty && !createdSuccessfully && !submitting} message={UNSAVED_PROMPT} />
+        <EuiPageContent color="transparent" hasBorder={false} paddingSize="none">
+          <EuiPageContentBody>
+            <EuiFlexGroup gutterSize="s" justifyContent="flexEnd" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  iconType="arrowLeft"
+                  onClick={() => history.replace('/slos/create')}
+                  size="s"
+                  data-test-subj="slosTemplateBack"
+                >
+                  Change template
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty href="#/slos" size="s" data-test-subj="slosWizardCancel">
+                  Cancel
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  fill
+                  size="s"
+                  isLoading={submitting}
+                  onClick={onSubmit}
+                  data-test-subj="slosWizardSubmit"
+                >
+                  Create SLO
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="m" />
+            <EuiFlexGroup gutterSize="l" alignItems="flexStart">
+              <EuiFlexItem grow={false}>
+                <WizardNav errors={errors} visibleSectionIds={visibleSectionIds} />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiForm component="form">
+                  {state.submitAttempted && <WizardValidationSummary errors={errors} />}
+
+                  <div id={sectionAnchorId('identity')}>
+                    <IdentityPanel
+                      state={state}
+                      errors={errors}
+                      dispatch={dispatch}
+                      template={template.name}
+                    />
+                  </div>
+
+                  <EuiSpacer size="m" />
+
+                  <div id={sectionAnchorId('window')}>
+                    <WindowPanel state={state} warnings={warnings} dispatch={dispatch} />
+                  </div>
+
+                  <EuiSpacer size="m" />
+
+                  <div id={sectionAnchorId('owner')}>
+                    <OwnerPanel state={state} errors={errors} dispatch={dispatch} />
+                  </div>
+
+                  <EuiSpacer size="m" />
+
+                  {template.note && (
+                    <>
+                      <EuiCallOut
+                        size="s"
+                        color="primary"
+                        iconType="iInCircle"
+                        title={template.note}
+                        data-test-subj="slosWizardTemplateNote"
+                      />
+                      <EuiSpacer size="m" />
+                    </>
+                  )}
+
+                  <div id={sectionAnchorId('sli')}>
+                    <SliPanel
+                      state={state}
+                      errors={errors}
+                      dispatch={dispatch}
+                      template={template}
+                    />
+                  </div>
+
+                  <EuiSpacer size="m" />
+
+                  {template.sli.type === 'custom' && (
+                    <>
+                      <div id={sectionAnchorId('promql')}>
+                        <CustomPromqlEditor
+                          value={state.customPromql}
+                          errors={errors}
+                          dispatch={dispatch}
+                        />
+                      </div>
+                      <EuiSpacer size="m" />
+                    </>
+                  )}
+
+                  <div id={sectionAnchorId('objectives')}>
+                    <ObjectivesSection
+                      objectives={state.objectives}
+                      latencyThresholdUnit={state.latencyThresholdUnit}
+                      windowDuration={state.windowDuration}
+                      template={template}
+                      errors={errors}
+                      dispatch={dispatch}
+                    />
+                  </div>
+
+                  <EuiSpacer size="m" />
+
+                  <div id={sectionAnchorId('advanced')}>
+                    <AdvancedSection
+                      burnRates={state.burnRates}
+                      budgetWarnings={state.budgetWarnings}
+                      alarms={state.alarms}
+                      errors={errors}
+                      dispatch={dispatch}
+                    />
+                  </div>
+
+                  <EuiSpacer size="m" />
+
+                  <div id={sectionAnchorId('exclusions')}>
+                    <ExclusionWindowsEditor
+                      exclusionWindows={state.exclusionWindows}
+                      dispatch={dispatch}
+                    />
+                  </div>
+
+                  <EuiSpacer size="m" />
+
+                  <div id={sectionAnchorId('labels')}>
+                    <LabelsAnnotationsPanel state={state} errors={errors} dispatch={dispatch} />
+                  </div>
+
+                  <EuiSpacer size="m" />
+
+                  <div id={sectionAnchorId('rulesPreview')}>
+                    <GeneratedRulesPreview
+                      apiClient={apiClient}
+                      input={liveInput}
+                      errors={liveErrors}
+                    />
+                  </div>
+
+                  {rulerError && (
+                    <>
+                      <EuiSpacer size="m" />
+                      <EuiCallOut
+                        title={rulerErrorTitle(rulerError)}
+                        color="danger"
+                        iconType="alert"
+                        data-test-subj="slosWizardRulerError"
+                      >
+                        <EuiText size="s">
+                          <p data-test-subj="slosWizardRulerErrorBody">{rulerError.rawBody}</p>
+                          <p>
+                            <small>
+                              Code: <code>{rulerError.code}</code> · upstream HTTP{' '}
+                              {rulerError.httpStatus}
+                            </small>
+                          </p>
+                        </EuiText>
+                      </EuiCallOut>
+                    </>
+                  )}
+                </EuiForm>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPageContentBody>
         </EuiPageContent>
       </EuiPageBody>
     </EuiPage>
   );
 };
+
+// ============================================================================
+// Inline panels (identity / owner / SLI / window / labels)
+//
+// Kept in-file because each is a thin wrapper over EuiFormRow+EuiFieldText
+// against a single state slice. Extracting would add import noise without
+// reducing coupling — they all depend on the same reducer.
+// ============================================================================
+
+interface PanelProps {
+  state: FormState;
+  errors: Record<string, string>;
+  dispatch: React.Dispatch<Action>;
+}
+
+const IdentityPanel: React.FC<PanelProps & { template: string }> = ({
+  state,
+  errors,
+  dispatch,
+  template,
+}) => (
+  <EuiPanel>
+    <EuiText size="m">
+      <h4>{template} — identity</h4>
+    </EuiText>
+    <EuiSpacer size="s" />
+    <EuiFormRow
+      label="Datasource ID"
+      isInvalid={!!errors['spec.datasourceId']}
+      error={errors['spec.datasourceId']}
+    >
+      <EuiFieldText
+        value={state.datasourceId}
+        onChange={(e) =>
+          dispatch({ kind: 'setField', field: 'datasourceId', value: e.target.value })
+        }
+        data-test-subj="slosWizardDatasourceId"
+        placeholder="ds-2"
+      />
+    </EuiFormRow>
+    <EuiFormRow label="Name" isInvalid={!!errors['spec.name']} error={errors['spec.name']}>
+      <EuiFieldText
+        value={state.name}
+        onChange={(e) => dispatch({ kind: 'setField', field: 'name', value: e.target.value })}
+        data-test-subj="slosWizardName"
+      />
+    </EuiFormRow>
+    <EuiFormRow label="Description">
+      <EuiTextArea
+        rows={2}
+        value={state.description}
+        onChange={(e) =>
+          dispatch({ kind: 'setField', field: 'description', value: e.target.value })
+        }
+        data-test-subj="slosWizardDescription"
+      />
+    </EuiFormRow>
+  </EuiPanel>
+);
+
+const OwnerPanel: React.FC<PanelProps> = ({ state, errors, dispatch }) => (
+  <EuiPanel>
+    <EuiText size="m">
+      <h4>Service &amp; owner</h4>
+    </EuiText>
+    <EuiSpacer size="s" />
+    <EuiFormRow label="Service" isInvalid={!!errors['spec.service']} error={errors['spec.service']}>
+      <EuiFieldText
+        value={state.service}
+        onChange={(e) => dispatch({ kind: 'setField', field: 'service', value: e.target.value })}
+        data-test-subj="slosWizardService"
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      label="Primary team"
+      isInvalid={!!errors['spec.owner.teams']}
+      error={errors['spec.owner.teams']}
+    >
+      <EuiFieldText
+        value={state.ownerTeam}
+        onChange={(e) => dispatch({ kind: 'setField', field: 'ownerTeam', value: e.target.value })}
+        data-test-subj="slosWizardOwnerTeam"
+      />
+    </EuiFormRow>
+    <EuiFormRow label="Primary user (optional)">
+      <EuiFieldText
+        value={state.ownerPrimaryUser}
+        onChange={(e) =>
+          dispatch({ kind: 'setField', field: 'ownerPrimaryUser', value: e.target.value })
+        }
+        data-test-subj="slosWizardOwnerPrimaryUser"
+      />
+    </EuiFormRow>
+    <EuiFormRow label="Tier (optional)">
+      <EuiFieldText
+        value={state.tier}
+        onChange={(e) => dispatch({ kind: 'setField', field: 'tier', value: e.target.value })}
+        data-test-subj="slosWizardTier"
+      />
+    </EuiFormRow>
+  </EuiPanel>
+);
+
+const SliPanel: React.FC<PanelProps & { template: SloTemplate }> = ({
+  state,
+  errors,
+  dispatch,
+  template,
+}) => (
+  <EuiPanel>
+    <EuiText size="m">
+      <h4>SLI</h4>
+    </EuiText>
+    <EuiSpacer size="s" />
+    {template.sli.type === 'availability' && (
+      <EuiFormRow
+        label="Good events filter"
+        helpText={`Default: ${template.sli.goodEventsFilter ?? ''}`}
+      >
+        <EuiFieldText
+          value={state.goodEventsFilter}
+          onChange={(e) =>
+            dispatch({ kind: 'setField', field: 'goodEventsFilter', value: e.target.value })
+          }
+          data-test-subj="slosWizardGoodEventsFilter"
+        />
+      </EuiFormRow>
+    )}
+    <EuiFormRow
+      label={template.sli.type === 'custom' ? 'Dimensions (optional)' : 'Dimensions'}
+      isInvalid={!!errors['spec.sli.dimensions']}
+      error={errors['spec.sli.dimensions']}
+      fullWidth
+    >
+      <div>
+        {state.dimensions.map((dim, i) => (
+          <EuiFlexGroup key={i} gutterSize="s" alignItems="flexEnd" style={{ marginBottom: 4 }}>
+            <EuiFlexItem>
+              <EuiFieldText
+                placeholder="label name"
+                value={dim.name}
+                onChange={(e) =>
+                  dispatch({
+                    kind: 'setDimension',
+                    index: i,
+                    dim: { ...dim, name: e.target.value },
+                  })
+                }
+                data-test-subj={`slosWizardDimName-${i}`}
+                compressed
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFieldText
+                placeholder="label value"
+                value={dim.value}
+                onChange={(e) =>
+                  dispatch({
+                    kind: 'setDimension',
+                    index: i,
+                    dim: { ...dim, value: e.target.value },
+                  })
+                }
+                data-test-subj={`slosWizardDimValue-${i}`}
+                compressed
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                color="danger"
+                onClick={() => dispatch({ kind: 'removeDimension', index: i })}
+                disabled={state.dimensions.length <= 1}
+                iconType="trash"
+                aria-label="Remove dimension"
+                size="s"
+                data-test-subj={`slosWizardDimRemove-${i}`}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ))}
+        <EuiButtonEmpty
+          iconType="plusInCircle"
+          size="s"
+          onClick={() => dispatch({ kind: 'addDimension' })}
+          data-test-subj="slosWizardDimAdd"
+        >
+          Add dimension
+        </EuiButtonEmpty>
+      </div>
+    </EuiFormRow>
+  </EuiPanel>
+);
+
+const WindowPanel: React.FC<{
+  state: FormState;
+  warnings: Record<string, string>;
+  dispatch: React.Dispatch<Action>;
+}> = ({ state, warnings, dispatch }) => (
+  <EuiPanel>
+    <EuiText size="m">
+      <h4>Window &amp; mode</h4>
+    </EuiText>
+    <EuiSpacer size="s" />
+    <EuiFormRow label="Rolling window">
+      <EuiSelect
+        value={state.windowDuration}
+        onChange={(e) =>
+          dispatch({
+            kind: 'setField',
+            field: 'windowDuration',
+            value: e.target.value as FormState['windowDuration'],
+          })
+        }
+        options={[
+          { value: '7d', text: '7 days' },
+          { value: '14d', text: '14 days' },
+          { value: '28d', text: '28 days (recommended)' },
+          { value: '30d', text: '30 days' },
+        ]}
+        data-test-subj="slosWizardWindow"
+      />
+    </EuiFormRow>
+    {warnings['spec.window.duration'] && (
+      <>
+        <EuiSpacer size="s" />
+        <EuiCallOut
+          title="Window approximation"
+          color="warning"
+          iconType="iInCircle"
+          size="s"
+          data-test-subj="slosWizardWindowWarning"
+        >
+          <EuiText size="s">{warnings['spec.window.duration']}</EuiText>
+        </EuiCallOut>
+      </>
+    )}
+    <EuiCheckbox
+      id="slosWizardShadow"
+      label="Shadow mode (deploy recording rules only; suppress alerts)"
+      checked={state.shadow}
+      onChange={(e) => dispatch({ kind: 'setField', field: 'shadow', value: e.target.checked })}
+      data-test-subj="slosWizardShadow"
+    />
+  </EuiPanel>
+);
+
+const LabelsAnnotationsPanel: React.FC<PanelProps> = ({ state, errors, dispatch }) => {
+  // Per-label validator errors are keyed as `spec.labels["<name>"]`. Walk the
+  // live labels array in order and attach the matching error to the row that
+  // declared the offending key. Untouched rows (empty key) surface no error.
+  const labelRowErrors = state.labels.map((entry) => {
+    if (!entry.key) return undefined;
+    return errors[`spec.labels["${entry.key}"]`];
+  });
+  // Annotation size-cap errors land on the scalar `spec.annotations` key —
+  // there's no per-row addressability. Attach to every row so at least the
+  // user sees the cap violation.
+  const annotationScalarError = errors['spec.annotations'];
+  const annotationRowErrors = state.annotations.map(() => annotationScalarError);
+
+  return (
+    <EuiPanel>
+      <EuiText size="m">
+        <h4>Labels &amp; annotations (optional)</h4>
+      </EuiText>
+      <EuiText size="xs" color="subdued">
+        Labels propagate to rules as <code>slo_label_&lt;key&gt;</code>. Annotations stay on the
+        document (e.g., runbook URLs).
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiFormRow
+        label="Labels"
+        fullWidth
+        data-test-subj="slosWizardLabelsRow"
+        display="rowCompressed"
+      >
+        <WizardKeyValueGrid
+          entries={state.labels}
+          rowErrors={labelRowErrors}
+          onChange={(index, field, value) =>
+            dispatch({ kind: 'setLabelEntry', index, field, value })
+          }
+          onAdd={() => dispatch({ kind: 'addLabelEntry' })}
+          onRemove={(index) => dispatch({ kind: 'removeLabelEntry', index })}
+          testSubjPrefix="slosWizardLabel"
+          addLabel="Add label"
+          keyPlaceholder="compliance"
+          valuePlaceholder="pci"
+        />
+      </EuiFormRow>
+      <EuiSpacer size="s" />
+      <EuiFormRow
+        label="Annotations"
+        fullWidth
+        isInvalid={!!annotationScalarError}
+        error={annotationScalarError}
+        data-test-subj="slosWizardAnnotationsRow"
+        display="rowCompressed"
+      >
+        <WizardKeyValueGrid
+          entries={state.annotations}
+          rowErrors={annotationRowErrors}
+          onChange={(index, field, value) =>
+            dispatch({ kind: 'setAnnotationEntry', index, field, value })
+          }
+          onAdd={() => dispatch({ kind: 'addAnnotationEntry' })}
+          onRemove={(index) => dispatch({ kind: 'removeAnnotationEntry', index })}
+          testSubjPrefix="slosWizardAnnotation"
+          addLabel="Add annotation"
+          keyPlaceholder="runbook"
+          valuePlaceholder="https://wiki/slo/..."
+        />
+      </EuiFormRow>
+    </EuiPanel>
+  );
+};
+
+function rulerErrorTitle(envelope: SloRulerErrorEnvelope): string {
+  switch (envelope.code) {
+    case 'RULER_VALIDATION_FAILED':
+      return 'Ruler rejected the rule group';
+    case 'RULER_AUTH_FAILED':
+      return 'Ruler authentication failed';
+    case 'RULER_UNREACHABLE':
+      return 'Ruler is unreachable';
+  }
+}

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -14,7 +14,7 @@
  * rule-health probe in PR 4.
  */
 
-import React, { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import {
   EuiButton,
@@ -338,6 +338,12 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [rulerError, setRulerError] = useState<SloRulerErrorEnvelope | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  // Synchronous mirror of `submitting`. Two concurrent onSubmit invocations
+  // (programmatic burst, Enter-on-form race) could both pass an
+  // `if (submitting) return` check before React's async state update lands.
+  // The ref flips synchronously inside onSubmit, so the second invocation
+  // sees the in-progress state immediately.
+  const submittingRef = useRef(false);
   const [createdSuccessfully, setCreatedSuccessfully] = useState(false);
 
   // Initialize from URL template on mount.
@@ -409,61 +415,70 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   );
 
   const onSubmit = useCallback(async () => {
-    // Guard against rapid double-submit (programmatic clicks, keyboard
-    // accelerator while the EuiButton is still in `isLoading` state). The
-    // button itself disables on `isLoading`, but a stray Enter on a focused
-    // form control would otherwise re-enter onSubmit and fire a second
-    // POST while the first is in flight.
-    if (!template || submitting) return;
-    dispatch({ kind: 'markSubmitAttempted' });
-    const input = buildCreateInput(state, template);
-    const { errors: specErrors } = validateSloSpec(input.spec);
-    if (Object.keys(specErrors).length > 0) {
-      setErrors(specErrors);
-      // Auto-scroll to the first failing field so users focused on a
-      // lower section see why their submit didn't land. The toast is a
-      // backup signal; the inline anchor is the actionable one.
-      const firstErrorKey = Object.keys(specErrors)[0];
-      if (firstErrorKey) scrollToErrorKey(firstErrorKey);
-      notifications.toasts.addWarning({
-        title: I18N.toastFixValidationTitle,
-        text: I18N.toastFixValidationText,
-      });
-      return;
-    }
-    setErrors({});
-    setRulerError(null);
-    setSubmitting(true);
+    // Guard against rapid double-submit (programmatic burst, Enter on a
+    // focused form control while the EuiButton's `isLoading` state hasn't
+    // landed yet, Cypress chained .click().click()). React state updates
+    // are async, so two consecutive invocations could both pass a
+    // `submitting === false` check before the first setSubmitting renders.
+    // `submittingRef` flips synchronously, before validation or any
+    // dispatch, so the second invocation sees in-progress immediately.
+    if (!template || submittingRef.current) return;
+    submittingRef.current = true;
     try {
-      const doc = await apiClient.create(input);
-      // Allow the post-create redirect to land without the unsaved-changes
-      // prompt firing on the navigation away.
-      setCreatedSuccessfully(true);
-      notifications.toasts.addSuccess({
-        title: I18N.toastCreatedTitle,
-        text: I18N.toastCreatedText(doc.spec.name),
-      });
-      history.push(`/slos/${encodeURIComponent(doc.id)}`);
-    } catch (e) {
-      // Ruler dual-write envelope: surface the raw upstream message inline.
-      // `rawBody` is the user-actionable diagnostic (e.g. "invalid PromQL:
-      // parse error at char 42"); a generic toast would hide it.
-      const envelope = extractRulerErrorEnvelope(e);
-      if (envelope) {
-        setRulerError(envelope);
-      } else {
-        // Use the OSD http-error envelope's `body.message` (richer) when
-        // available; falling back to `err.message` collapses route-layer
-        // 400s like "Datasource X is not registered" to "Bad Request".
-        notifications.toasts.addDanger({
-          title: I18N.toastCreateFailedTitle,
-          text: extractServerMessage(e),
+      dispatch({ kind: 'markSubmitAttempted' });
+      const input = buildCreateInput(state, template);
+      const { errors: specErrors } = validateSloSpec(input.spec);
+      if (Object.keys(specErrors).length > 0) {
+        setErrors(specErrors);
+        // Auto-scroll to the first failing field so users focused on a
+        // lower section see why their submit didn't land. The toast is a
+        // backup signal; the inline anchor is the actionable one.
+        const firstErrorKey = Object.keys(specErrors)[0];
+        if (firstErrorKey) scrollToErrorKey(firstErrorKey);
+        notifications.toasts.addWarning({
+          title: I18N.toastFixValidationTitle,
+          text: I18N.toastFixValidationText,
         });
+        return;
+      }
+      setErrors({});
+      setRulerError(null);
+      setSubmitting(true);
+      try {
+        const doc = await apiClient.create(input);
+        // Allow the post-create redirect to land without the unsaved-changes
+        // prompt firing on the navigation away.
+        setCreatedSuccessfully(true);
+        notifications.toasts.addSuccess({
+          title: I18N.toastCreatedTitle,
+          text: I18N.toastCreatedText(doc.spec.name),
+        });
+        history.push(`/slos/${encodeURIComponent(doc.id)}`);
+      } catch (e) {
+        // Ruler dual-write envelope: surface the raw upstream message inline.
+        // `rawBody` is the user-actionable diagnostic (e.g. "invalid PromQL:
+        // parse error at char 42"); a generic toast would hide it.
+        const envelope = extractRulerErrorEnvelope(e);
+        if (envelope) {
+          setRulerError(envelope);
+        } else {
+          // Use the OSD http-error envelope's `body.message` (richer) when
+          // available; falling back to `err.message` collapses route-layer
+          // 400s like "Datasource X is not registered" to "Bad Request".
+          notifications.toasts.addDanger({
+            title: I18N.toastCreateFailedTitle,
+            text: extractServerMessage(e),
+          });
+        }
+      } finally {
+        setSubmitting(false);
       }
     } finally {
-      setSubmitting(false);
+      // Always release the ref — including on the validation-error early
+      // return — so the user can fix and re-submit without a page reload.
+      submittingRef.current = false;
     }
-  }, [apiClient, history, notifications, state, submitting, template]);
+  }, [apiClient, history, notifications, state, template]);
 
   if (!template) {
     return (

--- a/public/components/apm/pages/slos/slos_page.tsx
+++ b/public/components/apm/pages/slos/slos_page.tsx
@@ -5,9 +5,10 @@
 
 /**
  * Root mount for the SLO/SLI app. Hash routes:
- *   /slos             — listing
- *   /slos/create      — wizard
- *   /slos/:id         — detail view
+ *   /slos                       — listing
+ *   /slos/create                — wizard template selector
+ *   /slos/create/:templateId    — wizard prefilled with the named template
+ *   /slos/:id                   — detail view
  */
 
 import React, { useMemo } from 'react';
@@ -54,7 +55,7 @@ export const SlosPage: React.FC<SlosPageProps> = ({
             parentBreadcrumb={parentBreadcrumb}
           />
         </Route>
-        <Route exact path="/slos/create">
+        <Route exact path={['/slos/create', '/slos/create/:templateId']}>
           <SloWizardPage
             apiClient={apiClient}
             chrome={chrome}

--- a/public/components/apm/pages/slos/wizard_builders.ts
+++ b/public/components/apm/pages/slos/wizard_builders.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Turns the wizard's form state into an `SloCreateInput` that the server
+ * accepts. Parsing (percent → decimal, seconds → number, key=value blocks)
+ * lives here so the section components stay render-only.
+ */
+
+import type {
+  Objective,
+  PrometheusSli,
+  SingleSli,
+  SloCreateInput,
+  SloSpec,
+} from '../../../../../common/slo/slo_types';
+import type { SloTemplate } from '../../../../../common/slo/slo_templates';
+import type { FormState } from './wizard_state';
+import type { KeyValueEntry } from './wizard_key_value_grid';
+
+export function parseKeyValueBlock(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Flatten a KeyValueEntry[] into the flat Record<string,string> shape the
+ * spec expects. Rows without a key are dropped (the user likely hasn't
+ * finished filling them in); empty values are preserved so the caller can
+ * express "this label key exists but has no value" if needed.
+ */
+export function entriesToRecord(entries: KeyValueEntry[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const { key, value } of entries) {
+    const trimmed = key.trim();
+    if (!trimmed) continue;
+    out[trimmed] = value;
+  }
+  return out;
+}
+
+function buildSli(state: FormState, template: SloTemplate): SingleSli {
+  const prom: PrometheusSli = {
+    backend: 'prometheus',
+    type: template.sli.type,
+    calcMethod: template.sli.calcMethod,
+    metric: template.sli.metric,
+    goodEventsFilter:
+      template.sli.type === 'availability' && state.goodEventsFilter
+        ? state.goodEventsFilter
+        : undefined,
+    latencyThresholdUnit:
+      template.sli.type === 'latency_threshold' ? state.latencyThresholdUnit : undefined,
+  };
+  if (template.sli.type === 'custom') {
+    // Custom SLIs carry the user's own PromQL. `metric` is omitted — the
+    // generator reads `customExpr` instead.
+    prom.metric = undefined;
+    if (state.customPromql.mode === 'events') {
+      prom.customExpr = {
+        mode: 'events',
+        goodQuery: state.customPromql.goodQuery,
+        totalQuery: state.customPromql.totalQuery,
+      };
+    } else {
+      prom.customExpr = {
+        mode: 'raw',
+        errorRatioQuery: state.customPromql.errorRatioQuery,
+      };
+    }
+  }
+  return {
+    type: 'single',
+    definition: prom,
+    // Custom SLIs don't require a dimension — the user's PromQL already scopes
+    // the series. Non-custom requires at least one; the validator enforces.
+    dimensions: state.dimensions.filter((d) => d.name && d.value),
+  };
+}
+
+function buildObjective(row: FormState['objectives'][number], template: SloTemplate): Objective {
+  const targetDecimal = Number(row.target) / 100;
+  const obj: Objective = {
+    name: row.name,
+    target: Number.isFinite(targetDecimal) ? targetDecimal : 0,
+  };
+  if (template.sli.type === 'latency_threshold') {
+    obj.latencyThreshold = Number(row.latencyThreshold);
+  }
+  return obj;
+}
+
+export function buildCreateInput(state: FormState, template: SloTemplate): SloCreateInput {
+  const spec: SloSpec = {
+    datasourceId: state.datasourceId,
+    name: state.name,
+    description: state.description || undefined,
+    enabled: true,
+    mode: state.shadow ? 'shadow' : 'active',
+    service: state.service,
+    owner: {
+      teams: state.ownerTeam ? [state.ownerTeam] : [],
+      primaryUser: state.ownerPrimaryUser || undefined,
+    },
+    tier: state.tier || undefined,
+    sli: buildSli(state, template),
+    objectives: state.objectives.map((row) => buildObjective(row, template)),
+    budgetWarningThresholds: state.budgetWarnings.map((b) => ({ ...b })),
+    window: { type: 'rolling', duration: state.windowDuration },
+    alerting: { strategy: 'mwmbr', burnRates: state.burnRates.map((t) => ({ ...t })) },
+    alarms: {
+      sliHealth: { enabled: state.alarms.sliHealth.enabled },
+      attainmentBreach: { enabled: state.alarms.attainmentBreach.enabled },
+      budgetWarning: { enabled: state.alarms.budgetWarning.enabled },
+      noData: {
+        enabled: state.alarms.noData.enabled,
+        forDuration: state.alarms.noData.forDuration,
+      },
+      resolved: { enabled: state.alarms.resolved.enabled },
+    },
+    exclusionWindows: state.exclusionWindows.map((ew) => ({ ...ew, schedule: { ...ew.schedule } })),
+    labels: entriesToRecord(state.labels),
+    annotations: entriesToRecord(state.annotations),
+  };
+  return { spec };
+}

--- a/public/components/apm/pages/slos/wizard_builders.ts
+++ b/public/components/apm/pages/slos/wizard_builders.ts
@@ -20,20 +20,6 @@ import type { SloTemplate } from '../../../../../common/slo/slo_templates';
 import type { FormState } from './wizard_state';
 import type { KeyValueEntry } from './wizard_key_value_grid';
 
-export function parseKeyValueBlock(raw: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const line of raw.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    const eq = trimmed.indexOf('=');
-    if (eq <= 0) continue;
-    const key = trimmed.slice(0, eq).trim();
-    const value = trimmed.slice(eq + 1).trim();
-    if (key) out[key] = value;
-  }
-  return out;
-}
-
 /**
  * Flatten a KeyValueEntry[] into the flat Record<string,string> shape the
  * spec expects. Rows without a key are dropped (the user likely hasn't

--- a/public/components/apm/pages/slos/wizard_key_value_grid.tsx
+++ b/public/components/apm/pages/slos/wizard_key_value_grid.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Two-column key=value editor for the wizard's Labels and Annotations rows.
+ * Replaces the former `<EuiTextArea>` lines-of-"key=value" UX so every row
+ * can (a) surface its own validation error inline and (b) be added or
+ * removed without editing free-form text.
+ *
+ * State lives in the wizard reducer as `state.labels` / `state.annotations`
+ * arrays of `{ key, value }`. Empty rows are tolerated in-state (the user
+ * may be mid-edit) and filtered out at build time.
+ */
+
+import React from 'react';
+import {
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiText,
+} from '@elastic/eui';
+
+export interface KeyValueEntry {
+  key: string;
+  value: string;
+}
+
+export interface KeyValueGridProps {
+  entries: KeyValueEntry[];
+  onChange: (index: number, field: 'key' | 'value', value: string) => void;
+  onAdd: () => void;
+  onRemove: (index: number) => void;
+  /** Per-row error messages, aligned by entry index (undefined = no error). */
+  rowErrors?: Array<string | undefined>;
+  /** data-test-subj prefix, e.g. "slosWizardLabel" or "slosWizardAnnotation". */
+  testSubjPrefix: string;
+  /** Visible button label on the footer Add action. */
+  addLabel?: string;
+  /** Placeholder text for the key column. */
+  keyPlaceholder?: string;
+  /** Placeholder text for the value column. */
+  valuePlaceholder?: string;
+}
+
+export const WizardKeyValueGrid: React.FC<KeyValueGridProps> = ({
+  entries,
+  onChange,
+  onAdd,
+  onRemove,
+  rowErrors,
+  testSubjPrefix,
+  addLabel = 'Add row',
+  keyPlaceholder = 'key',
+  valuePlaceholder = 'value',
+}) => {
+  return (
+    <div data-test-subj={`${testSubjPrefix}sGrid`}>
+      {entries.length === 0 && (
+        <EuiText size="xs" color="subdued" data-test-subj={`${testSubjPrefix}sEmpty`}>
+          No rows yet.
+        </EuiText>
+      )}
+      {entries.map((entry, i) => {
+        const rowError = rowErrors?.[i];
+        return (
+          <EuiFormRow
+            key={i}
+            isInvalid={!!rowError}
+            error={rowError}
+            fullWidth
+            display="rowCompressed"
+          >
+            <EuiFlexGroup
+              gutterSize="s"
+              alignItems="flexStart"
+              responsive={false}
+              data-test-subj={`${testSubjPrefix}Row-${i}`}
+            >
+              <EuiFlexItem>
+                <EuiFieldText
+                  compressed
+                  placeholder={keyPlaceholder}
+                  value={entry.key}
+                  onChange={(e) => onChange(i, 'key', e.target.value)}
+                  isInvalid={!!rowError}
+                  data-test-subj={`${testSubjPrefix}Key-${i}`}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFieldText
+                  compressed
+                  placeholder={valuePlaceholder}
+                  value={entry.value}
+                  onChange={(e) => onChange(i, 'value', e.target.value)}
+                  isInvalid={!!rowError}
+                  data-test-subj={`${testSubjPrefix}Value-${i}`}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonIcon
+                  color="danger"
+                  iconType="trash"
+                  aria-label={`Remove ${testSubjPrefix} ${i}`}
+                  onClick={() => onRemove(i)}
+                  data-test-subj={`${testSubjPrefix}Remove-${i}`}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFormRow>
+        );
+      })}
+      <EuiButtonEmpty
+        iconType="plusInCircle"
+        size="s"
+        onClick={onAdd}
+        data-test-subj={`${testSubjPrefix}Add`}
+      >
+        {addLabel}
+      </EuiButtonEmpty>
+    </div>
+  );
+};

--- a/public/components/apm/pages/slos/wizard_key_value_grid.tsx
+++ b/public/components/apm/pages/slos/wizard_key_value_grid.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { i18n } from '@osd/i18n';
 import {
   EuiButtonEmpty,
   EuiButtonIcon,
@@ -24,6 +25,26 @@ import {
   EuiFormRow,
   EuiText,
 } from '@elastic/eui';
+
+const I18N = {
+  defaultAddLabel: i18n.translate('observability.slo.kvGrid.defaultAddLabel', {
+    defaultMessage: 'Add row',
+  }),
+  defaultKeyPlaceholder: i18n.translate('observability.slo.kvGrid.defaultKeyPlaceholder', {
+    defaultMessage: 'key',
+  }),
+  defaultValuePlaceholder: i18n.translate('observability.slo.kvGrid.defaultValuePlaceholder', {
+    defaultMessage: 'value',
+  }),
+  empty: i18n.translate('observability.slo.kvGrid.empty', {
+    defaultMessage: 'No rows yet.',
+  }),
+  removeAria: (testSubjPrefix: string, index: number) =>
+    i18n.translate('observability.slo.kvGrid.removeAria', {
+      defaultMessage: 'Remove {testSubjPrefix} {index}',
+      values: { testSubjPrefix, index },
+    }),
+};
 
 export interface KeyValueEntry {
   key: string;
@@ -54,15 +75,15 @@ export const WizardKeyValueGrid: React.FC<KeyValueGridProps> = ({
   onRemove,
   rowErrors,
   testSubjPrefix,
-  addLabel = 'Add row',
-  keyPlaceholder = 'key',
-  valuePlaceholder = 'value',
+  addLabel = I18N.defaultAddLabel,
+  keyPlaceholder = I18N.defaultKeyPlaceholder,
+  valuePlaceholder = I18N.defaultValuePlaceholder,
 }) => {
   return (
     <div data-test-subj={`${testSubjPrefix}sGrid`}>
       {entries.length === 0 && (
         <EuiText size="xs" color="subdued" data-test-subj={`${testSubjPrefix}sEmpty`}>
-          No rows yet.
+          {I18N.empty}
         </EuiText>
       )}
       {entries.map((entry, i) => {
@@ -105,7 +126,7 @@ export const WizardKeyValueGrid: React.FC<KeyValueGridProps> = ({
                 <EuiButtonIcon
                   color="danger"
                   iconType="trash"
-                  aria-label={`Remove ${testSubjPrefix} ${i}`}
+                  aria-label={I18N.removeAria(testSubjPrefix, i)}
                   onClick={() => onRemove(i)}
                   data-test-subj={`${testSubjPrefix}Remove-${i}`}
                 />

--- a/public/components/apm/pages/slos/wizard_nav.tsx
+++ b/public/components/apm/pages/slos/wizard_nav.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Sticky left-rail anchor nav for the create wizard. One entry per visible
+ * section; an IntersectionObserver-style scroll listener tracks which
+ * section's panel is closest to the top of the viewport so the corresponding
+ * entry is marked selected.
+ *
+ * Scroll-to-section is `scrollIntoView({ behavior: 'smooth', block: 'start' })`
+ * against the section's anchor element (the wrapper `<div id={anchorId}>`
+ * emitted around each panel in slo_wizard_page.tsx).
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSideNav } from '@elastic/eui';
+import {
+  WIZARD_SECTIONS,
+  WizardSection,
+  WizardSectionId,
+  sectionsWithErrors,
+} from './wizard_sections';
+
+export interface WizardNavProps {
+  errors: Record<string, string>;
+  /**
+   * Section ids whose panels are currently mounted. PromQL and Exclusion
+   * Windows are conditional; excluded ids won't render a nav entry.
+   */
+  visibleSectionIds: readonly WizardSectionId[];
+}
+
+const SCROLL_OFFSET_PX = 16;
+const SPY_DEBOUNCE_MS = 100;
+
+export const WizardNav: React.FC<WizardNavProps> = ({ errors, visibleSectionIds }) => {
+  const sections = useMemo(() => WIZARD_SECTIONS.filter((s) => visibleSectionIds.includes(s.id)), [
+    visibleSectionIds,
+  ]);
+  const [activeId, setActiveId] = useState<WizardSectionId | null>(null);
+  const errorSections = useMemo(() => sectionsWithErrors(errors), [errors]);
+
+  useScrollSpy(sections, setActiveId);
+
+  const onPick = useCallback((section: WizardSection) => {
+    const el = document.getElementById(section.anchorId);
+    if (!el) return;
+    // Smooth-scroll with a small offset so the section title isn't flush with
+    // the page header. Using scrollIntoView + scrollBy instead of a single
+    // scrollTo keeps us agnostic to which ancestor is the scroll container.
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    window.scrollBy({ top: -SCROLL_OFFSET_PX, behavior: 'smooth' });
+  }, []);
+
+  const items = sections.map((section) => {
+    const hasError = errorSections.has(section.id);
+    return {
+      id: section.id,
+      name: (
+        <EuiFlexGroup
+          gutterSize="xs"
+          alignItems="center"
+          responsive={false}
+          data-test-subj={`slosWizardNavItem-${section.id}`}
+        >
+          {hasError && (
+            <EuiFlexItem grow={false}>
+              <EuiIcon
+                type="alert"
+                color="danger"
+                size="s"
+                data-test-subj={`slosWizardNavError-${section.id}`}
+              />
+            </EuiFlexItem>
+          )}
+          <EuiFlexItem grow={false}>{section.label}</EuiFlexItem>
+        </EuiFlexGroup>
+      ),
+      isSelected: activeId === section.id,
+      onClick: () => onPick(section),
+      'data-test-subj': `slosWizardNavItemRoot-${section.id}`,
+    };
+  });
+
+  return (
+    <div
+      data-test-subj="slosWizardNav"
+      style={{
+        position: 'sticky',
+        top: 8,
+        alignSelf: 'flex-start',
+        width: 180,
+      }}
+    >
+      <EuiSideNav
+        aria-label="SLO wizard sections"
+        items={[{ id: 'slosWizardNavRoot', name: 'Sections', items }]}
+      />
+    </div>
+  );
+};
+
+/**
+ * Watch the section anchors and pick the one closest to the viewport top. A
+ * small debounce keeps the selected indicator from thrashing while the user
+ * scrolls fast.
+ */
+function useScrollSpy(
+  sections: readonly WizardSection[],
+  setActive: (id: WizardSectionId | null) => void
+) {
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (sections.length === 0) return;
+
+    const computeActive = () => {
+      let best: { id: WizardSectionId; distance: number } | null = null;
+      for (const section of sections) {
+        const el = document.getElementById(section.anchorId);
+        if (!el) continue;
+        const rect = el.getBoundingClientRect();
+        // Pick the section whose top edge is closest to (and not below) the
+        // visual header — a section that is scrolled just past the top beats
+        // the next one sitting halfway down the viewport.
+        const top = rect.top - SCROLL_OFFSET_PX;
+        const distance = top <= 0 ? -top : Number.POSITIVE_INFINITY;
+        if (best === null || distance < best.distance) {
+          best = { id: section.id, distance };
+        }
+      }
+      // Nothing has scrolled past yet: default to the first section.
+      if (best === null || best.distance === Number.POSITIVE_INFINITY) {
+        setActive(sections[0].id);
+      } else {
+        setActive(best.id);
+      }
+    };
+
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const schedule = () => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+        rafRef.current = requestAnimationFrame(computeActive);
+      }, SPY_DEBOUNCE_MS);
+    };
+
+    computeActive();
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+    return () => {
+      window.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+      if (debounceTimer) clearTimeout(debounceTimer);
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [sections, setActive]);
+}

--- a/public/components/apm/pages/slos/wizard_nav.tsx
+++ b/public/components/apm/pages/slos/wizard_nav.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { i18n } from '@osd/i18n';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiSideNav } from '@elastic/eui';
 import {
   WIZARD_SECTIONS,
@@ -22,6 +23,15 @@ import {
   WizardSectionId,
   sectionsWithErrors,
 } from './wizard_sections';
+
+const I18N = {
+  ariaLabel: i18n.translate('observability.slo.wizardNav.ariaLabel', {
+    defaultMessage: 'SLO wizard sections',
+  }),
+  rootName: i18n.translate('observability.slo.wizardNav.rootName', {
+    defaultMessage: 'Sections',
+  }),
+};
 
 export interface WizardNavProps {
   errors: Record<string, string>;
@@ -95,8 +105,8 @@ export const WizardNav: React.FC<WizardNavProps> = ({ errors, visibleSectionIds 
       }}
     >
       <EuiSideNav
-        aria-label="SLO wizard sections"
-        items={[{ id: 'slosWizardNavRoot', name: 'Sections', items }]}
+        aria-label={I18N.ariaLabel}
+        items={[{ id: 'slosWizardNavRoot', name: I18N.rootName, items }]}
       />
     </div>
   );

--- a/public/components/apm/pages/slos/wizard_sections.ts
+++ b/public/components/apm/pages/slos/wizard_sections.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Section metadata shared between the anchor nav, the top-level validation
+ * summary, and the rule-preview empty state. Keeping it in one place means
+ * renames (e.g. "Advanced" → "Alerting") land in a single file and all three
+ * surfaces pick them up.
+ *
+ * `errorPrefixes` are matched against the validator's error keys (e.g.
+ * `spec.name`, `spec.alerting.burnRates[0].shortWindow`). The first matching
+ * section owns the error.
+ *
+ * Order is load-bearing — `WIZARD_SECTIONS` defines the visual order of the
+ * wizard panels and the anchor nav. A drift-guard test
+ * (`__tests__/wizard_sections.test.ts`) pins the order so a future refactor
+ * doesn't silently shuffle the user-facing layout.
+ */
+
+export type WizardSectionId =
+  | 'identity'
+  | 'owner'
+  | 'sli'
+  | 'promql'
+  | 'objectives'
+  | 'window'
+  | 'advanced'
+  | 'exclusions'
+  | 'labels'
+  | 'rulesPreview';
+
+export interface WizardSection {
+  id: WizardSectionId;
+  label: string;
+  /** DOM id rendered on the section wrapper; used for scroll-to-section. */
+  anchorId: string;
+  /** Error keys starting with any of these prefixes belong to this section. */
+  errorPrefixes: readonly string[];
+  /**
+   * Field-level DOM ids (or `data-test-subj` values) we know how to scroll to
+   * when the user clicks an error in the summary. Key = exact validator key.
+   */
+  fieldIds?: Readonly<Record<string, string>>;
+}
+
+export const WIZARD_SECTIONS: readonly WizardSection[] = [
+  {
+    id: 'identity',
+    label: 'Identity',
+    anchorId: 'slosWizardSection-identity',
+    errorPrefixes: ['spec.name', 'spec.datasourceId', 'spec.enabled', 'spec.mode'],
+    fieldIds: {
+      'spec.name': 'slosWizardName',
+      'spec.datasourceId': 'slosWizardDatasourceId',
+    },
+  },
+  // Window comes before SLI + objectives because the chosen time window
+  // conditions the SLI shape (Grafana SLO creation flow, audit cite S5).
+  {
+    id: 'window',
+    label: 'Window & mode',
+    anchorId: 'slosWizardSection-window',
+    errorPrefixes: ['spec.window'],
+  },
+  {
+    id: 'owner',
+    label: 'Service & owner',
+    anchorId: 'slosWizardSection-owner',
+    errorPrefixes: ['spec.service', 'spec.owner'],
+    fieldIds: {
+      'spec.service': 'slosWizardService',
+      'spec.owner.teams': 'slosWizardOwnerTeam',
+    },
+  },
+  {
+    id: 'sli',
+    label: 'SLI',
+    anchorId: 'slosWizardSection-sli',
+    errorPrefixes: ['spec.sli'],
+  },
+  {
+    id: 'promql',
+    label: 'Custom PromQL',
+    anchorId: 'slosWizardSection-promql',
+    errorPrefixes: ['spec.sli.definition.customExpr'],
+  },
+  {
+    id: 'objectives',
+    label: 'Objectives',
+    anchorId: 'slosWizardSection-objectives',
+    errorPrefixes: ['spec.objectives'],
+  },
+  {
+    id: 'advanced',
+    label: 'Advanced',
+    anchorId: 'slosWizardSection-advanced',
+    errorPrefixes: ['spec.alerting', 'spec.budgetWarningThresholds', 'spec.alarms'],
+  },
+  {
+    id: 'exclusions',
+    label: 'Exclusion windows',
+    anchorId: 'slosWizardSection-exclusions',
+    errorPrefixes: ['spec.exclusionWindows'],
+  },
+  {
+    id: 'labels',
+    label: 'Labels & annotations',
+    anchorId: 'slosWizardSection-labels',
+    errorPrefixes: ['spec.labels', 'spec.annotations'],
+  },
+  {
+    id: 'rulesPreview',
+    label: 'Rule preview',
+    anchorId: 'slosWizardSection-rulesPreview',
+    errorPrefixes: [],
+  },
+];
+
+/**
+ * Find the section that owns a given validator error key. Longest-prefix wins
+ * so `spec.sli.definition.customExpr.goodQuery` goes to PromQL rather than
+ * SLI even though both sections could claim it.
+ */
+export function findSectionForKey(key: string): WizardSection | undefined {
+  let match: { section: WizardSection; prefix: string } | undefined;
+  for (const section of WIZARD_SECTIONS) {
+    for (const prefix of section.errorPrefixes) {
+      if (key === prefix || key.startsWith(prefix + '.') || key.startsWith(prefix + '[')) {
+        if (!match || prefix.length > match.prefix.length) {
+          match = { section, prefix };
+        }
+      }
+    }
+  }
+  return match?.section;
+}
+
+/** Return the section ids that carry at least one error key. */
+export function sectionsWithErrors(errors: Record<string, string>): Set<WizardSectionId> {
+  const out = new Set<WizardSectionId>();
+  for (const key of Object.keys(errors)) {
+    const section = findSectionForKey(key);
+    if (section) out.add(section.id);
+  }
+  return out;
+}
+
+/**
+ * Best-effort scroll handler: resolves a validator error key to a scrollable
+ * element via the per-section `fieldIds` map (data-test-subj) or falls back
+ * to the section anchor. Returns `true` when a scroll happened.
+ */
+export function scrollToErrorKey(key: string): boolean {
+  const section = findSectionForKey(key);
+  if (!section) return false;
+  const fieldId = section.fieldIds?.[key];
+  if (fieldId) {
+    const el = document.querySelector<HTMLElement>(`[data-test-subj="${fieldId}"]`);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      el.focus({ preventScroll: true });
+      return true;
+    }
+  }
+  const anchor = document.getElementById(section.anchorId);
+  if (anchor) {
+    anchor.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    return true;
+  }
+  return false;
+}
+
+/** Human-friendly label for an error key, scoped by section. */
+export function labelForErrorKey(key: string): string {
+  const section = findSectionForKey(key);
+  return section ? `${section.label} — ${key}` : key;
+}

--- a/public/components/apm/pages/slos/wizard_state.ts
+++ b/public/components/apm/pages/slos/wizard_state.ts
@@ -1,0 +1,513 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Wizard form state + reducer, extracted so the wizard page stays an
+ * orchestrator. Every edit from the UI flows through `reducer` — no setState
+ * on nested arrays from the components themselves.
+ */
+
+import type {
+  BudgetWarningThreshold,
+  BurnRateConfig,
+  CustomPromQLExpr,
+  Dimension,
+  ExclusionWindow,
+  SloAlarmConfig,
+} from '../../../../../common/slo/slo_types';
+import { DEFAULT_MWMBR_TIERS } from '../../../../../common/slo/slo_promql_generator';
+import {
+  SLO_TEMPLATES,
+  substituteCustomPromqlDefaults,
+} from '../../../../../common/slo/slo_templates';
+import type { SloTemplate } from '../../../../../common/slo/slo_templates';
+import { getBurnRatePreset } from './burn_rate_presets';
+import type { BurnRatePresetId } from './burn_rate_presets';
+import type { KeyValueEntry } from './wizard_key_value_grid';
+
+/** One row in the Objectives section. Strings for form editing; built into
+ *  numeric `target` / `latencyThreshold` at submit time (keeps typing UX sane). */
+export interface ObjectiveRow {
+  name: string;
+  target: string;
+  latencyThreshold: string;
+}
+
+/** State for the custom PromQL editor. Only read when template.id === 'custom'. */
+export interface CustomPromqlState {
+  mode: 'events' | 'raw';
+  goodQuery: string;
+  totalQuery: string;
+  errorRatioQuery: string;
+}
+
+export interface FormState {
+  templateId: string | null;
+  datasourceId: string;
+  name: string;
+  description: string;
+  service: string;
+  ownerTeam: string;
+  ownerPrimaryUser: string;
+  tier: string;
+  windowDuration: '7d' | '14d' | '28d' | '30d';
+  objectives: ObjectiveRow[];
+  dimensions: Dimension[];
+  goodEventsFilter: string;
+  latencyThresholdUnit: 'seconds' | 'milliseconds';
+  customPromql: CustomPromqlState;
+  labels: KeyValueEntry[];
+  annotations: KeyValueEntry[];
+  shadow: boolean;
+
+  // Advanced section.
+  burnRates: BurnRateConfig[];
+  budgetWarnings: BudgetWarningThreshold[];
+  alarms: SloAlarmConfig;
+
+  // Exclusion windows — shape-only here; enforcement deferred post-GA.
+  exclusionWindows: ExclusionWindow[];
+
+  // Flipped by the Submit handler so the wizard only reveals the top-level
+  // validation summary AFTER the user has attempted submit at least once.
+  // Typing doesn't produce a sea of red; clicking Create does.
+  submitAttempted: boolean;
+}
+
+export type Action =
+  | { kind: 'setTemplate'; templateId: string | null }
+  | { kind: 'setField'; field: ScalarField; value: string | boolean }
+  | { kind: 'setObjectiveField'; index: number; field: keyof ObjectiveRow; value: string }
+  | { kind: 'addObjective' }
+  | { kind: 'removeObjective'; index: number }
+  | { kind: 'setDimension'; index: number; dim: Dimension }
+  | { kind: 'addDimension' }
+  | { kind: 'removeDimension'; index: number }
+  | { kind: 'setCustomPromql'; patch: Partial<CustomPromqlState> }
+  | {
+      kind: 'setBurnRateField';
+      index: number;
+      field: keyof BurnRateConfig;
+      value: string | number | boolean;
+    }
+  | { kind: 'addBurnRate' }
+  | { kind: 'removeBurnRate'; index: number }
+  | { kind: 'applyBurnRatePreset'; preset: BurnRatePresetId }
+  | {
+      kind: 'setBudgetWarningField';
+      index: number;
+      field: keyof BudgetWarningThreshold;
+      value: string | number;
+    }
+  | { kind: 'addBudgetWarning' }
+  | { kind: 'removeBudgetWarning'; index: number }
+  | { kind: 'setAlarmToggle'; alarm: ToggleableAlarm; enabled: boolean }
+  | { kind: 'setNoDataDuration'; forDuration: string }
+  | {
+      kind: 'setExclusionWindowField';
+      index: number;
+      field: keyof ExclusionWindowRowPatch;
+      value: string;
+    }
+  | { kind: 'setExclusionWindowScheduleType'; index: number; type: 'cron' | 'oneoff' }
+  | { kind: 'addExclusionWindow' }
+  | { kind: 'removeExclusionWindow'; index: number }
+  | { kind: 'markSubmitAttempted' }
+  | {
+      kind: 'setLabelEntry';
+      index: number;
+      field: 'key' | 'value';
+      value: string;
+    }
+  | { kind: 'addLabelEntry' }
+  | { kind: 'removeLabelEntry'; index: number }
+  | {
+      kind: 'setAnnotationEntry';
+      index: number;
+      field: 'key' | 'value';
+      value: string;
+    }
+  | { kind: 'addAnnotationEntry' }
+  | { kind: 'removeAnnotationEntry'; index: number };
+
+/**
+ * Scalar keys of FormState — the subset `setField` is allowed to assign.
+ * Array and record-valued state uses dedicated actions.
+ */
+type ScalarField =
+  | 'datasourceId'
+  | 'name'
+  | 'description'
+  | 'service'
+  | 'ownerTeam'
+  | 'ownerPrimaryUser'
+  | 'tier'
+  | 'windowDuration'
+  | 'goodEventsFilter'
+  | 'latencyThresholdUnit'
+  | 'shadow';
+
+export type ToggleableAlarm =
+  | 'sliHealth'
+  | 'attainmentBreach'
+  | 'budgetWarning'
+  | 'noData'
+  | 'resolved';
+
+/**
+ * Fields that can be edited on a single ExclusionWindow row regardless of
+ * schedule type. The schedule-type-specific keys (cron.expression,
+ * oneoff.start, ...) are covered by the same key names since they are
+ * mutually exclusive per row — the reducer routes the write.
+ */
+export interface ExclusionWindowRowPatch {
+  name: string;
+  reason: string;
+  cronExpression: string;
+  cronTimezone: string;
+  cronDuration: string;
+  oneoffStart: string;
+  oneoffEnd: string;
+}
+
+/** Default objective rows depend on the template. */
+function defaultObjective(template: SloTemplate | null): ObjectiveRow {
+  const t = template?.sli.type;
+  if (t === 'latency_threshold') {
+    return {
+      name: 'latency-threshold',
+      target: '99.9',
+      latencyThreshold: template?.defaultLatencyThreshold
+        ? String(template.defaultLatencyThreshold)
+        : '0.5',
+    };
+  }
+  return { name: 'availability-99-9', target: '99.9', latencyThreshold: '0.5' };
+}
+
+function defaultAlarms(): SloAlarmConfig {
+  return {
+    sliHealth: { enabled: false },
+    attainmentBreach: { enabled: false },
+    budgetWarning: { enabled: true },
+    noData: { enabled: false, forDuration: '10m' },
+    resolved: { enabled: false },
+  };
+}
+
+function defaultBurnRates(): BurnRateConfig[] {
+  return DEFAULT_MWMBR_TIERS.map((t) => ({ ...t }));
+}
+
+function defaultBudgetWarnings(): BudgetWarningThreshold[] {
+  return [
+    { threshold: 0.5, severity: 'warning' },
+    { threshold: 0.2, severity: 'critical' },
+  ];
+}
+
+export function initialState(): FormState {
+  return {
+    templateId: null,
+    datasourceId: '',
+    name: '',
+    description: '',
+    service: '',
+    ownerTeam: '',
+    ownerPrimaryUser: '',
+    tier: '',
+    windowDuration: '28d',
+    objectives: [defaultObjective(null)],
+    dimensions: [{ name: 'service', value: '' }],
+    goodEventsFilter: '',
+    latencyThresholdUnit: 'seconds',
+    customPromql: { mode: 'events', goodQuery: '', totalQuery: '', errorRatioQuery: '' },
+    labels: [],
+    annotations: [],
+    shadow: false,
+    burnRates: defaultBurnRates(),
+    budgetWarnings: defaultBudgetWarnings(),
+    alarms: defaultAlarms(),
+    exclusionWindows: [],
+    submitAttempted: false,
+  };
+}
+
+/**
+ * Applying a template preserves user edits to fields the template doesn't own
+ * (service/name/owner), and resets SLI-specific defaults (metric,
+ * goodEventsFilter, latency threshold). Objectives are reset to a single row
+ * sized for the template so the wizard isn't stuck with stale latency-only
+ * rows when flipping to availability.
+ *
+ * Templates that carry `customPromqlDefaults` (APM span-derived) also pre-fill
+ * the custom PromQL editor with `${service}` / `${remoteService}` already
+ * substituted from form state.
+ */
+export function applyTemplate(state: FormState, template: SloTemplate | null): FormState {
+  if (!template) return { ...state, templateId: null };
+  const nextCustomPromql = template.customPromqlDefaults
+    ? (() => {
+        const subbed = substituteCustomPromqlDefaults(template.customPromqlDefaults, {
+          service: state.service,
+        });
+        if (subbed.mode === 'events') {
+          return {
+            mode: 'events' as const,
+            goodQuery: subbed.goodQuery,
+            totalQuery: subbed.totalQuery,
+            errorRatioQuery: state.customPromql.errorRatioQuery,
+          };
+        }
+        return {
+          mode: 'raw' as const,
+          goodQuery: state.customPromql.goodQuery,
+          totalQuery: state.customPromql.totalQuery,
+          errorRatioQuery: subbed.errorRatioQuery,
+        };
+      })()
+    : state.customPromql;
+  return {
+    ...state,
+    templateId: template.id,
+    goodEventsFilter: template.sli.goodEventsFilter ?? '',
+    latencyThresholdUnit: template.sli.latencyThresholdUnit ?? 'seconds',
+    dimensions: [
+      { name: template.dimensionHints.serviceLabel, value: state.service || '' },
+      ...(state.dimensions.length > 1 ? state.dimensions.slice(1) : []),
+    ],
+    objectives: [defaultObjective(template)],
+    customPromql: nextCustomPromql,
+  };
+}
+
+function makeEmptyExclusionWindow(): ExclusionWindow {
+  return {
+    name: '',
+    schedule: { type: 'cron', expression: '0 0 * * *', timezone: 'UTC', duration: '1h' },
+  };
+}
+
+function patchExclusionWindow(
+  ew: ExclusionWindow,
+  field: keyof ExclusionWindowRowPatch,
+  value: string
+): ExclusionWindow {
+  switch (field) {
+    case 'name':
+      return { ...ew, name: value };
+    case 'reason':
+      return { ...ew, reason: value };
+    case 'cronExpression':
+      if (ew.schedule.type !== 'cron') return ew;
+      return { ...ew, schedule: { ...ew.schedule, expression: value } };
+    case 'cronTimezone':
+      if (ew.schedule.type !== 'cron') return ew;
+      return { ...ew, schedule: { ...ew.schedule, timezone: value } };
+    case 'cronDuration':
+      if (ew.schedule.type !== 'cron') return ew;
+      return { ...ew, schedule: { ...ew.schedule, duration: value } };
+    case 'oneoffStart':
+      if (ew.schedule.type !== 'oneoff') return ew;
+      return { ...ew, schedule: { ...ew.schedule, start: value } };
+    case 'oneoffEnd':
+      if (ew.schedule.type !== 'oneoff') return ew;
+      return { ...ew, schedule: { ...ew.schedule, end: value } };
+  }
+}
+
+export function reducer(state: FormState, action: Action): FormState {
+  switch (action.kind) {
+    case 'setTemplate': {
+      const t = SLO_TEMPLATES.find((x) => x.id === action.templateId) ?? null;
+      return applyTemplate(state, t);
+    }
+    case 'setField':
+      return { ...state, [action.field]: action.value } as FormState;
+    case 'setObjectiveField': {
+      const next = state.objectives.slice();
+      next[action.index] = { ...next[action.index], [action.field]: action.value };
+      return { ...state, objectives: next };
+    }
+    case 'addObjective': {
+      const next = state.objectives.slice();
+      const base = state.objectives[0] ?? defaultObjective(null);
+      next.push({
+        name: `objective-${state.objectives.length + 1}`,
+        target: base.target,
+        latencyThreshold: base.latencyThreshold,
+      });
+      return { ...state, objectives: next };
+    }
+    case 'removeObjective': {
+      if (state.objectives.length <= 1) return state;
+      const next = state.objectives.slice();
+      next.splice(action.index, 1);
+      return { ...state, objectives: next };
+    }
+    case 'setDimension': {
+      const next = state.dimensions.slice();
+      next[action.index] = action.dim;
+      return { ...state, dimensions: next };
+    }
+    case 'addDimension':
+      return { ...state, dimensions: [...state.dimensions, { name: '', value: '' }] };
+    case 'removeDimension': {
+      const next = state.dimensions.slice();
+      next.splice(action.index, 1);
+      return { ...state, dimensions: next };
+    }
+    case 'setCustomPromql':
+      return { ...state, customPromql: { ...state.customPromql, ...action.patch } };
+    case 'setBurnRateField': {
+      const next = state.burnRates.slice();
+      next[action.index] = {
+        ...next[action.index],
+        [action.field]: action.value,
+      } as BurnRateConfig;
+      return { ...state, burnRates: next };
+    }
+    case 'addBurnRate': {
+      const base = state.burnRates[state.burnRates.length - 1] ?? DEFAULT_MWMBR_TIERS[0];
+      return {
+        ...state,
+        burnRates: [...state.burnRates, { ...base, severity: 'warning', createAlarm: true }],
+      };
+    }
+    case 'removeBurnRate': {
+      const next = state.burnRates.slice();
+      next.splice(action.index, 1);
+      return { ...state, burnRates: next };
+    }
+    case 'applyBurnRatePreset': {
+      const preset = getBurnRatePreset(action.preset);
+      return { ...state, burnRates: preset.tiers.map((t) => ({ ...t })) };
+    }
+    case 'setBudgetWarningField': {
+      const next = state.budgetWarnings.slice();
+      next[action.index] = {
+        ...next[action.index],
+        [action.field]: action.value,
+      } as BudgetWarningThreshold;
+      return { ...state, budgetWarnings: next };
+    }
+    case 'addBudgetWarning':
+      return {
+        ...state,
+        budgetWarnings: [...state.budgetWarnings, { threshold: 0.1, severity: 'warning' }],
+      };
+    case 'removeBudgetWarning': {
+      const next = state.budgetWarnings.slice();
+      next.splice(action.index, 1);
+      return { ...state, budgetWarnings: next };
+    }
+    case 'setAlarmToggle': {
+      // Indexed write into SloAlarmConfig is awkward in TypeScript because
+      // each property is its own member type (`noData` carries `forDuration`
+      // as well). Switch on the discriminator so the `enabled` flip lands on
+      // the right shape without losing `forDuration`.
+      switch (action.alarm) {
+        case 'sliHealth':
+          return {
+            ...state,
+            alarms: { ...state.alarms, sliHealth: { enabled: action.enabled } },
+          };
+        case 'attainmentBreach':
+          return {
+            ...state,
+            alarms: { ...state.alarms, attainmentBreach: { enabled: action.enabled } },
+          };
+        case 'budgetWarning':
+          return {
+            ...state,
+            alarms: { ...state.alarms, budgetWarning: { enabled: action.enabled } },
+          };
+        case 'noData':
+          return {
+            ...state,
+            alarms: {
+              ...state.alarms,
+              noData: { ...state.alarms.noData, enabled: action.enabled },
+            },
+          };
+        case 'resolved':
+          return {
+            ...state,
+            alarms: { ...state.alarms, resolved: { enabled: action.enabled } },
+          };
+      }
+    }
+    case 'setNoDataDuration':
+      return {
+        ...state,
+        alarms: {
+          ...state.alarms,
+          noData: { ...state.alarms.noData, forDuration: action.forDuration },
+        },
+      };
+    case 'setExclusionWindowField': {
+      const next = state.exclusionWindows.slice();
+      next[action.index] = patchExclusionWindow(next[action.index], action.field, action.value);
+      return { ...state, exclusionWindows: next };
+    }
+    case 'setExclusionWindowScheduleType': {
+      const next = state.exclusionWindows.slice();
+      const ew = next[action.index];
+      if (action.type === 'cron') {
+        next[action.index] = {
+          ...ew,
+          schedule: { type: 'cron', expression: '0 0 * * *', timezone: 'UTC', duration: '1h' },
+        };
+      } else {
+        const now = new Date();
+        const later = new Date(now.getTime() + 60 * 60 * 1000);
+        next[action.index] = {
+          ...ew,
+          schedule: { type: 'oneoff', start: now.toISOString(), end: later.toISOString() },
+        };
+      }
+      return { ...state, exclusionWindows: next };
+    }
+    case 'addExclusionWindow':
+      return {
+        ...state,
+        exclusionWindows: [...state.exclusionWindows, makeEmptyExclusionWindow()],
+      };
+    case 'removeExclusionWindow': {
+      const next = state.exclusionWindows.slice();
+      next.splice(action.index, 1);
+      return { ...state, exclusionWindows: next };
+    }
+    case 'markSubmitAttempted':
+      return state.submitAttempted ? state : { ...state, submitAttempted: true };
+    case 'setLabelEntry': {
+      const next = state.labels.slice();
+      next[action.index] = { ...next[action.index], [action.field]: action.value };
+      return { ...state, labels: next };
+    }
+    case 'addLabelEntry':
+      return { ...state, labels: [...state.labels, { key: '', value: '' }] };
+    case 'removeLabelEntry': {
+      const next = state.labels.slice();
+      next.splice(action.index, 1);
+      return { ...state, labels: next };
+    }
+    case 'setAnnotationEntry': {
+      const next = state.annotations.slice();
+      next[action.index] = { ...next[action.index], [action.field]: action.value };
+      return { ...state, annotations: next };
+    }
+    case 'addAnnotationEntry':
+      return { ...state, annotations: [...state.annotations, { key: '', value: '' }] };
+    case 'removeAnnotationEntry': {
+      const next = state.annotations.slice();
+      next.splice(action.index, 1);
+      return { ...state, annotations: next };
+    }
+  }
+}
+
+// Re-export for wizard consumers who want the union type without a separate import.
+export type { CustomPromQLExpr };

--- a/public/components/apm/pages/slos/wizard_validation_summary.tsx
+++ b/public/components/apm/pages/slos/wizard_validation_summary.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Top-of-form "fix these errors" summary. Only renders after the user has
+ * clicked Create at least once — typing doesn't produce a sea of red; the
+ * explicit attempt does.
+ *
+ * Each row is an EuiLink that scrolls to the offending field (falling back
+ * to the section anchor if the field isn't individually addressable).
+ * Grouping by section mirrors the anchor nav so the two surfaces agree on
+ * what "belongs" where.
+ */
+
+import React from 'react';
+import { EuiCallOut, EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
+import {
+  WIZARD_SECTIONS,
+  WizardSection,
+  findSectionForKey,
+  scrollToErrorKey,
+} from './wizard_sections';
+
+export interface WizardValidationSummaryProps {
+  errors: Record<string, string>;
+}
+
+export const WizardValidationSummary: React.FC<WizardValidationSummaryProps> = ({ errors }) => {
+  const keys = Object.keys(errors);
+  if (keys.length === 0) return null;
+
+  const grouped = new Map<WizardSection, string[]>();
+  const orphans: string[] = [];
+  for (const key of keys) {
+    const section = findSectionForKey(key);
+    if (!section) {
+      orphans.push(key);
+      continue;
+    }
+    const list = grouped.get(section) ?? [];
+    list.push(key);
+    grouped.set(section, list);
+  }
+
+  return (
+    <>
+      <EuiCallOut
+        color="danger"
+        iconType="alert"
+        title={`Fix ${keys.length} ${
+          keys.length === 1 ? 'error' : 'errors'
+        } before creating the SLO`}
+        data-test-subj="slosWizardValidationSummary"
+      >
+        <EuiText size="s">
+          <ul data-test-subj="slosWizardValidationSummaryList">
+            {WIZARD_SECTIONS.map((section) => {
+              const sectionKeys = grouped.get(section);
+              if (!sectionKeys || sectionKeys.length === 0) return null;
+              return sectionKeys.map((key) => (
+                <li key={key}>
+                  <EuiLink
+                    onClick={() => scrollToErrorKey(key)}
+                    data-test-subj={`slosWizardValidationSummaryItem-${key}`}
+                  >
+                    <strong>{section.label}:</strong> {errors[key]}
+                  </EuiLink>
+                </li>
+              ));
+            })}
+            {orphans.map((key) => (
+              <li key={key}>
+                <EuiLink
+                  onClick={() => scrollToErrorKey(key)}
+                  data-test-subj={`slosWizardValidationSummaryItem-${key}`}
+                >
+                  {key}: {errors[key]}
+                </EuiLink>
+              </li>
+            ))}
+          </ul>
+        </EuiText>
+      </EuiCallOut>
+      <EuiSpacer size="m" />
+    </>
+  );
+};

--- a/public/components/apm/pages/slos/wizard_validation_summary.tsx
+++ b/public/components/apm/pages/slos/wizard_validation_summary.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { i18n } from '@osd/i18n';
 import { EuiCallOut, EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
 import {
   WIZARD_SECTIONS,
@@ -22,6 +23,20 @@ import {
   findSectionForKey,
   scrollToErrorKey,
 } from './wizard_sections';
+
+const I18N = {
+  title: (count: number, errorWord: string) =>
+    i18n.translate('observability.slo.wizardSummary.title', {
+      defaultMessage: 'Fix {count} {errorWord} before creating the SLO',
+      values: { count, errorWord },
+    }),
+  errorSingular: i18n.translate('observability.slo.wizardSummary.errorSingular', {
+    defaultMessage: 'error',
+  }),
+  errorPlural: i18n.translate('observability.slo.wizardSummary.errorPlural', {
+    defaultMessage: 'errors',
+  }),
+};
 
 export interface WizardValidationSummaryProps {
   errors: Record<string, string>;
@@ -49,9 +64,7 @@ export const WizardValidationSummary: React.FC<WizardValidationSummaryProps> = (
       <EuiCallOut
         color="danger"
         iconType="alert"
-        title={`Fix ${keys.length} ${
-          keys.length === 1 ? 'error' : 'errors'
-        } before creating the SLO`}
+        title={I18N.title(keys.length, keys.length === 1 ? I18N.errorSingular : I18N.errorPlural)}
         data-test-subj="slosWizardValidationSummary"
       >
         <EuiText size="s">

--- a/server/routes/slo/__tests__/resolve_request.test.ts
+++ b/server/routes/slo/__tests__/resolve_request.test.ts
@@ -88,6 +88,78 @@ describe('resolveActingUser', () => {
       })
     ).toBe('frank');
   });
+
+  it('rejects usernames longer than the audit-field cap and falls through', () => {
+    // 256-char username triggers the >255 reject; the proxy header takes
+    // over so audit attribution still has a real signal.
+    const tooLong = 'a'.repeat(256);
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: tooLong } },
+        headers: { 'x-proxy-user': 'fallback-from-overflow' },
+      })
+    ).toBe('fallback-from-overflow');
+  });
+
+  it('accepts a 255-char username at the cap', () => {
+    const atCap = 'a'.repeat(255);
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: atCap } },
+      })
+    ).toBe(atCap);
+  });
+
+  it('rejects usernames containing C0 control chars (log-injection / response-splitting vectors)', () => {
+    // CRLF + null byte + DEL — each rejected; falls through to 'unknown'
+    // when there is no other signal.
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: 'alice\r\nSet-Cookie: x=y' } },
+        headers: {},
+      })
+    ).toBe('unknown');
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: 'bob\x00admin' } },
+      })
+    ).toBe('unknown');
+    expect(
+      resolveActingUser({
+        headers: { 'x-proxy-user': 'mallory\x7f' },
+      })
+    ).toBe('unknown');
+  });
+
+  it('falls through to a clean header when the credential carries control chars', () => {
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: 'alice\nINJECT' } },
+        headers: { 'x-proxy-user': 'clean-fallback' },
+      })
+    ).toBe('clean-fallback');
+  });
+
+  it('accepts realistic non-ASCII username shapes (LDAP DN, email, Unicode) — only control chars are banned', () => {
+    expect(
+      resolveActingUser({
+        auth: {
+          isAuthenticated: true,
+          credentials: { username: 'CN=Alice,OU=Users,DC=example,DC=com' },
+        },
+      })
+    ).toBe('CN=Alice,OU=Users,DC=example,DC=com');
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: 'alice@example.com' } },
+      })
+    ).toBe('alice@example.com');
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: 'アリス' } },
+      })
+    ).toBe('アリス');
+  });
 });
 
 describe('resolveWorkspaceId', () => {

--- a/server/routes/slo/__tests__/resolve_request.test.ts
+++ b/server/routes/slo/__tests__/resolve_request.test.ts
@@ -178,6 +178,61 @@ describe('resolveActingUser', () => {
     ).toBe('alice');
     expect(debug).not.toHaveBeenCalled();
   });
+
+  it('rejects usernames containing C1 control chars (NEL, escape sequences)', () => {
+    // 0x85 is NEL — a line-break treated by some pipelines as equivalent
+    // to LF. 0x9b is CSI. Both belong to the C1 control block (0x80-0x9f).
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: 'alice\x85INJECT' } },
+      })
+    ).toBe('unknown');
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: 'bob\x9bsomething' } },
+      })
+    ).toBe('unknown');
+  });
+
+  it('emits a debug log per sanitize-rejection so forensics can correlate the bad header', () => {
+    const debug = jest.fn();
+    // Inject CRLF in the credential, then a too-long proxy header, then
+    // a clean forwarded-user. Expect: two debug lines (one per rejected
+    // step), no fallthrough log (the third step succeeds).
+    expect(
+      resolveActingUser(
+        {
+          auth: { isAuthenticated: true, credentials: { username: 'alice\r\nINJECT' } },
+          headers: {
+            'x-proxy-user': 'a'.repeat(256),
+            'x-forwarded-user': 'good-user',
+          },
+        },
+        { debug }
+      )
+    ).toBe('good-user');
+    expect(debug).toHaveBeenCalledTimes(2);
+    expect(debug.mock.calls[0][0]).toMatch(
+      /auth\.credentials\.username rejected \(control-chars\)/
+    );
+    expect(debug.mock.calls[1][0]).toMatch(/x-proxy-user rejected \(too-long\)/);
+  });
+
+  it('does NOT log when a candidate is just empty/whitespace (would be log spam)', () => {
+    const debug = jest.fn();
+    expect(
+      resolveActingUser(
+        {
+          auth: { isAuthenticated: true, credentials: { username: '' } },
+          headers: { 'x-proxy-user': '   ', 'x-forwarded-user': 'final' },
+        },
+        { debug }
+      )
+    ).toBe('final');
+    // No reject lines for the empty/whitespace candidates; no fallthrough
+    // line (succeeded on the third step).
+    expect(debug).not.toHaveBeenCalled();
+  });
 });
 
 describe('resolveWorkspaceId', () => {

--- a/server/routes/slo/__tests__/resolve_request.test.ts
+++ b/server/routes/slo/__tests__/resolve_request.test.ts
@@ -179,6 +179,22 @@ describe('resolveActingUser', () => {
     expect(debug).not.toHaveBeenCalled();
   });
 
+  it('rejects usernames containing Unicode line/paragraph separators (U+2028, U+2029)', () => {
+    // U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) are
+    // line-terminators in JS source and a few logging pipelines —
+    // outside the C0/C1 ranges so they need an explicit ban.
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: 'alice\u2028INJECT' } },
+      })
+    ).toBe('unknown');
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: 'bob\u2029PARA' } },
+      })
+    ).toBe('unknown');
+  });
+
   it('rejects usernames containing C1 control chars (NEL, escape sequences)', () => {
     // 0x85 is NEL — a line-break treated by some pipelines as equivalent
     // to LF. 0x9b is CSI. Both belong to the C1 control block (0x80-0x9f).

--- a/server/routes/slo/__tests__/resolve_request.test.ts
+++ b/server/routes/slo/__tests__/resolve_request.test.ts
@@ -160,6 +160,24 @@ describe('resolveActingUser', () => {
       })
     ).toBe('アリス');
   });
+
+  it('emits a debug log when falling through to "unknown" so operators can confirm the chain was walked', () => {
+    const debug = jest.fn();
+    expect(resolveActingUser({}, { debug })).toBe('unknown');
+    expect(debug).toHaveBeenCalledTimes(1);
+    expect(debug.mock.calls[0][0]).toMatch(/no signal in auth credentials or proxy headers/);
+  });
+
+  it('does NOT log when a candidate is found (debug noise stays bounded)', () => {
+    const debug = jest.fn();
+    expect(
+      resolveActingUser(
+        { auth: { isAuthenticated: true, credentials: { username: 'alice' } } },
+        { debug }
+      )
+    ).toBe('alice');
+    expect(debug).not.toHaveBeenCalled();
+  });
 });
 
 describe('resolveWorkspaceId', () => {

--- a/server/routes/slo/__tests__/resolve_request.test.ts
+++ b/server/routes/slo/__tests__/resolve_request.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for the per-request resolvers PR 2 introduces:
+ *   - `resolveActingUser` — picks the audit `createdBy` / `updatedBy` from the
+ *     security plugin's auth credentials, falling back to proxy headers, then
+ *     to `'unknown'`.
+ *   - `resolveWorkspaceId` — pulls the workspace id off OSD's request scope
+ *     via `getWorkspaceState`, falls back to `'default'` when workspaces are
+ *     disabled, and rejects malformed ids by throwing `SloValidationError`
+ *     so the route layer can return 400 instead of leaking the value into
+ *     `sloRulerNamespaceFor`.
+ */
+
+import { httpServerMock } from '../../../../../../src/core/server/mocks';
+import { updateWorkspaceState } from '../../../../../../src/core/server/utils';
+import { SloValidationError } from '../../../../common/slo/slo_service';
+import { resolveActingUser, resolveWorkspaceId } from '../index';
+
+describe('resolveActingUser', () => {
+  it('prefers req.auth.credentials.username when populated by the security plugin', () => {
+    const req = {
+      auth: { isAuthenticated: true, credentials: { username: 'alice' } },
+      headers: { 'x-proxy-user': 'should-not-be-picked' },
+    };
+    expect(resolveActingUser(req)).toBe('alice');
+  });
+
+  it('falls back to x-proxy-user when auth credentials are absent', () => {
+    const req = {
+      auth: { isAuthenticated: false },
+      headers: { 'x-proxy-user': 'bob' },
+    };
+    expect(resolveActingUser(req)).toBe('bob');
+  });
+
+  it('falls back to x-forwarded-user when both auth and x-proxy-user are absent', () => {
+    const req = { headers: { 'x-forwarded-user': 'carol' } };
+    expect(resolveActingUser(req)).toBe('carol');
+  });
+
+  it('returns "unknown" when no signal is available', () => {
+    expect(resolveActingUser({})).toBe('unknown');
+    expect(resolveActingUser({ headers: {} })).toBe('unknown');
+    expect(resolveActingUser({ auth: { isAuthenticated: false } })).toBe('unknown');
+  });
+
+  it('ignores empty / whitespace usernames so a malformed credential does not get persisted', () => {
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: '   ' } },
+        headers: { 'x-proxy-user': 'fallback' },
+      })
+    ).toBe('fallback');
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: '' } },
+        headers: {},
+      })
+    ).toBe('unknown');
+  });
+
+  it('treats non-string usernames as missing (defends against type drift in security creds)', () => {
+    expect(
+      resolveActingUser({
+        // simulate a security plugin variant that returns a structured credential
+        auth: { isAuthenticated: true, credentials: { username: { id: 42 } as unknown } },
+        headers: {},
+      })
+    ).toBe('unknown');
+  });
+
+  it('handles array-valued headers (multi-valued forwarded-user) by picking the first non-empty entry', () => {
+    expect(
+      resolveActingUser({
+        headers: { 'x-forwarded-user': ['', '   ', 'dave', 'edna'] as string[] },
+      })
+    ).toBe('dave');
+  });
+
+  it('trims surrounding whitespace from the resolved name', () => {
+    expect(
+      resolveActingUser({
+        auth: { isAuthenticated: true, credentials: { username: '  frank ' } },
+      })
+    ).toBe('frank');
+  });
+});
+
+describe('resolveWorkspaceId', () => {
+  it('returns the workspace id off the request scope when populated', () => {
+    const req = httpServerMock.createOpenSearchDashboardsRequest();
+    updateWorkspaceState(req, { requestWorkspaceId: 'team-a' });
+    expect(resolveWorkspaceId(req)).toBe('team-a');
+  });
+
+  it('falls back to "default" when the workspace state is unset (workspaces disabled)', () => {
+    const req = httpServerMock.createOpenSearchDashboardsRequest();
+    expect(resolveWorkspaceId(req)).toBe('default');
+  });
+
+  it('throws SloValidationError on a malformed workspace id (path traversal)', () => {
+    const req = httpServerMock.createOpenSearchDashboardsRequest();
+    updateWorkspaceState(req, { requestWorkspaceId: '../etc/passwd' });
+    expect(() => resolveWorkspaceId(req)).toThrow(SloValidationError);
+  });
+
+  it('throws SloValidationError on a workspace id with URL-special characters', () => {
+    const req = httpServerMock.createOpenSearchDashboardsRequest();
+    updateWorkspaceState(req, { requestWorkspaceId: 'team a/b' });
+    expect(() => resolveWorkspaceId(req)).toThrow(SloValidationError);
+  });
+
+  it('throws SloValidationError when the workspace id is too long for the regex cap', () => {
+    const req = httpServerMock.createOpenSearchDashboardsRequest();
+    updateWorkspaceState(req, { requestWorkspaceId: 'a'.repeat(64) });
+    expect(() => resolveWorkspaceId(req)).toThrow(SloValidationError);
+  });
+
+  it('the SloValidationError carries a workspaceId field key so the wizard can attribute the 400', () => {
+    const req = httpServerMock.createOpenSearchDashboardsRequest();
+    updateWorkspaceState(req, { requestWorkspaceId: '../traversal' });
+    let captured: unknown;
+    try {
+      resolveWorkspaceId(req);
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(SloValidationError);
+    expect((captured as SloValidationError).errors).toHaveProperty('workspaceId');
+  });
+
+  it('accepts the documented charset (alphanumerics, underscore, hyphen)', () => {
+    const req = httpServerMock.createOpenSearchDashboardsRequest();
+    updateWorkspaceState(req, { requestWorkspaceId: 'Workspace_123-prod' });
+    expect(resolveWorkspaceId(req)).toBe('Workspace_123-prod');
+  });
+});

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -14,13 +14,23 @@
  */
 
 import { schema } from '@osd/config-schema';
-import type { IRouter, Logger, RequestHandlerContext } from '../../../../../src/core/server';
+import type {
+  IRouter,
+  Logger,
+  OpenSearchDashboardsRequest,
+  RequestHandlerContext,
+} from '../../../../../src/core/server';
+import { getWorkspaceState } from '../../../../../src/core/server/utils';
 import { OBSERVABILITY_BASE } from '../../../common/constants/shared';
 import type {
   SloDeployContext,
   SloStatusAggregationContext,
 } from '../../../common/slo/slo_service';
-import { SloService, SloValidationError } from '../../../common/slo/slo_service';
+import {
+  SloService,
+  SloValidationError,
+  sloRulerNamespaceFor,
+} from '../../../common/slo/slo_service';
 import type { AlertingOSClient, Datasource } from '../../../common/types/alerting';
 import { SavedObjectDatasourceService } from '../../services/alerting/saved_object_datasource_service';
 import type { RulerClient } from '../../services/slo/ruler_client';
@@ -302,17 +312,92 @@ const previewBody = schema.object({
 // ============================================================================
 
 /**
- * FIXME(pr-2): extract the acting user from the request (OpenSearch
- * security plugin exposes it via `req.auth`, or the `securitytenant` /
- * `Authorization` headers when the plugin is disabled). PR 1 stamps a
- * sentinel so audit rows can be re-attributed once the resolver lands —
- * every mutation's createdBy / updatedBy comes through here.
+ * Pull a single string from a header value that may be a string, an array
+ * (multi-valued header), or undefined. Trims and rejects empty strings so
+ * a `''` header doesn't get stamped as the acting user.
  */
-const SLO_ACTING_USER_PLACEHOLDER = 'osd-user';
-function resolveActingUser(_req: {
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    for (const v of value) {
+      const trimmed = typeof v === 'string' ? v.trim() : '';
+      if (trimmed) return trimmed;
+    }
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the acting user for audit fields (`createdBy` / `updatedBy`).
+ *
+ * Lookup order:
+ *   1. `req.auth.credentials.username` — populated by the OpenSearch
+ *      security plugin's auth handler when installed.
+ *   2. `x-proxy-user` request header — set by SAML / proxy auth setups.
+ *   3. `x-forwarded-user` request header — set by reverse proxies that
+ *      front the cluster.
+ *   4. `'unknown'` — when no signal is available (security plugin
+ *      disabled, no proxy, anonymous request).
+ *
+ * The header names mirror the `auth.unsupported_trusted_header` config the
+ * security plugin documents, so deployments that already use one of those
+ * proxy auth modes get the right `createdBy` for free.
+ */
+export function resolveActingUser(req: {
+  auth?: { isAuthenticated?: boolean; credentials?: { username?: unknown } };
   headers?: Record<string, string | string[] | undefined>;
 }): string {
-  return SLO_ACTING_USER_PLACEHOLDER;
+  const credentials = req.auth?.credentials;
+  const username = credentials && (credentials as { username?: unknown }).username;
+  if (typeof username === 'string' && username.trim().length > 0) {
+    return username.trim();
+  }
+  const headers = req.headers ?? {};
+  const proxyUser = firstHeaderValue(headers['x-proxy-user']);
+  if (proxyUser) return proxyUser;
+  const forwardedUser = firstHeaderValue(headers['x-forwarded-user']);
+  if (forwardedUser) return forwardedUser;
+  return 'unknown';
+}
+
+// ============================================================================
+// Workspace id
+// ============================================================================
+
+/**
+ * Resolve the workspace id for the request.
+ *
+ * - When OSD workspaces are enabled, `getWorkspaceState(req).requestWorkspaceId`
+ *   carries the id off the request scope (set by the workspace plugin's
+ *   `onPreRouting` handler).
+ * - When workspaces are disabled (a supported deployment mode) the value is
+ *   absent and we fall through to `'default'` — matching the service-layer
+ *   contract that `effectiveWorkspaceId = spec.workspaceId ?? 'default'`.
+ *
+ * The result is then validated against `sloRulerNamespaceFor`'s shape check
+ * so a malformed id (path traversal, URL-special chars, overlong, empty)
+ * surfaces as a 400 rather than a 500 deep inside ruler dispatch. The
+ * AMP invariant — every rule group for workspace W lives in
+ * `slo-generated-<W>` — depends on this gate being the only path the
+ * value can take to reach the ruler.
+ */
+export function resolveWorkspaceId(req: OpenSearchDashboardsRequest): string {
+  const fromState = getWorkspaceState(req).requestWorkspaceId;
+  const candidate = typeof fromState === 'string' && fromState.length > 0 ? fromState : 'default';
+  // Throws Error on shape failure; we re-cast to SloValidationError so
+  // routes can fall through the existing 400 envelope.
+  try {
+    sloRulerNamespaceFor(candidate);
+  } catch (_e) {
+    throw new SloValidationError({
+      workspaceId: `Workspace id "${candidate}" is not valid for SLO routing. Workspace ids must match /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$/.`,
+    });
+  }
+  return candidate;
 }
 
 // ============================================================================
@@ -329,15 +414,15 @@ function resolveActingUser(_req: {
  * resolve it to a DirectQuery-Prometheus datasource, throws
  * SloValidationError so the route responds 400 with a field-keyed message.
  *
- * `workspaceId` resolution: for now we use `'default'` since OSD workspace
- * context isn't plumbed onto the deploy context. A follow-up PR will pull
- * the real workspace id from the request scope; the AMP invariant (every
- * rule group for workspace W writes to `slo-generated-<W>`) already resolves
- * through `sloRulerNamespaceFor(workspaceId)` so the change is isolated to
- * this one call site.
+ * `workspaceId` is resolved from request scope (`getWorkspaceState`) before
+ * this function is called and validated through `sloRulerNamespaceFor`'s
+ * regex. The AMP invariant — every rule group for workspace W writes to
+ * `slo-generated-<W>` — depends on this validation having already happened
+ * before any value reaches the ruler.
  */
 async function buildDeployContext(
   ctx: SloHandlerContext,
+  workspaceId: string,
   datasourceId: string | undefined,
   rulerClient: RulerClient | undefined,
   logger: Logger
@@ -372,22 +457,13 @@ async function buildDeployContext(
     ruler: rulerClient,
     client,
     datasource: ds as Datasource,
-    // FIXME(pr-2): this is the single site where PR 1 hard-codes the
-    // deploy-context workspace id. PR 2 will resolve the real workspace
-    // from OSD's request scope (`core.workspace.resolveRequest(req)`) and
-    // may refuse the write when the workspace isn't resolvable. The
-    // service layer already threads the value through `sloRulerNamespaceFor`
-    // so the AMP invariant ("every rule group for workspace W writes to
-    // `slo-generated-<W>`") holds regardless of how this value was
-    // obtained; PR 1 ships the plumbing, PR 2 ships the resolver. See the
-    // cross-workspace integration test for the invariant's service-layer
-    // contract (`common/slo/__tests__/slo_workspace_isolation.integration.test.ts`).
-    workspaceId: 'default',
+    workspaceId,
   };
 }
 
 async function tryBuildDeployContext(
   ctx: SloHandlerContext,
+  req: OpenSearchDashboardsRequest,
   datasourceId: string | undefined,
   rulerClient: RulerClient | undefined,
   logger: Logger
@@ -396,7 +472,8 @@ async function tryBuildDeployContext(
   | { deploy?: undefined; errorResponse: { status: number; body: Record<string, unknown> } }
 > {
   try {
-    const deploy = await buildDeployContext(ctx, datasourceId, rulerClient, logger);
+    const workspaceId = resolveWorkspaceId(req);
+    const deploy = await buildDeployContext(ctx, workspaceId, datasourceId, rulerClient, logger);
     return { deploy };
   } catch (e) {
     if (e instanceof SloValidationError) {
@@ -413,6 +490,7 @@ async function tryBuildDeployContext(
 
 function buildStatusContext(
   ctx: SloHandlerContext,
+  workspaceId: string,
   logger: Logger,
   ruleDedupEnabled?: boolean
 ): SloStatusAggregationContext | undefined {
@@ -420,10 +498,7 @@ function buildStatusContext(
   const datasourceService = new SavedObjectDatasourceService(ctx.core.savedObjects.client, logger);
   return {
     client,
-    // FIXME(pr-2): same as `buildDeployContext` — workspace id is hard-
-    // coded to 'default' in PR 1 and will be resolved from request scope
-    // in PR 2. Listing/status paths are read-only today; safe placeholder.
-    workspaceId: 'default',
+    workspaceId,
     resolveDatasource: async (datasourceId: string) => {
       const ds = await datasourceService.get(datasourceId);
       if (!ds) return undefined;
@@ -431,6 +506,31 @@ function buildStatusContext(
     },
     ruleDedupEnabled,
   };
+}
+
+/**
+ * Resolve the workspace id for read-only routes (list / get / statuses).
+ * On a malformed workspace id we return the same 400 envelope as a write
+ * route so the wizard / listing UI gets a consistent error shape.
+ */
+function tryResolveWorkspaceId(
+  req: OpenSearchDashboardsRequest
+):
+  | { workspaceId: string; errorResponse?: undefined }
+  | { workspaceId?: undefined; errorResponse: { status: number; body: Record<string, unknown> } } {
+  try {
+    return { workspaceId: resolveWorkspaceId(req) };
+  } catch (e) {
+    if (e instanceof SloValidationError) {
+      return {
+        errorResponse: {
+          status: 400,
+          body: { error: 'Validation failed', errors: e.errors },
+        },
+      };
+    }
+    throw e;
+  }
 }
 
 // ============================================================================
@@ -511,7 +611,24 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
         mode: q.mode ? (q.mode.split(',') as Array<'active' | 'shadow'>) : undefined,
         search: q.search,
       };
-      const statusCtx = buildStatusContext(ctx as SloHandlerContext, logger, ruleDedupEnabled);
+      const wsResolved = tryResolveWorkspaceId(req);
+      if (wsResolved.errorResponse) {
+        return res.customError({
+          statusCode: wsResolved.errorResponse.status,
+          body: {
+            message: String(
+              (wsResolved.errorResponse.body as { error?: string }).error ?? 'Failed'
+            ),
+            attributes: wsResolved.errorResponse.body,
+          },
+        });
+      }
+      const statusCtx = buildStatusContext(
+        ctx as SloHandlerContext,
+        wsResolved.workspaceId,
+        logger,
+        ruleDedupEnabled
+      );
       const result = await handleListSLOs(sloService, filters, logger, statusCtx);
       if (result.status >= 400) {
         return res.customError({
@@ -529,6 +646,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
   router.post({ path: SLO_BASE, validate: { body: createBody } }, async (ctx, req, res) => {
     const built = await tryBuildDeployContext(
       ctx as SloHandlerContext,
+      req,
       req.body?.spec?.datasourceId,
       rulerClient,
       logger
@@ -582,7 +700,24 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
       validate: { body: schema.object({ ids: schema.arrayOf(schema.string()) }) },
     },
     async (ctx, req, res) => {
-      const statusCtx = buildStatusContext(ctx as SloHandlerContext, logger, ruleDedupEnabled);
+      const wsResolved = tryResolveWorkspaceId(req);
+      if (wsResolved.errorResponse) {
+        return res.customError({
+          statusCode: wsResolved.errorResponse.status,
+          body: {
+            message: String(
+              (wsResolved.errorResponse.body as { error?: string }).error ?? 'Failed'
+            ),
+            attributes: wsResolved.errorResponse.body,
+          },
+        });
+      }
+      const statusCtx = buildStatusContext(
+        ctx as SloHandlerContext,
+        wsResolved.workspaceId,
+        logger,
+        ruleDedupEnabled
+      );
       const result = await handleGetSLOStatuses(sloService, req.body.ids, logger, statusCtx);
       if (result.status === 200) return res.ok({ body: result.body });
       return res.customError({
@@ -601,7 +736,24 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
       validate: { params: schema.object({ id: schema.string() }) },
     },
     async (ctx, req, res) => {
-      const statusCtx = buildStatusContext(ctx as SloHandlerContext, logger, ruleDedupEnabled);
+      const wsResolved = tryResolveWorkspaceId(req);
+      if (wsResolved.errorResponse) {
+        return res.customError({
+          statusCode: wsResolved.errorResponse.status,
+          body: {
+            message: String(
+              (wsResolved.errorResponse.body as { error?: string }).error ?? 'Not found'
+            ),
+            attributes: wsResolved.errorResponse.body,
+          },
+        });
+      }
+      const statusCtx = buildStatusContext(
+        ctx as SloHandlerContext,
+        wsResolved.workspaceId,
+        logger,
+        ruleDedupEnabled
+      );
       const result = await handleGetSLO(sloService, req.params.id, logger, statusCtx);
       if (result.status === 200) return res.ok({ body: result.body });
       return res.customError({
@@ -626,6 +778,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
       const existing = await sloService.get(req.params.id);
       const built = await tryBuildDeployContext(
         ctx as SloHandlerContext,
+        req,
         existing?.spec.datasourceId,
         rulerClient,
         logger
@@ -669,6 +822,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
       const existing = await sloService.get(req.params.id);
       const built = await tryBuildDeployContext(
         ctx as SloHandlerContext,
+        req,
         existing?.spec.datasourceId,
         rulerClient,
         logger
@@ -712,6 +866,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
       const existing = await sloService.get(req.params.id);
       const built = await tryBuildDeployContext(
         ctx as SloHandlerContext,
+        req,
         existing?.spec.datasourceId,
         rulerClient,
         logger
@@ -754,6 +909,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
       const existing = await sloService.get(req.params.id);
       const built = await tryBuildDeployContext(
         ctx as SloHandlerContext,
+        req,
         existing?.spec.datasourceId,
         rulerClient,
         logger

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -379,10 +379,13 @@ function sanitizeActingUser(raw: string): string | null {
   return trimmed;
 }
 
-export function resolveActingUser(req: {
-  auth?: { isAuthenticated?: boolean; credentials?: { username?: unknown } };
-  headers?: Record<string, string | string[] | undefined>;
-}): string {
+export function resolveActingUser(
+  req: {
+    auth?: { isAuthenticated?: boolean; credentials?: { username?: unknown } };
+    headers?: Record<string, string | string[] | undefined>;
+  },
+  logger?: Pick<Logger, 'debug'>
+): string {
   // We deliberately do NOT gate on `auth.isAuthenticated`: proxy-auth
   // deployments populate `credentials.username` without establishing a
   // security session, and we'd rather audit-attribute those writes to the
@@ -409,6 +412,14 @@ export function resolveActingUser(req: {
     const cleaned = sanitizeActingUser(forwardedUser);
     if (cleaned) return cleaned;
   }
+  // Debug-level (not warn): legitimately anonymous-write deployments
+  // exist (security plugin disabled, no proxy auth) and would otherwise
+  // pollute warn-level logs on every create/update. The signal is here
+  // so operators investigating "why is everything 'unknown'?" can flip
+  // log level and confirm the chain is being walked.
+  logger?.debug(
+    'resolveActingUser: no signal in auth credentials or proxy headers; using "unknown"'
+  );
   return 'unknown';
 }
 
@@ -718,7 +729,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
     const result = await handleCreateSLO(
       sloService,
       req.body,
-      resolveActingUser(req),
+      resolveActingUser(req, logger),
       logger,
       built.deploy
     );
@@ -851,7 +862,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
         sloService,
         req.params.id,
         req.body,
-        resolveActingUser(req),
+        resolveActingUser(req, logger),
         logger,
         built.deploy
       );
@@ -938,7 +949,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
       const result = await handleEnableSLO(
         sloService,
         req.params.id,
-        resolveActingUser(req),
+        resolveActingUser(req, logger),
         logger,
         built.deploy
       );
@@ -981,7 +992,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
       const result = await handleDisableSLO(
         sloService,
         req.params.id,
-        resolveActingUser(req),
+        resolveActingUser(req, logger),
         logger,
         built.deploy
       );

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -351,6 +351,10 @@ export function resolveActingUser(req: {
   auth?: { isAuthenticated?: boolean; credentials?: { username?: unknown } };
   headers?: Record<string, string | string[] | undefined>;
 }): string {
+  // We deliberately do NOT gate on `auth.isAuthenticated`: proxy-auth
+  // deployments populate `credentials.username` without establishing a
+  // security session, and we'd rather audit-attribute those writes to the
+  // proxied user than fall through to a header read or to 'unknown'.
   const credentials = req.auth?.credentials;
   const username = credentials && (credentials as { username?: unknown }).username;
   if (typeof username === 'string' && username.trim().length > 0) {
@@ -389,12 +393,17 @@ export function resolveWorkspaceId(req: OpenSearchDashboardsRequest): string {
   const fromState = getWorkspaceState(req).requestWorkspaceId;
   const candidate = typeof fromState === 'string' && fromState.length > 0 ? fromState : 'default';
   // Throws Error on shape failure; we re-cast to SloValidationError so
-  // routes can fall through the existing 400 envelope.
+  // routes can fall through the existing 400 envelope. Don't echo the
+  // candidate value back in the user-visible message — `requestWorkspaceId`
+  // is set from the URL path (`/w/<x>`) so it's user-controllable, and
+  // reflecting an arbitrary string into the response body invites
+  // log-injection / response-splitting style mischief.
   try {
     sloRulerNamespaceFor(candidate);
   } catch (_e) {
     throw new SloValidationError({
-      workspaceId: `Workspace id "${candidate}" is not valid for SLO routing. Workspace ids must match /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$/.`,
+      workspaceId:
+        'Workspace id is not valid for SLO routing. Workspace ids must match /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$/.',
     });
   }
   return candidate;

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -360,8 +360,14 @@ const ACTING_USER_MAX_LENGTH = 255;
  * can emit a structured debug log per rejection — preserves forensic
  * signal when a malicious proxy injects values that get sanitized away
  * (otherwise the chain falls through to `'unknown'` with no trail).
+ *
+ * `'empty'` is semantically distinct from the security rejections — it's
+ * "this slot wasn't populated", which is the common case for an unset
+ * header. The caller (`tryResolveActingUser`) suppresses logging for
+ * `'empty'` to keep debug noise bounded; the other reasons always log
+ * since they signal either a misconfigured proxy or an injection attempt.
  */
-type SanitizeRejectReason = 'too-long' | 'control-chars';
+type SanitizeRejectReason = 'empty' | 'too-long' | 'control-chars';
 
 /**
  * Sanitize a candidate username before it lands in the audit fields.
@@ -388,11 +394,13 @@ function sanitizeActingUser(
   raw: string
 ): { ok: true; value: string } | { ok: false; reason: SanitizeRejectReason } {
   const trimmed = raw.trim();
-  // Empty / whitespace-only is treated as "no signal" rather than a
+  // Empty / whitespace-only is "no signal" rather than a security
   // rejection — every fallback in the chain calls this with a possibly-
-  // empty header value, and we don't want to flood the debug log with
-  // "header was empty" lines.
-  if (trimmed.length === 0) return { ok: false, reason: 'control-chars' };
+  // empty header value. The dedicated `'empty'` reason keeps debug logs
+  // accurate (vs. earlier code that misreported these as `'control-chars'`)
+  // and the caller suppresses the log line for `'empty'` so we don't
+  // flood logs on every unset header.
+  if (trimmed.length === 0) return { ok: false, reason: 'empty' };
   if (trimmed.length > ACTING_USER_MAX_LENGTH) return { ok: false, reason: 'too-long' };
   if (/[\x00-\x1f\x7f-\x9f]/.test(trimmed)) return { ok: false, reason: 'control-chars' };
   return { ok: true, value: trimmed };
@@ -410,11 +418,14 @@ function tryResolveActingUser(
   logger?: Pick<Logger, 'debug'>
 ): string | null {
   if (raw === undefined) return null;
-  // Empty/whitespace doesn't get a log line — see sanitizeActingUser.
-  if (raw.trim().length === 0) return null;
   const result = sanitizeActingUser(raw);
   if (result.ok) return result.value;
-  logger?.debug(`resolveActingUser: ${source} rejected (${result.reason}); falling through`);
+  // `'empty'` is the unset-header case — common, expected, not worth a
+  // log line per request. Other reasons (`'too-long'`, `'control-chars'`)
+  // signal a misconfigured or hostile proxy and always log.
+  if (result.reason !== 'empty') {
+    logger?.debug(`resolveActingUser: ${source} rejected (${result.reason}); falling through`);
+  }
   return null;
 }
 

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -356,27 +356,66 @@ function firstHeaderValue(value: string | string[] | undefined): string | undefi
 const ACTING_USER_MAX_LENGTH = 255;
 
 /**
+ * Reason a candidate username was rejected. Surfaced to the caller so it
+ * can emit a structured debug log per rejection — preserves forensic
+ * signal when a malicious proxy injects values that get sanitized away
+ * (otherwise the chain falls through to `'unknown'` with no trail).
+ */
+type SanitizeRejectReason = 'too-long' | 'control-chars';
+
+/**
  * Sanitize a candidate username before it lands in the audit fields.
  *
- * - Returns `null` when the value contains C0 control chars or DEL — those
- *   are the realistic injection vectors (log injection, CRLF response
- *   splitting). We reject rather than strip so the caller's fallback chain
- *   keeps working.
- * - Returns `null` when the length exceeds `ACTING_USER_MAX_LENGTH` rather
- *   than silently truncating, since truncation could collapse two distinct
+ * Returns the trimmed value when accepted, or a rejection reason. The
+ * caller maps reasons to debug-level logs.
+ *
+ * - `too-long`: length exceeds `ACTING_USER_MAX_LENGTH`. We reject rather
+ *   than truncate, since truncation could collapse two distinct
  *   identities to the same prefix.
- * - Returns the trimmed value otherwise. Realistic usernames span email
- *   (`alice@example.com`), LDAP DN (`CN=Alice,OU=Users,DC=example,DC=com`),
- *   and Unicode forms; we deliberately don't impose a character allow-list
- *   beyond the control-char ban so deployments that use any of those don't
- *   silently fall through to `'unknown'`.
+ * - `control-chars`: contains C0 (0x00–0x1f), DEL (0x7f), or C1
+ *   (0x80–0x9f) control characters. These are the realistic injection
+ *   vectors (log injection, CRLF response splitting, NEL line breaks).
+ *   We reject rather than strip so the caller's fallback chain keeps
+ *   working when a misconfigured proxy injects junk.
+ *
+ * Realistic usernames span email (`alice@example.com`), LDAP DN
+ * (`CN=Alice,OU=Users,DC=example,DC=com`), and Unicode forms; we
+ * deliberately don't impose a character allow-list beyond the
+ * control-char ban so deployments that use any of those don't silently
+ * fall through to `'unknown'`.
  */
-function sanitizeActingUser(raw: string): string | null {
+function sanitizeActingUser(
+  raw: string
+): { ok: true; value: string } | { ok: false; reason: SanitizeRejectReason } {
   const trimmed = raw.trim();
-  if (trimmed.length === 0) return null;
-  if (trimmed.length > ACTING_USER_MAX_LENGTH) return null;
-  if (/[\x00-\x1f\x7f]/.test(trimmed)) return null;
-  return trimmed;
+  // Empty / whitespace-only is treated as "no signal" rather than a
+  // rejection — every fallback in the chain calls this with a possibly-
+  // empty header value, and we don't want to flood the debug log with
+  // "header was empty" lines.
+  if (trimmed.length === 0) return { ok: false, reason: 'control-chars' };
+  if (trimmed.length > ACTING_USER_MAX_LENGTH) return { ok: false, reason: 'too-long' };
+  if (/[\x00-\x1f\x7f-\x9f]/.test(trimmed)) return { ok: false, reason: 'control-chars' };
+  return { ok: true, value: trimmed };
+}
+
+/**
+ * Try one step of the resolveActingUser fallback chain. Logs at debug
+ * level when sanitization rejects a non-empty candidate so operators can
+ * correlate "everything's `unknown`" with the proxy header that
+ * caused it.
+ */
+function tryResolveActingUser(
+  raw: string | undefined,
+  source: string,
+  logger?: Pick<Logger, 'debug'>
+): string | null {
+  if (raw === undefined) return null;
+  // Empty/whitespace doesn't get a log line — see sanitizeActingUser.
+  if (raw.trim().length === 0) return null;
+  const result = sanitizeActingUser(raw);
+  if (result.ok) return result.value;
+  logger?.debug(`resolveActingUser: ${source} rejected (${result.reason}); falling through`);
+  return null;
 }
 
 export function resolveActingUser(
@@ -391,27 +430,24 @@ export function resolveActingUser(
   // security session, and we'd rather audit-attribute those writes to the
   // proxied user than fall through to a header read or to 'unknown'.
   //
-  // Each candidate runs through `sanitizeActingUser`, which rejects
-  // control chars + caps length. A rejected candidate falls through to the
-  // next step rather than aborting — a misconfigured proxy that injects a
-  // junk header shouldn't poison legitimate auth credentials.
+  // Each candidate runs through `sanitizeActingUser` (length cap + C0/C1
+  // control-char ban). A rejected candidate falls through to the next
+  // step rather than aborting — a misconfigured proxy that injects a
+  // junk header shouldn't poison legitimate auth credentials. Rejections
+  // are logged at debug level so a forensics pass can find them.
   const credentials = req.auth?.credentials;
   const username = credentials && (credentials as { username?: unknown }).username;
   if (typeof username === 'string') {
-    const cleaned = sanitizeActingUser(username);
+    const cleaned = tryResolveActingUser(username, 'auth.credentials.username', logger);
     if (cleaned) return cleaned;
   }
   const headers = req.headers ?? {};
   const proxyUser = firstHeaderValue(headers['x-proxy-user']);
-  if (proxyUser) {
-    const cleaned = sanitizeActingUser(proxyUser);
-    if (cleaned) return cleaned;
-  }
+  const cleanedProxy = tryResolveActingUser(proxyUser, 'x-proxy-user', logger);
+  if (cleanedProxy) return cleanedProxy;
   const forwardedUser = firstHeaderValue(headers['x-forwarded-user']);
-  if (forwardedUser) {
-    const cleaned = sanitizeActingUser(forwardedUser);
-    if (cleaned) return cleaned;
-  }
+  const cleanedForwarded = tryResolveActingUser(forwardedUser, 'x-forwarded-user', logger);
+  if (cleanedForwarded) return cleanedForwarded;
   // Debug-level (not warn): legitimately anonymous-write deployments
   // exist (security plugin disabled, no proxy auth) and would otherwise
   // pollute warn-level logs on every create/update. The signal is here

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -402,7 +402,14 @@ function sanitizeActingUser(
   // flood logs on every unset header.
   if (trimmed.length === 0) return { ok: false, reason: 'empty' };
   if (trimmed.length > ACTING_USER_MAX_LENGTH) return { ok: false, reason: 'too-long' };
-  if (/[\x00-\x1f\x7f-\x9f]/.test(trimmed)) return { ok: false, reason: 'control-chars' };
+  // C0 (0x00-0x1f) + DEL + C1 (0x7f-0x9f) cover ASCII-style injection
+  // vectors. Unicode line/paragraph separators (U+2028, U+2029) are also
+  // line-terminators in JavaScript and a few logging pipelines, so we
+  // ban them as the same class of vector — they're outside the C0/C1
+  // ranges so the regex needs them spelled out.
+  if (/[\x00-\x1f\x7f-\x9f\u2028\u2029]/.test(trimmed)) {
+    return { ok: false, reason: 'control-chars' };
+  }
   return { ok: true, value: trimmed };
 }
 

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -347,6 +347,38 @@ function firstHeaderValue(value: string | string[] | undefined): string | undefi
  * security plugin documents, so deployments that already use one of those
  * proxy auth modes get the right `createdBy` for free.
  */
+/**
+ * Cap on persisted `createdBy` / `updatedBy` length. The OpenSearch index
+ * mapping for these fields has its own bounds; this gate also closes off
+ * a payload-bloat vector where a malicious proxy injects a megabyte-scale
+ * header value into every audit row.
+ */
+const ACTING_USER_MAX_LENGTH = 255;
+
+/**
+ * Sanitize a candidate username before it lands in the audit fields.
+ *
+ * - Returns `null` when the value contains C0 control chars or DEL — those
+ *   are the realistic injection vectors (log injection, CRLF response
+ *   splitting). We reject rather than strip so the caller's fallback chain
+ *   keeps working.
+ * - Returns `null` when the length exceeds `ACTING_USER_MAX_LENGTH` rather
+ *   than silently truncating, since truncation could collapse two distinct
+ *   identities to the same prefix.
+ * - Returns the trimmed value otherwise. Realistic usernames span email
+ *   (`alice@example.com`), LDAP DN (`CN=Alice,OU=Users,DC=example,DC=com`),
+ *   and Unicode forms; we deliberately don't impose a character allow-list
+ *   beyond the control-char ban so deployments that use any of those don't
+ *   silently fall through to `'unknown'`.
+ */
+function sanitizeActingUser(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.length > ACTING_USER_MAX_LENGTH) return null;
+  if (/[\x00-\x1f\x7f]/.test(trimmed)) return null;
+  return trimmed;
+}
+
 export function resolveActingUser(req: {
   auth?: { isAuthenticated?: boolean; credentials?: { username?: unknown } };
   headers?: Record<string, string | string[] | undefined>;
@@ -355,16 +387,28 @@ export function resolveActingUser(req: {
   // deployments populate `credentials.username` without establishing a
   // security session, and we'd rather audit-attribute those writes to the
   // proxied user than fall through to a header read or to 'unknown'.
+  //
+  // Each candidate runs through `sanitizeActingUser`, which rejects
+  // control chars + caps length. A rejected candidate falls through to the
+  // next step rather than aborting — a misconfigured proxy that injects a
+  // junk header shouldn't poison legitimate auth credentials.
   const credentials = req.auth?.credentials;
   const username = credentials && (credentials as { username?: unknown }).username;
-  if (typeof username === 'string' && username.trim().length > 0) {
-    return username.trim();
+  if (typeof username === 'string') {
+    const cleaned = sanitizeActingUser(username);
+    if (cleaned) return cleaned;
   }
   const headers = req.headers ?? {};
   const proxyUser = firstHeaderValue(headers['x-proxy-user']);
-  if (proxyUser) return proxyUser;
+  if (proxyUser) {
+    const cleaned = sanitizeActingUser(proxyUser);
+    if (cleaned) return cleaned;
+  }
   const forwardedUser = firstHeaderValue(headers['x-forwarded-user']);
-  if (forwardedUser) return forwardedUser;
+  if (forwardedUser) {
+    const cleaned = sanitizeActingUser(forwardedUser);
+    if (cleaned) return cleaned;
+  }
   return 'unknown';
 }
 

--- a/server/services/slo/__tests__/ruler_client.test.ts
+++ b/server/services/slo/__tests__/ruler_client.test.ts
@@ -58,6 +58,7 @@ function promDatasource(overrides: Partial<Datasource> = {}): Datasource {
 function sampleGroup(): GeneratedRuleGroup {
   return {
     groupName: 'slo:checkout_api_availability_a1b2c3d4',
+    rulerNamespace: 'slo-generated-ws1',
     interval: 60,
     rules: [
       {
@@ -109,6 +110,7 @@ describe('ruleGroupToYaml', () => {
   it('omits labels/annotations when empty so the YAML is tidy', () => {
     const group: GeneratedRuleGroup = {
       groupName: 'g1',
+      rulerNamespace: 'slo-generated-default',
       interval: 60,
       rules: [
         {

--- a/server/services/slo/ruler_client.ts
+++ b/server/services/slo/ruler_client.ts
@@ -273,7 +273,7 @@ export class DirectQueryRulerClient implements RulerClient {
 
     const body = extractResponseBody(response);
     const parsed = parseYamlBody(body);
-    return coerceRuleGroupList(parsed);
+    return coerceRuleGroupList(parsed, namespace);
   }
 
   /**
@@ -459,7 +459,7 @@ function parseYamlBody(body: unknown): unknown {
  * Returns `null` when the input can't plausibly be a rule group so callers
  * can treat "unparseable" as "missing".
  */
-function coerceRuleGroup(doc: unknown): GeneratedRuleGroup | null {
+function coerceRuleGroup(doc: unknown, rulerNamespace: string): GeneratedRuleGroup | null {
   if (!doc || typeof doc !== 'object' || Array.isArray(doc)) return null;
   const record = doc as Record<string, unknown>;
   const name = record.name;
@@ -470,6 +470,7 @@ function coerceRuleGroup(doc: unknown): GeneratedRuleGroup | null {
 
   return {
     groupName: name,
+    rulerNamespace,
     interval: parseIntervalSeconds(record.interval),
     rules,
     yaml: '',
@@ -492,10 +493,10 @@ function isGeneratedRule(rule: GeneratedRule | null): rule is GeneratedRule {
  * reconciler (PR 5) would coerce the error to `[]` and start tearing
  * down rules it incorrectly thinks the ruler dropped.
  */
-function coerceRuleGroupList(doc: unknown): GeneratedRuleGroup[] {
+function coerceRuleGroupList(doc: unknown, rulerNamespace: string): GeneratedRuleGroup[] {
   if (!doc) return [];
   if (Array.isArray(doc)) {
-    return doc.map(coerceRuleGroup).filter(isGeneratedRuleGroup);
+    return doc.map((entry) => coerceRuleGroup(entry, rulerNamespace)).filter(isGeneratedRuleGroup);
   }
   if (typeof doc === 'object') {
     const record = doc as Record<string, unknown>;
@@ -515,7 +516,9 @@ function coerceRuleGroupList(doc: unknown): GeneratedRuleGroup[] {
     if (data && typeof data === 'object' && !Array.isArray(data)) {
       const groups = (data as Record<string, unknown>).groups;
       if (Array.isArray(groups)) {
-        return groups.map(coerceRuleGroup).filter(isGeneratedRuleGroup);
+        return groups
+          .map((entry) => coerceRuleGroup(entry, rulerNamespace))
+          .filter(isGeneratedRuleGroup);
       }
     }
     // Cortex namespace-keyed envelope: take every array-valued field and
@@ -527,14 +530,14 @@ function coerceRuleGroupList(doc: unknown): GeneratedRuleGroup[] {
       if (Array.isArray(value)) {
         sawArrayField = true;
         for (const entry of value) {
-          const group = coerceRuleGroup(entry);
+          const group = coerceRuleGroup(entry, rulerNamespace);
           if (group) fromEnvelope.push(group);
         }
       }
     }
     if (sawArrayField) return fromEnvelope;
     // Single-group shape: `{ name, interval, rules }`.
-    const single = coerceRuleGroup(doc);
+    const single = coerceRuleGroup(doc, rulerNamespace);
     return single ? [single] : [];
   }
   return [];


### PR DESCRIPTION
## Summary

PR 2 of an 8-PR SLO/SLI train. Resolves the two `FIXME(pr-2)` deferrals
from [PR 1](https://github.com/opensearch-project/dashboards-observability/pull/2676)
(merged) and lands wizard completeness. Surfaces continue to ship
**dark** — opt in via `observability.slo.enabled: true` in
`opensearch_dashboards.yml`. No schema changes, no migration risk; PR 2
is plumbing + UI.

> **For train-level context — read this first:**
> [SLO/SLI tracking issue](https://github.com/lezzago/dashboards-observability/issues/1)
>
> Covers the AMP-compatibility invariant, the schema design choices,
> the 8-PR roadmap, and cross-cutting constraints every PR in the train
> respects. The PR body below is scoped to **what changes in this diff**.

## What ships in PR 2

- **Workspace-id plumbing** end-to-end. `server/routes/slo/index.ts`
  resolves the caller's workspace via `getWorkspaceState(req).requestWorkspaceId`,
  falling through to `'default'` when OSD workspaces are disabled. The
  two `workspaceId: 'default'` hard-codes from PR 1 are gone. Malformed
  workspace ids now reject **400** at the route layer (the
  `sloRulerNamespaceFor` regex validation PR 1 codified is exercised by
  live request traffic for the first time). The `tryResolveWorkspaceId`
  envelope is inlined at three read routes; PR 3 consolidates the
  boilerplate into a shared helper alongside the new aggregate endpoint.

- **Acting-user extraction**. `resolveActingUser(req)` reads
  `req.auth.credentials.username` (security plugin), falls back to
  `x-proxy-user` / `x-forwarded-user` request headers (proxy-auth
  deployments), and finally `'unknown'`. Every route that writes
  `createdBy` / `updatedBy` flows through this extractor. PR 1's
  `SLO_ACTING_USER_PLACEHOLDER` constant + `'osd-user'` sentinel are
  gone. Test fixture covers each fallback branch including non-string
  credential payloads and whitespace-only headers.

- **Wizard completeness**. Template-driven create flow at
  `/slos/create/:templateId` (APM / OTel / custom). Multi-objective
  editing. Custom PromQL SLI mode with live `validateCustomPromQL`.
  Right-dock generated-rules preview with namespace + group-name
  preview. Burn-rate presets + custom tier editor. Labels +
  annotations key-value grid. Sticky anchor nav with order-drift guard
  test. Top-level `WizardValidationSummary` banner on submit-attempt.
  Target-% → allowed-downtime preview with high-target callout.
  Confirm + progress strip for batch creation. Unsaved-changes prompt.
<img width="1486" height="743" alt="Screenshot 2026-05-20 at 9 21 45 AM" src="https://github.com/user-attachments/assets/c467809c-e378-4da1-a493-d862f7eefea2" />
<img width="1495" height="749" alt="Screenshot 2026-05-20 at 9 21 56 AM" src="https://github.com/user-attachments/assets/33a5d304-9b8c-4898-b707-04a1db7fbb04" />
<img width="1501" height="748" alt="Screenshot 2026-05-20 at 9 22 11 AM" src="https://github.com/user-attachments/assets/a382af4d-72a9-496a-960e-f6facbcfccf2" />



## Security notes

- **Workspace-id shape**: now exercised live. The
  `/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$/` regex in `sloRulerNamespaceFor`
  is the only gate; route layer rejects malformed input as 400 before
  the value reaches `setRuleGroup` / `deleteRuleGroup`. Path-traversal
  via a malicious `/w/<x>` URL component is the class of attack this
  closes.

- **400 envelope hygiene**: the route does NOT echo the user-controlled
  workspace id back in the 400 body. `requestWorkspaceId` originates
  from the URL, so reflecting an arbitrary value invites
  log-injection / response-splitting style mischief. The wizard keys
  off the field name (`errors.workspaceId`), not the message text.

- **Acting-user attribution**: `resolveActingUser` deliberately reads
  `credentials.username` without gating on `auth.isAuthenticated`.
  Proxy-auth deployments populate `credentials` without a security
  session, and we'd rather attribute the audit row to the proxied
  user than fall through to `'unknown'`. Whitespace-only and
  non-string usernames are rejected.

## Explicit deferrals (carryover from PR 2 self-review)

Documented in `docs/slo/pr-3-listing-and-status.md` and
`docs/slo/pr-8-polish.md`:

| Item | Where | Deferred to |
|---|---|---|
| Consolidate `tryResolveWorkspaceId` envelope at three read routes | `server/routes/slo/index.ts` | **PR 3** |
| Wizard datasource picker (`EuiComboBox`) | wizard | **PR 3** |
| Merge `err.body.attributes.errors` into `WizardValidationSummary` (field-attributed inline errors) | wizard | **PR 8** |
| Wizard `dirty` heuristic — track all reducer mutations, not just identity-shaped subset | wizard | **PR 8** |

## AMP invariant audit

Every `ruler.upsertRuleGroup` / `deleteRuleGroup` caller resolves the
namespace via `sloRulerNamespaceFor(...)` or
`provisioning.rulerNamespace` (itself written by that helper). PR 2
introduces live workspace ids; the route layer rejects malformed ids
**400** before the value reaches the namespace composer. No new
namespace string introduced (`rg "'slo-"` returns only `slo-generated`,
`slo-rule-ref`, `slo-definition`).

## Test plan

- [x] **Jest**: 288 suites pass / 0 fail / 1 skip; 2197 tests pass / 3
  skips. 20 SLO-specific suites covering 280 tests.
- [x] **`resolve_request.test.ts`** (new) covers `resolveWorkspaceId`
  (returns the resolved id; rejects malformed ids as `SloValidationError`
  carrying the `workspaceId` field key) and `resolveActingUser` (each
  fallback branch — security credentials → `x-proxy-user` →
  `x-forwarded-user` → `'unknown'`; whitespace-only and non-string
  payloads rejected).
- [x] **`slo_workspace_isolation.integration.test.ts`** unchanged — the
  contract was authored at the service layer specifically so the
  route-layer change in PR 2 is drop-in.
- [x] **Wizard Jest**: `wizard_state` (reducer-shape sanity for the
  array mutators most prone to silent bugs), `wizard_sections`
  (drift-guard pinning the canonical visual order; longest-prefix-match
  resolution for keys that overlap shorter prefixes), `wizard_builders`
  (% → decimal conversion, multi-objective fan-out, custom-PromQL
  routing into `customExpr.{events|raw}`), `objectives_section`
  (`formatAllowedDowntime` two-largest-units formatter incl. the
  IEEE-754 ms→sec rounding case), `burn_rate_presets`
  (`isPresetApplied` detects user-edited tiers).
- [x] **AMP audit**: clean (see above).
- [x] **Cypress smoke (manual, against local observability-stack)**:
  - `slo_workspace_isolation.spec.js` — non-default workspace create
    writes to `slo-generated-<wsId>` and does NOT appear in the
    default workspace listing.
  - `slo_wizard_multi_objective.spec.js` — multi-objective happy path
    (preview renders, both downtime previews visible, persisted SLO
    carries both objectives) + validation-summary recovery flow
    (submit with missing name → summary appears → fill name → row
    clears on next submit).
  - Skips when no `workspaceId` env is supplied; CI without the stack
    skips cleanly.
- [x] **Reviewer**: with `observability.slo.enabled: true`, create an
  SLO under a non-default workspace (`/w/<wsId>`) and confirm
  `provisioning.rulerNamespace` is `slo-generated-<wsId>` on the
  saved-object document, and that the listing under the default
  workspace does NOT see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)