### PR TITLE
Fix Open Monitor button navigation in alert detail flyout

### DIFF
--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -163,12 +163,14 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     return () => window.removeEventListener('hashchange', onHashChange);
   }, []);
   const [activeTab, setActiveTab] = useState<TabId>(deepLink.tab ?? 'alerts');
-  // Switch tab whenever the deep-link tab updates. Guarded against the
-  // common case (no tab in the URL) so user-initiated tab clicks aren't
-  // immediately overridden by a stale URL state.
+  // Switch tab whenever the deep-link updates with a valid tab. Uses the
+  // full `deepLink` object as the dependency (not just `.tab`) so that
+  // repeated navigations to the same tab (e.g. #/rules?q=A then #/rules?q=B)
+  // still re-apply the tab switch even when the user has manually clicked
+  // away to a different tab in between.
   useEffect(() => {
     if (deepLink.tab) setActiveTab(deepLink.tab);
-  }, [deepLink.tab]);
+  }, [deepLink]);
 
   // ---- Datasource selection (priority order + persistence) ----
   const { selectedDsIds, setSelectedDsIds } = useDatasourceSelection({

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -34,8 +34,6 @@ import { FormattedMessage } from '@osd/i18n/react';
 import { UnifiedAlert, UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
 import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
 import { SEVERITY_COLORS, STATE_COLORS } from './shared_constants';
-import { coreRefs } from '../../framework/core_refs';
-import { observabilityAlertingID } from '../../../common/constants/shared';
 
 /** Internal label keys filtered from the Labels accordion display. */
 const INTERNAL_LABEL_KEYS = new Set([
@@ -196,9 +194,13 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
 
   const navigateToSource = () => {
     if (!sourceLinkPath) return;
-    coreRefs?.application?.navigateToApp(observabilityAlertingID, { path: sourceLinkPath });
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    // Same-app navigation: directly update the hash and dispatch a
+    // synthetic hashchange event so the AlarmsPage listener picks it up.
+    // Setting window.location.hash alone doesn't fire the event when
+    // called programmatically from within the same page.
     onClose();
+    window.location.hash = sourceLinkPath;
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
   };
 
   // Filter out internal/system labels for display (fix S-m2/6)


### PR DESCRIPTION
Two issues fixed:

1. navigateToApp() no-ops for same-app navigation in OSD's SPA router. Replaced with direct window.location.hash assignment + explicit HashChangeEvent dispatch (programmatic hash changes don't fire the event automatically). onClose() is called first so the flyout unmounts before the hash change fires.

2. Repeated navigation to the same tab (e.g. #/rules?q=A then #/rules?q=B) didn't re-apply the tab switch because the useEffect depended only on deepLink.tab which stayed 'rules'. Changed the dependency to the full deepLink object so any hash change re-fires the effect.

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
