### PR TITLE
Increment version to 3.8.0 + Hapi fix + Linker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -15,7 +15,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@6da1d14f3a43098a294b7696d93d938aa8d20fc0 # master
         with:
-          args: --accept=200,403,429  "./**/*.html" "./**/*.md" "./**/*.txt" --exclude "http://localhost" --exclude "https://localhost"
+          args: --accept=200,403,429 --max-retries=5 --retry-wait-time=10 --timeout=60 "./**/*.html" "./**/*.md" "./**/*.txt" --exclude "http://localhost" --exclude "https://localhost"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "observabilityDashboards",
-  "version": "3.7.0.0",
-  "opensearchDashboardsVersion": "3.7.0",
+  "version": "3.8.0.0",
+  "opensearchDashboardsVersion": "3.8.0",
   "server": true,
   "ui": true,
   "requiredPlugins": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observability-dashboards",
-  "version": "3.7.0.0",
+  "version": "3.8.0.0",
   "main": "index.ts",
   "license": "Apache-2.0",
   "scripts": {

--- a/server/adaptors/integrations/__data__/repository/k8s/info/README.md
+++ b/server/adaptors/integrations/__data__/repository/k8s/info/README.md
@@ -20,7 +20,7 @@ With the Kubernetes integration, you can gain valuable insights into the health 
 
 ### Collecting K8s
 
-The next OpenTelemetry [page](https://opentelemetry.io/docs/kubernetes/collector/components/) describes the K8s attributes and other components
+The next OpenTelemetry [page](https://opentelemetry.io/docs/platforms/kubernetes/collector/components/) describes the K8s attributes and other components
 
 #### Kubernetes Attributes Processor
 
@@ -83,8 +83,8 @@ The following attributes are added by default:
 
 ### Important Components for Kubernetes
 
-- [Kubeletstats Receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#kubeletstats-receiver): pulls pod metrics from the API server on a kubelet.
-- [Filelog Receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#filelog-receiver): collects Kubernetes logs and application logs written to stdout/stderr.
-- [Kubernetes Cluster Receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-cluster-receiver): collects cluster-level metrics and entity events.
-- [Kubernetes Objects Receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#kubernetes-objects-receiver): collects objects, such as events, from the Kubernetes API server.
-- [Host Metrics Receiver](https://opentelemetry.io/docs/kubernetes/collector/components/#host-metrics-receiver): scrapes host metrics from Kubernetes nodes.
+- [Kubeletstats Receiver](https://opentelemetry.io/docs/platforms/kubernetes/collector/components/#kubeletstats-receiver): pulls pod metrics from the API server on a kubelet.
+- [Filelog Receiver](https://opentelemetry.io/docs/platforms/kubernetes/collector/components/#filelog-receiver): collects Kubernetes logs and application logs written to stdout/stderr.
+- [Kubernetes Cluster Receiver](https://opentelemetry.io/docs/platforms/kubernetes/collector/components/#kubernetes-cluster-receiver): collects cluster-level metrics and entity events.
+- [Kubernetes Objects Receiver](https://opentelemetry.io/docs/platforms/kubernetes/collector/components/#kubernetes-objects-receiver): collects objects, such as events, from the Kubernetes API server.
+- [Host Metrics Receiver](https://opentelemetry.io/docs/platforms/kubernetes/collector/components/#host-metrics-receiver): scrapes host metrics from Kubernetes nodes.

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -32,6 +32,7 @@ module.exports = {
     '^opensearch-dashboards/server$': '<rootDir>/../../src/core/server',
     '^opensearch-dashboards/server/(.*)$': '<rootDir>/../../src/core/server/$1',
     '^opensearch-dashboards$': '<rootDir>/../../opensearch_dashboards',
+    '@hapi/hoek/(?!lib/)(.*)': '<rootDir>/../../node_modules/@hapi/hoek/lib/$1',
   },
   testEnvironment: 'jsdom',
 };


### PR DESCRIPTION
### Description
Increment version to 3.8.0

OSD bumped @hapi/hapi 20→21 (#12187), which pulls @hapi/hoek 11. Hoek 11
exposes its files via package.json `exports` (e.g. `@hapi/hoek/assert` →
`lib/assert.js`), but Jest's resolver does not honor `exports` here, so
`require('@hapi/hoek/assert')` from inside @hapi/validate fails with
"Cannot find module '@hapi/hoek/assert'". OSD core works around this in
`src/dev/jest/config.js` with the same mapping; plugins with their own
Jest config need to repeat it.

'@hapi/hoek/(?!lib/)(.*)': '<rootDir>/../../node_modules/@hapi/hoek/lib/$1',

Fix links and harden checker
Updated .github/workflows/link-checker.yml to add lychee retries and a longer timeout:

  - --max-retries=5 (default is 3)
  - --retry-wait-time=10 (seconds between retries — default is 1)
  - --timeout=60 (per-request timeout, seconds — default is 20)

  The URLs themselves are fine; this just makes the checker resilient to transient slowness from opentelemetry.io (Netlify-hosted, occasionally slow under load).

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
