### PR TITLE
Link checker

### DIFF
--- a/release-notes/opensearch-observability.release-notes-3.0.0.0.md
+++ b/release-notes/opensearch-observability.release-notes-3.0.0.0.md
@@ -9,7 +9,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.0.0
 ### Bug Fixes
 
 - Traces - Custom Traces mode pagination reset ([#2437](https://github.com/opensearch-project/dashboards-observability/pull/2437))
-- fix(notebook): fix set_paragraphs API ([#2417](https://github.com/opensearch-project/dashboards-observability/pull/2417))
+- fix(notebook): fix set_paragraphs API ([b2c8ca3](https://github.com/opensearch-project/dashboards-observability/commit/b2c8ca31d712caf9ebb7cd553233861a81c71780))
 - [Bug] Notebooks - Action popover ([#2418](https://github.com/opensearch-project/dashboards-observability/pull/2418))
 - Fix link checker 404 and update the table of content in README ([#2413](https://github.com/opensearch-project/dashboards-observability/pull/2413))
 - Cypress - Config fix ([#2408](https://github.com/opensearch-project/dashboards-observability/pull/2408))


### PR DESCRIPTION
### Description
Fixed release-notes/opensearch-observability.release-notes-3.0.0.0.md:12.

  PR #2417 was deleted upstream (returns 404), but the underlying commit b2c8ca31 still exists in opensearch-project/dashboards-observability. I swapped the link to point at that commit so the link checker passes while preserving the citation.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
