### PR TITLE
fix(alerting): SLO deep-link auto-selects DS; alert detail links to source

### DIFF
--- a/public/components/alerting/__tests__/alarms_page.test.tsx
+++ b/public/components/alerting/__tests__/alarms_page.test.tsx
@@ -392,6 +392,28 @@ describe('parseAlarmsHashRoute', () => {
     expect(parseAlarmsHashRoute('#/rules?q=%20')).toEqual({ tab: 'rules' });
   });
 
+  it('parses the optional ds param alongside q (BUG-12 SLO deep-link)', () => {
+    expect(parseAlarmsHashRoute('#/rules?q=slo_id:abc&ds=ds-prom-1')).toEqual({
+      tab: 'rules',
+      q: 'slo_id:abc',
+      ds: 'ds-prom-1',
+    });
+  });
+
+  it('parses ds without q', () => {
+    expect(parseAlarmsHashRoute('#/rules?ds=ds-prom-1')).toEqual({
+      tab: 'rules',
+      ds: 'ds-prom-1',
+    });
+  });
+
+  it('drops empty ds', () => {
+    expect(parseAlarmsHashRoute('#/rules?q=slo_id:abc&ds=')).toEqual({
+      tab: 'rules',
+      q: 'slo_id:abc',
+    });
+  });
+
   it('falls back when the path segment is unknown', () => {
     expect(parseAlarmsHashRoute('#/something-else')).toEqual({});
   });

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -24,7 +24,7 @@
  *   - `AlertManagerStartTime` — date-math string for picker start.
  *   - `AlertManagerEndTime`   — date-math string for picker end.
  */
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { EuiLink, EuiTab, EuiTabs } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
@@ -84,13 +84,21 @@ interface AlarmsPageProps {
 type TabId = 'alerts' | 'rules' | 'routing';
 
 /**
- * Parse a hash-route deep link of the form `#/rules?q=<query>` into the
- * tab to land on plus an optional initial search query. Returns
- * `{ tab: undefined, q: undefined }` on any unknown shape so the caller
- * keeps its default state (Alerts tab, empty search). Tested implicitly
+ * Parse a hash-route deep link of the form `#/rules?q=<query>&ds=<dsId>`
+ * into the tab to land on, an optional initial search query, and an
+ * optional datasource id to add to the selection on mount. Returns an
+ * empty object on any unknown shape so the caller keeps its default
+ * state (Alerts tab, empty search, persisted DS selection). Tested
  * through `<AlarmsPage>` mount tests.
+ *
+ * The `ds` param exists because deep-links from SLO detail (BUG-12) and
+ * any future cross-app entry point need to land the user on a filter
+ * selection that *includes* the rules they came to look at — without
+ * `ds`, the persisted last-used selection wins and an SLO whose rules
+ * live on a Prometheus datasource the user just unchecked silently
+ * shows zero matches.
  */
-export function parseAlarmsHashRoute(hash: string): { tab?: TabId; q?: string } {
+export function parseAlarmsHashRoute(hash: string): { tab?: TabId; q?: string; ds?: string } {
   if (!hash) return {};
   // Strip leading `#` then `/`. The hash router's URLs are
   // `#/rules?q=…` or `#/routing` etc.
@@ -101,16 +109,19 @@ export function parseAlarmsHashRoute(hash: string): { tab?: TabId; q?: string } 
   const tab: TabId | undefined =
     segment === 'rules' || segment === 'alerts' || segment === 'routing' ? segment : undefined;
   let q: string | undefined;
+  let ds: string | undefined;
   if (queryPart) {
     try {
       const params = new URLSearchParams(queryPart);
-      const raw = params.get('q');
-      if (raw && raw.trim()) q = raw;
+      const rawQ = params.get('q');
+      if (rawQ && rawQ.trim()) q = rawQ;
+      const rawDs = params.get('ds');
+      if (rawDs && rawDs.trim()) ds = rawDs;
     } catch {
       // Malformed query string — treat as no params rather than throwing.
     }
   }
-  return { tab, q };
+  return { tab, q, ds };
 }
 
 const TAB_LABELS: Record<TabId, string> = {
@@ -135,14 +146,29 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   const osService = useMemo(() => new AlertingOpenSearchService(), []);
 
   // Deep-link parsing — when SLO detail (or any other surface) navigates to
-  // `#/rules?q=<rulename>` we want to land on the Rules tab with the search
-  // box pre-filled. Read once on mount via `useMemo` with empty deps so we
-  // don't re-trigger the tab switch every time the user types in the search
-  // box. The hash-router lives at
+  // `#/rules?q=<rulename>&ds=<dsId>` we want to land on the Rules tab with
+  // the search box pre-filled and the right datasource selected. Tracked as
+  // state with a `hashchange` listener so cross-tab deep-links from inside
+  // the alerting app itself (e.g. the alert-detail flyout's "Open monitor"
+  // button — BUG-14) re-apply the params; otherwise `navigateToApp` within
+  // the same app would change `window.location.hash` without re-mounting
+  // this component, and the static one-shot read would miss the update.
+  // The hash-router lives at
   // `/<basepath>/app/observability-alerting#/rules?q=…`, so the `?q=…` is a
   // tail of `location.hash`, not `location.search`.
-  const initialDeepLink = useMemo(() => parseAlarmsHashRoute(window.location.hash), []);
-  const [activeTab, setActiveTab] = useState<TabId>(initialDeepLink.tab ?? 'alerts');
+  const [deepLink, setDeepLink] = useState(() => parseAlarmsHashRoute(window.location.hash));
+  useEffect(() => {
+    const onHashChange = () => setDeepLink(parseAlarmsHashRoute(window.location.hash));
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+  const [activeTab, setActiveTab] = useState<TabId>(deepLink.tab ?? 'alerts');
+  // Switch tab whenever the deep-link tab updates. Guarded against the
+  // common case (no tab in the URL) so user-initiated tab clicks aren't
+  // immediately overridden by a stale URL state.
+  useEffect(() => {
+    if (deepLink.tab) setActiveTab(deepLink.tab);
+  }, [deepLink.tab]);
 
   // ---- Datasource selection (priority order + persistence) ----
   const { selectedDsIds, setSelectedDsIds } = useDatasourceSelection({
@@ -151,6 +177,42 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     defaultDatasources,
     maxDatasources,
   });
+
+  // Apply the deep-link `ds` once the datasource list is hydrated so the
+  // landing tab actually has rows to show. Without this, a deep-link from
+  // SLO detail (BUG-12) or the alert-detail flyout (BUG-14) lands on
+  // Rules tab with the persisted DS selection — and if the linked DS
+  // isn't in that selection the rules table renders zero matches even
+  // though the rules exist. We *augment* (not replace) the persisted
+  // selection so the user doesn't lose unrelated DS picks; if the cap
+  // would be exceeded we slice off the oldest entries.
+  //
+  // Tracked via a ref so a single deep-link applies once even though the
+  // effect's deps churn on every selection change. The ref is reset to
+  // the latest `deepLink.ds` whenever a new hashchange brings a fresh
+  // value — that way cross-tab deep-links inside the same app (alert
+  // flyout's "Open monitor") still re-apply.
+  const lastAppliedDsRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const dsId = deepLink.ds;
+    if (!dsId) return;
+    if (datasourcesLoading) return;
+    if (lastAppliedDsRef.current === dsId) return;
+    if (!datasources.some((d) => d.id === dsId)) return;
+    if (selectedDsIds.includes(dsId)) {
+      lastAppliedDsRef.current = dsId;
+      return;
+    }
+    setSelectedDsIds([...selectedDsIds, dsId].slice(0, maxDatasources));
+    lastAppliedDsRef.current = dsId;
+  }, [
+    deepLink.ds,
+    datasources,
+    datasourcesLoading,
+    selectedDsIds,
+    setSelectedDsIds,
+    maxDatasources,
+  ]);
 
   // Probe each OS datasource once on mount to confirm `opensearch-alerting`
   // is installed. Without this check, users with the OSD feature flag on
@@ -773,7 +835,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           onDatasourceChange={handleDatasourceChange}
           maxDatasources={maxDatasources}
           onDatasourceCapReached={handleDatasourceCapReached}
-          initialSearchQuery={initialDeepLink.q}
+          initialSearchQuery={deepLink.q}
         />
       );
     }

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -25,6 +25,7 @@ import {
   EuiDescriptionList,
   EuiAccordion,
   EuiCodeBlock,
+  EuiLink,
   EuiLoadingContent,
   EuiToolTip,
 } from '@elastic/eui';
@@ -33,6 +34,8 @@ import { FormattedMessage } from '@osd/i18n/react';
 import { UnifiedAlert, UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
 import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
 import { SEVERITY_COLORS, STATE_COLORS } from './shared_constants';
+import { coreRefs } from '../../framework/core_refs';
+import { observabilityAlertingID } from '../../../common/constants/shared';
 
 /** Internal label keys filtered from the Labels accordion display. */
 const INTERNAL_LABEL_KEYS = new Set([
@@ -135,7 +138,69 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
 
   const dsName =
     datasources.find((d) => d.id === alert.datasourceId)?.name || alert.datasourceId || '\u2014';
-  const allLabels = alertData.labels || {};
+  // Memoize so `allLabels` keeps a stable reference between renders when
+  // `alertData.labels` is unchanged \u2014 the `useMemo` for `sourceLinkPath`
+  // below depends on it, and a fresh `{}` from the `||` fallback would
+  // otherwise re-run the dep-list check every render.
+  const allLabels = useMemo(() => alertData.labels || {}, [alertData.labels]);
+
+  // Source-rule deep-link computation (BUG-14). The unified alert shape
+  // doesn't carry a typed pointer to the originating monitor; we derive
+  // one from the labels available per-backend:
+  //   - OpenSearch alerts: `labels.monitor_id` is reliably populated.
+  //     Match on `monitor_id:<id>` so the Rules tab's `matchesSearch`
+  //     narrows to the originating monitor (rules carry the same id).
+  //   - Prometheus alerts: no `monitor_*` label exists; the closest
+  //     stable handle is `labels.alertname` (Prom convention) which
+  //     equals the rule's `name`. Match by name.
+  // SLO burn-rate alerts (Prometheus side) carry `slo_id` \u2014 match on
+  // that label so the Rules tab narrows to the burn-rate group rather
+  // than just the single firing tier.
+  // Falls back to undefined when no usable handle exists, in which case
+  // the source-link surfaces are simply not rendered. Includes the
+  // backing datasource id (`ds=\u2026`) so the Rules tab DS filter
+  // auto-selects the right cluster on landing \u2014 same mechanism as the
+  // SLO detail "View alert rules" deep-link (BUG-12).
+  const sourceLinkPath = useMemo(() => {
+    const dsId = alert.datasourceId;
+    if (!dsId) return undefined;
+    const labels = (allLabels as Record<string, string>) ?? {};
+    if (alert.datasourceType === 'opensearch') {
+      const monitorId = labels.monitor_id;
+      if (!monitorId) return undefined;
+      const params = new URLSearchParams({ q: `monitor_id:${monitorId}`, ds: dsId });
+      return `#/rules?${params.toString()}`;
+    }
+    if (alert.datasourceType === 'prometheus') {
+      const sloId = labels.slo_id;
+      if (sloId) {
+        const params = new URLSearchParams({ q: `slo_id:${sloId}`, ds: dsId });
+        return `#/rules?${params.toString()}`;
+      }
+      const alertname = labels.alertname;
+      if (!alertname) return undefined;
+      const params = new URLSearchParams({ q: alertname, ds: dsId });
+      return `#/rules?${params.toString()}`;
+    }
+    return undefined;
+  }, [alert.datasourceId, alert.datasourceType, allLabels]);
+
+  const monitorDisplayName = (allLabels as Record<string, string>)?.monitor_name;
+  const sourceLinkLabel = (allLabels as Record<string, string>)?.slo_id
+    ? i18n.translate('observability.alerting.alertDetailFlyout.openSlo', {
+        defaultMessage: 'Open SLO',
+      })
+    : i18n.translate('observability.alerting.alertDetailFlyout.openMonitor', {
+        defaultMessage: 'Open monitor',
+      });
+
+  const navigateToSource = () => {
+    if (!sourceLinkPath) return;
+    coreRefs?.application?.navigateToApp(observabilityAlertingID, { path: sourceLinkPath });
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    onClose();
+  };
+
   // Filter out internal/system labels for display (fix S-m2/6)
   const labels = Object.fromEntries(
     Object.entries(allLabels).filter(([k]) => !INTERNAL_LABEL_KEYS.has(k))
@@ -162,13 +227,26 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
             </EuiFlexGroup>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFlexGroup gutterSize="xs" responsive={false}>
+            <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
                 <EuiHealth color={STATE_COLORS[alert.state]}>{alert.state}</EuiHealth>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiBadge color={SEVERITY_COLORS[alert.severity]}>{alert.severity}</EuiBadge>
               </EuiFlexItem>
+              {sourceLinkPath && (
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    size="s"
+                    iconType="popout"
+                    iconSide="right"
+                    onClick={navigateToSource}
+                    data-test-subj="alertDetailOpenSource"
+                  >
+                    {sourceLinkLabel}
+                  </EuiButton>
+                </EuiFlexItem>
+              )}
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -258,6 +336,23 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
                 }),
                 description: getAlertDuration(alert.startTime),
               },
+              ...(sourceLinkPath
+                ? [
+                    {
+                      title: i18n.translate('observability.alerting.alertDetailFlyout.sourceRule', {
+                        defaultMessage: 'Source rule',
+                      }),
+                      description: (
+                        <EuiLink
+                          onClick={navigateToSource}
+                          data-test-subj="alertDetailSourceRuleLink"
+                        >
+                          {monitorDisplayName ?? sourceLinkLabel}
+                        </EuiLink>
+                      ),
+                    },
+                  ]
+                : []),
             ]}
           />
         </EuiAccordion>

--- a/public/components/alerting/monitors_table/__tests__/monitors_table_filters.test.ts
+++ b/public/components/alerting/monitors_table/__tests__/monitors_table_filters.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { matchesSearch } from '../monitors_table_filters';
+import type { UnifiedRuleSummary } from '../../../../../common/types/alerting';
+
+function rule(over: Partial<UnifiedRuleSummary> = {}): UnifiedRuleSummary {
+  return ({
+    id: 'rule-id-1',
+    datasourceId: 'ds-1',
+    datasourceType: 'opensearch',
+    name: 'My Monitor',
+    enabled: true,
+    severity: 'medium',
+    query: '',
+    condition: '',
+    labels: {},
+    annotations: {},
+    monitorType: 'ppl',
+    status: 'active',
+    healthStatus: 'healthy',
+    createdBy: 'system',
+    createdAt: '',
+    lastModified: '',
+    ...over,
+  } as unknown) as UnifiedRuleSummary;
+}
+
+describe('matchesSearch', () => {
+  it('matches by free-text against the rule name', () => {
+    expect(matchesSearch(rule({ name: 'My Monitor' }), 'monitor')).toBe(true);
+    expect(matchesSearch(rule({ name: 'My Monitor' }), 'other')).toBe(false);
+  });
+
+  it('matches `label:value` against rule.labels', () => {
+    expect(matchesSearch(rule({ labels: { team: 'infra' } }), 'team:infra')).toBe(true);
+    expect(matchesSearch(rule({ labels: { team: 'infra' } }), 'team:platform')).toBe(false);
+  });
+
+  it('matches `monitor_id:<id>` against `rule.id` (BUG-14 deep-link)', () => {
+    // Alerts only carry `monitor_id` in labels; the rule itself doesn't
+    // have a `monitor_id` label — its stable handle is `rule.id`.
+    expect(
+      matchesSearch(rule({ id: '197fa54B-r6EicsgSghN' }), 'monitor_id:197fa54B-r6EicsgSghN')
+    ).toBe(true);
+    expect(matchesSearch(rule({ id: '197fa54B-r6EicsgSghN' }), 'monitor_id:other-id')).toBe(false);
+  });
+
+  it('label:value still wins when the value also appears in another field', () => {
+    // Without a label match, `monitor_id:foo` must NOT fall back to
+    // matching `foo` against name/labels via the legacy free-text path.
+    expect(matchesSearch(rule({ id: 'rule-id-1', name: 'foo monitor' }), 'monitor_id:foo')).toBe(
+      false
+    );
+  });
+});

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -80,6 +80,17 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   initialSearchQuery,
 }) => {
   const [searchQuery, setSearchQuery] = useState(initialSearchQuery ?? '');
+  // Re-seed the search box whenever the parent supplies a fresh
+  // `initialSearchQuery`. The page propagates a hashchange-driven
+  // `deepLink.q` into this prop so cross-tab deep-links from inside the
+  // alerting app (alert-flyout "Open monitor" — BUG-14) update the
+  // filter live. Falsy values (empty string / undefined) don't clobber
+  // the user's typed query — only an actual deep-link update overrides.
+  useEffect(() => {
+    if (initialSearchQuery && initialSearchQuery.trim() !== '') {
+      setSearchQuery(initialSearchQuery);
+    }
+  }, [initialSearchQuery]);
   const [filters, setFilters] = useState<FilterState>(emptyFilters());
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [savedSearches, setSavedSearches] = useState<SavedSearch[]>([]);

--- a/public/components/alerting/monitors_table/monitors_table_filters.tsx
+++ b/public/components/alerting/monitors_table/monitors_table_filters.tsx
@@ -80,6 +80,12 @@ export function matchesSearch(rule: UnifiedRuleSummary, query: string): boolean 
       if (labelVal && labelVal.toLowerCase().includes(val)) return true;
       const annoVal = rule.annotations[key];
       if (annoVal && annoVal.toLowerCase().includes(val)) return true;
+      // Deep-link convenience: alerts only carry `monitor_id` in labels,
+      // never the rule itself. The rule's stable handle is `rule.id`.
+      // Match `monitor_id:<id>` against `rule.id` so deep-links from the
+      // alert detail flyout (BUG-14) and any other surface that knows
+      // only the OpenSearch alerting `monitor_id` resolve to the rule.
+      if (key === 'monitor_id' && rule.id.toLowerCase().includes(val)) return true;
     }
     if (rule.name.toLowerCase().includes(term)) return true;
     for (const v of Object.values(rule.labels)) {

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -836,7 +836,16 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
         // Recording rules don't surface in Alert Manager (they're
         // filtered to `type === 'alerting'` in alert_service.ts) — the
         // recording-rule list on this page is informational only.
-        const params = new URLSearchParams({ q: `slo_id:${doc.id}` });
+        //
+        // Also pass `ds=<spec.datasourceId>` so the alarms page can
+        // include the SLO's Prometheus datasource in `selectedDsIds`.
+        // Without this, the search filter narrows to zero rows whenever
+        // the user's last-used datasource selection didn't include the
+        // SLO's Prometheus DS — see BUG-12 in the bug report.
+        const params = new URLSearchParams({
+          q: `slo_id:${doc.id}`,
+          ds: doc.spec.datasourceId,
+        });
         coreRefs?.application?.navigateToApp(observabilityAlertingID, {
           path: `#/rules?${params.toString()}`,
         });


### PR DESCRIPTION
> ⚠️ **Independent of #2701, #2703, #2704, #2705** but kept in draft to keep the alerting-follow-up review queue ordered. Touches \`alarms_page.tsx\` alongside #2703 and #2705 at non-overlapping line ranges (this PR rewires deep-link state at the very top of the page; #2703 touches imports + error toast handlers; #2705 adds a handler near line 437 and JSX near line 750). Three-way merge expected to be clean.

## Summary

Three changes addressing the cross-surface deep-link gaps in the bug-report (**BUG-12**, **BUG-14**). **BUG-13 closes as won't-fix** — the existing OpenSearch / Prometheus badge in the alert detail header and the Datasource column in the alerts table already convey the broad source-type cut; finer typing (Log/PPL/Cluster Metrics/APM) isn't reliably available from alert labels and a derived per-row column would be a heavier follow-up.

### BUG-12 — SLO \"View alert rules\" deep-link returns 0 monitors

The SLO detail page navigates to \`#/rules?q=slo_id:<id>\` but doesn't pass the SLO's Prometheus datasource. If the user's last-used datasource selection didn't include that DS — common, since SLO detail and Alert Manager are independent surfaces — the rules table filters down to zero rows even though the SLO's burn-rate rules exist.

- Pass \`&ds=<spec.datasourceId>\` alongside \`q=\` from the SLO detail page.
- Teach \`parseAlarmsHashRoute\` to extract it.
- In \`AlarmsPage\`, on deep-link arrival add the DS to \`selectedDsIds\` (additively, capped at \`maxDatasources\`) once the datasource list has hydrated. A \`lastAppliedDsRef\` ensures the same deep-link doesn't repeatedly re-augment as the effect's deps churn through render passes.

The alarms-page deep-link state used to be captured once via \`useMemo([])\`; replaced with \`useState\` + a \`hashchange\` listener so cross-tab deep-links from inside the alerting app itself re-apply their params (e.g. the BUG-14 \"Open monitor\" button). \`MonitorsTable\` also re-applies a non-empty \`initialSearchQuery\` prop in a \`useEffect\` so search seeding follows the same path.

### BUG-14 — Alert detail flyout has no link to source monitor / SLO

Add a \"Source rule\" affordance in two places (per the chosen \"button + linked monitor name\" approach):
- **Header**: a primary \`Open monitor\` / \`Open SLO\` button next to the state / severity badges, only rendered when we can resolve a link target.
- **Body**: a new \"Source rule\" row in the Alert Details accordion rendered as an \`EuiLink\` displaying the monitor's name from \`labels.monitor_name\`.

Both targets navigate to the alerting app's Rules tab with a search query that resolves to the originating rule:
- **OpenSearch alerts**: \`q=monitor_id:<id>&ds=<dsId>\` (\`monitor_id\` is reliably populated in the alert's labels).
- **Prometheus SLO burn-rate alerts**: \`q=slo_id:<id>&ds=<dsId>\`.
- **Prometheus alerts otherwise**: \`q=<alertname>&ds=<dsId>\` (closest stable handle when no monitor link exists in labels).
- Falls back to undefined when no usable handle is available; the source-link surfaces simply don't render.

\`MonitorsTable.matchesSearch\` previously routed \`label:value\` syntax only against \`rule.labels\` and \`rule.annotations\`; rules don't carry a \`monitor_id\` label of their own — their stable handle is \`rule.id\`. Extend the matcher with one shortcut: when the key is \`monitor_id\` and the value substring-matches \`rule.id\`, return true. This is what makes the alert-flyout deep-link actually narrow the table to the originating rule.

## Test plan
- [x] \`yarn lint:es\` clean on all changed files
- [x] \`yarn typecheck\` from OSD root passes
- [x] \`yarn test public/components/alerting\` — 31/31 suites, 184/184 tests pass (7 new total: 3 \`parseAlarmsHashRoute\` cases for the \`ds\` param + 4 \`matchesSearch\` cases including the new \`monitor_id:<id>\` shortcut)
- [x] Live verified against OS 3.7.0 in the observability-stack docker cluster:
  - [x] Click an OS alert in the Alerts tab → detail flyout shows header \"Open monitor\" button + body \"Source rule\" link with the monitor's name
  - [x] Click Open monitor → URL changes to \`#/rules?q=monitor_id:<id>&ds=<dsId>\`, Rules tab activates, search box populates, table narrows to 1 row matching the originating monitor
  - [x] Hard-reload at the deep-link URL with DS filter empty → \`local_cluster\` checkbox auto-checks (BUG-12 mechanism), table renders correctly
  - [x] Other DS checkboxes are not clobbered — \`Prometheus\` stays unchecked when the deep-link only targeted \`local_cluster\`
- [ ] CI green