### PR TITLE
fix linux workflow

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -53,7 +53,8 @@ jobs:
           command: |
             chown -R 1000:1000 `pwd`
             cd ./OpenSearch-Dashboards/
-            su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && node -v && yarn -v &&
+            su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && node -v &&
+                                 npm i -g yarn@\$(node -p \"require('./package.json').engines.yarn\") && yarn -v &&
                                  yarn config set network-timeout 1000000 -g &&
                                  yarn osd bootstrap --single-version=loose"
 
@@ -61,7 +62,8 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           cd ./OpenSearch-Dashboards/
-          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && node -v && yarn -v &&
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && node -v &&
+                               npm i -g yarn@\$(node -p \"require('./package.json').engines.yarn\") && yarn -v &&
                                cd plugins/dashboards-observability &&
                                yarn osd bootstrap --single-version=loose && yarn test --coverage --maxWorkers=100%"
 
@@ -76,7 +78,8 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           cd ./OpenSearch-Dashboards/
-          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && node -v && yarn -v &&
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && node -v &&
+                               npm i -g yarn@\$(node -p \"require('./package.json').engines.yarn\") && yarn -v &&
                                cd plugins/dashboards-observability &&
                                yarn build && mv ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OPENSEARCH_PLUGIN_VERSION }}.zip"
 

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -53,7 +53,7 @@ jobs:
           command: |
             chown -R 1000:1000 `pwd`
             cd ./OpenSearch-Dashboards/
-            su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+            su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && node -v && yarn -v &&
                                  yarn config set network-timeout 1000000 -g &&
                                  yarn osd bootstrap --single-version=loose"
 
@@ -61,7 +61,7 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           cd ./OpenSearch-Dashboards/
-          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && node -v && yarn -v &&
                                cd plugins/dashboards-observability &&
                                yarn osd bootstrap --single-version=loose && yarn test --coverage --maxWorkers=100%"
 
@@ -76,7 +76,7 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           cd ./OpenSearch-Dashboards/
-          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && node -v && yarn -v &&
                                cd plugins/dashboards-observability &&
                                yarn build && mv ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OPENSEARCH_PLUGIN_VERSION }}.zip"
 


### PR DESCRIPTION
### Description
The build-linux job was failing at the Plugin Bootstrap step because OpenSearch-Dashboards main bumped .nvmrc to Node 22.22.3, which is not yet pre-installed in the shared OpenSearch CI Docker image.

Two issues were fixed:

1. nvm use → nvm install: The workflow was running nvm use, which only switches to an already-installed Node version. When the version isn't present in the CI image, it fails. nvm install reads .nvmrc and downloads the version if missing, then switches — making the build resilient to CI image refresh delays.

2. Install yarn after Node switch: When nvm install sets up a fresh Node version, it creates a new prefix directory with no global packages — so yarn is not on the PATH. We now install yarn (at the version specified in OSD's package.json engines.yarn) immediately after the Node switch, matching what the Windows/macOS job already does via actions/setup-node + explicit yarn install.

Both changes apply to all three su invocations in the build-linux job (Plugin Bootstrap, Test, Build Artifact). The Windows/macOS job is unaffected — it already uses actions/setup-node and a separate yarn install step.

Test plan

- Confirm build-linux passes Plugin Bootstrap with the correct Node version (node -v shows v22.22.3)
- Confirm yarn -v prints the expected version in CI logs
- Confirm Test and Build Artifact steps complete successfully
- Verify Windows and macOS jobs still pass (no changes)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
