### PR TITLE
Enable Mend remediate

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -11,5 +11,10 @@
   },
   "issueSettings": {
     "minSeverityLevel": "LOW"
+  },
+  "remediateSettings": {
+    "workflowRules": {
+      "enabled": true
+    }
   }
 }


### PR DESCRIPTION
### Description
Enables Mend Remediate workflow rules in `.whitesource`.

### Why
This allows Mend to create remediation pull requests for eligible dependency vulnerability findings. The existing scan mode remains `AUTO`; this change only enables remediation behavior.

### Validation
- Parsed `.whitesource` as JSON successfully
