### PR TITLE
fix(alerting): gate Create Monitor entries and empty state on DS selection

### DIFF
--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -109,14 +109,16 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
 
   // Logs / Metrics popover entries are grayed out when the parent's selection
   // can't satisfy them: Logs needs at least one OpenSearch datasource, Metrics
-  // needs at least one Prometheus. With a mixed selection (or none) both stay
-  // enabled — the flyout's own dropdown will narrow further.
+  // needs at least one Prometheus. The empty-selection case used to fall
+  // through to "both enabled", but the spec is "no datasource selected → no
+  // create options viable" — Logs without an OS DS is undefined, Metrics
+  // without a Prometheus DS is undefined. Gate both so the user can't enter
+  // a flyout that will silently re-default the datasource on them.
   const [logsCreateDisabled, metricsCreateDisabled] = useMemo(() => {
-    if (selectedDsIds.length === 0) return [false, false];
     const selected = selectedDsIds
       .map((id) => datasources.find((d) => d.id === id))
       .filter((d): d is Datasource => !!d);
-    if (selected.length === 0) return [false, false];
+    if (selected.length === 0) return [true, true];
     return [
       selected.every((d) => d.type === 'prometheus'),
       selected.every((d) => d.type === 'opensearch'),
@@ -383,6 +385,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
                 onCreateMonitor={onCreateMonitor}
                 logsCreateDisabled={logsCreateDisabled}
                 metricsCreateDisabled={metricsCreateDisabled}
+                noDatasourceSelected={selectedDsIds.length === 0}
                 showCreatePopover={showCreatePopover}
                 setShowCreatePopover={setShowCreatePopover}
                 showDeleteConfirm={showDeleteConfirm}

--- a/public/components/alerting/monitors_table/monitors_main_panel.tsx
+++ b/public/components/alerting/monitors_table/monitors_main_panel.tsx
@@ -66,15 +66,22 @@ export interface MonitorsMainPanelProps {
   /**
    * When true, the "Logs" popover entry is disabled with a hint that an
    * OpenSearch datasource is needed. Triggered when the parent's selection
-   * is non-empty and contains only Prometheus datasources.
+   * is empty or contains only Prometheus datasources.
    */
   logsCreateDisabled?: boolean;
   /**
    * Symmetric counterpart of `logsCreateDisabled`: true when the parent's
-   * selection is non-empty and contains only OpenSearch datasources, so a
+   * selection is empty or contains only OpenSearch datasources, so a
    * Metrics monitor can't be created without changing the selection.
    */
   metricsCreateDisabled?: boolean;
+  /**
+   * The parent's datasource filter is empty. Distinguishes the empty-state
+   * "No monitors configured yet" copy from "Select a datasource to see
+   * monitors" — the cluster could have plenty of monitors but the listing
+   * hits zero datasources to query against.
+   */
+  noDatasourceSelected?: boolean;
   showCreatePopover: boolean;
   setShowCreatePopover: React.Dispatch<React.SetStateAction<boolean>>;
 
@@ -113,6 +120,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
   onCreateMonitor,
   logsCreateDisabled = false,
   metricsCreateDisabled = false,
+  noDatasourceSelected = false,
   showCreatePopover,
   setShowCreatePopover,
   showDeleteConfirm,
@@ -399,15 +407,35 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
             <EuiEmptyPrompt
               title={
                 <h2>
-                  <FormattedMessage
-                    id="observability.alerting.monitorsTable.mainPanel.noMonitorsFoundTitle"
-                    defaultMessage="No Monitors Found"
-                  />
+                  {noDatasourceSelected ? (
+                    <FormattedMessage
+                      id="observability.alerting.monitorsTable.mainPanel.noDatasourceSelectedTitle"
+                      defaultMessage="No datasource selected"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="observability.alerting.monitorsTable.mainPanel.noMonitorsFoundTitle"
+                      defaultMessage="No Monitors Found"
+                    />
+                  )}
                 </h2>
               }
               body={
                 <p>
-                  {rules.length === 0 ? (
+                  {/* Three distinct cases ordered by precedence: (1) the
+                      datasource filter is empty so we have nothing to query;
+                      (2) the cluster genuinely has zero monitors across the
+                      selected datasources; (3) filters/search excluded all
+                      otherwise-present monitors. (1) used to fall through to
+                      (2)'s "No monitors configured yet" copy, which read as
+                      a flat lie when the workspace had monitors on a
+                      datasource the user just unchecked. */}
+                  {noDatasourceSelected ? (
+                    <FormattedMessage
+                      id="observability.alerting.monitorsTable.mainPanel.selectDatasourcePrompt"
+                      defaultMessage="Select a datasource in the filter panel to see monitors."
+                    />
+                  ) : rules.length === 0 ? (
                     <FormattedMessage
                       id="observability.alerting.monitorsTable.mainPanel.noMonitorsConfigured"
                       defaultMessage="No monitors configured yet."
@@ -421,7 +449,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                 </p>
               }
               actions={
-                activeFilterCount > 0 || searchQuery ? (
+                !noDatasourceSelected && (activeFilterCount > 0 || searchQuery) ? (
                   <EuiButton onClick={clearAllFilters}>
                     <FormattedMessage
                       id="observability.alerting.monitorsTable.mainPanel.clearFiltersButton"


### PR DESCRIPTION
> ⚠️ **Independent of #2701 and #2703** but kept in draft to keep the alerting-follow-up review queue ordered. No file overlap with either of the two earlier PRs, so it can rebase cleanly in any merge order. Reviewers may pick this up after #2701 merges.

## Summary

Two related fixes for the Rules-tab datasource-filter UX (**BUG-5**, **BUG-11**).

### BUG-5 — Logs / Metrics popover entries weren't gated on empty selection

The disable predicates in \`monitors_table/index.tsx\` short-circuited on \`selectedDsIds.length === 0\` and returned \`[false, false]\`, leaving both entries enabled. Clicking Logs opened the flyout, which silently re-defaulted the target datasource to whichever first OS source it found — directly contradicting the user's just-cleared selection.

The spec the existing tooltip quotes is \"Logs monitors require an OpenSearch datasource. Select one to enable.\" That predicate is literally true when the selection is empty: the user has zero OS datasources picked. Treat empty-selection as \"both gated\" so the tooltip serves its purpose. The symmetric Metrics entry is gated for the same reason.

### BUG-11 — Empty-state copy didn't distinguish \"no DS\" from \"no monitors\"

When the datasource filter cleared all rows out of the table, the empty state read \"No Monitors Found / No monitors configured yet\" — a flat lie when the cluster has 19+ monitors waiting on the just-unchecked datasource.

Add a \`noDatasourceSelected\` prop on \`MonitorsMainPanel\` so the panel can distinguish three cases ordered by precedence:

1. **Datasource filter is empty** (\`noDatasourceSelected\`) — title \"No datasource selected\", body \"Select a datasource in the filter panel to see monitors.\", no Clear-filters action.
2. **Selected datasources genuinely have zero monitors** (\`rules.length === 0\`) — keeps the existing \"No monitors configured yet.\" copy.
3. **Filters/search excluded otherwise-present monitors** — keeps the existing \"No monitors match your current search and filters.\" copy plus the Clear-filters button.

## Test plan
- [x] \`yarn lint:es\` clean on both changed files
- [x] \`yarn typecheck\` from OSD root passes
- [x] \`yarn test public/components/alerting\` — 30/30 suites, 177/177 tests pass
- [x] Live verified against OS 3.7.0 in the observability-stack docker cluster:
  - [x] Clearing the Datasource filter flips the empty-state title to \"No datasource selected\" and body to \"Select a datasource in the filter panel to see monitors.\"
  - [x] Same action disables both Logs and Metrics popover entries (rendered as disabled list-items, not buttons)
  - [x] Hovering the disabled Logs entry shows the existing tooltip \"Logs monitors require an OpenSearch datasource. Select one to enable.\"
  - [x] Re-checking a datasource restores the table and re-enables the popover entries
- [ ] CI green