### PR TITLE
Fix clone monitor: initialize missing osService in AlarmsPage

### DIFF
--- a/public/components/alerting/__tests__/alarms_page.test.tsx
+++ b/public/components/alerting/__tests__/alarms_page.test.tsx
@@ -42,8 +42,14 @@ jest.mock('../alerts_dashboard', () => ({
     return <div data-test-subj="alertsDashboard" />;
   },
 }));
+
+// Capture MonitorsTable props so we can invoke onClone in tests.
+const mockMonitorsTable = jest.fn();
 jest.mock('../monitors_table', () => ({
-  MonitorsTable: () => <div data-test-subj="monitorsTable" />,
+  MonitorsTable: (props: unknown) => {
+    mockMonitorsTable(props);
+    return <div data-test-subj="monitorsTable" />;
+  },
 }));
 jest.mock('../notification_routing_panel', () => ({
   NotificationRoutingPanel: () => <div data-test-subj="routingPanel" />,
@@ -51,6 +57,22 @@ jest.mock('../notification_routing_panel', () => ({
 jest.mock('../create_monitor', () => ({ CreateMonitor: () => null }));
 jest.mock('../create_monitor/edit_monitor', () => ({ EditMonitor: () => null }));
 jest.mock('../alert_detail_flyout', () => ({ AlertDetailFlyout: () => null }));
+
+const mockGetRuleDetail = jest.fn();
+jest.mock('../query_services/alerting_opensearch_service', () => ({
+  AlertingOpenSearchService: jest.fn().mockImplementation(() => ({
+    getRuleDetail: mockGetRuleDetail,
+  })),
+}));
+
+const mockCreateMonitor = jest.fn();
+jest.mock('../hooks/use_monitor_mutations', () => ({
+  useMonitorMutations: () => ({
+    createMonitor: mockCreateMonitor,
+    deleteMonitor: jest.fn(),
+    acknowledgeAlert: jest.fn(),
+  }),
+}));
 
 import { AlarmsPage, parseAlarmsHashRoute } from '../alarms_page';
 import type { Datasource } from '../../../../common/types/alerting';
@@ -73,6 +95,9 @@ beforeEach(() => {
   mockUseAlerts.mockReset();
   mockUseAlerts.mockReturnValue(emptyHookResult);
   mockDashboard.mockClear();
+  mockMonitorsTable.mockClear();
+  mockGetRuleDetail.mockReset();
+  mockCreateMonitor.mockReset();
   try {
     window.sessionStorage.clear();
   } catch (_e) {
@@ -284,6 +309,59 @@ describe('AlarmsPage', () => {
     // sessionStorage has also been healed so a reload starts clean.
     expect(window.sessionStorage.getItem('AlertManagerStartTime')).toBe('now-24h');
     expect(window.sessionStorage.getItem('AlertManagerEndTime')).toBe('now');
+  });
+
+  it('handleCloneRule calls getRuleDetail and createMonitor without throwing', async () => {
+    const fakeRaw = {
+      id: 'mon-1',
+      name: 'Test Monitor',
+      type: 'monitor',
+      last_update_time: 123,
+      enabled_time: 456,
+      schema_version: 1,
+      owner: 'alerting',
+      data_sources: {},
+      triggers: [
+        {
+          ppl_trigger: {
+            id: 'trig-1',
+            name: 'High errors',
+            actions: [{ id: 'act-1', name: 'notify' }],
+          },
+        },
+      ],
+    };
+    mockGetRuleDetail.mockResolvedValue({ raw: fakeRaw });
+    mockCreateMonitor.mockResolvedValue({ id: 'new-mon-1' });
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+
+    // Switch to Rules tab so MonitorsTable renders
+    fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+
+    // Get the onClone prop passed to MonitorsTable
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0] as {
+      onClone: (monitor: unknown) => Promise<void>;
+    };
+
+    expect(tableProps.onClone).toBeDefined();
+
+    // Invoke onClone — this would throw ReferenceError before the fix
+    await act(async () => {
+      await tableProps.onClone({
+        id: 'mon-1',
+        name: 'Test Monitor',
+        datasourceId: 'ds-1',
+      });
+    });
+
+    expect(mockGetRuleDetail).toHaveBeenCalledWith('ds-1', 'mon-1');
+    expect(mockCreateMonitor).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Test Monitor (Copy)' }),
+      'ds-1'
+    );
   });
 });
 

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -58,6 +58,7 @@ import { transformPplFormToPayload } from '../../../common/services/alerting/for
 import { PPL_MONITOR_NAME_MAX } from '../../../common/services/alerting/validators';
 import './alerting.scss';
 import type { OpenSearchFormState } from './create_monitor/create_monitor_types';
+import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
 import { formStateToRule, resolveDatasourceTokens } from './alarms_page_helpers';
 
 // ============================================================================
@@ -126,6 +127,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   maxDatasources,
 }) => {
   const mutations = useMonitorMutations();
+  const osService = useMemo(() => new AlertingOpenSearchService(), []);
 
   // Deep-link parsing — when SLO detail (or any other surface) navigates to
   // `#/rules?q=<rulename>` we want to land on the Rules tab with the search


### PR DESCRIPTION
## Description

Fixes the "Failed to clone a monitor: osService is not defined" error when clicking the Clone button on the rule detail flyout in the Unified Alerts View.

### Root Cause

`handleCloneRule` in `alarms_page.tsx` calls `osService.getRuleDetail()` but `osService` was never instantiated, causing a `ReferenceError` at runtime.

### Fix

Added the `AlertingOpenSearchService` import and a `useMemo`-based initialization — matching the pattern already used in `alert_detail_flyout.tsx`.

## Testing

1. Start the observability stack + OSD from source
2. Navigate to Alerts → Rules tab
3. Open any rule flyout (e.g. "OTel Demo - Cart Service Errors")
4. Click Clone
5. Verify the toast shows "Monitor cloned" instead of the error

<img width="3566" height="2146" alt="Image 5-28-26 at 4 52 PM" src="https://github.com/user-attachments/assets/23e6facf-7d63-4b6b-b89f-24216dfe7e70" />


## Issues Resolved

Fixes clone monitor bug (medium severity) from Bug Bash - Unified Alerts View.