### PR TITLE
Fix destinations link to point to notifications plugin

### DIFF
--- a/public/components/alerting/create_monitor/sections/destination_picker.tsx
+++ b/public/components/alerting/create_monitor/sections/destination_picker.tsx
@@ -68,7 +68,9 @@ export const DestinationPicker: React.FC<DestinationPickerProps> = ({
     ];
   }, [destinations, placeholderText]);
 
-  const destinationsHref = `${coreRefs.http?.basePath?.get?.() ?? ''}/app/alerting#/destinations`;
+  const destinationsHref = `${
+    coreRefs.http?.basePath?.get?.() ?? ''
+  }/app/notifications-dashboards#/channels`;
 
   const selectedValue = value || NONE_OPTION_VALUE;
 
@@ -97,7 +99,7 @@ export const DestinationPicker: React.FC<DestinationPickerProps> = ({
                   <EuiLink href={destinationsHref} target="_blank">
                     <FormattedMessage
                       id="observability.alerting.destinationPicker.openDestinations"
-                      defaultMessage="Open Destinations"
+                      defaultMessage="Open Notification Channels"
                     />
                   </EuiLink>
                 ),
@@ -109,7 +111,7 @@ export const DestinationPicker: React.FC<DestinationPickerProps> = ({
             <EuiLink href={destinationsHref} target="_blank">
               <FormattedMessage
                 id="observability.alerting.destinationPicker.manageDestinations"
-                defaultMessage="Manage destinations"
+                defaultMessage="Manage notification channels"
               />
             </EuiLink>
           </span>


### PR DESCRIPTION
## Description

The "Open Destinations" and "Manage destinations" links in the destination picker navigate to `/app/alerting#/destinations` — the deprecated alerting plugin destinations page which no longer exists, resulting in an "App not found" error.

### Fix

Updated the link to point to `/app/notifications-dashboards#/channels` which is the current notifications plugin UI for managing notification channels. Also updated the link text to say "notification channels" for clarity.

## Testing

1. Start the observability stack + OSD from source
2. Navigate to Alerts → Rules → Create Monitor
3. Scroll to the Triggers section with the Destination picker
4. Click "Manage notification channels" or "Open Notification Channels"
5. Verify it navigates to the Notifications plugin channels page instead of showing "App not found"

## Issues Resolved

Fixes destinations link bug from Bug Bash - Unified Alerts View.