### PR TITLE
Dynamic feature flags for Alerts/SLO

### DIFF
--- a/public/plugin.test.tsx
+++ b/public/plugin.test.tsx
@@ -378,7 +378,11 @@ describe('#setup with Alert Manager feature gate', () => {
     expect(alertingApp).toBeDefined();
   });
 
-  it('should NOT register alerting app when alertManager.enabled yml flag is false', async () => {
+  it('should still register alerting app even when yml flag is false (visibility is dynamic-flag-controlled)', async () => {
+    // After the move to dynamic feature flags, yml no longer gates app
+    // registration — the dynamic capability does, via AppUpdater. The app
+    // always registers so an AppConfig override flipping the capability on
+    // takes effect without an OSD restart.
     const initializerContextMock = coreMock.createPluginInitializerContext();
     initializerContextMock.config.get = jest.fn().mockReturnValue({
       query_assist: { enabled: false },
@@ -401,7 +405,7 @@ describe('#setup with Alert Manager feature gate', () => {
 
     const registerCalls = (coreSetup.application.register as jest.Mock).mock.calls;
     const alertingApp = registerCalls.find((call) => call[0].id === 'observability-alerting');
-    expect(alertingApp).toBeUndefined();
+    expect(alertingApp).toBeDefined();
   });
 
   it('should hide alerting nav link when capabilities.observability.alertManagerEnabled is false in start()', async () => {
@@ -455,6 +459,63 @@ describe('#setup with Alert Manager feature gate', () => {
     expect(alertingUpdater$.getValue()()).toEqual({
       navLinkStatus: AppNavLinkStatus.hidden,
     });
+  });
+
+  it('should leave alerting nav link visible when capabilities.observability.alertManagerEnabled is true in start()', async () => {
+    // Counterpart to the hidden test above. When the capability is `true`
+    // we must NOT push a hidden updater — otherwise a regression that
+    // always fires `next(hidden)` would silently break the visible path.
+    const initializerContextMock = coreMock.createPluginInitializerContext();
+    initializerContextMock.config.get = jest.fn().mockReturnValue({
+      query_assist: { enabled: false },
+      summarize: { enabled: false },
+      alertManager: { enabled: true },
+    });
+    const coreSetup = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetup);
+    let alertingUpdater$ = new BehaviorSubject<() => {}>(() => ({}));
+    coreSetup.application.register = jest.fn((args) => {
+      if (args.id === 'observability-alerting' && args.updater$) {
+        alertingUpdater$ = args.updater$;
+      }
+    });
+    const observabilityPlugin = new ObservabilityPlugin(initializerContextMock);
+
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+
+    await observabilityPlugin.setup(coreSetup, ({
+      embeddable: embeddablePluginMock.createSetupContract(),
+      visualizations: visualizationsPluginMock.createSetupContract(),
+      data: dataPluginMock.createSetupContract(),
+      uiActions: uiActionsPluginMock.createSetupContract(),
+      contentManagement: contentManagementPluginMocks.createSetupContract(),
+      dashboard: { registerDashboardProvider: jest.fn() },
+    } as unknown) as SetupDependencies);
+
+    const coreStart = coreMock.createStart();
+    const dataStartMock = dataPluginMock.createStartContract();
+    dataStartMock.dataSources.dataSourceFactory.registerDataSourceType = jest.fn();
+    observabilityPlugin.start(
+      {
+        ...coreStart,
+        application: {
+          ...coreStart.application,
+          capabilities: {
+            ...coreStart.application.capabilities,
+            observability: {
+              alertManagerEnabled: true,
+              sloEnabled: true,
+            },
+          },
+        },
+      },
+      ({ data: dataStartMock } as unknown) as AppPluginStartDependencies
+    );
+
+    // The default BehaviorSubject value is `() => ({})`. If `start()` did
+    // not call `next()` with a hidden updater, the value should still be
+    // the no-op updater.
+    expect(alertingUpdater$.getValue()()).toEqual({});
   });
 });
 
@@ -580,5 +641,67 @@ describe('#setup with SLO feature gate', () => {
     expect(latestSloUpdate).toMatchObject({
       navLinkStatus: AppNavLinkStatus.hidden,
     });
+  });
+
+  it('should leave SLO nav link visible when both APM and SLO updaters say visible', async () => {
+    // Counterpart to the hidden tests. Both inputs to the combined updater
+    // are no-ops, so the merged result must NOT carry navLinkStatus:
+    // hidden — otherwise a regression that always hides would slip past CI.
+    const initializerContextMock = coreMock.createPluginInitializerContext();
+    initializerContextMock.config.get = jest.fn().mockReturnValue({
+      query_assist: { enabled: false },
+      summarize: { enabled: false },
+      slo: { enabled: true },
+    });
+    const coreSetup = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetup);
+    let latestSloUpdate: ReturnType<AppUpdater> | undefined;
+    coreSetup.application.register = jest.fn((args) => {
+      if (args.id === 'observability-apm-slo' && args.updater$) {
+        (args.updater$ as Observable<AppUpdater>).subscribe((updater) => {
+          latestSloUpdate = updater({} as App);
+        });
+      }
+    });
+    const observabilityPlugin = new ObservabilityPlugin(initializerContextMock);
+
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    coreSetup.uiSettings.get = jest.fn().mockReturnValue(true);
+
+    await observabilityPlugin.setup(coreSetup, ({
+      embeddable: embeddablePluginMock.createSetupContract(),
+      visualizations: visualizationsPluginMock.createSetupContract(),
+      data: dataPluginMock.createSetupContract(),
+      uiActions: uiActionsPluginMock.createSetupContract(),
+      contentManagement: contentManagementPluginMocks.createSetupContract(),
+      dashboard: { registerDashboardProvider: jest.fn() },
+    } as unknown) as SetupDependencies);
+
+    const coreStart = coreMock.createStart();
+    const dataStartMock = dataPluginMock.createStartContract();
+    dataStartMock.dataSources.dataSourceFactory.registerDataSourceType = jest.fn();
+    observabilityPlugin.start(
+      {
+        ...coreStart,
+        application: {
+          ...coreStart.application,
+          capabilities: {
+            ...coreStart.application.capabilities,
+            // Traces enabled → APM updater no-ops. SLO capability on → SLO
+            // updater no-ops. Merged updater should not hide.
+            explore: { discoverTracesEnabled: true },
+            observability: {
+              alertManagerEnabled: true,
+              sloEnabled: true,
+            },
+          },
+        },
+      },
+      ({ data: dataStartMock } as unknown) as AppPluginStartDependencies
+    );
+
+    // Neither input emitted a hidden status, so the merged updater's
+    // `navLinkStatus` resolves to undefined and the link stays visible.
+    expect(latestSloUpdate?.navLinkStatus).not.toBe(AppNavLinkStatus.hidden);
   });
 });

--- a/public/plugin.test.tsx
+++ b/public/plugin.test.tsx
@@ -11,8 +11,8 @@ import { dataPluginMock } from '../../../src/plugins/data/public/mocks';
 import { uiActionsPluginMock } from '../../../src/plugins/ui_actions/public/mocks';
 import { AppPluginStartDependencies, SetupDependencies } from './types';
 import { contentManagementPluginMocks } from '../../../src/plugins/content_management/public';
-import { BehaviorSubject } from 'rxjs';
-import { AppNavLinkStatus } from '../../../src/core/public';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { App, AppNavLinkStatus, AppUpdater } from '../../../src/core/public';
 
 function ensureIconSideNavMock(coreSetup: ReturnType<typeof coreMock.createSetup>) {
   if (!coreSetup.chrome.getIsIconSideNavEnabled) {
@@ -402,5 +402,183 @@ describe('#setup with Alert Manager feature gate', () => {
     const registerCalls = (coreSetup.application.register as jest.Mock).mock.calls;
     const alertingApp = registerCalls.find((call) => call[0].id === 'observability-alerting');
     expect(alertingApp).toBeUndefined();
+  });
+
+  it('should hide alerting nav link when capabilities.observability.alertManagerEnabled is false in start()', async () => {
+    const initializerContextMock = coreMock.createPluginInitializerContext();
+    initializerContextMock.config.get = jest.fn().mockReturnValue({
+      query_assist: { enabled: false },
+      summarize: { enabled: false },
+      alertManager: { enabled: true },
+    });
+    const coreSetup = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetup);
+    let alertingUpdater$ = new BehaviorSubject<() => {}>(() => ({}));
+    coreSetup.application.register = jest.fn((args) => {
+      if (args.id === 'observability-alerting' && args.updater$) {
+        alertingUpdater$ = args.updater$;
+      }
+    });
+    const observabilityPlugin = new ObservabilityPlugin(initializerContextMock);
+
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+
+    await observabilityPlugin.setup(coreSetup, ({
+      embeddable: embeddablePluginMock.createSetupContract(),
+      visualizations: visualizationsPluginMock.createSetupContract(),
+      data: dataPluginMock.createSetupContract(),
+      uiActions: uiActionsPluginMock.createSetupContract(),
+      contentManagement: contentManagementPluginMocks.createSetupContract(),
+      dashboard: { registerDashboardProvider: jest.fn() },
+    } as unknown) as SetupDependencies);
+
+    const coreStart = coreMock.createStart();
+    const dataStartMock = dataPluginMock.createStartContract();
+    dataStartMock.dataSources.dataSourceFactory.registerDataSourceType = jest.fn();
+    observabilityPlugin.start(
+      {
+        ...coreStart,
+        application: {
+          ...coreStart.application,
+          capabilities: {
+            ...coreStart.application.capabilities,
+            observability: {
+              alertManagerEnabled: false,
+              sloEnabled: false,
+            },
+          },
+        },
+      },
+      ({ data: dataStartMock } as unknown) as AppPluginStartDependencies
+    );
+
+    expect(alertingUpdater$.getValue()()).toEqual({
+      navLinkStatus: AppNavLinkStatus.hidden,
+    });
+  });
+});
+
+describe('#setup with SLO feature gate', () => {
+  it('should hide SLO nav link when capabilities.observability.sloEnabled is false in start()', async () => {
+    const initializerContextMock = coreMock.createPluginInitializerContext();
+    initializerContextMock.config.get = jest.fn().mockReturnValue({
+      query_assist: { enabled: false },
+      summarize: { enabled: false },
+      slo: { enabled: true },
+    });
+    const coreSetup = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetup);
+    // SLO app's updater$ is a piped Observable (combineLatest of two
+    // BehaviorSubjects), so we subscribe and capture the latest emission
+    // rather than calling `.getValue()`.
+    let latestSloUpdate: ReturnType<AppUpdater> | undefined;
+    coreSetup.application.register = jest.fn((args) => {
+      if (args.id === 'observability-apm-slo' && args.updater$) {
+        (args.updater$ as Observable<AppUpdater>).subscribe((updater) => {
+          latestSloUpdate = updater({} as App);
+        });
+      }
+    });
+    const observabilityPlugin = new ObservabilityPlugin(initializerContextMock);
+
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    coreSetup.uiSettings.get = jest.fn().mockReturnValue(true); // APM enabled
+
+    await observabilityPlugin.setup(coreSetup, ({
+      embeddable: embeddablePluginMock.createSetupContract(),
+      visualizations: visualizationsPluginMock.createSetupContract(),
+      data: dataPluginMock.createSetupContract(),
+      uiActions: uiActionsPluginMock.createSetupContract(),
+      contentManagement: contentManagementPluginMocks.createSetupContract(),
+      dashboard: { registerDashboardProvider: jest.fn() },
+    } as unknown) as SetupDependencies);
+
+    const coreStart = coreMock.createStart();
+    const dataStartMock = dataPluginMock.createStartContract();
+    dataStartMock.dataSources.dataSourceFactory.registerDataSourceType = jest.fn();
+    observabilityPlugin.start(
+      {
+        ...coreStart,
+        application: {
+          ...coreStart.application,
+          capabilities: {
+            ...coreStart.application.capabilities,
+            // Traces enabled so APM updater leaves the link visible. SLO
+            // capability off — only the SLO updater should hide the link.
+            explore: { discoverTracesEnabled: true },
+            observability: {
+              alertManagerEnabled: false,
+              sloEnabled: false,
+            },
+          },
+        },
+      },
+      ({ data: dataStartMock } as unknown) as AppPluginStartDependencies
+    );
+
+    expect(latestSloUpdate).toMatchObject({
+      navLinkStatus: AppNavLinkStatus.hidden,
+    });
+  });
+
+  it('should hide SLO nav link when APM updater hides it even if sloEnabled capability is true', async () => {
+    // Verifies the merged-updater "either hiding wins" rule: with SLO
+    // capability on, but `discoverTracesEnabled` false (APM gate fires),
+    // the SLO link should still hide.
+    const initializerContextMock = coreMock.createPluginInitializerContext();
+    initializerContextMock.config.get = jest.fn().mockReturnValue({
+      query_assist: { enabled: false },
+      summarize: { enabled: false },
+      slo: { enabled: true },
+    });
+    const coreSetup = coreMock.createSetup();
+    ensureIconSideNavMock(coreSetup);
+    let latestSloUpdate: ReturnType<AppUpdater> | undefined;
+    coreSetup.application.register = jest.fn((args) => {
+      if (args.id === 'observability-apm-slo' && args.updater$) {
+        (args.updater$ as Observable<AppUpdater>).subscribe((updater) => {
+          latestSloUpdate = updater({} as App);
+        });
+      }
+    });
+    const observabilityPlugin = new ObservabilityPlugin(initializerContextMock);
+
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    coreSetup.uiSettings.get = jest.fn().mockReturnValue(true);
+
+    await observabilityPlugin.setup(coreSetup, ({
+      embeddable: embeddablePluginMock.createSetupContract(),
+      visualizations: visualizationsPluginMock.createSetupContract(),
+      data: dataPluginMock.createSetupContract(),
+      uiActions: uiActionsPluginMock.createSetupContract(),
+      contentManagement: contentManagementPluginMocks.createSetupContract(),
+      dashboard: { registerDashboardProvider: jest.fn() },
+    } as unknown) as SetupDependencies);
+
+    const coreStart = coreMock.createStart();
+    const dataStartMock = dataPluginMock.createStartContract();
+    dataStartMock.dataSources.dataSourceFactory.registerDataSourceType = jest.fn();
+    observabilityPlugin.start(
+      {
+        ...coreStart,
+        application: {
+          ...coreStart.application,
+          capabilities: {
+            ...coreStart.application.capabilities,
+            // Traces disabled → APM updater hides the link.
+            explore: { discoverTracesEnabled: false },
+            observability: {
+              alertManagerEnabled: false,
+              sloEnabled: true, // SLO capability ON.
+            },
+          },
+        },
+      },
+      ({ data: dataStartMock } as unknown) as AppPluginStartDependencies
+    );
+
+    expect(latestSloUpdate).toMatchObject({
+      navLinkStatus: AppNavLinkStatus.hidden,
+    });
   });
 });

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -454,43 +454,40 @@ export class ObservabilityPlugin
           updater$: this.apmAppUpdater$,
         });
 
-        // SLO app — gated behind observability.slo.enabled so PR 1 ships dark
-        // by default. Mirrors the alertManager.enabled pattern above; opt in
-        // via `opensearch_dashboards.yml` with `observability.slo.enabled: true`.
-        if (this.config.slo?.enabled) {
-          core.application.register({
-            id: observabilityApmSloID,
-            title: observabilityApmSloTitle,
-            category: APPLICATION_MONITORING_CATEGORY,
-            order: observabilityApmSloPluginOrder,
-            mount: appMountWithStartPage('apm-slo', '/slos'),
-            // Two updaters merge: `apmAppUpdater$` for the APM-vs-Trace-Analytics
-            // visibility gate (driven by `explore.discoverTracesEnabled`), and
-            // `apmSloAppUpdater$` for the dynamic SLO feature flag. Either one
-            // hiding the link wins — naive spread would let a later `visible`
-            // override an earlier `hidden`, so `navLinkStatus` is merged
-            // explicitly with `hidden` taking precedence.
-            updater$: combineLatest([this.apmAppUpdater$, this.apmSloAppUpdater$]).pipe(
-              map(([apmUpdater, sloUpdater]) => (app: App) => {
-                // `AppUpdater` may legally return `undefined`; default both
-                // to `{}` so the merge below doesn't crash on a no-op
-                // updater.
-                const apmUpdate = apmUpdater(app) ?? {};
-                const sloUpdate = sloUpdater(app) ?? {};
-                const eitherHidden =
-                  apmUpdate.navLinkStatus === AppNavLinkStatus.hidden ||
-                  sloUpdate.navLinkStatus === AppNavLinkStatus.hidden;
-                return {
-                  ...apmUpdate,
-                  ...sloUpdate,
-                  navLinkStatus: eitherHidden
-                    ? AppNavLinkStatus.hidden
-                    : sloUpdate.navLinkStatus ?? apmUpdate.navLinkStatus,
-                };
-              })
-            ),
-          });
-        }
+        // SLO app registers unconditionally. Visibility is controlled at
+        // request time by the dynamic capability flag — see the merged
+        // updater below. The merge keeps the existing APM-vs-Trace-Analytics
+        // gate (driven by `explore.discoverTracesEnabled`) and layers the
+        // SLO capability on top so either input can hide the link.
+        core.application.register({
+          id: observabilityApmSloID,
+          title: observabilityApmSloTitle,
+          category: APPLICATION_MONITORING_CATEGORY,
+          order: observabilityApmSloPluginOrder,
+          mount: appMountWithStartPage('apm-slo', '/slos'),
+          // Naive spread would let a later `visible` override an earlier
+          // `hidden`, so `navLinkStatus` is merged explicitly with `hidden`
+          // taking precedence.
+          updater$: combineLatest([this.apmAppUpdater$, this.apmSloAppUpdater$]).pipe(
+            map(([apmUpdater, sloUpdater]) => (app: App) => {
+              // `AppUpdater` may legally return `undefined`; default both
+              // to `{}` so the merge below doesn't crash on a no-op
+              // updater.
+              const apmUpdate = apmUpdater(app) ?? {};
+              const sloUpdate = sloUpdater(app) ?? {};
+              const eitherHidden =
+                apmUpdate.navLinkStatus === AppNavLinkStatus.hidden ||
+                sloUpdate.navLinkStatus === AppNavLinkStatus.hidden;
+              return {
+                ...apmUpdate,
+                ...sloUpdate,
+                navLinkStatus: eitherHidden
+                  ? AppNavLinkStatus.hidden
+                  : sloUpdate.navLinkStatus ?? apmUpdate.navLinkStatus,
+              };
+            })
+          ),
+        });
 
         // Trace Analytics apps - visible when traces capability DISABLED (fallback)
         core.application.register({
@@ -565,29 +562,22 @@ export class ObservabilityPlugin
       updater$: this.appUpdater$,
     });
 
-    if (this.config.alertManager?.enabled) {
-      core.application.register({
-        id: observabilityAlertingID,
-        title: observabilityAlertingTitle,
-        category: OBSERVABILITY_APP_CATEGORIES.observability,
-        order: observabilityAlertingPluginOrder,
-        euiIconType: 'beaker',
-        mount: appMountWithStartPage('alerting'),
-        // Visibility flipped in `start()` from
-        // `capabilities.observability.alertManagerEnabled`. Yml still
-        // controls registration so the route only mounts where the
-        // server-side routes/SOs were registered.
-        updater$: this.alertingAppUpdater$,
-      });
-    }
+    // Alerting app registers unconditionally. Visibility flipped in
+    // `start()` from `capabilities.observability.alertManagerEnabled`.
+    core.application.register({
+      id: observabilityAlertingID,
+      title: observabilityAlertingTitle,
+      category: OBSERVABILITY_APP_CATEGORIES.observability,
+      order: observabilityAlertingPluginOrder,
+      euiIconType: 'beaker',
+      mount: appMountWithStartPage('alerting'),
+      updater$: this.alertingAppUpdater$,
+    });
 
-    registerAllPluginNavGroups(
-      core,
-      this.apmEnabled,
-      APPLICATION_MONITORING_CATEGORY,
-      !!this.config.alertManager?.enabled,
-      !!this.config.slo?.enabled
-    );
+    // Register the alerting + SLO nav-group entries unconditionally; their
+    // visibility is governed by `capabilities.observability.{alertManagerEnabled,sloEnabled}`
+    // through the per-app updaters set up above.
+    registerAllPluginNavGroups(core, this.apmEnabled, APPLICATION_MONITORING_CATEGORY, true, true);
 
     const embeddableFactory = new ObservabilityEmbeddableFactoryDefinition(async () => ({
       getAttributeService: (await core.getStartServices())[1].dashboard.getAttributeService,
@@ -598,21 +588,27 @@ export class ObservabilityPlugin
 
     registerAsssitantDependencies(setupDeps.assistantDashboards);
 
-    // True when our alert manager is on AND we have an Explore registry to
-    // attach to. This is also the value we hand back through the setup
-    // contract so the alerting-dashboards-plugin can stand its own
-    // "Create monitor" entry down — when both plugins register, the user
-    // sees two duplicate entries; gating on `alertManager.enabled` (rather
-    // than mere plugin presence) lets observability ship loaded-but-quiet
-    // when the alert manager is intentionally disabled.
-    const ownsMonitorCreation = !!this.config.alertManager?.enabled;
+    // Register the "Create alert rule" entry under Explore's Query Panel
+    // "Actions" menu only when our `alertManagerEnabled` capability is on.
+    //
+    // Explore's registry has only `getIsEnabled` (greys out) and no
+    // `isVisible` hook, so to actually *hide* a duplicate when the
+    // alerting-dashboards-plugin also registers its own "Create monitor"
+    // entry we must skip `register()` entirely. We can't read capabilities
+    // synchronously at setup time, so we defer registration until
+    // `getStartServices()` resolves — that fires after capabilities are
+    // populated and well before any user can open the actions menu. The
+    // alerting plugin uses the mirror condition (registers only when our
+    // capability is *off*), so exactly one entry exists at any time.
+    //
+    // `ownsMonitorCreation` on the setup contract is preserved at `true`
+    // for the older alerting builds that still gate on it; newer builds
+    // ignore it and key off `capabilities.observability.alertManagerEnabled`
+    // directly.
+    const ownsMonitorCreation = true;
 
-    // Register the "Create monitor" entry under Explore's Query Panel
-    // "Actions" menu when our alert manager is enabled. Skipped when the
-    // flag is off so the alerting-dashboards-plugin keeps ownership.
-    // Lazy-loaded so we don't pay the import cost in setups that never
-    // open the menu.
-    if (ownsMonitorCreation && setupDeps.explore) {
+    if (setupDeps.explore) {
+      const exploreSetup = setupDeps.explore;
       // Lazy-load the flyout host once, at module scope of this closure — not
       // per-render. Defining `React.lazy` inside the action's `component`
       // would create a fresh lazy wrapper on every parent render, defeating
@@ -622,80 +618,69 @@ export class ObservabilityPlugin
         return { default: mod.ExploreCreateMonitor };
       });
 
-      setupDeps.explore.queryPanelActionsRegistry.register({
-        id: 'observability-create-logs-monitor-from-explore',
-        order: 1,
-        actionType: 'flyout',
-        getLabel: () =>
-          i18n.translate('observability.alerting.exploreCreateMonitor.actionLabel', {
-            defaultMessage: 'Create alert rule',
-          }),
-        getIcon: () => 'bell',
-        getIsEnabled: (deps) => {
-          // Capabilities live on `CoreStart`, not `CoreSetup` — read from
-          // `coreRefs` which `start()` populates. `getIsEnabled` is invoked
-          // when the menu opens, well after the start phase, so by the time
-          // this runs `coreRefs.application` is set.
-          //
-          // The structural cast names only the field we care about
-          // (`alertingDashboards.pplV2`) — owned by the alerting plugin and
-          // not declared in any shared type, so we can't import a stronger
-          // shape without coupling this plugin to alerting's internals.
-          const capabilities = coreRefs.application?.capabilities as
-            | {
-                alertingDashboards?: { pplV2?: boolean };
-                observability?: { alertManagerEnabled?: boolean };
-              }
-            | undefined;
-          // Hide the action when the dynamic flag has alerting off, even if
-          // yml registered the app. Lets AppConfig dark this entry without
-          // an OSD restart.
-          if (!capabilities?.observability?.alertManagerEnabled) return false;
-          // Reuse the alerting plugin's PPL capability — they own the agent
-          // config + cluster gate; we just light up alongside theirs so users
-          // see both options when PPL alerting is on.
-          if (!capabilities?.alertingDashboards?.pplV2) return false;
-          // AOSS clusters can't host monitors; their button hides itself the
-          // same way.
-          const isAOSS =
-            (deps.query as { dataset?: { dataSource?: { type?: string } } })?.dataset?.dataSource
-              ?.type === 'OpenSearch Serverless';
-          return !isAOSS;
-        },
-        component: (props) => {
-          const dataset = (props.dependencies.query as {
-            dataset?: {
-              dataSource?: { id?: string; title?: string; name?: string };
-              title?: string;
-              timeFieldName?: string;
+      core.getStartServices().then(([coreStart]) => {
+        const capabilities = coreStart.application.capabilities as
+          | { observability?: { alertManagerEnabled?: boolean } }
+          | undefined;
+        if (!capabilities?.observability?.alertManagerEnabled) {
+          return;
+        }
+        exploreSetup.queryPanelActionsRegistry.register({
+          id: 'observability-create-logs-monitor-from-explore',
+          order: 1,
+          actionType: 'flyout',
+          getLabel: () =>
+            i18n.translate('observability.alerting.exploreCreateMonitor.actionLabel', {
+              defaultMessage: 'Create alert rule',
+            }),
+          getIcon: () => 'bell',
+          getIsEnabled: (deps) => {
+            // Reuse the alerting plugin's PPL capability — they own the
+            // agent config + cluster gate; we just light up alongside
+            // theirs so users see this option when PPL alerting is on.
+            const liveCapabilities = coreRefs.application?.capabilities as
+              | { alertingDashboards?: { pplV2?: boolean } }
+              | undefined;
+            if (!liveCapabilities?.alertingDashboards?.pplV2) return false;
+            // AOSS clusters can't host monitors; the button greys out.
+            const isAOSS =
+              (deps.query as { dataset?: { dataSource?: { type?: string } } })?.dataset?.dataSource
+                ?.type === 'OpenSearch Serverless';
+            return !isAOSS;
+          },
+          component: (props) => {
+            const dataset = (props.dependencies.query as {
+              dataset?: {
+                dataSource?: { id?: string; title?: string; name?: string };
+                title?: string;
+                timeFieldName?: string;
+              };
+            }).dataset;
+            const exploreContext = {
+              dataSourceId: dataset?.dataSource?.id,
+              dataSourceName: dataset?.dataSource?.title ?? dataset?.dataSource?.name,
+              indexPattern: dataset?.title,
+              timeFieldName: dataset?.timeFieldName,
+              queryInEditor:
+                props.dependencies.queryInEditor ||
+                (props.dependencies.query as { query?: string })?.query ||
+                '',
             };
-          }).dataset;
-          const exploreContext = {
-            dataSourceId: dataset?.dataSource?.id,
-            dataSourceName: dataset?.dataSource?.title ?? dataset?.dataSource?.name,
-            indexPattern: dataset?.title,
-            timeFieldName: dataset?.timeFieldName,
-            queryInEditor:
-              props.dependencies.queryInEditor ||
-              (props.dependencies.query as { query?: string })?.query ||
-              '',
-          };
-          return (
-            <React.Suspense fallback={null}>
-              <LazyExploreCreateMonitor
-                exploreContext={exploreContext}
-                onClose={props.closeFlyout}
-              />
-            </React.Suspense>
-          );
-        },
+            return (
+              <React.Suspense fallback={null}>
+                <LazyExploreCreateMonitor
+                  exploreContext={exploreContext}
+                  onClose={props.closeFlyout}
+                />
+              </React.Suspense>
+            );
+          },
+        });
       });
     }
 
-    // Return contract for other plugins to consume. `ownsMonitorCreation` is
-    // the signal the alerting-dashboards-plugin reads to decide whether to
-    // register its own "Create monitor" entry on Explore — true when our
-    // alert manager is enabled, false otherwise.
+    // Setup contract preserved for backward compat; see the comment above
+    // the `ownsMonitorCreation = true` declaration for context.
     return { ownsMonitorCreation };
   }
 
@@ -717,11 +702,8 @@ export class ObservabilityPlugin
     coreRefs.queryAssistEnabled = this.config.query_assist.enabled;
     coreRefs.summarizeEnabled = this.config.summarize.enabled;
     // Resolved from the dynamic-config-backed capability so AppConfig flips
-    // take effect on the next page load. Falls back through the server-side
-    // switcher to yml when the dynamic store has no override. Components
-    // (`apm/pages/services_home`, `apm/pages/service_details`) read this ref;
-    // the switch from `this.config.slo?.enabled` is what makes them respond
-    // to dynamic flips without a restart.
+    // take effect on the next page load. Components
+    // (`apm/pages/services_home`, `apm/pages/service_details`) read this ref.
     const observabilityCapabilities = core.application.capabilities.observability as
       | { alertManagerEnabled?: boolean; sloEnabled?: boolean }
       | undefined;
@@ -729,16 +711,16 @@ export class ObservabilityPlugin
     const alertManagerEnabledFromCapability = !!observabilityCapabilities?.alertManagerEnabled;
     coreRefs.sloEnabled = sloEnabledFromCapability;
 
-    // Hide the alerting nav link when the capability says the feature is off,
-    // even if yml registered the app. When yml has it off the app isn't
-    // registered at all and `next()` is a no-op against a dead BehaviorSubject.
+    // Hide nav links whose dynamic capability says off. The apps register
+    // unconditionally, so URL access still works for users who type the
+    // path directly — the dynamic flag is a UI gate, not an access gate.
     if (!alertManagerEnabledFromCapability) {
       this.alertingAppUpdater$.next(() => ({
         navLinkStatus: AppNavLinkStatus.hidden,
       }));
     }
-    // Same pattern for the SLO app. Merged with `apmAppUpdater$` at register
-    // time so APM-vs-Trace-Analytics gating still applies.
+    // SLO updater is merged with `apmAppUpdater$` at register time so the
+    // APM-vs-Trace-Analytics gate still applies.
     if (!sloEnabledFromCapability) {
       this.apmSloAppUpdater$.next(() => ({
         navLinkStatus: AppNavLinkStatus.hidden,

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -6,8 +6,10 @@
 import { htmlIdGenerator } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import React from 'react';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
 import {
+  App,
   AppCategory,
   AppMountParameters,
   AppNavLinkStatus,
@@ -203,6 +205,11 @@ export class ObservabilityPlugin
   private appUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
   private apmAppUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
   private traceAnalyticsAppUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
+  // Updaters for dynamic feature-flag-controlled apps. Visibility is set in
+  // `start()` from `capabilities.observability.{alertManagerEnabled,sloEnabled}`,
+  // which the server-side switcher resolves from the DynamicConfigService.
+  private alertingAppUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
+  private apmSloAppUpdater$ = new BehaviorSubject<AppUpdater>(() => ({}));
 
   public async setup(
     core: CoreSetup<AppPluginStartDependencies>,
@@ -457,7 +464,16 @@ export class ObservabilityPlugin
             category: APPLICATION_MONITORING_CATEGORY,
             order: observabilityApmSloPluginOrder,
             mount: appMountWithStartPage('apm-slo', '/slos'),
-            updater$: this.apmAppUpdater$,
+            // Two updaters merge: `apmAppUpdater$` for the APM-vs-Trace-Analytics
+            // visibility gate (driven by `explore.discoverTracesEnabled`), and
+            // `apmSloAppUpdater$` for the dynamic SLO feature flag. Either one
+            // hiding the link wins.
+            updater$: combineLatest([this.apmAppUpdater$, this.apmSloAppUpdater$]).pipe(
+              map(([apmUpdater, sloUpdater]) => (app: App) => ({
+                ...apmUpdater(app),
+                ...sloUpdater(app),
+              }))
+            ),
           });
         }
 
@@ -542,6 +558,11 @@ export class ObservabilityPlugin
         order: observabilityAlertingPluginOrder,
         euiIconType: 'beaker',
         mount: appMountWithStartPage('alerting'),
+        // Visibility flipped in `start()` from
+        // `capabilities.observability.alertManagerEnabled`. Yml still
+        // controls registration so the route only mounts where the
+        // server-side routes/SOs were registered.
+        updater$: this.alertingAppUpdater$,
       });
     }
 
@@ -606,8 +627,15 @@ export class ObservabilityPlugin
           // not declared in any shared type, so we can't import a stronger
           // shape without coupling this plugin to alerting's internals.
           const capabilities = coreRefs.application?.capabilities as
-            | { alertingDashboards?: { pplV2?: boolean } }
+            | {
+                alertingDashboards?: { pplV2?: boolean };
+                observability?: { alertManagerEnabled?: boolean };
+              }
             | undefined;
+          // Hide the action when the dynamic flag has alerting off, even if
+          // yml registered the app. Lets AppConfig dark this entry without
+          // an OSD restart.
+          if (!capabilities?.observability?.alertManagerEnabled) return false;
           // Reuse the alerting plugin's PPL capability — they own the agent
           // config + cluster gate; we just light up alongside theirs so users
           // see both options when PPL alerting is on.
@@ -673,7 +701,34 @@ export class ObservabilityPlugin
     coreRefs.dashboard = startDeps.dashboard;
     coreRefs.queryAssistEnabled = this.config.query_assist.enabled;
     coreRefs.summarizeEnabled = this.config.summarize.enabled;
-    coreRefs.sloEnabled = !!this.config.slo?.enabled;
+    // Resolved from the dynamic-config-backed capability so AppConfig flips
+    // take effect on the next page load. Falls back through the server-side
+    // switcher to yml when the dynamic store has no override. Components
+    // (`apm/pages/services_home`, `apm/pages/service_details`) read this ref;
+    // the switch from `this.config.slo?.enabled` is what makes them respond
+    // to dynamic flips without a restart.
+    const observabilityCapabilities = core.application.capabilities.observability as
+      | { alertManagerEnabled?: boolean; sloEnabled?: boolean }
+      | undefined;
+    const sloEnabledFromCapability = !!observabilityCapabilities?.sloEnabled;
+    const alertManagerEnabledFromCapability = !!observabilityCapabilities?.alertManagerEnabled;
+    coreRefs.sloEnabled = sloEnabledFromCapability;
+
+    // Hide the alerting nav link when the capability says the feature is off,
+    // even if yml registered the app. When yml has it off the app isn't
+    // registered at all and `next()` is a no-op against a dead BehaviorSubject.
+    if (!alertManagerEnabledFromCapability) {
+      this.alertingAppUpdater$.next(() => ({
+        navLinkStatus: AppNavLinkStatus.hidden,
+      }));
+    }
+    // Same pattern for the SLO app. Merged with `apmAppUpdater$` at register
+    // time so APM-vs-Trace-Analytics gating still applies.
+    if (!sloEnabledFromCapability) {
+      this.apmSloAppUpdater$.next(() => ({
+        navLinkStatus: AppNavLinkStatus.hidden,
+      }));
+    }
     coreRefs.overlays = core.overlays;
     coreRefs.dataSource = startDeps.dataSource;
     coreRefs.navigation = startDeps.navigation;

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -600,13 +600,6 @@ export class ObservabilityPlugin
     // populated and well before any user can open the actions menu. The
     // alerting plugin uses the mirror condition (registers only when our
     // capability is *off*), so exactly one entry exists at any time.
-    //
-    // `ownsMonitorCreation` on the setup contract is preserved at `true`
-    // for the older alerting builds that still gate on it; newer builds
-    // ignore it and key off `capabilities.observability.alertManagerEnabled`
-    // directly.
-    const ownsMonitorCreation = true;
-
     if (setupDeps.explore) {
       const exploreSetup = setupDeps.explore;
       // Lazy-load the flyout host once, at module scope of this closure — not
@@ -691,9 +684,7 @@ export class ObservabilityPlugin
         });
     }
 
-    // Setup contract preserved for backward compat; see the comment above
-    // the `ownsMonitorCreation = true` declaration for context.
-    return { ownsMonitorCreation };
+    return {};
   }
 
   public start(core: CoreStart, startDeps: AppPluginStartDependencies): ObservabilityStart {

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -467,12 +467,27 @@ export class ObservabilityPlugin
             // Two updaters merge: `apmAppUpdater$` for the APM-vs-Trace-Analytics
             // visibility gate (driven by `explore.discoverTracesEnabled`), and
             // `apmSloAppUpdater$` for the dynamic SLO feature flag. Either one
-            // hiding the link wins.
+            // hiding the link wins — naive spread would let a later `visible`
+            // override an earlier `hidden`, so `navLinkStatus` is merged
+            // explicitly with `hidden` taking precedence.
             updater$: combineLatest([this.apmAppUpdater$, this.apmSloAppUpdater$]).pipe(
-              map(([apmUpdater, sloUpdater]) => (app: App) => ({
-                ...apmUpdater(app),
-                ...sloUpdater(app),
-              }))
+              map(([apmUpdater, sloUpdater]) => (app: App) => {
+                // `AppUpdater` may legally return `undefined`; default both
+                // to `{}` so the merge below doesn't crash on a no-op
+                // updater.
+                const apmUpdate = apmUpdater(app) ?? {};
+                const sloUpdate = sloUpdater(app) ?? {};
+                const eitherHidden =
+                  apmUpdate.navLinkStatus === AppNavLinkStatus.hidden ||
+                  sloUpdate.navLinkStatus === AppNavLinkStatus.hidden;
+                return {
+                  ...apmUpdate,
+                  ...sloUpdate,
+                  navLinkStatus: eitherHidden
+                    ? AppNavLinkStatus.hidden
+                    : sloUpdate.navLinkStatus ?? apmUpdate.navLinkStatus,
+                };
+              })
             ),
           });
         }

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -618,65 +618,77 @@ export class ObservabilityPlugin
         return { default: mod.ExploreCreateMonitor };
       });
 
-      core.getStartServices().then(([coreStart]) => {
-        const capabilities = coreStart.application.capabilities as
-          | { observability?: { alertManagerEnabled?: boolean } }
-          | undefined;
-        if (!capabilities?.observability?.alertManagerEnabled) {
-          return;
-        }
-        exploreSetup.queryPanelActionsRegistry.register({
-          id: 'observability-create-logs-monitor-from-explore',
-          order: 1,
-          actionType: 'flyout',
-          getLabel: () =>
-            i18n.translate('observability.alerting.exploreCreateMonitor.actionLabel', {
-              defaultMessage: 'Create alert rule',
-            }),
-          getIcon: () => 'bell',
-          getIsEnabled: (deps) => {
-            // Reuse the alerting plugin's PPL capability — they own the
-            // agent config + cluster gate; we just light up alongside
-            // theirs so users see this option when PPL alerting is on.
-            const liveCapabilities = coreRefs.application?.capabilities as
-              | { alertingDashboards?: { pplV2?: boolean } }
-              | undefined;
-            if (!liveCapabilities?.alertingDashboards?.pplV2) return false;
-            // AOSS clusters can't host monitors; the button greys out.
-            const isAOSS =
-              (deps.query as { dataset?: { dataSource?: { type?: string } } })?.dataset?.dataSource
-                ?.type === 'OpenSearch Serverless';
-            return !isAOSS;
-          },
-          component: (props) => {
-            const dataset = (props.dependencies.query as {
-              dataset?: {
-                dataSource?: { id?: string; title?: string; name?: string };
-                title?: string;
-                timeFieldName?: string;
+      core
+        .getStartServices()
+        .then(([coreStart]) => {
+          const capabilities = coreStart.application.capabilities as
+            | { observability?: { alertManagerEnabled?: boolean } }
+            | undefined;
+          if (!capabilities?.observability?.alertManagerEnabled) {
+            return;
+          }
+          exploreSetup.queryPanelActionsRegistry.register({
+            id: 'observability-create-logs-monitor-from-explore',
+            order: 1,
+            actionType: 'flyout',
+            getLabel: () =>
+              i18n.translate('observability.alerting.exploreCreateMonitor.actionLabel', {
+                defaultMessage: 'Create alert rule',
+              }),
+            getIcon: () => 'bell',
+            getIsEnabled: (deps) => {
+              // Reuse the alerting plugin's PPL capability — they own the
+              // agent config + cluster gate; we just light up alongside
+              // theirs so users see this option when PPL alerting is on.
+              const liveCapabilities = coreRefs.application?.capabilities as
+                | { alertingDashboards?: { pplV2?: boolean } }
+                | undefined;
+              if (!liveCapabilities?.alertingDashboards?.pplV2) return false;
+              // AOSS clusters can't host monitors; the button greys out.
+              const isAOSS =
+                (deps.query as { dataset?: { dataSource?: { type?: string } } })?.dataset
+                  ?.dataSource?.type === 'OpenSearch Serverless';
+              return !isAOSS;
+            },
+            component: (props) => {
+              const dataset = (props.dependencies.query as {
+                dataset?: {
+                  dataSource?: { id?: string; title?: string; name?: string };
+                  title?: string;
+                  timeFieldName?: string;
+                };
+              }).dataset;
+              const exploreContext = {
+                dataSourceId: dataset?.dataSource?.id,
+                dataSourceName: dataset?.dataSource?.title ?? dataset?.dataSource?.name,
+                indexPattern: dataset?.title,
+                timeFieldName: dataset?.timeFieldName,
+                queryInEditor:
+                  props.dependencies.queryInEditor ||
+                  (props.dependencies.query as { query?: string })?.query ||
+                  '',
               };
-            }).dataset;
-            const exploreContext = {
-              dataSourceId: dataset?.dataSource?.id,
-              dataSourceName: dataset?.dataSource?.title ?? dataset?.dataSource?.name,
-              indexPattern: dataset?.title,
-              timeFieldName: dataset?.timeFieldName,
-              queryInEditor:
-                props.dependencies.queryInEditor ||
-                (props.dependencies.query as { query?: string })?.query ||
-                '',
-            };
-            return (
-              <React.Suspense fallback={null}>
-                <LazyExploreCreateMonitor
-                  exploreContext={exploreContext}
-                  onClose={props.closeFlyout}
-                />
-              </React.Suspense>
-            );
-          },
+              return (
+                <React.Suspense fallback={null}>
+                  <LazyExploreCreateMonitor
+                    exploreContext={exploreContext}
+                    onClose={props.closeFlyout}
+                  />
+                </React.Suspense>
+              );
+            },
+          });
+        })
+        .catch((error) => {
+          // Surface failures from the deferred-registration path. Without
+          // this catch, a `getStartServices()` rejection (rare, but
+          // possible during a failed start lifecycle or late teardown)
+          // would become an unhandled promise rejection and the
+          // registration silently no-op. Matches the existing
+          // `console.error` precedent below for the S3 datasource path.
+
+          console.error('Failed to register Explore "Create alert rule" action', error);
         });
-      });
     }
 
     // Setup contract preserved for backward compat; see the comment above

--- a/public/types.ts
+++ b/public/types.ts
@@ -56,20 +56,8 @@ export interface SetupDependencies {
   explore?: ExplorePluginSetup;
 }
 
-export interface ObservabilitySetup {
-  /**
-   * Signals to other plugins that observability owns the "Create monitor"
-   * entry-point on Explore's Query Panel "Actions" menu — true when the
-   * observability alert manager is enabled in config (`observability.alertManager.enabled`).
-   *
-   * Consumers (currently the alerting-dashboards-plugin) read this flag in
-   * their own `setup()` and skip their parallel registration to avoid two
-   * "Create monitor" entries appearing side-by-side. Always defined so the
-   * boolean check is unambiguous — a missing field would force consumers
-   * to coalesce against `undefined`.
-   */
-  ownsMonitorCreation: boolean;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ObservabilitySetup {}
 
 export interface ObservabilityStart {
   renderAccelerationDetailsFlyout: ({

--- a/server/plugin.test.ts
+++ b/server/plugin.test.ts
@@ -24,3 +24,93 @@ describe('#setup', () => {
     );
   });
 });
+
+describe('#setup capability switcher (dynamic feature flags)', () => {
+  // Helper: drive the dynamic-config-service mock so the switcher resolves
+  // a particular `getConfig` outcome. Returns the captured switcher fn so
+  // tests can invoke it directly. `yml` seeds the yml-derived defaults
+  // the switcher uses as its fallback chain.
+  async function captureSwitcher(opts: {
+    yml?: { alertManager?: { enabled: boolean }; slo?: { enabled: boolean } };
+    getConfigBehavior:
+      | { ok: { alertManager?: { enabled: boolean }; slo?: { enabled: boolean } } }
+      | { reject: Error };
+  }) {
+    const initializerContext = coreMock.createPluginInitializerContext(opts.yml ?? {});
+    const coreSetup = coreMock.createSetup();
+    const getConfigMock = jest.fn();
+    if ('ok' in opts.getConfigBehavior) {
+      getConfigMock.mockResolvedValue(opts.getConfigBehavior.ok);
+    } else {
+      getConfigMock.mockRejectedValue(opts.getConfigBehavior.reject);
+    }
+    (coreSetup.dynamicConfigService.getStartService as jest.Mock).mockResolvedValue({
+      getClient: () => ({ getConfig: getConfigMock }),
+      getAsyncLocalStore: () => ({}),
+    });
+
+    const plugin = new ObservabilityPlugin(initializerContext);
+    await plugin.setup(coreSetup, {
+      dataSource: ({
+        registerCustomApiSchema: jest.fn(),
+      } as unknown) as ObservabilityPluginSetupDependencies,
+    });
+
+    // The plugin calls `registerSwitcher` once for the dynamic flag path.
+    // The pre-existing readonly-security switcher is registered after
+    // ours, so the first call is the one we want.
+    const switcherCalls = (coreSetup.capabilities.registerSwitcher as jest.Mock).mock.calls;
+    const switcher = switcherCalls[0]?.[0] as (
+      request: unknown,
+      capabilities: Record<string, unknown>
+    ) => Promise<Record<string, unknown>>;
+
+    return { switcher, plugin, initializerContext, getConfigMock };
+  }
+
+  it('dynamic value overrides yml when both are set', async () => {
+    // yml says off, dynamic says on → dynamic wins.
+    const { switcher } = await captureSwitcher({
+      yml: { alertManager: { enabled: false }, slo: { enabled: false } },
+      getConfigBehavior: { ok: { alertManager: { enabled: true }, slo: { enabled: true } } },
+    });
+    const result = (await switcher({}, { observability: {} })) as {
+      observability: { alertManagerEnabled: boolean; sloEnabled: boolean };
+    };
+    expect(result.observability.alertManagerEnabled).toBe(true);
+    expect(result.observability.sloEnabled).toBe(true);
+  });
+
+  it('falls back to yml value when dynamic config omits a flag', async () => {
+    // yml has alertManager on, slo off. Dynamic config only specifies slo
+    // → alertManager falls through to its yml value.
+    const { switcher } = await captureSwitcher({
+      yml: { alertManager: { enabled: true }, slo: { enabled: false } },
+      getConfigBehavior: { ok: { slo: { enabled: true } } },
+    });
+    const result = (await switcher({}, { observability: {} })) as {
+      observability: { alertManagerEnabled: boolean; sloEnabled: boolean };
+    };
+    expect(result.observability.alertManagerEnabled).toBe(true);
+    expect(result.observability.sloEnabled).toBe(true);
+  });
+
+  it('falls back to yml value when dynamic config layer rejects', async () => {
+    // No DynamicConfigService present (open-source / GitHub OSD case
+    // simulated by a getConfig rejection). yml is the source of truth.
+    // The catch path returns capabilities unchanged so the yml-seeded
+    // provider defaults remain in effect.
+    const { switcher } = await captureSwitcher({
+      yml: { alertManager: { enabled: true }, slo: { enabled: false } },
+      getConfigBehavior: { reject: new Error('no dynamic config available') },
+    });
+    const seededCapabilities = {
+      observability: { alertManagerEnabled: true, sloEnabled: false },
+    };
+    const result = (await switcher({}, seededCapabilities)) as {
+      observability: { alertManagerEnabled: boolean; sloEnabled: boolean };
+    };
+    expect(result.observability.alertManagerEnabled).toBe(true);
+    expect(result.observability.sloEnabled).toBe(false);
+  });
+});

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -323,13 +323,23 @@ export class ObservabilityPlugin
         },
       },
     };
-    // Hoisted above `setupRoutes` so the alerting-route gate (mirrors the
-    // existing `dataSourceEnabled` pattern) can read the flag at registration
-    // time. Keep the same fetch downstream consumers depend on — UI settings
-    // registration below reuses `observabilityConfig.alertManager?.enabled`.
+    // SLO + alerting backends register unconditionally so the dynamic
+    // capability flag (resolved at request time from DynamicConfigService,
+    // see `registerSwitcher` below) can flip user-visible UI on or off
+    // without an OSD restart.
+    //
+    // yml flag semantics:
+    //   - `alertManager.enabled` / `slo.enabled` — UI visibility default
+    //     for environments without a configured DynamicConfigService
+    //     (open-source / GitHub OSD). Read once here and used as the
+    //     fallback in both the capability provider and the switcher's
+    //     `??` chain. The dynamic store overrides them when present.
+    //   - `slo.reconciler.enabled` — whether the GC timer ticks on this
+    //     host (host-level cost, not a UI concern).
+    //   - `slo.ruleDedup.enabled` — fingerprint-keyed selector behavior.
     const observabilityConfig = await this.initializerContext.config
       .create<{
-        alertManager: { enabled: boolean };
+        alertManager?: { enabled?: boolean };
         slo?: {
           enabled?: boolean;
           ruleDedup?: { enabled: boolean };
@@ -338,19 +348,13 @@ export class ObservabilityPlugin
       }>()
       .pipe(first())
       .toPromise();
-    const alertManagerEnabled = observabilityConfig.alertManager?.enabled ?? false;
-    // Feature-flag: SLO surfaces ship dark by default. Opt in via
-    // `observability.slo.enabled: true` in `opensearch_dashboards.yml`.
-    // Mirrors the alertManager.enabled pattern. When disabled we skip SO
-    // type registration, route registration, and service construction —
-    // the plugin acts as if SLOs don't exist.
-    //
-    // Toggling this value in the yml requires an OSD restart to take
-    // effect. The value is captured once here at plugin setup so route
-    // closures and SO-type registrations can key off it; moving the check
-    // per-request would re-register OSD apps and SO types after boot,
-    // which is not supported.
-    const sloEnabled = observabilityConfig.slo?.enabled ?? false;
+    // yml-derived defaults for the two UI-visibility flags. When the
+    // dynamic-config layer is absent (open-source / GitHub OSD) these
+    // values flow straight through to the registered capability defaults
+    // so operators can still hide the links via yml. In Nexus the
+    // dynamic store overrides them per account/application.
+    const ymlAlertManagerEnabled = observabilityConfig.alertManager?.enabled ?? false;
+    const ymlSloEnabled = observabilityConfig.slo?.enabled ?? false;
     const ruleDedupEnabled = observabilityConfig.slo?.ruleDedup?.enabled ?? true;
     this.sloReconcilerOpts = {
       enabled: observabilityConfig.slo?.reconciler?.enabled ?? true,
@@ -358,26 +362,24 @@ export class ObservabilityPlugin
       graceMs: observabilityConfig.slo?.reconciler?.graceMs ?? 24 * 3600 * 1000,
     };
 
-    if (sloEnabled) {
-      core.savedObjects.registerType(sloDefinitionType);
-      core.savedObjects.registerType(sloRuleRefType);
-      if (core.workspace.isWorkspaceEnabled()) {
-        // SLO documents and slo-rule-ref refcount registry are partitioned
-        // per OSD workspace via the saved-objects workspace wrapper. The
-        // ruler recording-rule namespace (`slo-generated-<datasourceId>`)
-        // is shared across workspaces that target the same Cortex tenant —
-        // two workspaces creating SLOs over the same SLI fingerprint share
-        // one rule group on the ruler, with refcount tracked separately
-        // per workspace. The grace-GC pass owns recording-group cleanup
-        // and fires only when the cross-workspace aggregate refcount for a
-        // (datasourceId, fingerprint) tuple hits zero past the grace window.
-        this.logger.info(
-          'Observability: SLO is enabled on a workspace-enabled cluster. ' +
-            'SLO documents and dedup refcounts are scoped per workspace; ' +
-            'ruler recording rules are shared per datasource and GC-ed only ' +
-            'when no workspace references them past the grace period.'
-        );
-      }
+    core.savedObjects.registerType(sloDefinitionType);
+    core.savedObjects.registerType(sloRuleRefType);
+    if (core.workspace.isWorkspaceEnabled()) {
+      // SLO documents and slo-rule-ref refcount registry are partitioned
+      // per OSD workspace via the saved-objects workspace wrapper. The
+      // ruler recording-rule namespace (`slo-generated-<datasourceId>`)
+      // is shared across workspaces that target the same Cortex tenant —
+      // two workspaces creating SLOs over the same SLI fingerprint share
+      // one rule group on the ruler, with refcount tracked separately
+      // per workspace. The grace-GC pass owns recording-group cleanup
+      // and fires only when the cross-workspace aggregate refcount for a
+      // (datasourceId, fingerprint) tuple hits zero past the grace window.
+      this.logger.info(
+        'Observability: SLO running on a workspace-enabled cluster. ' +
+          'SLO documents and dedup refcounts are scoped per workspace; ' +
+          'ruler recording rules are shared per datasource and GC-ed only ' +
+          'when no workspace references them past the grace period.'
+      );
     }
 
     // Register server side APIs
@@ -385,118 +387,117 @@ export class ObservabilityPlugin
       router,
       client: openSearchObservabilityClient,
       dataSourceEnabled,
-      alertManagerEnabled,
       logger: this.logger,
     });
 
-    if (sloEnabled) {
-      // SLO service + routes. Starts on `InMemorySloStore` so it's available
-      // during setup; `start()` swaps it out for the saved-object-backed
-      // store once the internal repository is available. The ruler client is
-      // a transport abstraction — today it writes per-group via the
-      // DirectQuery plugin; a future Amazon-Managed-Prometheus transport will
-      // write whole namespaces atomically. Callers pass the namespace
-      // (`sloRulerNamespaceFor(workspaceId)`) explicitly so the AMP invariant
-      // "every rule group for workspace W lives in `slo-generated-<W>`"
-      // holds regardless of transport.
-      const sloLogger = {
-        info: (msg: string) => this.logger.info(msg),
-        warn: (msg: string) => this.logger.warn(msg),
-        error: (msg: string) => this.logger.error(msg),
-        debug: (msg: string) => this.logger.debug(msg),
-      };
-      const initialStore: ISloStore = new InMemorySloStore();
-      const sloService = new SloService(sloLogger, initialStore);
-      sloService.setDedupEnabled(ruleDedupEnabled);
-      sloService.setPluginVersion(this.initializerContext.env.packageInfo.version);
-      // Wire the DirectQuery status aggregator so SLO list/detail responses
-      // surface real Cortex-derived state (healthy/breaching/warning) instead
-      // of the no-op stub that always returns no_data.
-      // Per-server datasource health tracker. One instance per plugin
-      // start; failure counts and cooldown are in-memory and reset on
-      // process restart. Logs once per open/close transition so an
-      // operator sees a flapping datasource without log spam every
-      // listing call.
-      const sloCircuitBreaker = new DatasourceCircuitBreaker({
-        onTransition: (datasourceId, transition) => {
-          if (transition === 'open') {
-            sloLogger.warn(
-              `SLO status aggregator: datasource ${datasourceId} circuit OPEN — fast-failing to no_data until cooldown elapses`
-            );
-          } else {
-            sloLogger.info(
-              `SLO status aggregator: datasource ${datasourceId} circuit CLOSED — resumed live status reads`
-            );
-          }
-        },
-      });
-      sloService.setStatusAggregator(new DirectQueryStatusAggregator(sloLogger, sloCircuitBreaker));
-      this.sloService = sloService;
+    // SLO service + routes. Starts on `InMemorySloStore` so it's available
+    // during setup; `start()` swaps it out for the saved-object-backed
+    // store once the internal repository is available. The ruler client is
+    // a transport abstraction — today it writes per-group via the
+    // DirectQuery plugin; a future Amazon-Managed-Prometheus transport will
+    // write whole namespaces atomically. Callers pass the namespace
+    // (`sloRulerNamespaceFor(workspaceId)`) explicitly so the AMP invariant
+    // "every rule group for workspace W lives in `slo-generated-<W>`"
+    // holds regardless of transport.
+    const sloLogger = {
+      info: (msg: string) => this.logger.info(msg),
+      warn: (msg: string) => this.logger.warn(msg),
+      error: (msg: string) => this.logger.error(msg),
+      debug: (msg: string) => this.logger.debug(msg),
+    };
+    const initialStore: ISloStore = new InMemorySloStore();
+    const sloService = new SloService(sloLogger, initialStore);
+    sloService.setDedupEnabled(ruleDedupEnabled);
+    sloService.setPluginVersion(this.initializerContext.env.packageInfo.version);
+    // Wire the DirectQuery status aggregator so SLO list/detail responses
+    // surface real Cortex-derived state (healthy/breaching/warning) instead
+    // of the no-op stub that always returns no_data.
+    // Per-server datasource health tracker. One instance per plugin
+    // start; failure counts and cooldown are in-memory and reset on
+    // process restart. Logs once per open/close transition so an
+    // operator sees a flapping datasource without log spam every
+    // listing call.
+    const sloCircuitBreaker = new DatasourceCircuitBreaker({
+      onTransition: (datasourceId, transition) => {
+        if (transition === 'open') {
+          sloLogger.warn(
+            `SLO status aggregator: datasource ${datasourceId} circuit OPEN — fast-failing to no_data until cooldown elapses`
+          );
+        } else {
+          sloLogger.info(
+            `SLO status aggregator: datasource ${datasourceId} circuit CLOSED — resumed live status reads`
+          );
+        }
+      },
+    });
+    sloService.setStatusAggregator(new DirectQueryStatusAggregator(sloLogger, sloCircuitBreaker));
+    this.sloService = sloService;
 
-      const rulerClient = new DirectQueryRulerClient(this.logger);
-      // Stash for `start()` so the reconciler can reuse the same ruler
-      // transport the routes use. Avoids constructing a second client +
-      // ensures any future configuration on the ruler client is applied
-      // consistently across CRUD and GC paths.
-      this.sloRulerClient = rulerClient;
-      // Followups' SLO routes need an InMemoryDatasourceService + a
-      // DatasourceDiscoveryService to resolve free-text Datasource IDs at
-      // create/update/delete time. Without these, buildDeployContext returns
-      // undefined, the SO is saved, but the ruler dual-write silently no-ops
-      // (commit 4de0c0cf). Wired here to keep the SLO ruler write path live
-      // on this branch.
-      const sloDatasourceService = new InMemoryDatasourceService(sloLogger);
-      const sloDiscoveryService = new DatasourceDiscoveryService(sloDatasourceService, sloLogger);
-      // Rule-health checker probes the ruler for the SLO's expected rule
-      // groups. Without it the detail page's `GET /rule_health` returns 501
-      // and surfaces a "Could not load rule health: Not Implemented" toast
-      // every time a user opens an SLO. Backed by the same ruler client the
-      // SLO write path uses, with the default 30s in-memory cache.
-      const ruleHealthChecker = createRuleHealthChecker(rulerClient, sloLogger);
-      // Probe-SLI route is gated on a non-null prometheusBackend; without it
-      // the wizard's "Probe SLI" button always 404s. The backend is stateless
-      // (see comment in routes/index.ts beside the alerting promBackend) so
-      // the second instance is fine.
-      const sloPrometheusBackend = new DirectQueryPrometheusBackend(this.logger);
-      registerSloRoutes({
-        router,
-        sloService,
-        logger: this.logger,
-        rulerClient,
-        ruleDedupEnabled,
-        datasourceService: sloDatasourceService,
-        discoveryService: sloDiscoveryService,
-        ruleHealthChecker,
-        prometheusBackend: sloPrometheusBackend,
-      });
-    }
+    const rulerClient = new DirectQueryRulerClient(this.logger);
+    // Stash for `start()` so the reconciler can reuse the same ruler
+    // transport the routes use. Avoids constructing a second client +
+    // ensures any future configuration on the ruler client is applied
+    // consistently across CRUD and GC paths.
+    this.sloRulerClient = rulerClient;
+    // Followups' SLO routes need an InMemoryDatasourceService + a
+    // DatasourceDiscoveryService to resolve free-text Datasource IDs at
+    // create/update/delete time. Without these, buildDeployContext returns
+    // undefined, the SO is saved, but the ruler dual-write silently no-ops
+    // (commit 4de0c0cf). Wired here to keep the SLO ruler write path live
+    // on this branch.
+    const sloDatasourceService = new InMemoryDatasourceService(sloLogger);
+    const sloDiscoveryService = new DatasourceDiscoveryService(sloDatasourceService, sloLogger);
+    // Rule-health checker probes the ruler for the SLO's expected rule
+    // groups. Without it the detail page's `GET /rule_health` returns 501
+    // and surfaces a "Could not load rule health: Not Implemented" toast
+    // every time a user opens an SLO. Backed by the same ruler client the
+    // SLO write path uses, with the default 30s in-memory cache.
+    const ruleHealthChecker = createRuleHealthChecker(rulerClient, sloLogger);
+    // Probe-SLI route is gated on a non-null prometheusBackend; without it
+    // the wizard's "Probe SLI" button always 404s. The backend is stateless
+    // (see comment in routes/index.ts beside the alerting promBackend) so
+    // the second instance is fine.
+    const sloPrometheusBackend = new DirectQueryPrometheusBackend(this.logger);
+    registerSloRoutes({
+      router,
+      sloService,
+      logger: this.logger,
+      rulerClient,
+      ruleDedupEnabled,
+      datasourceService: sloDatasourceService,
+      discoveryService: sloDiscoveryService,
+      ruleHealthChecker,
+      prometheusBackend: sloPrometheusBackend,
+    });
 
     core.savedObjects.registerType(getVisualizationSavedObject(dataSourceEnabled));
     core.savedObjects.registerType(getSearchSavedObject(dataSourceEnabled));
     if (!deps.investigationDashboards) {
       core.savedObjects.registerType(notebookSavedObject);
     }
+    // Defaults seeded from yml so environments without a DynamicConfigService
+    // (open-source / GitHub OSD) still respect `observability.alertManager.enabled`
+    // and `observability.slo.enabled`. Routes/SOs/services exist on every
+    // host regardless, so the capability is purely a UI visibility gate.
+    // The switcher below overrides these values per request when the
+    // dynamic store has an entry for this account/application.
     core.capabilities.registerProvider(() => ({
       observability: {
         show: true,
-        // Default to the yml values so dev/test environments without a
-        // configured dynamic-config source still see the flags they set in
-        // `opensearch_dashboards.yml`. The switcher below overrides these
-        // when the dynamic store has a value.
-        alertManagerEnabled,
-        sloEnabled,
+        alertManagerEnabled: ymlAlertManagerEnabled,
+        sloEnabled: ymlSloEnabled,
       },
     }));
 
     // Dynamic feature-flag switcher. Reads `observability.alertManager.enabled`
     // and `observability.slo.enabled` from the DynamicConfigService at
     // request time so AppConfig-driven flag flips take effect on the next
-    // page load without an OSD restart. Server-side route/SO/service
-    // registration still keys off yml at setup (see `sloEnabled` /
-    // `alertManagerEnabled` above) — this only governs UI visibility.
-    // Failures fall back to the yml-derived values rather than the schema
-    // default so a degraded dynamic-config path can't silently dark a feature
-    // that operators explicitly enabled in yml.
+    // page load without an OSD restart.
+    //
+    // Fallback chain: dynamic-store value → yml value → schema default
+    // (`false`). On error, returns capabilities unchanged so the
+    // yml-seeded provider defaults survive — a degraded dynamic-config
+    // path can't silently flip a feature that operators set in yml.
     core.capabilities.registerSwitcher(async (_request, capabilities) => {
       try {
         const dynamicConfig = await core.dynamicConfigService.getStartService();
@@ -510,29 +511,22 @@ export class ObservabilityPlugin
           ...capabilities,
           observability: {
             ...(capabilities.observability || {}),
-            alertManagerEnabled: config.alertManager?.enabled ?? alertManagerEnabled,
-            sloEnabled: config.slo?.enabled ?? sloEnabled,
+            alertManagerEnabled: config.alertManager?.enabled ?? ymlAlertManagerEnabled,
+            sloEnabled: config.slo?.enabled ?? ymlSloEnabled,
           },
         };
       } catch (error) {
         this.logger.error(
-          'Observability: failed to resolve dynamic config flags, falling back to yml values',
+          'Observability: failed to resolve dynamic config flags, falling back to yml-seeded defaults',
           error as Error
         );
-        return {
-          ...capabilities,
-          observability: {
-            ...(capabilities.observability || {}),
-            alertManagerEnabled,
-            sloEnabled,
-          },
-        };
+        return capabilities;
       }
     });
 
     assistantDashboards?.registerMessageParser(PPLParsers);
 
-    registerObservabilityUISettings(core.uiSettings, alertManagerEnabled);
+    registerObservabilityUISettings(core.uiSettings);
 
     core.uiSettings.register({
       'observability:defaultDashboard': {
@@ -558,22 +552,20 @@ export class ObservabilityPlugin
       },
     });
 
-    if (sloEnabled) {
-      core.uiSettings.register({
-        'observability.slo.ruleDedup.enabled': {
-          name: 'SLO recording-rule dedup',
-          value: true,
-          description:
-            'When enabled, SLO recording rules are shared across SLOs with equivalent ' +
-            'SLI shapes via a workspace-scoped fingerprint registry. ' +
-            'Saves evaluation cost on the ruler when many SLOs share a backend query.',
-          schema: schema.boolean(),
-          scope: core.workspace.isWorkspaceEnabled()
-            ? UiSettingScope.WORKSPACE
-            : UiSettingScope.GLOBAL,
-        },
-      });
-    }
+    core.uiSettings.register({
+      'observability.slo.ruleDedup.enabled': {
+        name: 'SLO recording-rule dedup',
+        value: true,
+        description:
+          'When enabled, SLO recording rules are shared across SLOs with equivalent ' +
+          'SLI shapes via a workspace-scoped fingerprint registry. ' +
+          'Saves evaluation cost on the ruler when many SLOs share a backend query.',
+        schema: schema.boolean(),
+        scope: core.workspace.isWorkspaceEnabled()
+          ? UiSettingScope.WORKSPACE
+          : UiSettingScope.GLOBAL,
+      },
+    });
 
     return {};
   }

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -479,8 +479,56 @@ export class ObservabilityPlugin
     core.capabilities.registerProvider(() => ({
       observability: {
         show: true,
+        // Default to the yml values so dev/test environments without a
+        // configured dynamic-config source still see the flags they set in
+        // `opensearch_dashboards.yml`. The switcher below overrides these
+        // when the dynamic store has a value.
+        alertManagerEnabled,
+        sloEnabled,
       },
     }));
+
+    // Dynamic feature-flag switcher. Reads `observability.alertManager.enabled`
+    // and `observability.slo.enabled` from the DynamicConfigService at
+    // request time so AppConfig-driven flag flips take effect on the next
+    // page load without an OSD restart. Server-side route/SO/service
+    // registration still keys off yml at setup (see `sloEnabled` /
+    // `alertManagerEnabled` above) — this only governs UI visibility.
+    // Failures fall back to the yml-derived values rather than the schema
+    // default so a degraded dynamic-config path can't silently dark a feature
+    // that operators explicitly enabled in yml.
+    core.capabilities.registerSwitcher(async (_request, capabilities) => {
+      try {
+        const dynamicConfig = await core.dynamicConfigService.getStartService();
+        const client = dynamicConfig.getClient();
+        const store = dynamicConfig.getAsyncLocalStore();
+        const config = await client.getConfig(
+          { name: 'observability' },
+          { asyncLocalStorageContext: store! }
+        );
+        return {
+          ...capabilities,
+          observability: {
+            ...(capabilities.observability || {}),
+            alertManagerEnabled: config.alertManager?.enabled ?? alertManagerEnabled,
+            sloEnabled: config.slo?.enabled ?? sloEnabled,
+          },
+        };
+      } catch (error) {
+        this.logger.error(
+          'Observability: failed to resolve dynamic config flags, falling back to yml values',
+          error as Error
+        );
+        return {
+          ...capabilities,
+          observability: {
+            ...(capabilities.observability || {}),
+            alertManagerEnabled,
+            sloEnabled,
+          },
+        };
+      }
+    });
 
     assistantDashboards?.registerMessageParser(PPLParsers);
 

--- a/server/plugin_helper/register_settings.test.ts
+++ b/server/plugin_helper/register_settings.test.ts
@@ -46,30 +46,25 @@ describe('registerObservabilityUISettings', () => {
   });
 
   describe('Alert Manager settings', () => {
-    const findSetting = (key: string, alertManagerEnabled: boolean) => {
-      registerObservabilityUISettings(mockUiSettings, alertManagerEnabled);
+    // After the move to dynamic feature flags, registration is
+    // unconditional — the alerting nav UI is gated by the dynamic
+    // capability instead of yml. The settings always register so they're
+    // available the moment the dynamic flag flips on.
+    const findSetting = (key: string) => {
+      registerObservabilityUISettings(mockUiSettings);
       const calls = (mockUiSettings.register as jest.Mock).mock.calls;
       const match = calls.find((call) => call[0][key]);
       return match?.[0][key];
     };
 
-    it('does not register datasource settings when yml flag is off', () => {
-      registerObservabilityUISettings(mockUiSettings, false);
-      const calls = (mockUiSettings.register as jest.Mock).mock.calls;
-      expect(calls.find((call) => call[0][ALERT_MANAGER_MAX_DATASOURCES_SETTING])).toBeUndefined();
-      expect(
-        calls.find((call) => call[0][ALERT_MANAGER_DEFAULT_DATASOURCES_SETTING])
-      ).toBeUndefined();
-    });
-
-    it('registers alertManagerMaxDatasources with default value 5 when yml flag is on', () => {
-      const setting = findSetting(ALERT_MANAGER_MAX_DATASOURCES_SETTING, true);
+    it('registers alertManagerMaxDatasources with default value 5', () => {
+      const setting = findSetting(ALERT_MANAGER_MAX_DATASOURCES_SETTING);
       expect(setting.value).toBe(ALERT_MANAGER_MAX_DATASOURCES_DEFAULT);
       expect(setting.value).toBe(5);
     });
 
-    it('registers alertManagerSelectedDatasources with empty array default when yml flag is on', () => {
-      const setting = findSetting(ALERT_MANAGER_DEFAULT_DATASOURCES_SETTING, true);
+    it('registers alertManagerSelectedDatasources with empty array default', () => {
+      const setting = findSetting(ALERT_MANAGER_DEFAULT_DATASOURCES_SETTING);
       expect(setting.value).toEqual([]);
     });
   });

--- a/server/plugin_helper/register_settings.ts
+++ b/server/plugin_helper/register_settings.ts
@@ -29,10 +29,7 @@ import {
   ALERT_MANAGER_MAX_DATASOURCES_SETTING,
 } from '../../common/constants/alerting_settings';
 
-export const registerObservabilityUISettings = (
-  uiSettings: UiSettingsServiceSetup,
-  alertManagerEnabled: boolean = false
-) => {
+export const registerObservabilityUISettings = (uiSettings: UiSettingsServiceSetup) => {
   uiSettings.register({
     [TRACE_CUSTOM_SPAN_INDEX_SETTING]: {
       name: i18n.translate('observability.traceAnalyticsCustomSpanIndices.name', {
@@ -167,13 +164,9 @@ export const registerObservabilityUISettings = (
     },
   });
 
-  // Alert Manager datasource settings — only registered when the feature is
-  // enabled in opensearch_dashboards.yml (observability.alertManager.enabled).
-  // The on/off toggle itself is a yml flag, not a uiSetting.
-  if (!alertManagerEnabled) {
-    return;
-  }
-
+  // Alert Manager datasource settings register unconditionally so they
+  // exist whenever the dynamic flag flips the UI on. UI visibility is
+  // gated by `capabilities.observability.alertManagerEnabled`.
   uiSettings.register({
     [ALERT_MANAGER_DEFAULT_DATASOURCES_SETTING]: {
       name: i18n.translate('observability.alertManagerSelectedDatasources.name', {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -38,13 +38,11 @@ export function setupRoutes({
   router,
   client,
   dataSourceEnabled,
-  alertManagerEnabled,
   logger,
 }: {
   router: IRouter;
   client: ILegacyClusterClient;
   dataSourceEnabled: boolean;
-  alertManagerEnabled: boolean;
   logger: Logger;
 }) {
   PanelsRouter(router);
@@ -77,32 +75,31 @@ export function setupRoutes({
   registerGettingStartedRoutes(router);
   registerMLCommonsRCFRoute({ router, facet: new MLCommonsRCFFacet() });
 
-  // Alerting routes — gated by `observability.alertManager.enabled`
-  // (mirrors the existing `dataSourceEnabled` plumbing pattern). When the
-  // flag is off the routes are never registered, so curl returns 404 for
-  // both mutations and the AM config endpoint.
-  if (alertManagerEnabled) {
-    // Only construct the genuinely stateless deps at server start. The
-    // per-request `MultiBackendAlertService` and `PrometheusMetadataService`
-    // instances — both of which hold a `SavedObjectDatasourceService` — are
-    // built inside each route handler so the per-request scoped SavedObjects
-    // client never bleeds across concurrent requests.
-    const osBackend = new HttpOpenSearchBackend(logger);
-    const promBackend = new DirectQueryPrometheusBackend(logger);
-    // MonitorMutationService delegates to HttpOpenSearchBackend — shared
-    // stateless backend + thin write-path wrapper.
-    const mutationSvc = new MonitorMutationService(osBackend, logger);
-    // RulerClient for Prometheus rule CRUD via Cortex ruler API.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { DirectQueryRulerClient } = require('../services/slo/ruler_client');
-    const rulerClient = new DirectQueryRulerClient(logger);
+  // Alerting routes register unconditionally so the dynamic capability
+  // flag (`capabilities.observability.alertManagerEnabled`, resolved per
+  // request from DynamicConfigService) can hide the UI on a per-account
+  // basis without leaving the routes unreachable when re-enabled.
+  // Only construct the genuinely stateless deps at server start. The
+  // per-request `MultiBackendAlertService` and `PrometheusMetadataService`
+  // instances — both of which hold a `SavedObjectDatasourceService` — are
+  // built inside each route handler so the per-request scoped SavedObjects
+  // client never bleeds across concurrent requests.
+  const osBackend = new HttpOpenSearchBackend(logger);
+  const promBackend = new DirectQueryPrometheusBackend(logger);
+  // MonitorMutationService delegates to HttpOpenSearchBackend — shared
+  // stateless backend + thin write-path wrapper.
+  const mutationSvc = new MonitorMutationService(osBackend, logger);
+  // RulerClient for Prometheus rule CRUD via Cortex ruler API. Brought in
+  // by upstream's Prometheus metrics rule support (#2718).
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { DirectQueryRulerClient } = require('../services/slo/ruler_client');
+  const rulerClient = new DirectQueryRulerClient(logger);
 
-    registerAlertingRoutes(router, {
-      osBackend,
-      promBackend,
-      mutationSvc,
-      logger,
-      rulerClient,
-    });
-  }
+  registerAlertingRoutes(router, {
+    osBackend,
+    promBackend,
+    mutationSvc,
+    logger,
+    rulerClient,
+  });
 }


### PR DESCRIPTION
### Description
Adopts the OpenSearch UI feature-flag pattern (per the OpenSearch UI Feature Flag Developer Guidelines and reference [PR #11220](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11220)) for the two feature gates this plugin owns:

- `observability.alertManager.enabled` — alerting app + the "Create alert rule" entry on Explore's Query Panel actions menu.
- `observability.slo.enabled` — APM SLO app under Application Monitoring.

Server-side surfaces (routes, saved-object types, services, uiSettings) register **unconditionally** so the dynamic flag is sufficient to fully enable or disable a feature on a per-account basis. UI visibility is driven by capabilities resolved at request time from `DynamicConfigService`.

Fallback chain for both flags: **dynamic store → yml → schema default (`false`)**. That means:

- **When no `DynamicConfigService` is configured**: yml is the source of truth — flip `observability.slo.enabled: false` in `opensearch_dashboards.yml` and the link hides on restart, just like before.
- **When `DynamicConfigService` is available**: the dynamic flag overrides yml on the next page load. No restart required.

## What changed

### `server/plugin.ts`

1. **Removed yml gates** around SLO + alerting registration. Saved-object types (`slo-definition`, `slo-rule-ref`), routes (`registerSloRoutes`, alerting routes inside `setupRoutes`), and services (`SloService`, `DirectQueryRulerClient`, `DatasourceCircuitBreaker`, etc.) now register on every host. The yml options that remain are operational ones — `slo.reconciler.enabled` (whether the GC timer ticks) and `slo.ruleDedup.enabled` (fingerprint-keyed selector behavior).

2. **yml-seeded capability provider.** `core.capabilities.registerProvider` declares `observability.alertManagerEnabled` and `observability.sloEnabled` defaulted to the yml-derived values. Dev/test environments without a configured dynamic-config source still respect yml.

3. **Capability switcher.** `core.capabilities.registerSwitcher(...)` calls `core.dynamicConfigService.getStartService()` → `getClient().getConfig({ name: 'observability' }, { asyncLocalStorageContext: store })` and overrides the two capability fields with `config.alertManager?.enabled` / `config.slo?.enabled` from the dynamic store, falling back to the yml-seeded values when the dynamic store has no entry. On error, the switcher returns capabilities unchanged so the yml-seeded provider defaults survive.

The plugin's `configPath: ["observability"]` (in `opensearch_dashboards.json`) matches the `name: 'observability'` passed to `getConfig`, so the dynamic store sees keys at `${configPath}.alertManager.enabled` and `${configPath}.slo.enabled`.

### `server/routes/index.ts`

Removed the `if (alertManagerEnabled)` gate around `registerAlertingRoutes`. Routes register every time. `setupRoutes` no longer accepts `alertManagerEnabled` as a parameter.

### `server/plugin_helper/register_settings.ts`

Removed the `alertManagerEnabled` parameter and the early-return that conditionally skipped alerting datasource uiSettings. They register unconditionally.

### `public/plugin.tsx`

1. **Two new BehaviorSubjects** for `AppUpdater` plumbing:
   - `alertingAppUpdater$` — drives the alerting app's nav-link visibility.
   - `apmSloAppUpdater$` — drives the SLO app's nav-link visibility.

2. **App registrations now carry `updater$`.** The alerting app gets `alertingAppUpdater$` directly. The SLO app gets a `combineLatest`-merged updater that respects both `apmAppUpdater$` (the existing APM-vs-Trace-Analytics gate driven by `explore.discoverTracesEnabled`) and the new `apmSloAppUpdater$`. The merge explicitly resolves `navLinkStatus` so either input emitting `hidden` wins (addresses PR review feedback — naive spread would let a later `visible` override an earlier `hidden`).

3. **Removed yml gates** around `core.application.register(...)` for the alerting and SLO apps. They register every time; `registerAllPluginNavGroups(...)` is also called with `true, true` so nav-group entries register every time.

4. **`start()` reads the resolved capabilities** off `core.application.capabilities.observability` and pushes `navLinkStatus: AppNavLinkStatus.hidden` through the updaters when a capability is `false`.

5. **`coreRefs.sloEnabled` sources from the capability** instead of `this.config.slo?.enabled`. The two consumers (`public/components/apm/pages/services_home/services_home.tsx`, `public/components/apm/pages/service_details/service_details.tsx`) react to dynamic flag flips because they read the live capability value through this ref.

6. **Explore "Create alert rule" action coordination.** Registration is now deferred until `core.getStartServices()` resolves so we can read `capabilities.observability.alertManagerEnabled`. We register only when it's `true`. The companion change in [`alerting-dashboards-plugin`](https://github.com/opensearch-project/alerting-dashboards-plugin) does the mirror — it registers only when our capability is `false` or absent. Exactly one entry shows at any time. We had to defer registration because Explore's `queryPanelActionsRegistry` exposes only `getIsEnabled` (greys out) and no `isVisible` hook, so the only way to truly hide a duplicate is to skip `register(...)`. The companion alerting PR is required for the swap to work end-to-end.

7. **`ownsMonitorCreation`** on the setup contract is preserved at `true` for backwards compatibility with older alerting-plugin builds that still gate on it.

## Behavior

| `DynamicConfigService` | yml says | Dynamic flag | Result |
|---|---|---|---|
| Not configured | `false` | (n/a) | Hidden — yml wins |
| Not configured | `true` | (n/a) | Visible — yml wins |
| Not configured | unset | (n/a) | Hidden — schema default `false` |
| Configured | `false` | unset | Hidden — yml seed flows through |
| Configured | `true` | unset | Visible — yml seed flows through |
| Configured | (any) | `false` | Hidden — dynamic wins |
| Configured | (any) | `true` | Visible — dynamic wins |

Routes / SO types / services exist on every host regardless, so toggling either flag on yields a fully-working feature.

The Explore "Create alert rule" entry follows the same rule for the `alertManager` flag — when our capability is `true`, we own the menu entry; when `false`, alerting-dashboards-plugin's "Create monitor" entry shows instead (requires the companion alerting PR).

## Tests

Added/updated tests covering both states for both flags:

- `public/plugin.test.tsx` — alerting and SLO nav-link visibility paths (both hidden when capability is off and visible when on); merged-updater "either hiding wins" coverage; alerting app registers regardless of yml.
- `server/plugin.test.ts` — capability switcher: dynamic value overrides yml when both are set, falls back to yml when dynamic config omits a flag, falls back to yml when dynamic config layer rejects.
- `server/plugin_helper/register_settings.test.ts` — alerting datasource uiSettings register unconditionally.

22 plugin-level tests passing; 197 tests pass across the touched test directories.

## Files changed

- `server/plugin.ts`
- `server/routes/index.ts`
- `server/plugin_helper/register_settings.ts`
- `server/plugin_helper/register_settings.test.ts`
- `server/plugin.test.ts`
- `public/plugin.tsx`
- `public/plugin.test.tsx`

## Companion change

[`alerting-dashboards-plugin`](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1461) — coordinates the Explore "Create monitor" entry against this plugin's new `capabilities.observability.alertManagerEnabled`. **Required** for the menu-entry swap to work — without it, the alerting plugin's existing setup-time gate would still defer to our old `ownsMonitorCreation` boolean and the menu entry would not swap when the flag flips.

## Testing the changes

### Local / yml-only (no dynamic-config service)

1. `observability.alertManager.enabled: true` and `observability.slo.enabled: true` in `opensearch_dashboards.yml`.
2. `yarn start` — both nav entries visible. Apps mount, "Create alert rule" appears in Explore's actions menu.
3. Flip either flag to `false`, restart — corresponding nav link disappears. With the companion alerting PR, the Explore menu entry swaps to alerting's "Create monitor".

### With a `DynamicConfigService` configured

1. yml has both flags `true`.
2. Have the configured dynamic-config store return `${configPath}.slo.enabled: false` for a request.
3. Reload the page — SLO nav link hides without restart.
4. Flip the dynamic value back to `true` — reload, link reappears, app fully functional.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
