### PR TITLE
feat(data-source): exclude AnalyticEngine from DSL-only sub-apps

### DIFF
--- a/common/utils/shared.ts
+++ b/common/utils/shared.ts
@@ -75,3 +75,27 @@ export const dataSourceFilterFn = (dataSource: SavedObject<DataSourceAttributes>
     pluginManifest.requiredOSDataSourcePlugins.every((plugin) => installedPlugins.includes(plugin))
   );
 };
+
+// Engine types this plugin declines via its manifest's `unsupportedOSDataSourceEngineTypes`.
+// Driven by the manifest declaration so changes flow from one source of truth.
+const UNSUPPORTED_ENGINE_TYPES: readonly string[] =
+  (pluginManifest as { unsupportedOSDataSourceEngineTypes?: readonly string[] })
+    .unsupportedOSDataSourceEngineTypes ?? [];
+
+// Slim filter: rejects only data sources whose engine type is in
+// `unsupportedOSDataSourceEngineTypes`. Use this where the existing picker had no
+// filter at all (e.g. trace analytics) — adding the chained version/plugin gates
+// would silently exclude data sources that used to work, including AOSS domains
+// (`OpenSearchServerless`) whose installed-plugin set differs from a managed OS
+// cluster's. Sub-apps that already enforce those gates pre-PR (metrics, integrations)
+// use `dataSourceFilterFnExcludeAnalyticEngine` instead.
+export const dataSourceFilterFnByEngineType = (dataSource: SavedObject<DataSourceAttributes>) => {
+  const engineType = dataSource?.attributes?.dataSourceEngineType;
+  return !(engineType && UNSUPPORTED_ENGINE_TYPES.includes(engineType));
+};
+
+// Same checks as dataSourceFilterFn (version + required plugins) plus the engine-type
+// exclusion. Use for sub-apps that already enforced version/plugin gates pre-PR.
+export const dataSourceFilterFnExcludeAnalyticEngine = (
+  dataSource: SavedObject<DataSourceAttributes>
+) => dataSourceFilterFnByEngineType(dataSource) && dataSourceFilterFn(dataSource);

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -34,5 +34,6 @@
   "requiredOSDataSourcePlugins": [
     "opensearch-sql",
     "opensearch-observability"
-  ]
+  ],
+  "unsupportedOSDataSourceEngineTypes": ["AnalyticEngine"]
 }

--- a/public/components/integrations/components/integration.tsx
+++ b/public/components/integrations/components/integration.tsx
@@ -23,7 +23,7 @@ import {
 import React, { ComponentType, useEffect, useState } from 'react';
 import { DataSourceSelectorProps } from '../../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { INTEGRATIONS_BASE } from '../../../../common/constants/shared';
-import { dataSourceFilterFn } from '../../../../common/utils/shared';
+import { dataSourceFilterFnExcludeAnalyticEngine } from '../../../../common/utils/shared';
 import { useToast } from '../../../../public/components/common/toast';
 import { coreRefs } from '../../../framework/core_refs';
 import { addIntegrationRequest } from './create_integration_helpers';
@@ -188,7 +188,7 @@ export function Integration(props: AvailableIntegrationProps) {
             fullWidth={false}
             removePrepend={true}
             onSelectedDataSource={onSelectedDataSource}
-            dataSourceFilter={dataSourceFilterFn}
+            dataSourceFilter={dataSourceFilterFnExcludeAnalyticEngine}
           />
           <EuiSpacer />
         </EuiModalBody>

--- a/public/components/integrations/components/setup_integration_inputs.tsx
+++ b/public/components/integrations/components/setup_integration_inputs.tsx
@@ -21,7 +21,7 @@ import React, { useEffect, useState } from 'react';
 import { NotificationsStart, SavedObjectsStart } from '../../../../../../src/core/public';
 import { DataSourceManagementPluginSetup } from '../../../../../../src/plugins/data_source_management/public';
 import { CONSOLE_PROXY, DATACONNECTIONS_BASE } from '../../../../common/constants/shared';
-import { dataSourceFilterFn } from '../../../../common/utils/shared';
+import { dataSourceFilterFnExcludeAnalyticEngine } from '../../../../common/utils/shared';
 import { coreRefs } from '../../../framework/core_refs';
 import { IntegrationConfigProps, IntegrationSetupInputs } from './setup_integration';
 
@@ -237,7 +237,7 @@ export function IntegrationConnectionInputs({
               fullWidth={false}
               removePrepend={true}
               onSelectedDataSource={onSelectedDataSource}
-              dataSourceFilter={dataSourceFilterFn}
+              dataSourceFilter={dataSourceFilterFnExcludeAnalyticEngine}
             />
           </EuiCompressedFormRow>
           <EuiSpacer />

--- a/public/components/metrics/index.tsx
+++ b/public/components/metrics/index.tsx
@@ -21,7 +21,7 @@ import {
 import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
 import { OptionType } from '../../../common/types/metrics';
 import { setNavBreadCrumbs } from '../../../common/utils/set_nav_bread_crumbs';
-import { dataSourceFilterFn } from '../../../common/utils/shared';
+import { dataSourceFilterFnExcludeAnalyticEngine } from '../../../common/utils/shared';
 import PPLService from '../../services/requests/ppl';
 import SavedObjects from '../../services/saved_objects/event_analytics/saved_objects';
 import './index.scss';
@@ -96,7 +96,7 @@ export const Home = ({
           fullWidth: true,
           // activeOption: dataSourceMDSId,
           onSelectedDataSources: onSelectedDataSource,
-          dataSourceFilter: dataSourceFilterFn,
+          dataSourceFilter: dataSourceFilterFnExcludeAnalyticEngine,
         }}
       />
     );

--- a/public/components/trace_analytics/home.tsx
+++ b/public/components/trace_analytics/home.tsx
@@ -25,6 +25,7 @@ import { DataSourceAttributes } from '../../../../../src/plugins/data_source_man
 import { observabilityTracesNewNavID } from '../../../common/constants/shared';
 import { TRACE_TABLE_TYPE_KEY } from '../../../common/constants/trace_analytics';
 import { TraceAnalyticsMode, TraceQueryMode } from '../../../common/types/trace_analytics';
+import { dataSourceFilterFnByEngineType } from '../../../common/utils/shared';
 import { coreRefs } from '../../framework/core_refs';
 import { FilterType } from './components/common/filters/filters';
 import {
@@ -186,6 +187,7 @@ export const Home = (props: HomeProps) => {
         componentConfig={{
           ...sharedProps.componentConfig,
           onSelectedDataSources: onSelectedDataSource,
+          dataSourceFilter: dataSourceFilterFnByEngineType,
         }}
       />
     ) : (


### PR DESCRIPTION
## Summary

AnalyticEngine data sources support PPL/SQL but **not DSL queries against user data**. Sub-apps in this plugin that depend on DSL aggregations against user data — **trace analytics**, **metrics analytics**, and **integrations' pre-built dashboards** — should hide AnalyticEngine domains from their data-source pickers so users don't pick a connection that will 5xx.

Sub-apps that work over PPL/SQL (notebooks paragraphs, getting started, the added-integration listing) keep showing AnalyticEngine resources unchanged.

This change mirrors the manifest-driven pattern from upstream OSD:

- [opensearch-project/OpenSearch-Dashboards#12023](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12023) — added `unsupportedOSDataSourceEngineTypes` to `PluginManifest`; legacy Discover declares `["AnalyticEngine"]` and `data_explorer` filters its picker.
- [opensearch-project/OpenSearch-Dashboards#12103](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12103) — wired the same field into `data` plugin: vis-builder / sample-data / Vega / TSVB / Timeline / Controls all opt out, plus `AnalyticEngineError` for deep-link paths.

## Changes

- **`opensearch_dashboards.json`** — declare `"unsupportedOSDataSourceEngineTypes": ["AnalyticEngine"]` so the plugin's stance is machine-readable to other consumers (consistent with #12023 / #12103).
- **`common/utils/shared.ts`** — read `UNSUPPORTED_ENGINE_TYPES` from the manifest (single source of truth) and export two filter helpers:
  - `dataSourceFilterFnByEngineType` — engine-type exclusion only. Used where the picker had **no filter at all** before this PR; chaining the existing `dataSourceFilterFn` would also silently start enforcing `requiredOSDataSourcePlugins` and `supportedOSDataSourceVersions`, which would regress AOSS / OpenSearchServerless flows that don't carry those plugins.
  - `dataSourceFilterFnExcludeAnalyticEngine` — chains the existing version + plugins gates (`dataSourceFilterFn`) plus the engine-type check. Used where the picker already enforced those gates before this PR.
- **`public/components/trace_analytics/home.tsx`** — wire the **slim** filter (no version/plugins chaining; trace_analytics had no filter prior, see justification above for AOSS).
- **`public/components/metrics/index.tsx`** — swap the chained filter (was on `dataSourceFilterFn`).
- **`public/components/integrations/components/setup_integration_inputs.tsx`** — swap the chained filter.
- **`public/components/integrations/components/integration.tsx`** — swap the chained filter.

Pickers explicitly **left on `dataSourceFilterFn`** (AnalyticEngine remains selectable):

- `notebooks/components/paragraph_components/paragraphs.tsx` (per-paragraph picker — PPL paragraphs work on AnalyticEngine)
- `notebooks/components/helpers/modal_containers.tsx` (sample-notebooks confirmation modal)
- `getting_started/home.tsx`
- `integrations/components/added_integration.tsx` (display-only `DataSourceView`; filter is moot)

## Test plan

- [x] **Trace analytics dropdown** hides an AnalyticEngine-tagged data source.
- [x] **Metrics analytics dropdown** hides an AnalyticEngine-tagged data source.
- [x] **Integrations setup wizard / available-integration modal** hide an AnalyticEngine-tagged data source.
- [x] **Notebooks → "Add paragraph"** picker still shows the AnalyticEngine-tagged data source.
- [x] **Getting started** picker still shows the AnalyticEngine-tagged data source.
- [x] Force-flip `dataSourceEngineType` on a saved data source from `AnalyticEngine` back to `OpenSearch` → all four pickers above now show it again.
- [ ] `yarn test:jest`
- [ ] `yarn test:jest_integration`

## Issues Resolved

Companion to #12023 and #12103 — extends the same manifest-driven AnalyticEngine opt-out into `dashboards-observability`'s sub-app data-source pickers.

## Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff