### PR TITLE
fix: skip histogram and patterns sub-queries when PPL query contains stats

### DIFF
--- a/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
+++ b/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
@@ -52,7 +52,7 @@ export class PPLDataFetcher extends DataFetcherBase implements IDataFetcher {
           text: `Schema conflicts detected while fetching default timestamp, ${defaultTimestamp.message}`,
         });
       }
-    } catch (error) {
+    } catch (_error) {
       /* this.notifications.toasts.addError(error, {
         title: 'Unable to get default timestamp',
       }); */
@@ -143,12 +143,15 @@ export class PPLDataFetcher extends DataFetcherBase implements IDataFetcher {
       );
     }
     // still need all fields when query contains stats
-    if (finalQuery.match(PPL_STATS_REGEX)) getAvailableFields(`search source=${this.queryIndex}`);
-    getCountVisualizations(selectedInterval.current.value.replace(/^auto_/, ''));
-    // patterns
-    this.setLogPattern(this.query, this.queryIndex, finalQuery);
-    if (!finalQuery.match(PATTERNS_REGEX)) {
-      getPatterns(selectedInterval.current.value.replace(/^auto_/, ''));
+    const hasStats = finalQuery.match(PPL_STATS_REGEX);
+    if (hasStats) getAvailableFields(`search source=${this.queryIndex}`);
+    if (!hasStats) {
+      getCountVisualizations(selectedInterval.current.value.replace(/^auto_/, ''));
+      // patterns
+      this.setLogPattern(this.query, this.queryIndex, finalQuery);
+      if (!finalQuery.match(PATTERNS_REGEX)) {
+        getPatterns(selectedInterval.current.value.replace(/^auto_/, ''));
+      }
     }
 
     // live tail - for comparing usage if for the same tab, user changed index from one to another


### PR DESCRIPTION
## Description

When a user runs a PPL query containing `| stats` in Event Analytics (e.g., `source=myindex | stats count()`), the UI shows "No results match your search criteria" even though the query executes successfully.

### Root Cause

`PPLDataFetcher.search()` unconditionally calls `getCountVisualizations()` and `getPatterns()` after every query. These functions append additional `| stats count() by span(dateTime, ...)` and `| patterns ... | stats count()` clauses to the user's query. When the user's query already contains `| stats`, this produces invalid PPL like:

```
source=myindex | stats count() | stats count() by span(dateTime, 1m)
```

After the first `stats count()`, fields like `dateTime` no longer exist in the schema, causing 400 errors ("Field [dateTime] not found"). The cascading failures suppress the valid query result in the UI.

### Fix

Guard `getCountVisualizations`, `setLogPattern`, and `getPatterns` behind `PPL_STATS_REGEX` check so these sub-queries are only generated for non-aggregation queries. When the query contains stats, only `getAvailableFields` is called (which was already behind a stats check).

### Issues Resolved

Resolves #759

### Check List
- [x] New functionality includes testing (verified manually with exact repro steps from the reported issue)
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff

## Test Plan

1. Start OpenSearch 3.5.0 and OpenSearch Dashboards
2. Create an index with a `dateTime` (date) field and ingest sample data
3. Navigate to Observability > Logs > Explorer
4. Run: `source=<index> | stats count()`
5. **Before fix**: Shows "No results match your search criteria" with 400 errors in network tab
6. **After fix**: Shows the result (e.g., `count() = 5`) correctly in the Events tab

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).