### PR TITLE
fix(alerting): resolve local-cluster placeholder; probe alerting plugin directly

### DIFF
--- a/public/components/alerting/hooks/use_alerting_plugin_availability.ts
+++ b/public/components/alerting/hooks/use_alerting_plugin_availability.ts
@@ -13,11 +13,14 @@
  * single "alerting plugin not detected" callout and avoid noisy errors
  * downstream.
  *
- * Probe target: `GET /destinations`. It's already part of the read surface
- * registered by this plugin and doesn't require write permissions, so it's
- * safe to issue at mount time. We treat any 404/502/transport failure as
- * "unavailable" — the destinations route only returns 200 when the alerting
- * plugin successfully proxied the request.
+ * Probe target: `GET /probe`, which on the server side issues a cheap
+ * `POST /_plugins/_alerting/monitors/_search` with `size:0,
+ * terminate_after:1`. Targeting the alerting plugin's own REST surface
+ * (rather than `/destinations`, which calls the *notifications* plugin)
+ * means a cluster missing `opensearch-alerting` is correctly flagged as
+ * unavailable and a cluster missing only `opensearch-notifications` no
+ * longer falsely flips the callout. Any 404/502/transport failure is
+ * treated as "unavailable".
  */
 import { useEffect, useMemo, useState } from 'react';
 import type { Datasource } from '../../../../common/types/alerting';
@@ -69,7 +72,7 @@ export function useAlertingPluginAvailability(
           activeControllers.push(ctrl);
           const timer = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
           try {
-            await http.get(`/api/alerting/opensearch/${encodeURIComponent(dsId)}/destinations`, {
+            await http.get(`/api/alerting/opensearch/${encodeURIComponent(dsId)}/probe`, {
               signal: ctrl.signal,
             });
           } catch {

--- a/public/components/alerting/hooks/use_datasources.ts
+++ b/public/components/alerting/hooks/use_datasources.ts
@@ -75,7 +75,12 @@ export function mapSavedObjectsToDatasources(
       ? []
       : [
           {
-            id: 'local',
+            // Matches the synthetic id the server-side resolvers use for the
+            // no-MDS local cluster (see `getAlertingClient` and
+            // `SavedObjectDatasourceService.get`). Keeping the two in sync
+            // means the per-dsId probe and read routes resolve cleanly when
+            // no `data-source` SOs exist.
+            id: 'local-cluster',
             name: i18n.translate('observability.alerting.hooks.useDatasources.localCluster', {
               defaultMessage: 'Local Cluster',
             }),

--- a/server/routes/alerting/__tests__/get_alerting_client.test.ts
+++ b/server/routes/alerting/__tests__/get_alerting_client.test.ts
@@ -138,6 +138,18 @@ describe('getAlertingClient', () => {
     expect(client).toBe(localClient);
   });
 
+  it('short-circuits the synthetic local-cluster id to the local client even when MDS is loaded', async () => {
+    // The data_source plugin is loaded (`hasMds: true`) but no `data-source`
+    // saved objects exist — the client falls back to the synthetic
+    // "local-cluster" id. Without the short-circuit, both SO lookups miss
+    // and the route 404s with "Datasource not found: local-cluster".
+    const { ctx, soClient } = makeCtx({ hasMds: true, osSO: null, promSOs: [] });
+    const client = await getAlertingClient(ctx, 'local-cluster', mockLogger);
+    expect(client).toBe(localClient);
+    expect(soClient.get).not.toHaveBeenCalled();
+    expect(soClient.find).not.toHaveBeenCalled();
+  });
+
   it('returns an MDS client when the dsId resolves to a data-source SO', async () => {
     const { ctx } = makeCtx({
       hasMds: true,

--- a/server/routes/alerting/__tests__/index.test.ts
+++ b/server/routes/alerting/__tests__/index.test.ts
@@ -14,9 +14,9 @@
  *       POST   /api/alerting/opensearch/{dsId}/monitors/{monitorId}/acknowledge
  *       PUT    /api/alerting/opensearch/{dsId}/monitors/{monitorId}
  *       DELETE /api/alerting/opensearch/{dsId}/monitors/{monitorId}
- *   - 9 read routes + 1 destinations read route + 2 index-discovery read
- *     routes (indices, aliases) + 1 Alertmanager admin route registered
- *     inline (13 GETs)
+ *   - 9 read routes + 1 destinations read route + 1 plugin-probe read route
+ *     + 2 index-discovery read routes (indices, aliases) + 1 Alertmanager
+ *     admin route registered inline (14 GETs)
  *   - 1 mappings POST route (POSTs index list in body to avoid URL limits)
  *   - 4 Prometheus metadata routes inside `if (enableMetadataRoutes)` (4 GETs)
  *
@@ -55,7 +55,7 @@ describe('registerAlertingRoutes', () => {
     mockRouter.delete.mockClear();
   });
 
-  it('registers all runtime routes when metadata routes are enabled (17 GET + 5 POST + 1 PUT + 1 DELETE = 24)', () => {
+  it('registers all runtime routes when metadata routes are enabled (18 GET + 3 POST + 1 PUT + 1 DELETE = 23)', () => {
     registerAlertingRoutes(mockRouter as never, {
       osBackend: mockOsBackend,
       promBackend: mockPromBackend,
@@ -68,13 +68,13 @@ describe('registerAlertingRoutes', () => {
       mockRouter.post.mock.calls.length +
       mockRouter.put.mock.calls.length +
       mockRouter.delete.mock.calls.length;
-    // 13 inline GETs (incl. destinations + indices + aliases) + 4 metadata GETs = 17 GETs
+    // 14 inline GETs (incl. probe + destinations + indices + aliases) + 4 metadata GETs = 18 GETs
     // 2 monitor POSTs + 1 PUT + 1 DELETE + 1 mappings POST = 5 non-GET routes
-    expect(total).toBe(22);
-    expect(mockRouter.get.mock.calls.length).toBe(17);
+    expect(total).toBe(23);
+    expect(mockRouter.get.mock.calls.length).toBe(18);
   });
 
-  it('skips the 4 metadata GET routes when enableMetadataRoutes is false (13 GET + 5 mutations = 18)', () => {
+  it('skips the 4 metadata GET routes when enableMetadataRoutes is false (14 GET + 3 POST + 1 PUT + 1 DELETE = 19)', () => {
     registerAlertingRoutes(mockRouter as never, {
       osBackend: mockOsBackend,
       promBackend: mockPromBackend,
@@ -87,8 +87,8 @@ describe('registerAlertingRoutes', () => {
       mockRouter.post.mock.calls.length +
       mockRouter.put.mock.calls.length +
       mockRouter.delete.mock.calls.length;
-    expect(total).toBe(18);
-    expect(mockRouter.get.mock.calls.length).toBe(13);
+    expect(total).toBe(19);
+    expect(mockRouter.get.mock.calls.length).toBe(14);
   });
 
   it('registers the destinations read route', () => {
@@ -101,6 +101,18 @@ describe('registerAlertingRoutes', () => {
     });
     const getPaths = mockRouter.get.mock.calls.map(([c]: [RouteConfig]) => c.path);
     expect(getPaths).toContain('/api/alerting/opensearch/{dsId}/destinations');
+  });
+
+  it('registers the alerting plugin probe route', () => {
+    registerAlertingRoutes(mockRouter as never, {
+      osBackend: mockOsBackend,
+      promBackend: mockPromBackend,
+      mutationSvc: mockMutationSvc,
+      logger: mockLogger,
+      enableMetadataRoutes: false,
+    });
+    const getPaths = mockRouter.get.mock.calls.map(([c]: [RouteConfig]) => c.path);
+    expect(getPaths).toContain('/api/alerting/opensearch/{dsId}/probe');
   });
 
   it('registers the index-discovery routes', () => {

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -203,6 +203,14 @@ export async function getAlertingClient(
     logger?.warn(`alerting: Rejecting workspace-scoped datasource ID: ${dsId}`);
     throw createNotFoundError(`Unsupported workspace-scoped datasource ID: ${dsId}`);
   }
+  // The synthetic local-cluster id used when no MDS data sources are
+  // registered. Skip SO resolution so the local client is returned even
+  // when the data_source plugin is loaded (otherwise the lookup throws
+  // not_found and the UI sees "Datasource not found: local-cluster"
+  // for a probe that should just hit the local cluster).
+  if (dsId === 'local-cluster') {
+    return ctx.core.opensearch.client.asCurrentUser;
+  }
   if (dsId && ctx.dataSource) {
     const ds = await resolveOpenSearchDatasource(ctx, dsId);
     if (ds?.mdsId) {
@@ -459,6 +467,37 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
           { startTime: req.query.startTime, endTime: req.query.endTime }
         );
       })
+  );
+
+  // Cheap "is the alerting plugin installed?" probe. Used by the Alerts page
+  // on mount; falling back to one of the heavier read routes (e.g. monitors,
+  // destinations) would conflate alerting plugin presence with notifications
+  // plugin presence and would also surface noisy 502s on every page load
+  // when the plugin is genuinely missing. This route swallows the typed
+  // 400/404 from a missing handler into a single 502 the UI can match on.
+  router.get(
+    {
+      path: '/api/alerting/opensearch/{dsId}/probe',
+      validate: { params: schema.object({ dsId: alertingIdSchema }) },
+    },
+    async (ctx, req, res) => {
+      try {
+        const client = await getAlertingClientCtx(ctx as AlertingHandlerContext, req.params.dsId);
+        await osBackend.probe(client);
+        return res.ok({ body: { ok: true } });
+      } catch (err) {
+        if (isAlertManagerError(err)) {
+          const result = toHandlerResult(err, logger);
+          return res.customError({ statusCode: result.status, body: toErrorBody(result.body) });
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(`alerting probe failed for ds ${req.params.dsId}: ${message}`);
+        return res.customError({
+          statusCode: 502,
+          body: toErrorBody({ message: 'Alerting plugin probe failed' }),
+        });
+      }
+    }
   );
 
   // Read-only destinations list. Destination CRUD lives in the OpenSearch

--- a/server/services/alerting/__tests__/opensearch_backend.test.ts
+++ b/server/services/alerting/__tests__/opensearch_backend.test.ts
@@ -522,6 +522,30 @@ describe('HttpOpenSearchBackend', () => {
     });
   });
 
+  describe('probe', () => {
+    it("hits the alerting plugin's monitors/_search with size=0 and terminate_after=1", async () => {
+      // Probe uses the alerting plugin's own REST surface (not notifications)
+      // so a missing `opensearch-alerting` install is correctly flagged.
+      // `terminate_after: 1` lets a non-empty alerting index short-circuit
+      // segment scanning; `size: 0` drops the response payload.
+      const { client, request } = makeClient([{ body: { took: 1, hits: { total: 0 } } }]);
+      await backend.probe(client);
+      expect(request).toHaveBeenCalledWith({
+        method: 'POST',
+        path: '/_plugins/_alerting/monitors/_search',
+        body: { size: 0, terminate_after: 1, query: { match_all: {} } },
+      });
+    });
+
+    it('propagates transport errors so the route layer can map them to 502', async () => {
+      // A missing alerting plugin returns "no handler found for uri ..."
+      // from the OS HTTP layer; the route's try/catch turns that into the
+      // 502 the UI hook treats as "unavailable".
+      const { client } = makeClient([new Error('no handler found for uri')]);
+      await expect(backend.probe(client)).rejects.toThrow('no handler found');
+    });
+  });
+
   describe('getDestinations', () => {
     it('hits the /_plugins/_notifications/channels endpoint', async () => {
       const { client, request } = makeClient([{ body: { total_hits: 0, channel_list: [] } }]);

--- a/server/services/alerting/__tests__/saved_object_datasource_service.test.ts
+++ b/server/services/alerting/__tests__/saved_object_datasource_service.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SavedObjectDatasourceService } from '../saved_object_datasource_service';
+import type { Logger } from '../../../../common/types/alerting';
+
+const noopLogger = (): Logger => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+function makeSoClient(opts: {
+  os?: Array<{ id: string; attributes: { title?: string; endpoint?: string } }>;
+  dc?: Array<{ id: string; attributes: { connectionId?: string; type?: string } }>;
+  osThrows?: boolean;
+  dcThrows?: boolean;
+}) {
+  return ({
+    find: jest.fn(async ({ type }: { type: string }) => {
+      if (type === 'data-source') {
+        if (opts.osThrows) throw new Error('OS find boom');
+        return { saved_objects: opts.os ?? [] };
+      }
+      if (type === 'data-connection') {
+        if (opts.dcThrows) throw new Error('DC find boom');
+        return { saved_objects: opts.dc ?? [] };
+      }
+      return { saved_objects: [] };
+    }),
+    get: jest.fn(async () => {
+      throw new Error('saved object not found');
+    }),
+  } as unknown) as ConstructorParameters<typeof SavedObjectDatasourceService>[0];
+}
+
+describe('SavedObjectDatasourceService.list', () => {
+  it('emits the local-cluster fallback when no data-source SOs exist', async () => {
+    const svc = new SavedObjectDatasourceService(makeSoClient({}), noopLogger());
+    const all = await svc.list();
+    expect(all).toEqual([
+      {
+        id: 'local-cluster',
+        name: 'Local Cluster',
+        type: 'opensearch',
+        url: 'local',
+        enabled: true,
+      },
+    ]);
+  });
+
+  it('still emits the local-cluster fallback when ONLY a Prometheus data-connection exists', async () => {
+    // Repro: registering a DirectQuery Prometheus connection used to suppress
+    // the local-cluster fallback (the gate was on `all.length === 0` — any
+    // entry, not specifically an OS one). The unified-alerts route then saw
+    // zero OS datasources and the UI silently lost every OS monitor / alert.
+    const svc = new SavedObjectDatasourceService(
+      makeSoClient({
+        dc: [{ id: 'so-prom', attributes: { type: 'Prometheus', connectionId: 'prom-1' } }],
+      }),
+      noopLogger()
+    );
+    const all = await svc.list();
+    expect(all.find((d) => d.id === 'local-cluster')).toBeDefined();
+    expect(all.find((d) => d.directQueryName === 'prom-1')).toBeDefined();
+  });
+
+  it('does NOT emit the local-cluster fallback when an OS data-source SO is registered', async () => {
+    const svc = new SavedObjectDatasourceService(
+      makeSoClient({
+        os: [{ id: 'mds-1', attributes: { title: 'Cluster 1', endpoint: 'https://c1' } }],
+        dc: [{ id: 'so-prom', attributes: { type: 'Prometheus', connectionId: 'prom-1' } }],
+      }),
+      noopLogger()
+    );
+    const all = await svc.list();
+    expect(all.find((d) => d.id === 'local-cluster')).toBeUndefined();
+    expect(all.find((d) => d.id === 'mds-1')).toBeDefined();
+    expect(all.find((d) => d.directQueryName === 'prom-1')).toBeDefined();
+  });
+
+  it('skips non-Prometheus data-connection types', async () => {
+    const svc = new SavedObjectDatasourceService(
+      makeSoClient({
+        dc: [{ id: 's3', attributes: { type: 'S3', connectionId: 's3-1' } }],
+      }),
+      noopLogger()
+    );
+    const all = await svc.list();
+    expect(all.find((d) => d.id === 's3')).toBeUndefined();
+    // Local fallback still emitted because no OS data-source SOs exist.
+    expect(all.find((d) => d.id === 'local-cluster')).toBeDefined();
+  });
+
+  it('still emits the local-cluster fallback when the data-source find throws', async () => {
+    // A SO-API outage on the OS-data-source side shouldn't strand the user
+    // with no datasources at all — the local cluster is always reachable
+    // through the local OS client, so the fallback gives the unified-view
+    // routes something to talk to.
+    const svc = new SavedObjectDatasourceService(makeSoClient({ osThrows: true }), noopLogger());
+    const all = await svc.list();
+    expect(all.find((d) => d.id === 'local-cluster')).toBeDefined();
+  });
+});
+
+describe('SavedObjectDatasourceService.get', () => {
+  it('short-circuits the local-cluster id without consulting saved objects', async () => {
+    const soClient = makeSoClient({});
+    const svc = new SavedObjectDatasourceService(soClient, noopLogger());
+    const ds = await svc.get('local-cluster');
+    expect(ds).toMatchObject({ id: 'local-cluster', type: 'opensearch' });
+    expect((soClient as { get: jest.Mock }).get).not.toHaveBeenCalled();
+    expect((soClient as { find: jest.Mock }).find).not.toHaveBeenCalled();
+  });
+
+  it('returns null for an unknown id when no SOs match', async () => {
+    const svc = new SavedObjectDatasourceService(makeSoClient({}), noopLogger());
+    expect(await svc.get('nope')).toBeNull();
+  });
+});

--- a/server/services/alerting/opensearch_backend.ts
+++ b/server/services/alerting/opensearch_backend.ts
@@ -74,6 +74,31 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
   constructor(private readonly logger: Logger) {}
 
   // =========================================================================
+  // Plugin probe
+  // =========================================================================
+  //
+  // Cheap "is the alerting plugin installed?" probe used by the Alerts page
+  // to render a single user-friendly callout instead of N noisy errors when
+  // a cluster doesn't have `opensearch-alerting`. We hit the alerting plugin's
+  // own `monitors/_search` endpoint so we exercise the exact REST handler the
+  // rest of the UI depends on — a probe against `_plugins/_notifications/...`
+  // would only confirm a different plugin (`opensearch-notifications`).
+  //
+  // `terminate_after: 1` lets a non-empty alerting index short-circuit on the
+  // first segment per shard; `size: 0` drops the response payload. A missing
+  // plugin returns `no handler found for uri ...` with status 400 from the
+  // HTTP layer, which surfaces as a transport error here — we let it
+  // propagate so the route can report 502 and the UI shows the callout.
+
+  async probe(client: AlertingOSClient): Promise<void> {
+    await this.req(client, 'POST', '/_plugins/_alerting/monitors/_search', {
+      size: 0,
+      terminate_after: 1,
+      query: { match_all: {} },
+    });
+  }
+
+  // =========================================================================
   // Monitors
   // =========================================================================
 

--- a/server/services/alerting/saved_object_datasource_service.ts
+++ b/server/services/alerting/saved_object_datasource_service.ts
@@ -46,6 +46,7 @@ export class SavedObjectDatasourceService implements DatasourceService {
 
   async list(): Promise<Datasource[]> {
     const all: Datasource[] = [];
+    let osCount = 0;
     try {
       const osRes = await this.savedObjects.find<DataSourceSOAttributes>({
         type: 'data-source',
@@ -60,6 +61,7 @@ export class SavedObjectDatasourceService implements DatasourceService {
           enabled: true,
           mdsId: so.id,
         });
+        osCount++;
       }
     } catch (e) {
       this.logger?.debug(`SavedObjectDatasourceService: data-source lookup failed: ${e}`);
@@ -85,8 +87,14 @@ export class SavedObjectDatasourceService implements DatasourceService {
     } catch (e) {
       this.logger?.debug(`SavedObjectDatasourceService: data-connection lookup failed: ${e}`);
     }
-    // Fallback so unified-view routes can still respond on a bare cluster.
-    if (all.length === 0) {
+    // Synthetic local-cluster fallback so unified-view routes can read from
+    // the local OS when no MDS `data-source` saved objects exist. Gated on
+    // OS count, NOT total `all.length`: a Prometheus-only `data-connection`
+    // shouldn't suppress the local OS cluster — without this, registering
+    // any DirectQuery connection silently hides every OS monitor / alert
+    // from the unified endpoints. Mirrors the client-side gate in
+    // `mapSavedObjectsToDatasources`.
+    if (osCount === 0) {
       all.push({
         id: 'local-cluster',
         name: 'Local Cluster',


### PR DESCRIPTION
## Summary
- Aligns the client-emitted no-MDS placeholder id with the server-side `local-cluster` convention and short-circuits it in `getAlertingClient` so the per-dsId routes resolve cleanly when the `data_source` plugin is loaded but no `data-source` saved objects exist. Without this, the Alerts page rendered a false **Alerting plugin not detected** callout against a healthy cluster.
- Replaces the plugin-availability probe with a dedicated route (`GET /api/alerting/opensearch/{dsId}/probe`) that hits `POST /_plugins/_alerting/monitors/_search` with `size:0, terminate_after:1`. The previous probe targeted `/_plugins/_notifications/channels`, conflating `opensearch-alerting` presence with `opensearch-notifications`.
- Fixes `SavedObjectDatasourceService.list()` so registering any Prometheus `data-connection` no longer suppresses the synthetic local-cluster fallback. Before this, every OpenSearch monitor / alert silently disappeared from the unified Alerts and Rules views the moment a single DirectQuery connection existed.

## Why
On a stock OSD installation with the `data_source` plugin loaded but zero `data-source` saved objects, the Alerts page was unusable: the page-level callout claimed the alerting plugin was missing (it wasn't), and even after dismissing it, unified queries returned zero OpenSearch alerts because the local cluster wasn't in the registry.

Live verification on a local cluster with 6 OS monitors + 1 Prometheus connection: unified endpoint now returns 28 alerts across 2 datasources (5 OS + 23 Prom); previously it returned 23 across 1.

## Files changed
- `server/routes/alerting/index.ts` — `getAlertingClient` short-circuit + new `/probe` route
- `server/services/alerting/opensearch_backend.ts` — `probe()` method
- `server/services/alerting/saved_object_datasource_service.ts` — gate the local-cluster fallback on OS count, not total list length
- `public/components/alerting/hooks/use_datasources.ts` — placeholder id `local` → `local-cluster`
- `public/components/alerting/hooks/use_alerting_plugin_availability.ts` — call `/probe` instead of `/destinations`
- Tests: new `saved_object_datasource_service.test.ts` (7 tests including regression repro), new `probe()` and short-circuit cases, route-count updates

## Test plan
- [x] `yarn test server/services/alerting server/routes/alerting public/components/alerting` — 523/523 pass
- [x] `yarn typecheck` — clean
- [x] `yarn lint:es` (touched files) — clean
- [x] Live: `GET /api/alerting/opensearch/local-cluster/probe` → `{"ok":true}` (was 404)
- [x] Live: `GET /api/alerting/unified/alerts` returns OS + Prom alerts (was Prom-only)
- [x] Live: Alerts page no longer renders the "Alerting plugin not detected" callout against the healthy cluster