### PR TITLE
fix(alerting): wire Disable Monitor for PPL types and confirm-discard on Cancel

### DIFF
--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -490,6 +490,66 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     }
   };
 
+  const handleToggleMonitorEnabled = async (monitor: UnifiedRuleSummary): Promise<void> => {
+    // The detail flyout only renders this for PPL monitors today; defend at
+    // the page boundary anyway so a wider rollout doesn't accidentally PUT
+    // against an unsupported monitor type.
+    if (monitor.monitorType !== 'ppl') {
+      addToast(
+        i18n.translate('observability.alerting.alarmsPage.toast.toggleEnabledUnsupported', {
+          defaultMessage: 'Enabling/disabling is only supported for PPL monitors.',
+        }),
+        'warning'
+      );
+      return;
+    }
+    const nextEnabled = !monitor.enabled;
+    try {
+      // Server-side `updateMonitor` runs a GET-merge-PUT against the upstream
+      // alerting plugin and explicitly preserves plugin-owned keys against
+      // client overwrites, so a minimal partial body is sufficient. `name` is
+      // the only field the route schema requires; `enabled` is the only field
+      // we actually want to change.
+      await mutations.updateMonitor(
+        monitor.id,
+        { name: monitor.name, enabled: nextEnabled },
+        monitor.datasourceId
+      );
+      // Optimistically reflect the new state in the loaded rules list so the
+      // flyout footer button label / status badge flips immediately. The
+      // refetch reconciles whatever the backend ultimately persisted.
+      setRules((prev) =>
+        prev.map((r) =>
+          r.id === monitor.id
+            ? { ...r, enabled: nextEnabled, status: nextEnabled ? 'active' : 'disabled' }
+            : r
+        )
+      );
+      addToast(
+        nextEnabled
+          ? i18n.translate('observability.alerting.alarmsPage.toast.monitorEnabled', {
+              defaultMessage: 'Monitor enabled',
+            })
+          : i18n.translate('observability.alerting.alarmsPage.toast.monitorDisabled', {
+              defaultMessage: 'Monitor disabled',
+            })
+      );
+      refetchRules();
+    } catch (e: unknown) {
+      addToast(
+        nextEnabled
+          ? i18n.translate('observability.alerting.alarmsPage.toast.enableMonitorFailed', {
+              defaultMessage: 'Failed to enable monitor',
+            })
+          : i18n.translate('observability.alerting.alarmsPage.toast.disableMonitorFailed', {
+              defaultMessage: 'Failed to disable monitor',
+            }),
+        'danger',
+        e instanceof Error ? e.message : String(e)
+      );
+    }
+  };
+
   const handleCloneRule = async (monitor: UnifiedRuleSummary) => {
     try {
       // Fetch the full rule detail to get the raw backend payload — the
@@ -755,6 +815,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           onDelete={handleDeleteRules}
           onClone={handleCloneRule}
           onEdit={(monitor) => setEditTarget({ dsId: monitor.datasourceId, ruleId: monitor.id })}
+          onToggleEnabled={handleToggleMonitorEnabled}
           onCreateMonitor={(type) => {
             if (type === 'logs') {
               setCreateBackendType('opensearch');

--- a/public/components/alerting/create_monitor/index.tsx
+++ b/public/components/alerting/create_monitor/index.tsx
@@ -22,6 +22,7 @@ import {
   EuiBadge,
   EuiButton,
   EuiButtonEmpty,
+  EuiConfirmModal,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -30,6 +31,7 @@ import {
   EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiFormRow,
+  EuiOverlayMask,
   EuiPanel,
   EuiSelect,
   EuiSpacer,
@@ -185,6 +187,51 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
   );
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+
+  // Snapshot the initial form so we can detect "dirty" against the value the
+  // user actually saw on open. Captured once via lazy initializer; never
+  // updated — even if the form's identity-of-state mutates, dirty is always
+  // measured against the original. JSON-stringify is fine for these small
+  // forms.
+  const [initialPromSnapshot] = useState(() =>
+    JSON.stringify(
+      initialForm && initialForm.datasourceType === 'prometheus'
+        ? initialForm
+        : {
+            ...DEFAULT_PROM_FORM,
+            datasourceId: initialType === 'prometheus' && initialDs ? initialDs.id : '',
+          }
+    )
+  );
+  const [initialOsSnapshot] = useState(() =>
+    JSON.stringify(
+      initialForm && initialForm.datasourceType === 'opensearch'
+        ? initialForm
+        : {
+            ...DEFAULT_OS_FORM,
+            datasourceId: initialType === 'opensearch' && initialDs ? initialDs.id : '',
+          }
+    )
+  );
+  // Compare only the active backend's form — switching backendType mid-edit
+  // doesn't itself constitute dirtiness; only typed changes within whichever
+  // form variant is currently rendered do.
+  const isDirty =
+    backendType === 'prometheus'
+      ? JSON.stringify(promForm) !== initialPromSnapshot
+      : JSON.stringify(osForm) !== initialOsSnapshot;
+  // Single entry point for "user wants to abandon edits". Bare onCancel
+  // discards immediately; the wrapped version asks first when dirty. Used
+  // by the footer Cancel button, the flyout's overlay-click / Esc handler,
+  // and any other affordance that closes the flyout without saving.
+  const requestCancel = useCallback(() => {
+    if (isDirty) {
+      setShowDiscardConfirm(true);
+      return;
+    }
+    onCancel();
+  }, [isDirty, onCancel]);
 
   const updateProm = useCallback(
     <K extends keyof PrometheusFormState>(key: K, value: PrometheusFormState[K]) => {
@@ -321,245 +368,290 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
   }
 
   return (
-    <EuiFlyout onClose={onCancel} size="l" ownFocus aria-labelledby="createMonitorFlyoutTitle">
-      <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="m">
-          <h2 id="createMonitorFlyoutTitle">
+    <>
+      <EuiFlyout
+        onClose={requestCancel}
+        size="l"
+        ownFocus
+        aria-labelledby="createMonitorFlyoutTitle"
+      >
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="m">
+            <h2 id="createMonitorFlyoutTitle">
+              {backendType === 'prometheus'
+                ? isEdit
+                  ? i18n.translate('observability.alerting.createMonitor.editTitleMetrics', {
+                      defaultMessage: 'Edit Metrics Monitor',
+                    })
+                  : i18n.translate('observability.alerting.createMonitor.titleMetrics', {
+                      defaultMessage: 'Create Metrics Monitor',
+                    })
+                : isEdit
+                ? i18n.translate('observability.alerting.createMonitor.editTitleLogs', {
+                    defaultMessage: 'Edit Logs Monitor',
+                  })
+                : i18n.translate('observability.alerting.createMonitor.titleLogs', {
+                    defaultMessage: 'Create Logs Monitor',
+                  })}
+            </h2>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiText size="xs" color="subdued">
             {backendType === 'prometheus'
-              ? isEdit
-                ? i18n.translate('observability.alerting.createMonitor.editTitleMetrics', {
-                    defaultMessage: 'Edit Metrics Monitor',
-                  })
-                : i18n.translate('observability.alerting.createMonitor.titleMetrics', {
-                    defaultMessage: 'Create Metrics Monitor',
-                  })
-              : isEdit
-              ? i18n.translate('observability.alerting.createMonitor.editTitleLogs', {
-                  defaultMessage: 'Edit Logs Monitor',
+              ? i18n.translate('observability.alerting.createMonitor.subtitlePromql', {
+                  defaultMessage: 'PromQL-based alerting rule',
                 })
-              : i18n.translate('observability.alerting.createMonitor.titleLogs', {
-                  defaultMessage: 'Create Logs Monitor',
+              : i18n.translate('observability.alerting.createMonitor.subtitlePpl', {
+                  defaultMessage: 'PPL-based alerting rule',
                 })}
-          </h2>
-        </EuiTitle>
-        <EuiSpacer size="s" />
-        <EuiText size="xs" color="subdued">
-          {backendType === 'prometheus'
-            ? i18n.translate('observability.alerting.createMonitor.subtitlePromql', {
-                defaultMessage: 'PromQL-based alerting rule',
-              })
-            : i18n.translate('observability.alerting.createMonitor.subtitlePpl', {
-                defaultMessage: 'PPL-based alerting rule',
-              })}
-        </EuiText>
-      </EuiFlyoutHeader>
+          </EuiText>
+        </EuiFlyoutHeader>
 
-      <EuiFlyoutBody>
-        {/* Target Datasource — locked in edit mode (the existing monitor
+        <EuiFlyoutBody>
+          {/* Target Datasource — locked in edit mode (the existing monitor
             already binds a datasource; changing it would require re-creating).
             Scoped to the active backend so a Logs flyout never shows
             Prometheus datasources and vice versa. */}
-        <DatasourceTargetSelector
-          datasources={datasources.filter((d) => d.type === backendType)}
-          selectedId={activeForm.datasourceId}
-          onChange={isEdit ? () => undefined : handleDatasourceChange}
-        />
+          <DatasourceTargetSelector
+            datasources={datasources.filter((d) => d.type === backendType)}
+            selectedId={activeForm.datasourceId}
+            onChange={isEdit ? () => undefined : handleDatasourceChange}
+          />
 
-        <EuiSpacer size="m" />
+          <EuiSpacer size="m" />
 
-        {/* Creation Mode Toggle — AI only available for Prometheus, hidden in edit mode */}
-        {!isEdit && backendType === 'prometheus' && (
-          <>
-            <EuiPanel paddingSize="s" hasBorder>
-              <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false}>
+          {/* Creation Mode Toggle — AI only available for Prometheus, hidden in edit mode */}
+          {!isEdit && backendType === 'prometheus' && (
+            <>
+              <EuiPanel paddingSize="s" hasBorder>
+                <EuiFlexGroup gutterSize="m" alignItems="center" responsive={false}>
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="xs">
+                      <strong>
+                        {i18n.translate(
+                          'observability.alerting.createMonitor.creationMethodLabel',
+                          {
+                            defaultMessage: 'Creation method',
+                          }
+                        )}
+                      </strong>
+                    </EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiFlexGroup gutterSize="xs" responsive={false}>
+                      <EuiFlexItem grow={false}>
+                        <EuiBadge
+                          color={creationMode === 'manual' ? 'primary' : 'hollow'}
+                          onClick={() => setCreationMode('manual')}
+                          onClickAriaLabel={i18n.translate(
+                            'observability.alerting.createMonitor.manualCreationAriaLabel',
+                            { defaultMessage: 'Manual creation' }
+                          )}
+                        >
+                          {i18n.translate('observability.alerting.createMonitor.manualBadge', {
+                            defaultMessage: 'Manual',
+                          })}
+                        </EuiBadge>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiBadge
+                          color={creationMode === 'ai' ? 'secondary' : 'hollow'}
+                          onClick={() => setCreationMode('ai')}
+                          onClickAriaLabel={i18n.translate(
+                            'observability.alerting.createMonitor.fromTemplateAriaLabel',
+                            { defaultMessage: 'Create from template' }
+                          )}
+                          iconType="sparkles"
+                        >
+                          {i18n.translate(
+                            'observability.alerting.createMonitor.fromTemplateBadge',
+                            {
+                              defaultMessage: 'From template',
+                            }
+                          )}
+                        </EuiBadge>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiPanel>
+              <EuiSpacer size="m" />
+            </>
+          )}
+
+          {/* Monitor Name */}
+          <EuiFormRow
+            label={i18n.translate('observability.alerting.createMonitor.monitorNameLabel', {
+              defaultMessage: 'Monitor Name',
+            })}
+            fullWidth
+            isInvalid={
+              duplicateName ||
+              (hasSubmitted && (!!validationErrors.name || activeForm.name.trim() === ''))
+            }
+            error={
+              duplicateNameError ||
+              (hasSubmitted
+                ? validationErrors.name ||
+                  (activeForm.name.trim() === ''
+                    ? i18n.translate('observability.alerting.createMonitor.nameRequired', {
+                        defaultMessage: 'Name is required',
+                      })
+                    : undefined)
+                : undefined)
+            }
+          >
+            <EuiFieldText
+              placeholder={
+                backendType === 'prometheus'
+                  ? i18n.translate(
+                      'observability.alerting.createMonitor.monitorNamePlaceholderPrometheus',
+                      { defaultMessage: 'e.g. HighCpuUsage, PaymentErrorRate' }
+                    )
+                  : i18n.translate(
+                      'observability.alerting.createMonitor.monitorNamePlaceholderOpensearch',
+                      { defaultMessage: 'e.g. High Error Rate, Disk Usage Alert' }
+                    )
+              }
+              value={activeForm.name}
+              onChange={(e) => updateName(e.target.value)}
+              fullWidth
+              aria-label={i18n.translate(
+                'observability.alerting.createMonitor.monitorNameAriaLabel',
+                {
+                  defaultMessage: 'Monitor name',
+                }
+              )}
+            />
+          </EuiFormRow>
+
+          <EuiSpacer size="m" />
+
+          {/* Severity + Enabled */}
+          <EuiFlexGroup gutterSize="m" alignItems="center">
+            <EuiFlexItem grow={3}>
+              <EuiFormRow
+                label={i18n.translate('observability.alerting.createMonitor.severityLabel', {
+                  defaultMessage: 'Severity',
+                })}
+                display="rowCompressed"
+              >
+                <EuiSelect
+                  options={SEVERITY_OPTIONS}
+                  value={activeForm.severity}
+                  onChange={(e) => updateSeverity(e.target.value as UnifiedAlertSeverity)}
+                  compressed
+                  aria-label={i18n.translate(
+                    'observability.alerting.createMonitor.severityAriaLabel',
+                    { defaultMessage: 'Severity' }
+                  )}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={1}>
+              <EuiFormRow
+                label={i18n.translate('observability.alerting.createMonitor.enabledLabel', {
+                  defaultMessage: 'Enabled',
+                })}
+                display="rowCompressed"
+              >
+                <EuiSwitch
+                  label=""
+                  checked={activeForm.enabled}
+                  onChange={(e) => updateEnabled(e.target.checked)}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+
+          <EuiSpacer size="m" />
+
+          {/* Backend-specific form */}
+          {backendType === 'prometheus' ? (
+            <PrometheusFormSection
+              form={promForm}
+              onUpdate={updateProm}
+              validationErrors={validationErrors}
+              hasSubmitted={hasSubmitted}
+              context={context}
+            />
+          ) : (
+            <OpenSearchFormSection
+              form={osForm}
+              onUpdate={updateOs}
+              validationErrors={validationErrors}
+              hasSubmitted={hasSubmitted}
+              pplServerError={submitError?.pplMessage}
+            />
+          )}
+        </EuiFlyoutBody>
+
+        <EuiFlyoutFooter>
+          <EuiFlexGroup justifyContent="spaceBetween" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty onClick={requestCancel}>
+                {i18n.translate('observability.alerting.createMonitor.cancelButton', {
+                  defaultMessage: 'Cancel',
+                })}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup gutterSize="s" responsive={false}>
                 <EuiFlexItem grow={false}>
-                  <EuiText size="xs">
-                    <strong>
-                      {i18n.translate('observability.alerting.createMonitor.creationMethodLabel', {
-                        defaultMessage: 'Creation method',
-                      })}
-                    </strong>
-                  </EuiText>
+                  <EuiButton onClick={handleSave} isDisabled={!isValid}>
+                    {isEdit
+                      ? i18n.translate('observability.alerting.createMonitor.saveChangesButton', {
+                          defaultMessage: 'Save Changes',
+                        })
+                      : i18n.translate('observability.alerting.createMonitor.saveMonitorButton', {
+                          defaultMessage: 'Save Monitor',
+                        })}
+                  </EuiButton>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiFlexGroup gutterSize="xs" responsive={false}>
-                    <EuiFlexItem grow={false}>
-                      <EuiBadge
-                        color={creationMode === 'manual' ? 'primary' : 'hollow'}
-                        onClick={() => setCreationMode('manual')}
-                        onClickAriaLabel={i18n.translate(
-                          'observability.alerting.createMonitor.manualCreationAriaLabel',
-                          { defaultMessage: 'Manual creation' }
-                        )}
-                      >
-                        {i18n.translate('observability.alerting.createMonitor.manualBadge', {
-                          defaultMessage: 'Manual',
-                        })}
-                      </EuiBadge>
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiBadge
-                        color={creationMode === 'ai' ? 'secondary' : 'hollow'}
-                        onClick={() => setCreationMode('ai')}
-                        onClickAriaLabel={i18n.translate(
-                          'observability.alerting.createMonitor.fromTemplateAriaLabel',
-                          { defaultMessage: 'Create from template' }
-                        )}
-                        iconType="sparkles"
-                      >
-                        {i18n.translate('observability.alerting.createMonitor.fromTemplateBadge', {
-                          defaultMessage: 'From template',
-                        })}
-                      </EuiBadge>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
+                  <EuiButton fill onClick={handleSave} isDisabled={!isValid}>
+                    {i18n.translate('observability.alerting.createMonitor.saveAndEnableButton', {
+                      defaultMessage: 'Save & Enable',
+                    })}
+                  </EuiButton>
                 </EuiFlexItem>
               </EuiFlexGroup>
-            </EuiPanel>
-            <EuiSpacer size="m" />
-          </>
-        )}
-
-        {/* Monitor Name */}
-        <EuiFormRow
-          label={i18n.translate('observability.alerting.createMonitor.monitorNameLabel', {
-            defaultMessage: 'Monitor Name',
-          })}
-          fullWidth
-          isInvalid={
-            duplicateName ||
-            (hasSubmitted && (!!validationErrors.name || activeForm.name.trim() === ''))
-          }
-          error={
-            duplicateNameError ||
-            (hasSubmitted
-              ? validationErrors.name ||
-                (activeForm.name.trim() === ''
-                  ? i18n.translate('observability.alerting.createMonitor.nameRequired', {
-                      defaultMessage: 'Name is required',
-                    })
-                  : undefined)
-              : undefined)
-          }
-        >
-          <EuiFieldText
-            placeholder={
-              backendType === 'prometheus'
-                ? i18n.translate(
-                    'observability.alerting.createMonitor.monitorNamePlaceholderPrometheus',
-                    { defaultMessage: 'e.g. HighCpuUsage, PaymentErrorRate' }
-                  )
-                : i18n.translate(
-                    'observability.alerting.createMonitor.monitorNamePlaceholderOpensearch',
-                    { defaultMessage: 'e.g. High Error Rate, Disk Usage Alert' }
-                  )
-            }
-            value={activeForm.name}
-            onChange={(e) => updateName(e.target.value)}
-            fullWidth
-            aria-label={i18n.translate(
-              'observability.alerting.createMonitor.monitorNameAriaLabel',
-              {
-                defaultMessage: 'Monitor name',
-              }
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutFooter>
+      </EuiFlyout>
+      {showDiscardConfirm && (
+        <EuiOverlayMask>
+          <EuiConfirmModal
+            title={i18n.translate('observability.alerting.createMonitor.discardConfirmTitle', {
+              defaultMessage: 'Discard unsaved changes?',
+            })}
+            onCancel={() => setShowDiscardConfirm(false)}
+            onConfirm={() => {
+              setShowDiscardConfirm(false);
+              onCancel();
+            }}
+            cancelButtonText={i18n.translate(
+              'observability.alerting.createMonitor.discardConfirmCancel',
+              { defaultMessage: 'Keep editing' }
             )}
-          />
-        </EuiFormRow>
-
-        <EuiSpacer size="m" />
-
-        {/* Severity + Enabled */}
-        <EuiFlexGroup gutterSize="m" alignItems="center">
-          <EuiFlexItem grow={3}>
-            <EuiFormRow
-              label={i18n.translate('observability.alerting.createMonitor.severityLabel', {
-                defaultMessage: 'Severity',
+            confirmButtonText={i18n.translate(
+              'observability.alerting.createMonitor.discardConfirmConfirm',
+              { defaultMessage: 'Discard changes' }
+            )}
+            buttonColor="danger"
+            defaultFocusedButton="cancel"
+            data-test-subj="alertManagerDiscardChangesConfirm"
+          >
+            <p>
+              {i18n.translate('observability.alerting.createMonitor.discardConfirmBody', {
+                defaultMessage:
+                  "You've made changes to this monitor that haven't been saved. Discarding will lose them.",
               })}
-              display="rowCompressed"
-            >
-              <EuiSelect
-                options={SEVERITY_OPTIONS}
-                value={activeForm.severity}
-                onChange={(e) => updateSeverity(e.target.value as UnifiedAlertSeverity)}
-                compressed
-                aria-label={i18n.translate(
-                  'observability.alerting.createMonitor.severityAriaLabel',
-                  { defaultMessage: 'Severity' }
-                )}
-              />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem grow={1}>
-            <EuiFormRow
-              label={i18n.translate('observability.alerting.createMonitor.enabledLabel', {
-                defaultMessage: 'Enabled',
-              })}
-              display="rowCompressed"
-            >
-              <EuiSwitch
-                label=""
-                checked={activeForm.enabled}
-                onChange={(e) => updateEnabled(e.target.checked)}
-              />
-            </EuiFormRow>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer size="m" />
-
-        {/* Backend-specific form */}
-        {backendType === 'prometheus' ? (
-          <PrometheusFormSection
-            form={promForm}
-            onUpdate={updateProm}
-            validationErrors={validationErrors}
-            hasSubmitted={hasSubmitted}
-            context={context}
-          />
-        ) : (
-          <OpenSearchFormSection
-            form={osForm}
-            onUpdate={updateOs}
-            validationErrors={validationErrors}
-            hasSubmitted={hasSubmitted}
-            pplServerError={submitError?.pplMessage}
-          />
-        )}
-      </EuiFlyoutBody>
-
-      <EuiFlyoutFooter>
-        <EuiFlexGroup justifyContent="spaceBetween" responsive={false}>
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={onCancel}>
-              {i18n.translate('observability.alerting.createMonitor.cancelButton', {
-                defaultMessage: 'Cancel',
-              })}
-            </EuiButtonEmpty>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="s" responsive={false}>
-              <EuiFlexItem grow={false}>
-                <EuiButton onClick={handleSave} isDisabled={!isValid}>
-                  {isEdit
-                    ? i18n.translate('observability.alerting.createMonitor.saveChangesButton', {
-                        defaultMessage: 'Save Changes',
-                      })
-                    : i18n.translate('observability.alerting.createMonitor.saveMonitorButton', {
-                        defaultMessage: 'Save Monitor',
-                      })}
-                </EuiButton>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton fill onClick={handleSave} isDisabled={!isValid}>
-                  {i18n.translate('observability.alerting.createMonitor.saveAndEnableButton', {
-                    defaultMessage: 'Save & Enable',
-                  })}
-                </EuiButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlyoutFooter>
-    </EuiFlyout>
+            </p>
+          </EuiConfirmModal>
+        </EuiOverlayMask>
+      )}
+    </>
   );
 };

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -68,6 +68,14 @@ export interface MonitorDetailFlyoutProps {
    * an edit flyout.
    */
   onEdit?: (monitor: UnifiedRuleSummary) => void;
+  /**
+   * Optional Disable / Enable handler. The page wires this only for PPL
+   * monitors, which is the surface where {@link onEdit} is also wired —
+   * the underlying transport (`PUT /monitors/{id}`) and trigger payload
+   * stripping are the same. Non-PPL monitor types stay disabled with an
+   * explanatory tooltip until their edit path is implemented.
+   */
+  onToggleEnabled?: (monitor: UnifiedRuleSummary) => Promise<void> | void;
 }
 
 // ============================================================================
@@ -80,8 +88,13 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
   onDelete,
   onClone,
   onEdit,
+  onToggleEnabled,
 }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isTogglingEnabled, setIsTogglingEnabled] = useState(false);
+  // Mirror the Edit-button gate (PPL only). Non-PPL types stay read-only;
+  // the existing tooltip surfaces explains the limitation.
+  const canToggleEnabled = !!onToggleEnabled && monitor.monitorType === 'ppl';
   const { detail, isLoading: detailLoading, error: detailError } = useMonitorDetail({
     dsId: monitor.datasourceId,
     ruleId: monitor.id,
@@ -700,15 +713,21 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
             <EuiFlexItem grow={false}>
               <EuiFlexGroup gutterSize="s" responsive={false}>
                 <EuiFlexItem grow={false}>
-                  <EuiToolTip
-                    content={i18n.translate(
-                      'observability.alerting.monitorDetailFlyout.enableDisableTooltip',
-                      {
-                        defaultMessage: 'Enable/disable is not yet wired to the backend API',
-                      }
-                    )}
-                  >
-                    <EuiButton size="s" isDisabled>
+                  {canToggleEnabled ? (
+                    <EuiButton
+                      size="s"
+                      isLoading={isTogglingEnabled}
+                      onClick={async () => {
+                        if (!onToggleEnabled || isTogglingEnabled) return;
+                        setIsTogglingEnabled(true);
+                        try {
+                          await onToggleEnabled(monitor);
+                        } finally {
+                          setIsTogglingEnabled(false);
+                        }
+                      }}
+                      data-test-subj="alertManagerMonitorDetailToggleEnabled"
+                    >
                       {monitor.enabled === false
                         ? i18n.translate(
                             'observability.alerting.monitorDetailFlyout.enableMonitor',
@@ -719,7 +738,28 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                             { defaultMessage: 'Disable Monitor' }
                           )}
                     </EuiButton>
-                  </EuiToolTip>
+                  ) : (
+                    <EuiToolTip
+                      content={i18n.translate(
+                        'observability.alerting.monitorDetailFlyout.enableDisableTooltip',
+                        {
+                          defaultMessage: 'Enable/disable is only supported for PPL monitors.',
+                        }
+                      )}
+                    >
+                      <EuiButton size="s" isDisabled>
+                        {monitor.enabled === false
+                          ? i18n.translate(
+                              'observability.alerting.monitorDetailFlyout.enableMonitor',
+                              { defaultMessage: 'Enable Monitor' }
+                            )
+                          : i18n.translate(
+                              'observability.alerting.monitorDetailFlyout.disableMonitor',
+                              { defaultMessage: 'Disable Monitor' }
+                            )}
+                      </EuiButton>
+                    </EuiToolTip>
+                  )}
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -44,6 +44,11 @@ interface MonitorsTableProps {
   onDelete: (ids: string[]) => void;
   onClone?: (monitor: UnifiedRuleSummary) => void;
   onEdit?: (monitor: UnifiedRuleSummary) => void;
+  /**
+   * Optional Disable / Enable handler. Forwarded to the detail flyout.
+   * Wired only for PPL monitors at the page layer.
+   */
+  onToggleEnabled?: (monitor: UnifiedRuleSummary) => Promise<void> | void;
   onCreateMonitor?: (type: 'logs' | 'prometheus' | 'metrics' | 'slo') => void;
   /** Currently selected datasource IDs */
   selectedDsIds: string[];
@@ -72,6 +77,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   onDelete,
   onClone,
   onEdit,
+  onToggleEnabled,
   onCreateMonitor,
   selectedDsIds,
   onDatasourceChange,
@@ -89,6 +95,17 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   const [activeSuggestion, setActiveSuggestion] = useState(-1);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({ ...DEFAULT_WIDTHS });
   const [selectedMonitor, setSelectedMonitor] = useState<UnifiedRuleSummary | null>(null);
+  // Keep `selectedMonitor` in sync with the latest version of itself in the
+  // rules list. Without this, an optimistic update at the page level (e.g.
+  // toggling `enabled` from the detail flyout) wouldn't reflect back into
+  // the flyout's button label / status pill — the flyout would render off
+  // a stale snapshot until the user closes and reopens it.
+  useEffect(() => {
+    if (!selectedMonitor) return;
+    const fresh = rules.find((r) => r.id === selectedMonitor.id);
+    if (!fresh) return;
+    if (fresh !== selectedMonitor) setSelectedMonitor(fresh);
+  }, [rules, selectedMonitor]);
   const [showCreatePopover, setShowCreatePopover] = useState(false);
   const [showSaveSearchInput, setShowSaveSearchInput] = useState(false);
   const [saveSearchName, setSaveSearchName] = useState('');
@@ -393,6 +410,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
                 onDelete={onDelete}
                 onClone={onClone}
                 onEdit={onEdit}
+                onToggleEnabled={onToggleEnabled}
               />
             </EuiResizablePanel>
           </>

--- a/public/components/alerting/monitors_table/monitors_main_panel.tsx
+++ b/public/components/alerting/monitors_table/monitors_main_panel.tsx
@@ -89,6 +89,12 @@ export interface MonitorsMainPanelProps {
   onDelete: (ids: string[]) => void;
   onClone?: (monitor: UnifiedRuleSummary) => void;
   onEdit?: (monitor: UnifiedRuleSummary) => void;
+  /**
+   * Forwarded to {@link MonitorDetailFlyout.onToggleEnabled}. Page provides
+   * an awaitable handler that PUTs the monitor with `enabled` flipped; the
+   * flyout shows a loading spinner on the button until it resolves.
+   */
+  onToggleEnabled?: (monitor: UnifiedRuleSummary) => Promise<void> | void;
 }
 
 export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
@@ -123,6 +129,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
   onDelete,
   onClone,
   onEdit,
+  onToggleEnabled,
 }) => {
   return (
     <>
@@ -483,6 +490,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                 }
               : undefined
           }
+          onToggleEnabled={onToggleEnabled}
         />
       )}
     </>


### PR DESCRIPTION
> ⚠️ **Independent of #2701, #2703, #2704** but kept in draft to keep the alerting-follow-up review queue ordered. Touches \`alarms_page.tsx\` alongside #2703, but at non-overlapping line ranges (this PR adds a new \`handleToggleMonitorEnabled\` near line 437 and a single prop in the \`MonitorsTable\` JSX near line 750; #2703 touches imports + error toast handlers). They will three-way merge cleanly.

## Summary

Two fixes around the monitor detail / create flyouts (**BUG-8**, **BUG-10**). The third bug-report finding (**BUG-7**: Edit disabled on Log monitors) is a working-as-designed expectation mismatch — the existing tooltip already explains \"Editing is only supported for PPL monitors\", which the bug-report tester appears to have missed. **No code change for BUG-7.** Hover state confirmed live.

### BUG-8 — Disable Monitor button always disabled

\`monitor_detail_flyout.tsx\` hard-coded \`<EuiButton size=\"s\" isDisabled>\` with the tooltip \"Enable/disable is not yet wired to the backend API\". Wire it through for PPL monitors, mirroring the existing Edit-button gate. Non-PPL types keep a disabled button with the more accurate tooltip \"Enable/disable is only supported for PPL monitors.\"

The actual round-trip is straightforward: \`mutations.updateMonitor\` already handles GET-merge-PUT against the upstream alerting plugin and explicitly preserves plugin-owned keys against client overwrites (see \`opensearch_backend.ts\` lines 188–200), so the page-level handler sends only \`{ name, enabled: !current }\`. The button shows a loading spinner until the PUT resolves; the page optimistically flips the local rule's \`enabled\` and \`status\` so the flyout label / status pill update immediately, and a \`useEffect\` in \`monitors_table/index.tsx\` keeps \`selectedMonitor\` synced to the latest rules entry by id so the flyout doesn't render off a stale snapshot.

Toast copy: \"Monitor enabled\" / \"Monitor disabled\" on success; \"Failed to enable monitor\" / \"Failed to disable monitor\" on failure with the server's actionable message in the body.

### BUG-10 — Cancel mid-edit drops unsaved changes silently

The Create / Edit flyout's Cancel handler called \`onCancel()\` immediately, dropping any typed changes. Capture an initial form snapshot via lazy \`useState\` initializer (one for the Prometheus form, one for the OpenSearch form) and compare via \`JSON.stringify\` on every render. When \`isDirty\` and the user clicks Cancel — or clicks the flyout's Esc / overlay-click handler — show an \`EuiConfirmModal\` titled \"Discard unsaved changes?\" with a \"Keep editing\" cancel and a danger-styled \"Discard changes\" confirm. Default focus is on Keep-editing so an accidental Enter keeps the work. Clean cancels (no edits) close the flyout immediately; no spurious modal.

## Test plan
- [x] \`yarn lint:es\` clean on all changed files
- [x] \`yarn typecheck\` from OSD root passes
- [x] \`yarn test public/components/alerting\` — 30/30 suites, 177/177 tests pass
- [x] Live verified against OS 3.7.0 in the observability-stack docker cluster:
  - [x] BUG-7: Hovering disabled Edit on a Log monitor surfaces tooltip \"Editing is only supported for PPL monitors\"
  - [x] BUG-8 (Log): Disable Monitor stays disabled with new tooltip \"Enable/disable is only supported for PPL monitors.\"
  - [x] BUG-8 (PPL): Click Disable → toast \"Monitor disabled\" + label flips to \"Enable Monitor\" + backend persists \`enabled: false\`
  - [x] BUG-8 (PPL): Click Enable → toast \"Monitor enabled\" + label flips back + backend persists \`enabled: true\`
  - [x] BUG-10: Open Edit, modify name, click Cancel → \"Discard unsaved changes?\" modal renders
  - [x] BUG-10: \"Keep editing\" closes modal, dirty value preserved, Edit flyout stays open
  - [x] BUG-10: \"Discard changes\" closes modal AND Edit flyout
  - [x] BUG-10: Open Edit, click Cancel without modifying → flyout closes immediately, no spurious modal
- [ ] CI green