### PR TITLE
fix: use validate callback for length checks in alerting schemas

### DIFF
--- a/server/routes/alerting/mutations/body_schema.ts
+++ b/server/routes/alerting/mutations/body_schema.ts
@@ -71,9 +71,17 @@ const ACK_ID_MAX = 64;
 const ACK_BATCH_MAX = 1000;
 
 export const monitorAcknowledgeBodySchema = schema.object({
-  alerts: schema.arrayOf(schema.string({ minLength: 1, maxLength: ACK_ID_MAX }), {
-    maxSize: ACK_BATCH_MAX,
-  }),
+  alerts: schema.arrayOf(
+    schema.string({
+      validate: (value: string) => {
+        if (value.length < 1)
+          return `value has length [0] but it must have a minimum length of [1].`;
+        if (value.length > ACK_ID_MAX)
+          return `value has length [${value.length}] but it must have a maximum length of [${ACK_ID_MAX}].`;
+      },
+    }),
+    { maxSize: ACK_BATCH_MAX }
+  ),
 });
 
 // Re-exported for tests / docs.

--- a/server/routes/alerting/schema_helpers.ts
+++ b/server/routes/alerting/schema_helpers.ts
@@ -28,12 +28,18 @@ const ID_MAX_LENGTH = 512;
  * than 512 chars, and anything outside the `[A-Za-z0-9_-]` charset.
  * Prometheus rule IDs use format {dsId}-{groupName}-{ruleName} which can
  * exceed 128 chars with long metric names.
+ *
+ * NOTE: Length checks are done inside `validate` because @osd/config-schema
+ * with joi v17 only executes the last custom rule when both minLength/maxLength
+ * and validate are specified.
  */
 export const alertingIdSchema = schema.string({
-  maxLength: ID_MAX_LENGTH,
-  minLength: 1,
-  validate: (value: string) =>
-    ID_PATTERN.test(value) ? undefined : 'must match /^[A-Za-z0-9_-]+$/',
+  validate: (value: string) => {
+    if (value.length < 1) return `value has length [0] but it must have a minimum length of [1].`;
+    if (value.length > ID_MAX_LENGTH)
+      return `value has length [${value.length}] but it must have a maximum length of [${ID_MAX_LENGTH}].`;
+    if (!ID_PATTERN.test(value)) return 'must match /^[A-Za-z0-9_-]+$/';
+  },
 });
 
 /** Prometheus label name — `[a-zA-Z_:][a-zA-Z0-9_:]*`, bounded. */
@@ -41,8 +47,10 @@ const LABEL_NAME_PATTERN = /^[a-zA-Z_:][a-zA-Z0-9_:]*$/;
 const LABEL_NAME_MAX_LENGTH = 256;
 
 export const prometheusLabelNameSchema = schema.string({
-  maxLength: LABEL_NAME_MAX_LENGTH,
-  minLength: 1,
-  validate: (value: string) =>
-    LABEL_NAME_PATTERN.test(value) ? undefined : 'must match /^[a-zA-Z_:][a-zA-Z0-9_:]*$/',
+  validate: (value: string) => {
+    if (value.length < 1) return `value has length [0] but it must have a minimum length of [1].`;
+    if (value.length > LABEL_NAME_MAX_LENGTH)
+      return `value has length [${value.length}] but it must have a maximum length of [${LABEL_NAME_MAX_LENGTH}].`;
+    if (!LABEL_NAME_PATTERN.test(value)) return 'must match /^[a-zA-Z_:][a-zA-Z0-9_:]*$/';
+  },
 });


### PR DESCRIPTION
## Description

Fixes #2729

The alerting schema unit tests fail after the upstream [joi v14→v17 migration](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11957) in OpenSearch Dashboards. The migration renamed the internal custom rule from `custom` to `osdCustom`, but in joi v17, calling the same rule name multiple times on a schema replaces the previous rule instead of accumulating.

`@osd/config-schema`'s `StringType` chains up to 3 `osdCustom` rules (type check, minLength, maxLength), plus the user's `validate` callback adds a 4th. Only the **last** one executes:
- `alertingIdSchema`: had `minLength` + `maxLength` + `validate` → only regex validate ran, length checks skipped
- `monitorAcknowledgeBodySchema`: had `minLength` + `maxLength` → only maxLength ran, minLength skipped

## Fix

Move length checks into the `validate` callback so all validation runs in a single `osdCustom` rule.

## Testing

All 131 alerting route tests pass:
```
Test Suites: 8 passed, 8 total
Tests:       131 passed, 131 total
```

Signed-off-by: joshuali925-osdbot <joshuali925-osdbot@users.noreply.github.com>