### PR TITLE
fix(alerting): clone crash, PPL subtitle, system indices in picker, and Notification Channels rename

### DIFF
--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -48,6 +48,7 @@ import { useAlertingPluginAvailability } from './hooks/use_alerting_plugin_avail
 import { useDatasourceSelection } from './hooks/use_datasource_selection';
 import { useMonitorMutations } from './hooks/use_monitor_mutations';
 import { useRulesData } from './hooks/use_rules_data';
+import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
 import { useTimeRange } from './hooks/use_time_range';
 import { AlarmsPageCallouts } from './alarms_page_callouts';
 import { coreRefs } from '../../framework/core_refs';
@@ -126,6 +127,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   maxDatasources,
 }) => {
   const mutations = useMonitorMutations();
+  const osService = useMemo(() => new AlertingOpenSearchService(), []);
 
   // Deep-link parsing — when SLO detail (or any other surface) navigates to
   // `#/rules?q=<rulename>` we want to land on the Rules tab with the search

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -1227,7 +1227,7 @@ const ActionsSection = React.memo<{
                   'observability.alerting.createMetricsMonitor.comingSoonCalloutBody',
                   {
                     defaultMessage:
-                      'Full action configuration (destination, message template, throttling) will be available in a future update.',
+                      'Full action configuration (notification channel, message template, throttling) will be available in a future update.',
                   }
                 )}
               </EuiText>

--- a/public/components/alerting/create_monitor/index.tsx
+++ b/public/components/alerting/create_monitor/index.tsx
@@ -298,8 +298,8 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
             ? i18n.translate('observability.alerting.createMonitor.subtitlePromql', {
                 defaultMessage: 'PromQL-based alerting rule',
               })
-            : i18n.translate('observability.alerting.createMonitor.subtitleQueryLevel', {
-                defaultMessage: 'Query-level monitor with triggers',
+            : i18n.translate('observability.alerting.createMonitor.subtitlePpl', {
+                defaultMessage: 'PPL-based alerting rule',
               })}
         </EuiText>
       </EuiFlyoutHeader>

--- a/public/components/alerting/create_monitor/sections/destination_picker.tsx
+++ b/public/components/alerting/create_monitor/sections/destination_picker.tsx
@@ -4,8 +4,13 @@
  */
 
 /**
- * Read-only destination picker for trigger actions. Destinations are
- * managed in the OpenSearch Alerting plugin's own Destinations page.
+ * Read-only notification-channel picker for trigger actions. Channels are
+ * managed in the OpenSearch Notifications plugin's Channels page.
+ *
+ * Note: this component is named `DestinationPicker` and the trigger action
+ * shape carries `destination_id` because that's the wire-format field name
+ * the OpenSearch Alerting backend accepts on its `actions[]` payload. We
+ * surface the user-facing concept as "notification channel" everywhere.
  */
 import React, { useMemo } from 'react';
 import { EuiFormRow, EuiLink, EuiSpacer, EuiSuperSelect, EuiText } from '@elastic/eui';
@@ -43,7 +48,7 @@ export const DestinationPicker: React.FC<DestinationPickerProps> = ({
   });
 
   const placeholderText = i18n.translate('observability.alerting.destinationPicker.placeholder', {
-    defaultMessage: 'Select a destination',
+    defaultMessage: 'Select a notification channel',
   });
 
   const options = useMemo(() => {
@@ -68,20 +73,22 @@ export const DestinationPicker: React.FC<DestinationPickerProps> = ({
     ];
   }, [destinations, placeholderText]);
 
-  const destinationsHref = `${coreRefs.http?.basePath?.get?.() ?? ''}/app/alerting#/destinations`;
+  const destinationsHref = `${
+    coreRefs.http?.basePath?.get?.() ?? ''
+  }/app/notifications-dashboards#/channels`;
 
   const selectedValue = value || NONE_OPTION_VALUE;
 
   const resolvedAriaLabel =
     ariaLabel ??
     i18n.translate('observability.alerting.destinationPicker.defaultAriaLabel', {
-      defaultMessage: 'Notification destination',
+      defaultMessage: 'Notification channel',
     });
 
   return (
     <EuiFormRow
       label={i18n.translate('observability.alerting.destinationPicker.label', {
-        defaultMessage: 'Destination',
+        defaultMessage: 'Notification channel',
       })}
       isInvalid={isInvalid}
       error={errorMessage}
@@ -91,13 +98,13 @@ export const DestinationPicker: React.FC<DestinationPickerProps> = ({
           <span>
             <FormattedMessage
               id="observability.alerting.destinationPicker.noneConfigured"
-              defaultMessage="No destinations configured for this datasource. {openLink}"
+              defaultMessage="No notification channels configured for this datasource. {openLink}"
               values={{
                 openLink: (
                   <EuiLink href={destinationsHref} target="_blank">
                     <FormattedMessage
                       id="observability.alerting.destinationPicker.openDestinations"
-                      defaultMessage="Open Destinations"
+                      defaultMessage="Open Notification Channels"
                     />
                   </EuiLink>
                 ),
@@ -109,7 +116,7 @@ export const DestinationPicker: React.FC<DestinationPickerProps> = ({
             <EuiLink href={destinationsHref} target="_blank">
               <FormattedMessage
                 id="observability.alerting.destinationPicker.manageDestinations"
-                defaultMessage="Manage destinations"
+                defaultMessage="Manage notification channels"
               />
             </EuiLink>
           </span>
@@ -132,7 +139,7 @@ export const DestinationPicker: React.FC<DestinationPickerProps> = ({
             <EuiText size="xs" color="danger">
               <FormattedMessage
                 id="observability.alerting.destinationPicker.loadError"
-                defaultMessage="Failed to load destinations: {message}"
+                defaultMessage="Failed to load notification channels: {message}"
                 values={{ message: error.message }}
               />
             </EuiText>
@@ -144,7 +151,7 @@ export const DestinationPicker: React.FC<DestinationPickerProps> = ({
             <EuiText size="xs" color="subdued" data-test-subj="alertManagerDestinationsTruncated">
               <FormattedMessage
                 id="observability.alerting.destinationPicker.truncated"
-                defaultMessage="Showing the first {shown} of {total} destinations. Manage older entries from the Alerting plugin."
+                defaultMessage="Showing the first {shown} of {total} notification channels. Manage older entries from the Alerting plugin."
                 values={{ shown: destinations.length, total: totalDestinations }}
               />
             </EuiText>

--- a/public/components/alerting/create_monitor/sections/ppl_triggers.tsx
+++ b/public/components/alerting/create_monitor/sections/ppl_triggers.tsx
@@ -438,7 +438,7 @@ export const PplTriggersSection: React.FC<PplTriggersSectionProps> = ({
                     <EuiText size="xs">
                       <FormattedMessage
                         id="observability.alerting.pplTriggers.pickDatasourceFirst"
-                        defaultMessage="Pick a datasource first to load notification destinations."
+                        defaultMessage="Pick a datasource first to load notification channels."
                       />
                     </EuiText>
                   </EuiCallOut>
@@ -509,7 +509,7 @@ export const PplTriggersSection: React.FC<PplTriggersSectionProps> = ({
                             ariaLabel={i18n.translate(
                               'observability.alerting.pplTriggers.destinationAriaLabel',
                               {
-                                defaultMessage: 'Destination for {name}',
+                                defaultMessage: 'Notification channel for {name}',
                                 values: { name: action.name },
                               }
                             )}
@@ -518,7 +518,7 @@ export const PplTriggersSection: React.FC<PplTriggersSectionProps> = ({
                               destinationInvalid
                                 ? i18n.translate(
                                     'observability.alerting.pplTriggers.destinationRequiredError',
-                                    { defaultMessage: 'Destination is required' }
+                                    { defaultMessage: 'Notification channel is required' }
                                   )
                                 : undefined
                             }

--- a/public/components/alerting/hooks/__tests__/use_indices.test.ts
+++ b/public/components/alerting/hooks/__tests__/use_indices.test.ts
@@ -133,6 +133,33 @@ describe('useIndices', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it('filters out hidden / system indices and aliases (names starting with `.`)', async () => {
+    mockListIndices.mockResolvedValueOnce([
+      { index: '.kibana' },
+      { index: '.kibana_1' },
+      { index: '.opendistro_security' },
+      { index: '.opendistro-alerting-alert-history-write' },
+      { index: 'logs-otel-v1' },
+      { index: 'metrics' },
+    ]);
+    mockListAliases.mockResolvedValueOnce([
+      { alias: '.hidden-alias', index: '.kibana' },
+      { alias: 'all-logs', index: 'logs-otel-v1' },
+    ]);
+
+    const { result } = renderHook(() => useIndices({ dsId: 'ds-1', search: '' }));
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    await waitFor(() => expect(result.current.options.length).toBeGreaterThan(0));
+
+    expect(result.current.options).toEqual([
+      { label: 'all-logs', aliasFor: 'logs-otel-v1' },
+      { label: 'logs-otel-v1' },
+      { label: 'metrics' },
+    ]);
+  });
+
   it('merges indices and aliases, de-duping and sorting alphabetically', async () => {
     mockListIndices.mockResolvedValueOnce([
       { index: 'logs-2026' },

--- a/public/components/alerting/hooks/use_indices.ts
+++ b/public/components/alerting/hooks/use_indices.ts
@@ -90,16 +90,25 @@ export function useIndices({
   return { options, isLoading, error };
 }
 
+/**
+ * Hidden indices/aliases — those whose name starts with `.` — are noise for a
+ * log-monitor target picker (`.kibana*`, `.opendistro_security`, etc.) and
+ * selecting one by mistake can expose internal state. Free-text wildcards
+ * starting with `.` still pass through `onCreateOption`, so power users can
+ * still target them deliberately.
+ */
+const isHiddenName = (name: string): boolean => name.startsWith('.');
+
 function mergeOptions(indices: IndexSummary[], aliases: AliasSummary[]): IndexOption[] {
   const seen = new Set<string>();
   const out: IndexOption[] = [];
   for (const i of indices) {
-    if (!i.index || seen.has(i.index)) continue;
+    if (!i.index || seen.has(i.index) || isHiddenName(i.index)) continue;
     seen.add(i.index);
     out.push({ label: i.index });
   }
   for (const a of aliases) {
-    if (!a.alias || seen.has(a.alias)) continue;
+    if (!a.alias || seen.has(a.alias) || isHiddenName(a.alias)) continue;
     seen.add(a.alias);
     out.push({ label: a.alias, aliasFor: a.index });
   }

--- a/public/components/alerting/monitors_table/monitors_table_columns.tsx
+++ b/public/components/alerting/monitors_table/monitors_table_columns.tsx
@@ -295,7 +295,7 @@ export function buildTableColumns({
       cols.push({
         field: 'notificationDestinations',
         name: i18n.translate('observability.alerting.monitorsTable.columns.destinations', {
-          defaultMessage: 'Destinations',
+          defaultMessage: 'Notification channels',
         }),
         width: w('destinations'),
         render: (dests: string[]) =>


### PR DESCRIPTION
## Summary

Targeted fixes for issues surfaced in a recent UI bug report against the Observability Alert Manager. Two commits, scoped tightly so they can merge in parallel with other in-flight alerting follow-ups.

### Commit 1: clone crash, PPL flyout subtitle, system indices in picker

- **BUG-6 (SEV-1) — Clone monitor crashed** with toast \`osService is not defined\`. The clone handler in \`alarms_page.tsx\` referenced a bare \`osService\` symbol that was never declared in this file. Added \`useMemo(() => new AlertingOpenSearchService(), [])\` next to the existing \`mutations\` hook (mirrors the pattern in \`use_rules_data.ts\` and \`alert_detail_flyout.tsx\`).

- **BUG-9 (SEV-3) — PPL monitors had no language indicator in the flyout**. The Prometheus subtitle reads \`PromQL-based alerting rule\`, but the OpenSearch subtitle just said \`Query-level monitor with triggers\`. Updated the OpenSearch subtitle to \`PPL-based alerting rule\` so it parallels the PromQL one. The flyout title (\"Edit/Create Logs Monitor\") and the popover entry button (\"Logs\") are intentionally unchanged — \"Logs\" is the user-facing monitor category; \"PPL\" is the language used to express it, surfaced one line down.

- **BUG-2 (SEV-3) — Indices picker showed system indices**. \`.kibana*\` and \`.opendistro*\` indices appeared as default suggestions, risking accidental selection. Filter hidden names (those starting with \`.\`) at the merge layer in \`use_indices.ts\`. Free-text \`onCreateOption\` is unaffected, so power users can still target hidden indices deliberately.

### Commit 2: Notification Channels rename

The OpenSearch Alerting plugin's Destinations page is deprecated; notification channels are now managed in the Notifications Dashboards plugin.

- Repointed the destination picker's helper link from \`/app/alerting#/destinations\` to \`/app/notifications-dashboards#/channels\`.
- Renamed every user-facing \"destination\" string to \"notification channel\":
  - Form label, placeholder, ARIA label, empty-state copy, error/truncation text in \`destination_picker.tsx\`
  - Trigger-section callout, per-action ARIA label, validation message in \`ppl_triggers.tsx\`
  - Notification Routing column header in \`monitor_detail_flyout.tsx\`
  - Monitors-table column \"Destinations\" → \"Notification channels\"
  - Coming-soon callout in \`create_metrics_monitor.tsx\`

Wire-format field name \`destination_id\` is owned by the OpenSearch Alerting backend and is left untouched. Internal symbol names (\`DestinationPicker\`, \`useDestinations\`, \`destinationId\`, etc.) are also unchanged — this PR is scoped to user-visible copy only. Updated the \`destination_picker.tsx\` JSDoc to record this distinction.

## Test plan

- [x] \`yarn lint:es\` clean on all changed files
- [x] \`yarn typecheck\` passes from OSD root
- [x] \`yarn test public/components/alerting\` — 30/30 suites, 178/178 tests pass
- [x] New unit test in \`use_indices.test.ts\` locks in the hidden-index filter
- [x] Live manual verification against local dev cluster:
  - [x] BUG-6: Cloning \`OTel Demo - Frontend Error Logs\` produced \`(Copy)\` row with no \`osService\` ReferenceError; cloned monitor deleted via standard delete confirmation flow
  - [x] BUG-9: Create Logs Monitor flyout shows title \"Create Logs Monitor\" with subtitle \"PPL-based alerting rule\"
  - [x] BUG-2: Indices picker dropdown showed only user-facing indices; the 9 dot-prefixed indices from the bug report (\`.kibana*\`, \`.opendistro*\`, \`.plugins-ml-config\`, \`.ql-datasources\`) were absent
  - [x] Destination picker form label \"Notification channel\", placeholder \"Select a notification channel\", empty-state \"No notification channels configured for this datasource.\", and \"Open Notification Channels\" link pointing at \`/app/notifications-dashboards#/channels\`
- [ ] CI green