### PR TITLE
Fix: clear stale histogram and patterns when switching to a stats query

### DIFF
--- a/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
+++ b/public/services/data_fetchers/ppl/ppl_data_fetcher.ts
@@ -25,6 +25,8 @@ import {
   composeFinalQueryWithoutTimestamp,
   getDescribeQueryIndexFromRawQuery,
 } from '../../../components/common/query_utils';
+import { reset as resetCountDistribution } from '../../../components/event_analytics/redux/slices/count_distribution_slice';
+import { reset as resetPatterns } from '../../../components/event_analytics/redux/slices/patterns_slice';
 import { DataFetcherBase } from '../fetcher_base';
 import { IDataFetcher } from '../fetch_interface';
 
@@ -144,7 +146,11 @@ export class PPLDataFetcher extends DataFetcherBase implements IDataFetcher {
     }
     // still need all fields when query contains stats
     const hasStats = finalQuery.match(PPL_STATS_REGEX);
-    if (hasStats) getAvailableFields(`search source=${this.queryIndex}`);
+    if (hasStats) {
+      getAvailableFields(`search source=${this.queryIndex}`);
+      dispatch(resetCountDistribution({ tabId }));
+      dispatch(resetPatterns({ tabId }));
+    }
     if (!hasStats) {
       getCountVisualizations(selectedInterval.current.value.replace(/^auto_/, ''));
       // patterns


### PR DESCRIPTION
### Description
PR #2695 added a `!hasStats` guard around `getCountVisualizations`, `setLogPattern`, and `getPatterns` so stats queries no longer fire malformed sub-queries. The unguarded path was what previously kept the `count_distribution` and `patterns` redux slices in sync with the active query — for stats queries those slices are now never refreshed, so the histogram and patterns panels render stale data from the prior non-stats query. This change dispatches `reset` on both slices in the `hasStats` branch.

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
