### PR TITLE
fix(alerting): surface backend error detail and pre-check duplicate names

### DIFF
--- a/public/components/alerting/__tests__/alarms_page_helpers.test.ts
+++ b/public/components/alerting/__tests__/alarms_page_helpers.test.ts
@@ -8,6 +8,8 @@ import {
   ALERT_MANAGER_START_TIME_KEY,
   DEFAULT_END_TIME,
   DEFAULT_START_TIME,
+  extractPplValidationError,
+  extractServerErrorMessage,
   formStateToRule,
   isAlertingConfigMissingError,
   loadPersistedEndTime,
@@ -193,6 +195,70 @@ describe('alarms_page_helpers', () => {
       expect(rule.datasourceType).toBe('prometheus');
       expect(rule.monitorType).toBe('metric');
       expect(rule.firingPeriod).toBe('10m');
+    });
+  });
+
+  describe('extractServerErrorMessage', () => {
+    it('prefers `body.message` over `Error.message`', () => {
+      // Shape mirrors OSD core's IHttpFetchError: HTTP status text on the
+      // outer Error.message, actionable detail on body.message.
+      const err = Object.assign(new Error('Bad Request'), {
+        body: {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'alerting_exception: PPL Query validation failed: ...',
+        },
+      });
+      expect(extractServerErrorMessage(err)).toBe(
+        'alerting_exception: PPL Query validation failed: ...'
+      );
+    });
+
+    it('falls back to `body.error` when `body.message` is missing', () => {
+      const err = Object.assign(new Error('Bad Request'), {
+        body: { statusCode: 400, error: 'Validation failed' },
+      });
+      expect(extractServerErrorMessage(err)).toBe('Validation failed');
+    });
+
+    it('falls back to `Error.message` when no body is present', () => {
+      expect(extractServerErrorMessage(new Error('boom'))).toBe('boom');
+    });
+
+    it('handles plain strings and unknown shapes', () => {
+      expect(extractServerErrorMessage('a string')).toBe('a string');
+      expect(extractServerErrorMessage(null)).toBe('Unknown error');
+      expect(extractServerErrorMessage(undefined)).toBe('Unknown error');
+      expect(extractServerErrorMessage(42)).toBe('42');
+    });
+
+    it('ignores empty `body.message` and falls through', () => {
+      const err = Object.assign(new Error('Bad Request'), {
+        body: { message: '', error: 'Something else' },
+      });
+      expect(extractServerErrorMessage(err)).toBe('Something else');
+    });
+  });
+
+  describe('extractPplValidationError', () => {
+    it('extracts the validation message from a PPL parse error', () => {
+      const msg =
+        'alerting_exception: [alerting_exception] Reason: PPL Query validation failed: ' +
+        '[INVALID_KEYWORD] is not a valid term at this part of the query: ' +
+        "'...e = logs-otel-v1* | INVALID_KEYWORD' <-- HERE. Expecting one of 56 possible tokens.";
+      expect(extractPplValidationError(msg)).toBe(
+        'PPL Query validation failed: [INVALID_KEYWORD] is not a valid term at this part of the query: ' +
+          "'...e = logs-otel-v1* | INVALID_KEYWORD' <-- HERE. Expecting one of 56 possible tokens."
+      );
+    });
+
+    it('returns null when the message is not a PPL validation error', () => {
+      expect(extractPplValidationError('Bad Request')).toBeNull();
+      expect(extractPplValidationError('alerting_exception: monitor not found')).toBeNull();
+    });
+
+    it('returns null for empty input', () => {
+      expect(extractPplValidationError('')).toBeNull();
     });
   });
 });

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -59,8 +59,12 @@ import { transformPplFormToPayload } from '../../../common/services/alerting/for
 import { PPL_MONITOR_NAME_MAX } from '../../../common/services/alerting/validators';
 import './alerting.scss';
 import type { OpenSearchFormState } from './create_monitor/create_monitor_types';
-import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
-import { formStateToRule, resolveDatasourceTokens } from './alarms_page_helpers';
+import {
+  extractPplValidationError,
+  extractServerErrorMessage,
+  formStateToRule,
+  resolveDatasourceTokens,
+} from './alarms_page_helpers';
 
 // ============================================================================
 // Main Page Component
@@ -260,6 +264,55 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
 
   const [deletedRuleIds, setDeletedRuleIds] = useState<Set<string>>(new Set());
   const [showCreateMonitor, setShowCreateMonitor] = useState(false);
+
+  // Inline error surface for the PPL editor — set when the most recent
+  // create/update returns a `PPL Query validation failed: ...` 400 (BUG-4).
+  // Cleared as soon as the user edits the query, the flyout closes, or a
+  // subsequent save succeeds.
+  const [pplSubmitError, setPplSubmitError] = useState<string | null>(null);
+
+  // Build a (dsId, name) lookup over the currently-loaded rules, used by the
+  // create/edit flyouts to flag duplicates inline before submit (BUG-1).
+  // Comparison is case-insensitive against the trimmed candidate, matching
+  // how a human reads alert lists. Note: this only knows about rules the
+  // datasource filter has surfaced — saving against an unselected DS could
+  // still create a same-name monitor on that DS, but that's a much narrower
+  // footgun than the original "two identical names on the same cluster".
+  const rulesByDsName = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    rules.forEach((r) => {
+      if (deletedRuleIds.has(r.id)) return;
+      const dsKey = r.datasourceId;
+      const names = map.get(dsKey) ?? new Set<string>();
+      names.add(r.name.trim().toLowerCase());
+      map.set(dsKey, names);
+    });
+    return map;
+  }, [rules, deletedRuleIds]);
+
+  const isNameTakenForCreate = useCallback(
+    (name: string, dsId: string) => {
+      const set = rulesByDsName.get(dsId);
+      return !!set?.has(name.trim().toLowerCase());
+    },
+    [rulesByDsName]
+  );
+
+  const buildIsNameTakenForEdit = useCallback(
+    (excludeRuleId: string) => (name: string, dsId: string) => {
+      const trimmed = name.trim().toLowerCase();
+      // Walk the rule list directly so we can exclude the monitor being
+      // edited; the cached map doesn't carry id information.
+      return rules.some(
+        (r) =>
+          r.id !== excludeRuleId &&
+          !deletedRuleIds.has(r.id) &&
+          r.datasourceId === dsId &&
+          r.name.trim().toLowerCase() === trimmed
+      );
+    },
+    [rules, deletedRuleIds]
+  );
   // The popover's "Logs" entry maps to an OpenSearch monitor; "Metrics" toasts
   // "coming soon" until PR 2 lights up the Prom create flyout. When the user
   // picks Logs the flyout is forced to the OS variant via this override even
@@ -382,7 +435,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           defaultMessage: 'Failed to acknowledge alert',
         }),
         'danger',
-        e instanceof Error ? e.message : String(e)
+        extractServerErrorMessage(e)
       );
     }
   };
@@ -414,7 +467,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             defaultMessage: 'Failed to delete monitor',
           }),
           'danger',
-          e instanceof Error ? e.message : String(e)
+          extractServerErrorMessage(e)
         );
       }
     }
@@ -501,7 +554,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           defaultMessage: 'Failed to clone monitor',
         }),
         'danger',
-        e instanceof Error ? e.message : String(e)
+        extractServerErrorMessage(e)
       );
     }
   };
@@ -552,6 +605,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       );
       setShowCreateMonitor(false);
       setCreateBackendType(null);
+      setPplSubmitError(null);
       // Refetch rules so the new monitor (with backend-assigned id /
       // last_update_time) shows up in the list. Optimistic insert is kept
       // for the UI to feel instant; the refetch reconciles.
@@ -559,12 +613,15 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       setRulesTotal((prev) => prev + 1);
       refetchRules();
     } catch (e: unknown) {
+      const message = extractServerErrorMessage(e);
+      const pplError = extractPplValidationError(message);
+      if (pplError) setPplSubmitError(pplError);
       addToast(
         i18n.translate('observability.alerting.alarmsPage.toast.createMonitorFailed', {
           defaultMessage: 'Failed to create monitor',
         }),
         'danger',
-        e instanceof Error ? e.message : String(e)
+        message
       );
     }
   };
@@ -580,14 +637,18 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         })
       );
       setEditTarget(null);
+      setPplSubmitError(null);
       refetchRules();
     } catch (e: unknown) {
+      const message = extractServerErrorMessage(e);
+      const pplError = extractPplValidationError(message);
+      if (pplError) setPplSubmitError(pplError);
       addToast(
         i18n.translate('observability.alerting.alarmsPage.toast.updateMonitorFailed', {
           defaultMessage: 'Failed to update monitor',
         }),
         'danger',
-        e instanceof Error ? e.message : String(e)
+        message
       );
     }
   };
@@ -606,7 +667,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             defaultMessage: 'Failed to create monitor',
           }),
           'danger',
-          e instanceof Error ? e.message : String(e)
+          extractServerErrorMessage(e)
         );
       }
     }
@@ -767,20 +828,30 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           onCancel={() => {
             setShowCreateMonitor(false);
             setCreateBackendType(null);
+            setPplSubmitError(null);
           }}
           datasources={datasources}
           selectedDsIds={selectedDsIds}
           initialBackendType={createBackendType ?? undefined}
+          isNameTaken={isNameTakenForCreate}
+          submitError={pplSubmitError ? { pplMessage: pplSubmitError } : undefined}
+          onClearPplSubmitError={() => setPplSubmitError(null)}
         />
       )}
       {editTarget && (
         <EditMonitor
           dsId={editTarget.dsId}
           ruleId={editTarget.ruleId}
-          onCancel={() => setEditTarget(null)}
+          onCancel={() => {
+            setEditTarget(null);
+            setPplSubmitError(null);
+          }}
           onSave={handleEditMonitor}
           datasources={datasources}
           selectedDsIds={selectedDsIds}
+          isNameTaken={buildIsNameTakenForEdit(editTarget.ruleId)}
+          submitError={pplSubmitError ? { pplMessage: pplSubmitError } : undefined}
+          onClearPplSubmitError={() => setPplSubmitError(null)}
         />
       )}
       {selectedAlert && (

--- a/public/components/alerting/alarms_page_helpers.ts
+++ b/public/components/alerting/alarms_page_helpers.ts
@@ -17,6 +17,10 @@
  *     `.opendistro-alerting-config` index-not-found error.
  *   - `formStateToRule` — pure transform from a create-monitor form state
  *     to a UnifiedRule, used for optimistic insertion into the rules list.
+ *   - `extractServerErrorMessage` — prefers the parsed response body's
+ *     `message` (where OSD/our route_utils place actionable text) over the
+ *     bare `Error.message` (which is the HTTP status text like "Bad
+ *     Request"). Used by toast handlers to surface real error detail.
  *
  * Constants are exported so the page can import them by name.
  */
@@ -264,4 +268,56 @@ export function formStateToRule(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw field is empty for new monitors
     raw: {} as any,
   };
+}
+
+// =========================================================================
+// Error message extraction
+// =========================================================================
+
+/**
+ * Substring fingerprint emitted by the OS alerting plugin when PPL fails
+ * to parse — e.g. "alerting_exception: ... Reason: PPL Query validation
+ * failed: [INVALID_KEYWORD] is not a valid term ... <-- HERE. Expecting
+ * one of N possible tokens. ...". The `Reason:` prefix is the same shape
+ * `route_utils.toHandlerResult` produces for any 400 PPL error, so a
+ * substring check is enough for routing the message to the inline editor
+ * surface (BUG-4). Returns the message stripped of the `alerting_exception`
+ * wrapper so the editor's small footprint shows just the actionable detail.
+ */
+export function extractPplValidationError(message: string): string | null {
+  if (!message) return null;
+  const match = message.match(/PPL Query validation failed:\s*(.*)$/);
+  if (!match) return null;
+  return `PPL Query validation failed: ${match[1].trim()}`;
+}
+
+/**
+ * OSD's `IHttpFetchError` has both `message` (HTTP status text, e.g. "Bad
+ * Request") and `body` (the parsed response payload). Our server route util
+ * `toHandlerResult` (and OSD core's CustomHttpResponseOptions) puts the
+ * actionable detail under `body.message` — e.g. "alerting_exception: PPL
+ * Query validation failed: [INVALID_KEYWORD] is not a valid term…".
+ *
+ * `Error.message` alone is useless for users when the real signal lives
+ * one level deeper. Prefer `body.message` and fall back through a few
+ * other shapes before settling on the bare message.
+ */
+export function extractServerErrorMessage(e: unknown): string {
+  if (e == null) return 'Unknown error';
+  if (typeof e === 'string') return e;
+  if (typeof e !== 'object') return String(e);
+  const errorish = e as {
+    body?: unknown;
+    message?: unknown;
+  };
+  const body = errorish.body;
+  if (body && typeof body === 'object') {
+    const b = body as { message?: unknown; error?: unknown };
+    if (typeof b.message === 'string' && b.message.length > 0) return b.message;
+    if (typeof b.error === 'string' && b.error.length > 0) return b.error;
+  }
+  if (typeof errorish.message === 'string' && errorish.message.length > 0) {
+    return errorish.message;
+  }
+  return String(e);
 }

--- a/public/components/alerting/create_monitor/edit_monitor.tsx
+++ b/public/components/alerting/create_monitor/edit_monitor.tsx
@@ -39,6 +39,16 @@ export interface EditMonitorProps {
   onSave: (form: MonitorFormState, ruleId: string) => Promise<void> | void;
   datasources: Datasource[];
   selectedDsIds?: string[];
+  /**
+   * Forwarded to {@link CreateMonitor.isNameTaken}. Callers should already
+   * exclude this monitor's own ruleId so renaming back to the current value
+   * is allowed.
+   */
+  isNameTaken?: (trimmedName: string, dsId: string) => boolean;
+  /** Forwarded to {@link CreateMonitor.submitError}. */
+  submitError?: { pplMessage?: string };
+  /** Forwarded to {@link CreateMonitor.onClearPplSubmitError}. */
+  onClearPplSubmitError?: () => void;
 }
 
 /**
@@ -119,6 +129,9 @@ export const EditMonitor: React.FC<EditMonitorProps> = ({
   onSave,
   datasources,
   selectedDsIds,
+  isNameTaken,
+  submitError,
+  onClearPplSubmitError,
 }) => {
   const { data, isLoading, error } = useRuleDetail(dsId, ruleId);
   const [seededForm, setSeededForm] = useState<OpenSearchFormState | null>(null);
@@ -212,6 +225,9 @@ export const EditMonitor: React.FC<EditMonitorProps> = ({
       onCancel={onCancel}
       datasources={datasources}
       selectedDsIds={selectedDsIds}
+      isNameTaken={isNameTaken}
+      submitError={submitError}
+      onClearPplSubmitError={onClearPplSubmitError}
     />
   );
 };

--- a/public/components/alerting/create_monitor/index.tsx
+++ b/public/components/alerting/create_monitor/index.tsx
@@ -95,6 +95,27 @@ export interface CreateMonitorProps {
    * variant even if the user's selected datasource is the other type.
    */
   initialBackendType?: MonitorBackendType;
+  /**
+   * Predicate the form uses to surface an inline "name already in use"
+   * error before submit. Receives the trimmed candidate name and the
+   * datasource id the form is currently bound to. Returning `true` flags
+   * the row as invalid. The OS alerting backend silently accepts duplicate
+   * monitor names, so this guard is purely client-side; the page wires it
+   * up against the loaded rules list (excluding `initialForm`'s own id in
+   * edit mode so renaming back to the current name passes).
+   */
+  isNameTaken?: (trimmedName: string, dsId: string) => boolean;
+  /**
+   * Server-side error from the most recent save attempt, routed by the
+   * parent to whichever form field it belongs under so the user sees it
+   * inline in addition to the toast. Currently only `pplMessage` is wired
+   * — set it from a `PPL Query validation failed: ...` 400 response and
+   * the OpenSearch form section will render it under the PPL editor. The
+   * error clears as soon as the user edits the query.
+   */
+  submitError?: { pplMessage?: string };
+  /** Called when the user edits the PPL query, so the parent can clear `submitError.pplMessage`. */
+  onClearPplSubmitError?: () => void;
 }
 
 type CreationMode = 'manual' | 'ai';
@@ -109,6 +130,9 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
   mode = 'create',
   initialForm,
   initialBackendType,
+  isNameTaken,
+  submitError,
+  onClearPplSubmitError,
 }) => {
   const isEdit = mode === 'edit';
 
@@ -171,8 +195,12 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
   const updateOs = useCallback(
     <K extends keyof OpenSearchFormState>(key: K, value: OpenSearchFormState[K]) => {
       setOsForm((prev) => ({ ...prev, [key]: value }));
+      // Clear the inline PPL submit error as soon as the user edits the
+      // query — keeping a stale error visible after the offending text has
+      // been changed is misleading. Other field edits don't dismiss it.
+      if (key === 'query' && onClearPplSubmitError) onClearPplSubmitError();
     },
-    []
+    [onClearPplSubmitError]
   );
 
   const handleDatasourceChange = (id: string, type: MonitorBackendType) => {
@@ -206,15 +234,37 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
   // Validation
   const queryErrors = backendType === 'prometheus' ? validatePromQL(promForm.query) : [];
   const hasQueryErrors = queryErrors.some((e) => e.severity === 'error');
+  // Live duplicate-name check (BUG-1). The OS alerting backend silently
+  // accepts duplicates, so we have to guard client-side. Skip when the field
+  // is empty (the "required" error handles that case) or when the parent
+  // page didn't supply a checker.
+  const trimmedName = activeForm.name.trim();
+  const dsForCheck = activeForm.datasourceId;
+  const duplicateName = !!(
+    isNameTaken &&
+    trimmedName !== '' &&
+    dsForCheck !== '' &&
+    isNameTaken(trimmedName, dsForCheck)
+  );
+  const duplicateNameError = duplicateName
+    ? i18n.translate('observability.alerting.createMonitor.nameDuplicate', {
+        defaultMessage: 'A monitor with this name already exists on the selected datasource.',
+      })
+    : undefined;
   const isValid =
-    activeForm.name.trim() !== '' &&
+    trimmedName !== '' &&
     activeForm.datasourceId !== '' &&
+    !duplicateName &&
     (backendType === 'prometheus'
       ? promForm.query.trim() !== '' && !hasQueryErrors
       : osForm.query.trim() !== '');
 
   const handleSave = useCallback(() => {
     setHasSubmitted(true);
+    // Guard against duplicate names client-side. The Save button is also
+    // disabled via `isValid`, but defending here too means programmatic
+    // submission paths (Enter key on a field) can't bypass the check.
+    if (duplicateName) return;
     if (backendType === 'prometheus') {
       const result = validateMonitorForm(promForm as ValidatorFormState);
       if (!result.valid) {
@@ -236,7 +286,7 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
       setValidationErrors({});
       onSave(osForm);
     }
-  }, [backendType, promForm, osForm, onSave]);
+  }, [backendType, promForm, osForm, onSave, duplicateName]);
 
   // When AI wizard is active and user is on a Prometheus datasource, delegate to MonitorTemplateWizard
   if (creationMode === 'ai' && backendType === 'prometheus') {
@@ -376,16 +426,20 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
             defaultMessage: 'Monitor Name',
           })}
           fullWidth
-          isInvalid={hasSubmitted && (!!validationErrors.name || activeForm.name.trim() === '')}
+          isInvalid={
+            duplicateName ||
+            (hasSubmitted && (!!validationErrors.name || activeForm.name.trim() === ''))
+          }
           error={
-            hasSubmitted
+            duplicateNameError ||
+            (hasSubmitted
               ? validationErrors.name ||
                 (activeForm.name.trim() === ''
                   ? i18n.translate('observability.alerting.createMonitor.nameRequired', {
                       defaultMessage: 'Name is required',
                     })
                   : undefined)
-              : undefined
+              : undefined)
           }
         >
           <EuiFieldText
@@ -468,6 +522,7 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
             onUpdate={updateOs}
             validationErrors={validationErrors}
             hasSubmitted={hasSubmitted}
+            pplServerError={submitError?.pplMessage}
           />
         )}
       </EuiFlyoutBody>

--- a/public/components/alerting/create_monitor/opensearch_form_section.tsx
+++ b/public/components/alerting/create_monitor/opensearch_form_section.tsx
@@ -69,7 +69,9 @@ export const OpenSearchFormSection: React.FC<{
   onUpdate: <K extends keyof OpenSearchFormState>(key: K, value: OpenSearchFormState[K]) => void;
   validationErrors: Record<string, string>;
   hasSubmitted: boolean;
-}> = ({ form, onUpdate, validationErrors, hasSubmitted }) => {
+  /** Server-reported PPL parse error from a failed save; rendered under the editor. */
+  pplServerError?: string;
+}> = ({ form, onUpdate, validationErrors, hasSubmitted, pplServerError }) => {
   // Rewrite the leading `source = ...` clause whenever the picker changes,
   // preserving any later pipes the user has authored. Prevents stranding
   // the user with `source = old-index | ...` after they swap indices.
@@ -140,6 +142,7 @@ export const OpenSearchFormSection: React.FC<{
           indices={form.indices}
           value={form.query}
           onChange={(v) => onUpdate('query', v)}
+          serverError={pplServerError}
         />
         <EuiSpacer size="xs" />
         <EuiText size="xs" color="subdued">

--- a/public/components/alerting/create_monitor/sections/ppl_query_editor.tsx
+++ b/public/components/alerting/create_monitor/sections/ppl_query_editor.tsx
@@ -140,6 +140,14 @@ export interface PplQueryEditorProps {
   onChange: (value: string) => void;
   /** Visual height. Defaults to a comfortable 5-line area. */
   height?: number | string;
+  /**
+   * Server-reported PPL parse / validation error to render below the editor
+   * (e.g. "PPL Query validation failed: [INVALID_KEYWORD] is not a valid
+   * term..."). Pulled from a failed Save and cleared when the user edits.
+   * Distinct from autocomplete `mappingsError`, which warns about field
+   * suggestions only.
+   */
+  serverError?: string;
 }
 
 export const PplQueryEditor: React.FC<PplQueryEditorProps> = ({
@@ -148,6 +156,7 @@ export const PplQueryEditor: React.FC<PplQueryEditorProps> = ({
   value,
   onChange,
   height = 140,
+  serverError,
 }) => {
   const { fieldsByType, error: mappingsError } = useIndexMappings({ dsId, indices });
 
@@ -269,7 +278,12 @@ export const PplQueryEditor: React.FC<PplQueryEditorProps> = ({
           Cypress / functional tests have a stable selector. */}
       <div
         data-test-subj="alertManagerPplQueryEditor"
-        style={{ border: '1px solid var(--euiColorLightShade)', borderRadius: 4 }}
+        style={{
+          border: serverError
+            ? '1px solid var(--euiColorDanger)'
+            : '1px solid var(--euiColorLightShade)',
+          borderRadius: 4,
+        }}
       >
         <CodeEditor
           languageId={PPLLang.ID}
@@ -282,6 +296,11 @@ export const PplQueryEditor: React.FC<PplQueryEditorProps> = ({
           editorDidMount={editorDidMount}
         />
       </div>
+      {serverError && (
+        <EuiText color="danger" size="xs" data-test-subj="alertManagerPplQueryEditorServerError">
+          {serverError}
+        </EuiText>
+      )}
       {mappingsError && (
         <EuiText color="danger" size="xs" data-test-subj="alertManagerPplQueryEditorMappingsError">
           {i18n.translate('observability.alerting.pplQueryEditor.mappingsErrorMessage', {


### PR DESCRIPTION
> ⚠️ **Depends on #2701** (\`fix/alerting-crashes-and-polish\`). This PR is opened in draft and should be reviewed/merged after #2701 lands. The two branches were carved up to be conflict-free, but reviewing in order keeps the diff context coherent.

## Summary

Three changes for the bug-report findings around generic \`Bad Request\` toasts on monitor save (**BUG-1**, **BUG-3**, **BUG-4**).

The OpenSearch alerting backend on 3.7+ already returns actionable detail under \`body.message\` for every PPL-related 400 — e.g. \`alerting_exception: Reason: PPL Query validation failed: [INVALID_KEYWORD] is not a valid term...\`. The plugin's toast handlers were reading \`Error.message\`, which is just the HTTP status text (\`Bad Request\`), discarding the real signal.

> **Note on BUG-3 root cause:** the original report was filed against an OS 3.4.0 cluster where \`ppl_monitor\` create hits a backend NPE (\`Cannot read the array length because \"buf\" is null\` at \`RestIndexMonitorAction.kt:141\`). That NPE is fixed in 3.7.0; this PR focuses on the client-side surface so future 400s remain actionable. We also discovered a duplicate \`OPENSEARCH_IMAGE=\` line in \`observability-stack/.env\` that was pinning the local stack to 3.4.0 — that should be filed against \`opensearch-project/observability-stack\`.

### Verbose toast (BUG-3)
Add \`extractServerErrorMessage\` in \`alarms_page_helpers.ts\` that prefers \`body.message\` over \`Error.message\`, falling back through \`body.error\` and bare strings. Applied at all 6 toast call sites in \`alarms_page.tsx\` (create, update, batch-create, delete, clone, ack).

### Inline duplicate-name error (BUG-1)
The OS alerting backend silently accepts duplicate monitor names on the same datasource (verified against OS 3.7.0). Add a client-side guard that compares the trimmed candidate name against the loaded rules list, scoped to the picked datasource. Edit mode excludes the monitor's own \`ruleId\` so renaming back to the current value passes. Renders as an inline error on the Monitor Name row and disables Save.

### Inline PPL editor error (BUG-4)
Catch \`PPL Query validation failed: ...\` from the save-failure body, strip the \`alerting_exception\` wrapper, and route the message to the PPL editor as an inline error (with a danger border) in addition to the toast. Clears as soon as the user edits the query, the flyout closes, or a subsequent save succeeds.

### Wiring
\`alarms_page\` owns \`pplSubmitError\` state plus a \`(name, dsId) => boolean\` predicate, both passed down through \`CreateMonitor\` (and \`EditMonitor\` which forwards). The PPL editor gets a new \`serverError\` prop; the OpenSearch form section receives \`pplServerError\`. Cleanup props (\`onClearPplSubmitError\`) round-trip back up so any query edit clears the inline error before the next save.

## Test plan
- [x] \`yarn lint:es\` clean on all changed files
- [x] \`yarn typecheck\` from OSD root passes
- [x] \`yarn test public/components/alerting\` — 30/30 suites, 188/188 tests pass (7 new)
- [x] New unit tests in \`alarms_page_helpers.test.ts\` for \`extractServerErrorMessage\` (5 cases) and \`extractPplValidationError\` (3 cases)
- [x] Live verified against OS 3.7.0 in the observability-stack docker cluster:
  - [x] BUG-1: Typing a seeded name in the Monitor Name field triggers \"A monitor with this name already exists on the selected datasource.\" inline error and disables Save
  - [x] BUG-3: \`source = logs-otel-v1* | INVALID_KEYWORD foo\` save → toast body shows the full \`alerting_exception: ... PPL Query validation failed: [INVALID_KEYWORD] is not a valid term...\` message instead of \"Bad Request\"
  - [x] BUG-4: Same save also renders the PPL message inline under the Monaco editor; editing the query clears the inline error
- [ ] CI green (rebase after #2701 merges)