### PR TITLE
Fix label search to match values and prevent double-save on create monitor

### DIFF
--- a/public/components/alerting/__tests__/create_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_monitor.test.tsx
@@ -198,3 +198,33 @@ describe('CreateMonitor — PPL form', () => {
     expect(arg.pplTriggers[0].type).toBe('custom');
   });
 });
+
+describe('CreateMonitor — double-save prevention', () => {
+  it('disables save buttons after first click to prevent duplicate submissions', () => {
+    const onSave = jest.fn();
+    render(
+      <CreateMonitor
+        onSave={onSave}
+        onCancel={jest.fn()}
+        datasources={[osDs]}
+        selectedDsIds={['ds-os']}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Monitor name'), {
+      target: { value: 'double-click-test' },
+    });
+    fireEvent.change(screen.getByLabelText('PPL query'), {
+      target: { value: 'source = logs-* | stats count() as cnt' },
+    });
+
+    const saveBtn = screen.getAllByText(/^Save Monitor$/i)[0];
+    // First click — should call onSave
+    fireEvent.click(saveBtn);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    // Second click — should NOT call onSave again (isSaving guard)
+    fireEvent.click(saveBtn);
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/components/alerting/__tests__/facet_filter_panel.test.tsx
+++ b/public/components/alerting/__tests__/facet_filter_panel.test.tsx
@@ -112,3 +112,27 @@ describe('useFacetCollapse', () => {
     expect(snapshot!.isCollapsed('dynamic-facet', true)).toBe(true);
   });
 });
+
+describe('FacetFilterGroup — search matches both display label and raw value', () => {
+  it('filters by raw option value when displayMap provides a different label', () => {
+    const props: FacetFilterGroupProps = {
+      ...defaultProps,
+      options: ['field_a', 'field_b', 'field_c'],
+      counts: { field_a: 3, field_b: 2, field_c: 1 },
+      displayMap: { field_a: 'Alpha', field_b: 'Beta', field_c: 'Charlie' },
+      searchable: true,
+    };
+    const { getByRole, queryByText, getByText } = render(<FacetFilterGroup {...props} />);
+    const searchBox = getByRole('searchbox');
+
+    // Search by display label — should match
+    fireEvent.change(searchBox, { target: { value: 'Alpha' } });
+    expect(getByText('Alpha')).toBeInTheDocument();
+    expect(queryByText('Beta')).not.toBeInTheDocument();
+
+    // Search by raw field name — should also match (the fix)
+    fireEvent.change(searchBox, { target: { value: 'field_b' } });
+    expect(getByText('Beta')).toBeInTheDocument();
+    expect(queryByText('Alpha')).not.toBeInTheDocument();
+  });
+});

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -657,7 +657,13 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                   if (visibleLabelKeys.length === 0) return null;
                   const q = labelSearch.trim().toLowerCase();
                   const matchedLabelKeys = q
-                    ? visibleLabelKeys.filter((k) => k.toLowerCase().includes(q))
+                    ? visibleLabelKeys.filter(
+                        (k) =>
+                          k.toLowerCase().includes(q) ||
+                          collectAlertLabelValues(alerts, k).some((v) =>
+                            v.toLowerCase().includes(q)
+                          )
+                      )
                     : visibleLabelKeys;
                   const cappedLabelKeys = showAllLabels
                     ? matchedLabelKeys

--- a/public/components/alerting/create_monitor/index.tsx
+++ b/public/components/alerting/create_monitor/index.tsx
@@ -187,6 +187,7 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
   );
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 
   // Snapshot the initial form so we can detect "dirty" against the value the
@@ -308,6 +309,7 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
 
   const handleSave = useCallback(() => {
     setHasSubmitted(true);
+    if (isSaving) return;
     // Guard against duplicate names client-side. The Save button is also
     // disabled via `isValid`, but defending here too means programmatic
     // submission paths (Enter key on a field) can't bypass the check.
@@ -319,6 +321,7 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
         return;
       }
       setValidationErrors({});
+      setIsSaving(true);
       onSave(promForm);
     } else {
       const result = validatePplForm({
@@ -331,9 +334,10 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
         return;
       }
       setValidationErrors({});
+      setIsSaving(true);
       onSave(osForm);
     }
-  }, [backendType, promForm, osForm, onSave, duplicateName]);
+  }, [backendType, promForm, osForm, onSave, duplicateName, isSaving]);
 
   // When AI wizard is active and user is on a Prometheus datasource, delegate to MonitorTemplateWizard
   if (creationMode === 'ai' && backendType === 'prometheus') {
@@ -598,7 +602,11 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
             <EuiFlexItem grow={false}>
               <EuiFlexGroup gutterSize="s" responsive={false}>
                 <EuiFlexItem grow={false}>
-                  <EuiButton onClick={handleSave} isDisabled={!isValid}>
+                  <EuiButton
+                    onClick={handleSave}
+                    isDisabled={!isValid || isSaving}
+                    isLoading={isSaving}
+                  >
                     {isEdit
                       ? i18n.translate('observability.alerting.createMonitor.saveChangesButton', {
                           defaultMessage: 'Save Changes',
@@ -609,7 +617,12 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
                   </EuiButton>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiButton fill onClick={handleSave} isDisabled={!isValid}>
+                  <EuiButton
+                    fill
+                    onClick={handleSave}
+                    isDisabled={!isValid || isSaving}
+                    isLoading={isSaving}
+                  >
                     {i18n.translate('observability.alerting.createMonitor.saveAndEnableButton', {
                       defaultMessage: 'Save & Enable',
                     })}

--- a/public/components/alerting/facet_filter_panel.tsx
+++ b/public/components/alerting/facet_filter_panel.tsx
@@ -172,13 +172,16 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
   const [searchTerm, setSearchTerm] = useState('');
   const [showAll, setShowAll] = useState(false);
 
-  // Apply case-insensitive search filter against the display label.
+  // Apply case-insensitive search filter against both the display label
+  // and the raw option value (field name). This ensures searching for
+  // either the human-readable label or the underlying field name returns
+  // matching results.
   const filteredOptions = useMemo(() => {
     if (!searchable || !searchTerm.trim()) return options;
     const q = searchTerm.trim().toLowerCase();
     return options.filter((opt) => {
       const display = displayMap?.[opt] || opt;
-      return display.toLowerCase().includes(q);
+      return display.toLowerCase().includes(q) || opt.toLowerCase().includes(q);
     });
   }, [options, displayMap, searchable, searchTerm]);
 

--- a/public/components/alerting/monitors_table/monitors_filters_panel.tsx
+++ b/public/components/alerting/monitors_table/monitors_filters_panel.tsx
@@ -304,7 +304,11 @@ export const MonitorsFiltersPanel: React.FC<MonitorsFiltersPanelProps> = ({
           if (visibleLabelKeys.length === 0) return null;
           const q = labelSearch.trim().toLowerCase();
           const matchedLabelKeys = q
-            ? visibleLabelKeys.filter((k) => k.toLowerCase().includes(q))
+            ? visibleLabelKeys.filter(
+                (k) =>
+                  k.toLowerCase().includes(q) ||
+                  collectLabelValues(rules, k).some((v) => v.toLowerCase().includes(q))
+              )
             : visibleLabelKeys;
           const cappedLabelKeys = showAllLabels
             ? matchedLabelKeys


### PR DESCRIPTION
## Description

Two fixes:

### 1. Label filter search matches both key names and values

Previously, searching in the Labels filter panel only matched against label **key names**. Searching for a label value like "riysaxen" would show "No labels match" even though the `monitor_name` label had values containing "riysaxen-testing".

Now the search matches against:
- Label key names (e.g., searching "monitor" matches `monitor_name`)
- Label values within each key (e.g., searching "riysaxen" matches because `monitor_name` contains "riysaxen-testing")
- Raw option values in addition to display labels in the facet filter component

Applied to both Alerts tab (`alerts_dashboard.tsx`) and Rules tab (`monitors_filters_panel.tsx`).

### 2. Prevent double-submission on Create Monitor

Clicking Save twice rapidly would create duplicate monitors. Added `isSaving` state that:
- Guards `handleSave` from executing twice
- Disables both Save buttons after first click
- Shows a loading spinner on the buttons

## Testing

### Label search:
1. Open Alerts tab with alerts that have labels (e.g., `monitor_name: riysaxen-testing`)
2. In the Labels filter search box, type a label value (e.g., "riysaxen")
3. Verify the label group appears (instead of "No labels match")

### Double-save prevention:
1. Open Create Monitor flyout
2. Fill in name + query
3. Rapidly click Save twice
4. Verify only one monitor is created (check Rules tab)

## Issues Resolved

Fixes label search and double-save bugs from Bug Bash - Unified Alerts View.