### PR TITLE
Adding Ashish as dashboards-observability maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
 
-- @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @anirudha @paulstn @sumukhswamy @sejli @TackAdam @RyanL1997 @lezzago
+- @ps48 @joshuali925 @dai-chen @mengweieric @vamsi-amazon @swiddis @penghuo @anirudha @sumukhswamy @sejli @TackAdam @RyanL1997 @lezzago

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
 
-- @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @anirudha @paulstn @sumukhswamy @sejli @TackAdam @RyanL1997
+- @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @anirudha @paulstn @sumukhswamy @sejli @TackAdam @RyanL1997 @lezzago

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,17 +9,11 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Eric Wei                | [mengweieric](https://github.com/mengweieric)   | Amazon      |
 | Joshua Li               | [joshuali925](https://github.com/joshuali925)   | Amazon      |
 | Shenoy Pratik           | [ps48](https://github.com/ps48)                 | Amazon      |
-| Kavitha Mohan           | [kavithacm](https://github.com/kavithacm)       | Amazon      |
-| Rupal Mahajan           | [rupal-bq](https://github.com/rupal-bq)         | Amazon      |
-| Derek Ho                | [derek-ho](https://github.com/derek-ho)         | Amazon      |
-| Lior Perry              | [YANG-DB](https://github.com/YANG-DB)           | Amazon      |
 | Simeon Widdis           | [swiddis](https://github.com/swiddis)           | Amazon      |
 | Chen Dai                | [dai-chen](https://github.com/dai-chen)         | Amazon      |
 | Vamsi Manohar           | [vamsi-amazon](https://github.com/vamsimanohar) | Amazon      |
 | Peng Huo                | [penghuo](https://github.com/penghuo)           | Amazon      |
-| Sean Kao                | [seankao-az](https://github.com/seankao-az)     | Amazon      |
 | Anirudha Jadhav         | [anirudha](https://github.com/anirudha)         | Amazon      |
-| Paul Sebastian          | [paulstn](https://github.com/paulstn)           | Amazon      |
 | Sumukh Hanumantha Swamy | [sumukhswamy](https://github.com/sumukhswamy)   | Amazon      |
 | Sean Li                 | [sejli](https://github.com/sejli)               | Amazon      |
 | Adam Tackett            | [TackAdam](https://github.com/TackAdam)         | Amazon      |
@@ -36,3 +30,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Eugene Lee        | [eugenesk24](https://github.com/eugenesk24)       | Amazon      |
 | Zhongnan Su       | [zhongnansu](https://github.com/zhongnansu)       | Amazon      |
 | Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons) | Amazon      |
+| Kavitha Mohan     | [kavithacm](https://github.com/kavithacm)         | Amazon      |
+| Lior Perry        | [YANG-DB](https://github.com/YANG-DB)             | Amazon      |
+| Derek Ho          | [derek-ho](https://github.com/derek-ho)           | Amazon      |
+| Rupal Mahajan     | [rupal-bq](https://github.com/rupal-bq)           | Amazon      |
+| Sean Kao          | [seankao-az](https://github.com/seankao-az)       | Amazon      |
+| Paul Sebastian    | [paulstn](https://github.com/paulstn)             | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,6 +24,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sean Li                 | [sejli](https://github.com/sejli)               | Amazon      |
 | Adam Tackett            | [TackAdam](https://github.com/TackAdam)         | Amazon      |
 | Jialiang Liang          | [RyanL1997](https://github.com/RyanL1997)       | Amazon      |
+| Ashish Agrawal          | [lezzago](https://github.com/lezzago)           | Amazon      |
 
 ## Emeritus Maintainers
 


### PR DESCRIPTION
### Description
PRs contributed by Ashish to this repository:

Ashish: https://github.com/opensearch-project/dashboards-observability/pulls?q=is%3Apr+author%3Alezzago

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
