### PR TITLE
fix(slo): invalidate SLO status cache after repair

### DIFF
--- a/common/slo/__tests__/slo_service_repair.test.ts
+++ b/common/slo/__tests__/slo_service_repair.test.ts
@@ -353,6 +353,70 @@ describe('SloService.repair', () => {
     expect(health.invalidateCalls).not.toHaveBeenCalled();
   });
 
+  it('invalidates the SLO status cache after a successful repair', async () => {
+    // Regression for the rule_health.spec.js Cypress flake: after Restore,
+    // the danger callout stayed visible because `liveStatus.state =
+    // "rules_missing"` remained cached for 60s while the fresh rule-health
+    // probe already returned `ok`. Repair must drop the cached liveStatus
+    // alongside the rule-health cache so the next read re-aggregates.
+    const { ruler, store, deploy } = makeDeps();
+    const svc = new SloService(noopLogger(), store);
+    svc.setDedupEnabled(false);
+
+    let aggregateCalls = 0;
+    let aggregateState: 'rules_missing' | 'ok' = 'rules_missing';
+    svc.setStatusAggregator({
+      aggregate: async (docs) => {
+        aggregateCalls += 1;
+        return docs.map((d) => ({
+          sloId: d.id,
+          objectives: [],
+          state: aggregateState,
+          firingCount: 0,
+          ruleCount: 0,
+          computedAt: new Date().toISOString(),
+        }));
+      },
+    });
+
+    const statusCtx = {
+      client: ({} as unknown) as AlertingOSClient,
+      workspaceId: 'default',
+      resolveDatasource: async () => undefined as Datasource | undefined,
+    };
+
+    const doc = await svc.create({ spec: validSpec() }, 'alice', deploy);
+    ruler.upsertRuleGroup.mockClear();
+
+    // Warm the status cache with the broken state — this matches what the
+    // listing aggregator writes when the user lands on the detail page.
+    const first = await svc.getStatus(doc.id, statusCtx);
+    expect(first.state).toBe('rules_missing');
+    expect(aggregateCalls).toBe(1);
+
+    // Cache hit — same answer, no second aggregate call.
+    const cached = await svc.getStatus(doc.id, statusCtx);
+    expect(cached.state).toBe('rules_missing');
+    expect(aggregateCalls).toBe(1);
+
+    // Repair flips the ruler state. The next read of liveStatus must pick up
+    // the new world, not the cached `rules_missing`.
+    aggregateState = 'ok';
+    const expected = [
+      doc.status.provisioning.backend === 'prometheus' && doc.status.provisioning.alertGroupName
+        ? doc.status.provisioning.alertGroupName
+        : '',
+    ];
+    const health = makeHealthProbe([missingReport(expected), okReport(expected)]);
+    const result = await svc.repair(doc.id, { health, deploy });
+    expect(result.repaired).toBe(true);
+    expect(result.health.state).toBe('ok');
+
+    const after = await svc.getStatus(doc.id, statusCtx);
+    expect(after.state).toBe('ok');
+    expect(aggregateCalls).toBe(2);
+  });
+
   it('first repair flips a missing group to healthy; second repair is a no-op', async () => {
     const { ruler, store, deploy } = makeDeps();
     const svc = new SloService(noopLogger(), store);

--- a/common/slo/slo_lifecycle_service.ts
+++ b/common/slo/slo_lifecycle_service.ts
@@ -909,6 +909,11 @@ export class SloLifecycleService {
     );
 
     ctx.health.invalidate(ctx.deploy.workspaceId, ctx.deploy.datasource.id, doc.id);
+    // Status cache holds an aggregated `liveStatus.state` (e.g. 'rules_missing')
+    // that the detail page falls back to when the fresh rule-health probe is
+    // 'ok'. Without this, the danger callout re-renders off the stale snapshot
+    // for up to 60s after a successful repair.
+    this.statusService.invalidate(doc.id);
 
     const post = await ctx.health.check({
       workspaceId: ctx.deploy.workspaceId,
@@ -1023,6 +1028,7 @@ export class SloLifecycleService {
     );
 
     ctx.health.invalidate(ctx.deploy.workspaceId, ctx.deploy.datasource.id, doc.id);
+    this.statusService.invalidate(doc.id);
 
     const post = await ctx.health.check({
       workspaceId: ctx.deploy.workspaceId,


### PR DESCRIPTION
## Summary
- Repair only invalidated the rule-health probe cache. The 60s SLO status cache held the stale `liveStatus.state = 'rules_missing'` snapshot, and the detail page falls back to it whenever the fresh rule-health probe returns `'ok'` ([`slo_detail_page.tsx:691-699`](https://github.com/opensearch-project/dashboards-observability/blob/main/public/components/apm/pages/slos/slo_detail_page.tsx#L691-L699)). Result: the danger callout re-rendered for up to 60s after a successful Restore, causing `rule_health.spec.js` to flake on the `Expected <div.euiCallOut.euiCallOut--danger> not to exist` assertion.
- Adds `this.statusService.invalidate(doc.id)` after the ruler upsert in both `repair` (single-group) and `repairDedup`, matching the pattern already used by every other lifecycle method (create / update / delete / enable / disable).
- Adds a regression test that drives `getStatus → repair → getStatus` through the public `SloService` API and asserts the second read re-aggregates instead of returning a stale `'rules_missing'`. Without the fix the new test fails with `Expected: 'ok' / Received: 'rules_missing'` — the same shape the Cypress spec sees.

## Failure context
Original CI failure: https://github.com/opensearch-project/dashboards-observability/actions/runs/26532215393/job/78151594782
```
AssertionError: Timed out retrying after 30000ms:
Expected <div.euiCallOut.euiCallOut--danger> not to exist in the DOM,
but it was continuously found.
  at rule_health.spec.js:230
```
"Continuously found" is the smoking gun — the DOM is in a stable bad state, not slow-loading. The Restore handler's `await load()` re-fetches the SLO doc, but `handleGetSLO` returns the cached `liveStatus.state = 'rules_missing'` written by the listing aggregator within the prior 60s. The detail-page render at `slo_detail_page.tsx:697` then re-shows the danger callout from the stale `liveStatus` even though `ruleHealth.state === 'ok'`.

## Test plan
- [x] Unit: `yarn test --testPathPattern="slo_service_repair|slo_service\.test|slo_status_writeback|slo_lifecycle"` — 48/48 pass with the fix; the new regression test fails without it (`Expected: 'ok' / Received: 'rules_missing'`).
- [x] Server-side breadth: `yarn test --testPathPattern="server/(routes|services)/slo"` — 178/178 pass.
- [x] Front-end breadth: `yarn test --testPathPattern="public/components/apm/pages/slos/__tests__"` — 353/353 pass.
- [x] End-to-end: dispatched `cypress-slo-cortex.yml` against this branch on the lezzago fork — [run 26600851291](https://github.com/lezzago/dashboards-observability/actions/runs/26600851291) — `✔ All specs passed!` including `rule_health.spec.js ✔ 1/1 passing (03:06)`.