### PR TITLE
feat(apm): exclude AnalyticEngine datasets from APM settings selectors

### DIFF
--- a/common/utils/shared.ts
+++ b/common/utils/shared.ts
@@ -99,3 +99,42 @@ export const dataSourceFilterFnByEngineType = (dataSource: SavedObject<DataSourc
 export const dataSourceFilterFnExcludeAnalyticEngine = (
   dataSource: SavedObject<DataSourceAttributes>
 ) => dataSourceFilterFnByEngineType(dataSource) && dataSourceFilterFn(dataSource);
+
+// Given a set of data-source saved-object ids, returns the subset whose
+// `dataSourceEngineType` is in `unsupportedOSDataSourceEngineTypes` (AnalyticEngine /
+// Mustang). Callers that list datasets (index patterns) bound to a data source — e.g. the
+// APM settings modal's traces / service-map selectors — use this to drop datasets that sit
+// on a Mustang domain, since those serve PPL/SQL but not the DSL aggregations APM issues.
+//
+// Resolves engine type with a single `bulkGet` on `data-source` saved objects. Fails open:
+// if the lookup throws, an empty set is returned so callers keep showing every dataset.
+export const getUnsupportedEngineDataSourceIds = async (
+  dataSourceIds: string[]
+): Promise<Set<string>> => {
+  const unsupported = new Set<string>();
+  const ids = Array.from(new Set(dataSourceIds.filter(Boolean)));
+  if (UNSUPPORTED_ENGINE_TYPES.length === 0 || ids.length === 0) {
+    return unsupported;
+  }
+
+  const blocked = new Set(UNSUPPORTED_ENGINE_TYPES);
+  try {
+    const response = await coreRefs.savedObjectsClient!.bulkGet<DataSourceAttributes>(
+      ids.map((id) => ({ id, type: 'data-source' }))
+    );
+    for (const dataSource of response.savedObjects) {
+      if (dataSource.error) {
+        continue;
+      }
+      const engineType = dataSource.attributes?.dataSourceEngineType;
+      if (engineType && blocked.has(engineType)) {
+        unsupported.add(dataSource.id);
+      }
+    }
+  } catch {
+    // Data-source lookup failed — return an empty set so callers fail open.
+    return new Set<string>();
+  }
+
+  return unsupported;
+};

--- a/public/components/apm/shared/hooks/__tests__/use_apm_config.test.ts
+++ b/public/components/apm/shared/hooks/__tests__/use_apm_config.test.ts
@@ -247,6 +247,92 @@ describe('useDatasets', () => {
       expect(result.current.error?.message).toBe('String error message');
     });
   });
+
+  describe('AnalyticEngine (Mustang) exclusion', () => {
+    const mockBulkGet = jest.fn();
+
+    beforeEach(() => {
+      mockBulkGet.mockReset();
+      (coreRefs as any).savedObjectsClient = { bulkGet: mockBulkGet };
+    });
+
+    it('drops datasets backed by an AnalyticEngine data source from both lists', async () => {
+      mockDataService.dataViews.getIdsWithTitle.mockResolvedValue([
+        { id: 'trace-mustang', title: 'Mustang Traces' },
+        { id: 'trace-os', title: 'OpenSearch Traces' },
+      ]);
+      mockDataService.dataViews.get
+        .mockResolvedValueOnce({
+          getDisplayName: () => 'Mustang Traces',
+          signalType: 'traces',
+          dataSourceRef: { id: 'ds-mustang', type: 'data-source' },
+        })
+        .mockResolvedValueOnce({
+          getDisplayName: () => 'OpenSearch Traces',
+          signalType: 'traces',
+          dataSourceRef: { id: 'ds-os', type: 'data-source' },
+        });
+      mockBulkGet.mockResolvedValue({
+        savedObjects: [
+          { id: 'ds-mustang', attributes: { dataSourceEngineType: 'AnalyticEngine' } },
+          { id: 'ds-os', attributes: { dataSourceEngineType: 'OpenSearch' } },
+        ],
+      });
+
+      (coreRefs as any).data = mockDataService;
+
+      const { result } = renderHook(() => useDatasets());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.tracesDatasets).toHaveLength(1);
+      expect(result.current.tracesDatasets[0].label).toBe('OpenSearch Traces');
+      expect(result.current.allDatasets).toHaveLength(1);
+      expect(result.current.allDatasets[0].label).toBe('OpenSearch Traces');
+      expect(mockBulkGet).toHaveBeenCalledWith([
+        { id: 'ds-mustang', type: 'data-source' },
+        { id: 'ds-os', type: 'data-source' },
+      ]);
+    });
+
+    it('keeps all datasets when the data-source lookup fails (fail-open)', async () => {
+      mockDataService.dataViews.getIdsWithTitle.mockResolvedValue([
+        { id: 'trace-1', title: 'Traces 1' },
+      ]);
+      mockDataService.dataViews.get.mockResolvedValueOnce({
+        getDisplayName: () => 'Traces 1',
+        signalType: 'traces',
+        dataSourceRef: { id: 'ds-1', type: 'data-source' },
+      });
+      mockBulkGet.mockRejectedValue(new Error('bulkGet failed'));
+
+      (coreRefs as any).data = mockDataService;
+
+      const { result } = renderHook(() => useDatasets());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.tracesDatasets).toHaveLength(1);
+      expect(result.current.allDatasets).toHaveLength(1);
+    });
+
+    it('skips the data-source lookup when no dataset has a backing data source', async () => {
+      mockDataService.dataViews.getIdsWithTitle.mockResolvedValue([
+        { id: 'local-1', title: 'Local Traces' },
+      ]);
+      mockDataService.dataViews.get.mockResolvedValueOnce({
+        getDisplayName: () => 'Local Traces',
+        signalType: 'traces',
+        // no dataSourceRef -> local cluster
+      });
+
+      (coreRefs as any).data = mockDataService;
+
+      const { result } = renderHook(() => useDatasets());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.tracesDatasets).toHaveLength(1);
+      expect(mockBulkGet).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('usePrometheusDataSources', () => {

--- a/public/components/apm/shared/hooks/use_apm_config.ts
+++ b/public/components/apm/shared/hooks/use_apm_config.ts
@@ -6,6 +6,7 @@
 import { useEffect, useState } from 'react';
 import { EuiComboBoxOptionOption } from '@elastic/eui';
 import { coreRefs } from '../../../../framework/core_refs';
+import { getUnsupportedEngineDataSourceIds } from '../../../../../common/utils/shared';
 
 interface DatasetOptionData {
   id: string;
@@ -53,6 +54,12 @@ export const useDatasets = () => {
         const allDataViews = await dataService.dataViews.getIdsWithTitle(true);
         const tracesOptions: Array<EuiComboBoxOptionOption<DatasetOptionData>> = [];
         const allOptions: Array<EuiComboBoxOptionOption<DatasetOptionData>> = [];
+        // Backing data-source id per option, used to drop AnalyticEngine-backed datasets
+        // after the loop (single bulkGet rather than one lookup per dataset).
+        const dataSourceIdByOption = new Map<
+          EuiComboBoxOptionOption<DatasetOptionData>,
+          string | undefined
+        >();
 
         for (const { id, title } of allDataViews) {
           if (abortController.signal.aborted) break;
@@ -69,6 +76,7 @@ export const useDatasets = () => {
                 title,
               },
             };
+            dataSourceIdByOption.set(option, dataView.dataSourceRef?.id);
 
             // Add to all datasets
             allOptions.push(option);
@@ -82,10 +90,21 @@ export const useDatasets = () => {
           }
         }
 
+        // Drop datasets backed by an AnalyticEngine (Mustang) data source: Mustang serves
+        // PPL/SQL but not the DSL aggregations the APM traces / service-map views run, so
+        // selecting one here would 5xx. Fails open if the data-source lookup fails.
+        const unsupportedDataSourceIds = await getUnsupportedEngineDataSourceIds(
+          Array.from(dataSourceIdByOption.values()).filter((dsId): dsId is string => Boolean(dsId))
+        );
+        const isSupported = (option: EuiComboBoxOptionOption<DatasetOptionData>) => {
+          const dsId = dataSourceIdByOption.get(option);
+          return !(dsId && unsupportedDataSourceIds.has(dsId));
+        };
+
         if (!abortController.signal.aborted) {
           setState({
-            tracesDatasets: tracesOptions,
-            allDatasets: allOptions,
+            tracesDatasets: tracesOptions.filter(isSupported),
+            allDatasets: allOptions.filter(isSupported),
             loading: false,
           });
         }


### PR DESCRIPTION
## Summary

The APM settings/config modal's **traces** and **service-map** dataset selectors list every index pattern (dataset). AnalyticEngine (Mustang) data sources support PPL/SQL but **not DSL queries against user data** — and the APM traces / service-map views run DSL aggregations. So a dataset created on top of a Mustang domain would 5xx if a user selected it in either selector.

This hides datasets backed by an AnalyticEngine data source from **both** APM dataset selectors, so users can't pick a connection that will fail.

This is a follow-up to #2707, which excluded AnalyticEngine from the **trace analytics**, **metrics**, and **integrations** data-source pickers. That PR covered data-source *pickers*; this one covers the APM *dataset* selectors (which list index patterns, not data sources directly).

## Changes

- **`common/utils/shared.ts`** — add `getUnsupportedEngineDataSourceIds(dataSourceIds)`: given a set of `data-source` saved-object ids, returns the subset whose `dataSourceEngineType` is in the manifest's `unsupportedOSDataSourceEngineTypes` (`AnalyticEngine`). Resolves engine type with a single `bulkGet`; **fails open** (returns an empty set) if the lookup throws, so a transient error never hides datasets. Driven by the same manifest field #2707 introduced — single source of truth.
- **`public/components/apm/shared/hooks/use_apm_config.ts`** — in `useDatasets`, track each dataset's backing data-source id (from the `DataView`'s `dataSourceRef`), then filter both `tracesDatasets` and `allDatasets` to drop AnalyticEngine-backed datasets. The traces selector binds to `tracesDatasets`, the service-map selector binds to `allDatasets`, so both are covered. The existing sequential fetch loop is preserved; only one extra `bulkGet` is added after it.

## Why a dataset-level filter (not a picker filter)

The APM modal doesn't render a `DataSourceSelectable`; it lists **datasets** (`index-pattern` saved objects) via the `data` plugin's `dataViews` service. So the exclusion has to resolve each dataset's backing data source and check its engine type — mirroring the core `data` plugin's `IndexPatterns.applyEngineTypeFilter` (OpenSearch-Dashboards#12023), but applied at the consumer because this hook reads `DataView`s rather than raw saved objects.

## Testing

- `useDatasets` unit tests extended (`use_apm_config.test.ts`) — **30/30 pass**, including 3 new cases:
  - drops AnalyticEngine-backed datasets from both `tracesDatasets` and `allDatasets`
  - keeps all datasets when the data-source lookup fails (fail-open)
  - skips the `bulkGet` entirely when no dataset has a backing data source (local-cluster datasets)
- No behavior change for non-AnalyticEngine data sources or local-cluster datasets.

## Check List
- [x] All tests pass
- [x] New functionality includes testing
- [x] New functionality has been documented in code comments
- [x] Commit changes are listed out in CHANGELOG.md file (n/a — follows #2707 convention)
- [x] Commits are signed per the DCO using `--signoff`
