### PR TITLE
[SLO/Alerting] Fix SLO status incorrectly degrading to no-data

### DIFF
--- a/common/types/alerting/prometheus_types.ts
+++ b/common/types/alerting/prometheus_types.ts
@@ -239,7 +239,18 @@ export interface PrometheusBackend {
     query: string,
     start: number,
     end: number,
-    step: number
+    step: number,
+    opts?: {
+      requestTimeoutMs?: number;
+      /**
+       * The originating inbound request, forwarded opaquely so the
+       * implementation's scoped client carries the caller's auth (OSD
+       * `client.asScoped(request)` contract). The backend does not inspect it.
+       * Typed as `unknown` here (narrowed in the implementation) so the common
+       * types stay browser-importable.
+       */
+      sourceRequest?: unknown;
+    }
   ): Promise<PromTimeSeriesPoint[]>;
 
   /** Execute a PromQL instant query and return point-in-time values. */
@@ -290,7 +301,17 @@ export interface PrometheusBackend {
     startEpochSec: number,
     endEpochSec: number,
     stepSec: number,
-    endIsNow: boolean
+    endIsNow: boolean,
+    opts?: {
+      /**
+       * The originating inbound request, forwarded opaquely so the
+       * implementation's scoped client carries the caller's auth (OSD
+       * `client.asScoped(request)` contract). The backend does not inspect it.
+       * Typed as `unknown` here (narrowed to `OpenSearchDashboardsRequest` in
+       * the implementation) so the common types stay browser-importable.
+       */
+      sourceRequest?: unknown;
+    }
   ): Promise<{
     alerts: UnifiedAlertSummary[];
     fallback?: 'prometheus-alerts-current-only';

--- a/common/types/alerting/prometheus_types.ts
+++ b/common/types/alerting/prometheus_types.ts
@@ -244,10 +244,9 @@ export interface PrometheusBackend {
       requestTimeoutMs?: number;
       /**
        * The originating inbound request, forwarded opaquely so the
-       * implementation's scoped client carries the caller's auth (OSD
-       * `client.asScoped(request)` contract). The backend does not inspect it.
-       * Typed as `unknown` here (narrowed in the implementation) so the common
-       * types stay browser-importable.
+       * implementation's datasource client can derive the caller's auth from
+       * it. The backend does not inspect it. Typed as `unknown` here (narrowed
+       * in the implementation) so the common types stay browser-importable.
        */
       sourceRequest?: unknown;
     }
@@ -263,10 +262,9 @@ export interface PrometheusBackend {
       requestTimeoutMs?: number;
       /**
        * The originating inbound request, forwarded opaquely so the
-       * implementation's scoped client carries the caller's auth (OSD
-       * `client.asScoped(request)` contract). The backend does not inspect it.
-       * Typed as `unknown` here (narrowed in the implementation) so the common
-       * types stay browser-importable.
+       * implementation's datasource client can derive the caller's auth from
+       * it. The backend does not inspect it. Typed as `unknown` here (narrowed
+       * in the implementation) so the common types stay browser-importable.
        */
       sourceRequest?: unknown;
     }
@@ -316,10 +314,10 @@ export interface PrometheusBackend {
     opts?: {
       /**
        * The originating inbound request, forwarded opaquely so the
-       * implementation's scoped client carries the caller's auth (OSD
-       * `client.asScoped(request)` contract). The backend does not inspect it.
-       * Typed as `unknown` here (narrowed to `OpenSearchDashboardsRequest` in
-       * the implementation) so the common types stay browser-importable.
+       * implementation's datasource client can derive the caller's auth from
+       * it. The backend does not inspect it. Typed as `unknown` here (narrowed
+       * to `OpenSearchDashboardsRequest` in the implementation) so the common
+       * types stay browser-importable.
        */
       sourceRequest?: unknown;
     }

--- a/common/types/alerting/prometheus_types.ts
+++ b/common/types/alerting/prometheus_types.ts
@@ -258,7 +258,18 @@ export interface PrometheusBackend {
     ctx: unknown,
     ds: Datasource,
     query: string,
-    time?: number
+    time?: number,
+    opts?: {
+      requestTimeoutMs?: number;
+      /**
+       * The originating inbound request, forwarded opaquely so the
+       * implementation's scoped client carries the caller's auth (OSD
+       * `client.asScoped(request)` contract). The backend does not inspect it.
+       * Typed as `unknown` here (narrowed in the implementation) so the common
+       * types stay browser-importable.
+       */
+      sourceRequest?: unknown;
+    }
   ): Promise<PromTimeSeriesPoint[]>;
 
   /**

--- a/server/routes/alerting/__tests__/handlers.test.ts
+++ b/server/routes/alerting/__tests__/handlers.test.ts
@@ -87,8 +87,11 @@ describe('handlers', () => {
         maxResults: 10,
       }),
       // Third positional arg is the optional RequestHandlerContext threaded
-      // for prom-historical's strategy call; this handler test doesn't pass
-      // one, so expect undefined.
+      // for prom-historical's strategy call; the fourth is the optional source
+      // request forwarded so the prom-historical matrix read carries the
+      // caller's auth. This handler test passes neither, so expect both
+      // undefined.
+      undefined,
       undefined
     );
   });
@@ -113,22 +116,25 @@ describe('handlers', () => {
     expect(result.status).toBe(404);
   });
 
-  it('handleGetRuleDetail forwards definitionType to the service', async () => {
+  it('handleGetRuleDetail forwards definitionType and the source request to the service', async () => {
     mockAlertSvc.getRuleDetail.mockResolvedValueOnce({ id: 'detector-1' } as never);
+    const sourceRequest = { headers: { 'encrypted-fas-creds': 'cipher' }, auth: { isAuthenticated: true } } as never;
     await handleGetRuleDetail(
       mockAlertSvc as never,
       mockClient,
       'ds-1',
       'detector-1',
       undefined,
-      'detector'
+      'detector',
+      sourceRequest
     );
     expect(mockAlertSvc.getRuleDetail).toHaveBeenCalledWith(
       mockClient,
       'ds-1',
       'detector-1',
       undefined,
-      'detector'
+      'detector',
+      sourceRequest
     );
   });
 
@@ -150,6 +156,7 @@ describe('handlers', () => {
         startTime: 'now-1h',
         endTime: 'now',
       }),
+      undefined,
       undefined
     );
   });

--- a/server/routes/alerting/__tests__/handlers.test.ts
+++ b/server/routes/alerting/__tests__/handlers.test.ts
@@ -118,7 +118,7 @@ describe('handlers', () => {
 
   it('handleGetRuleDetail forwards definitionType and the source request to the service', async () => {
     mockAlertSvc.getRuleDetail.mockResolvedValueOnce({ id: 'detector-1' } as never);
-    const sourceRequest = { headers: { 'encrypted-fas-creds': 'cipher' }, auth: { isAuthenticated: true } } as never;
+    const sourceRequest = { headers: { authorization: 'Bearer tok' }, auth: { isAuthenticated: true } } as never;
     await handleGetRuleDetail(
       mockAlertSvc as never,
       mockClient,

--- a/server/routes/alerting/__tests__/handlers.test.ts
+++ b/server/routes/alerting/__tests__/handlers.test.ts
@@ -118,7 +118,10 @@ describe('handlers', () => {
 
   it('handleGetRuleDetail forwards definitionType and the source request to the service', async () => {
     mockAlertSvc.getRuleDetail.mockResolvedValueOnce({ id: 'detector-1' } as never);
-    const sourceRequest = { headers: { authorization: 'Bearer tok' }, auth: { isAuthenticated: true } } as never;
+    const sourceRequest = {
+      headers: { authorization: 'Bearer tok' },
+      auth: { isAuthenticated: true },
+    } as never;
     await handleGetRuleDetail(
       mockAlertSvc as never,
       mockClient,

--- a/server/routes/alerting/handlers.ts
+++ b/server/routes/alerting/handlers.ts
@@ -11,7 +11,10 @@
  * datasource discovery + mutation moved to the client via saved-object
  * services (`useDatasources`, `SavedObjectDatasourceService`).
  */
-import type { RequestHandlerContext } from '../../../../../src/core/server';
+import type {
+  RequestHandlerContext,
+  OpenSearchDashboardsRequest,
+} from '../../../../../src/core/server';
 import type {
   AlertingOSClient,
   OSMonitor,
@@ -186,7 +189,8 @@ export async function handleGetUnifiedAlerts(
     startTime?: string;
     endTime?: string;
   },
-  ctx?: RequestHandlerContext
+  ctx?: RequestHandlerContext,
+  sourceRequest?: OpenSearchDashboardsRequest
 ): Promise<HandlerResult> {
   try {
     const dsIds = query?.dsIds ? query.dsIds.split(',').filter(Boolean) : undefined;
@@ -205,7 +209,8 @@ export async function handleGetUnifiedAlerts(
         startTime: query?.startTime,
         endTime: query?.endTime,
       },
-      ctx
+      ctx,
+      sourceRequest
     );
     return { status: 200, body: response };
   } catch (e: unknown) {
@@ -247,10 +252,18 @@ export async function handleGetRuleDetail(
   dsId: string,
   ruleId: string,
   ctx?: RequestHandlerContext,
-  definitionType?: UnifiedDefinitionType
+  definitionType?: UnifiedDefinitionType,
+  sourceRequest?: OpenSearchDashboardsRequest
 ): Promise<HandlerResult> {
   try {
-    const rule = await alertSvc.getRuleDetail(client, dsId, ruleId, ctx, definitionType);
+    const rule = await alertSvc.getRuleDetail(
+      client,
+      dsId,
+      ruleId,
+      ctx,
+      definitionType,
+      sourceRequest
+    );
     if (!rule) return { status: 404, body: { error: 'Rule not found' } };
     return { status: 200, body: rule };
   } catch (e: unknown) {

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -409,7 +409,8 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
           startTime: req.query.startTime,
           endTime: req.query.endTime,
         },
-        ctx
+        ctx,
+        req
       );
       return res.ok({ body: result.body });
     }
@@ -744,7 +745,8 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
           req.params.dsId,
           req.params.ruleId,
           ctx,
-          req.query.definitionType
+          req.query.definitionType,
+          req
         );
       })
   );

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -531,6 +531,15 @@ function buildStatusContext(
     // Propagate the dedup flag so the aggregator can pick fingerprint-keyed
     // selectors when true.
     ruleDedupEnabled,
+    // Forward the inbound request so the aggregator's PromQL reads carry the
+    // caller's auth onto the search strategy's scoped client (the standard OSD
+    // `client.asScoped(request)` contract). Server-initiated reads otherwise
+    // build a synthetic search request that holds only the PromQL body and has
+    // no auth context, so the scoped client can't authenticate to the
+    // datasource. Forwarded opaquely (never inspected here) so it stays
+    // agnostic to whatever the deployment's datasource client reads off the
+    // request.
+    sourceRequest: request,
   };
 }
 

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -532,13 +532,12 @@ function buildStatusContext(
     // selectors when true.
     ruleDedupEnabled,
     // Forward the inbound request so the aggregator's PromQL reads carry the
-    // caller's auth onto the search strategy's scoped client (the standard OSD
-    // `client.asScoped(request)` contract). Server-initiated reads otherwise
+    // caller's auth to the datasource client. Server-initiated reads otherwise
     // build a synthetic search request that holds only the PromQL body and has
-    // no auth context, so the scoped client can't authenticate to the
-    // datasource. Forwarded opaquely (never inspected here) so it stays
-    // agnostic to whatever the deployment's datasource client reads off the
-    // request.
+    // no inbound auth context, so the datasource client can't authenticate.
+    // Forwarded opaquely (never inspected here) so it stays agnostic to
+    // whatever the deployment's datasource client reads off the request — see
+    // `PromQLSearchOptions.sourceRequest` for the forwarding details/caveats.
     sourceRequest: request,
   };
 }

--- a/server/routes/slo/probe_sli.ts
+++ b/server/routes/slo/probe_sli.ts
@@ -211,6 +211,7 @@ export function registerProbeSliRoute(
       withTimeout(
         prometheusBackend.queryInstant(ctx, ds, goodQuery, endSec, {
           requestTimeoutMs: QUERY_TIMEOUT_MS,
+          sourceRequest: req,
         }),
         QUERY_TIMEOUT_MS,
         'good-query instant'
@@ -222,6 +223,7 @@ export function registerProbeSliRoute(
       withTimeout(
         prometheusBackend.queryInstant(ctx, ds, totalQuery, endSec, {
           requestTimeoutMs: QUERY_TIMEOUT_MS,
+          sourceRequest: req,
         }),
         QUERY_TIMEOUT_MS,
         'total-query instant'
@@ -239,6 +241,7 @@ export function registerProbeSliRoute(
     const rangePoints = await withTimeout(
       prometheusBackend.queryRange(ctx, ds, ratioRangeQuery, startSec, endSec, stepSec, {
         requestTimeoutMs: QUERY_TIMEOUT_MS,
+        sourceRequest: req,
       }),
       QUERY_TIMEOUT_MS,
       'ratio range'

--- a/server/services/alerting/__tests__/directquery_prometheus_backend.test.ts
+++ b/server/services/alerting/__tests__/directquery_prometheus_backend.test.ts
@@ -233,6 +233,46 @@ describe('DirectQueryPrometheusBackend', () => {
     expect((request as { dataSourceId?: string }).dataSourceId).toBe('mds-saved-object-id');
   });
 
+  it('queryRange forwards the source request opaquely onto the search request', async () => {
+    searcher.mockResolvedValueOnce(matrixDF([]));
+    // A representative inbound request carrying both IAM-style FAS headers and
+    // the IDC-style `auth` object — the backend forwards the whole thing
+    // opaquely, so both survive regardless of auth type.
+    const sourceRequest = {
+      headers: { 'encrypted-fas-creds': 'cipher', 'fas-kms-key-arn': 'arn:aws:kms:...' },
+      auth: { isAuthenticated: true },
+    } as never;
+    await backend.queryRange(ctx, ds, 'up', 100, 200, 15, { sourceRequest });
+    const [, request] = searcher.mock.calls[0];
+    expect((request as { headers?: Record<string, unknown> }).headers).toEqual({
+      'encrypted-fas-creds': 'cipher',
+      'fas-kms-key-arn': 'arn:aws:kms:...',
+    });
+    expect((request as { auth?: Record<string, unknown> }).auth).toEqual({ isAuthenticated: true });
+  });
+
+  it('queryInstant forwards the source request, and omits its fields when none supplied', async () => {
+    searcher.mockResolvedValueOnce(
+      buildDataFrame([{ metric: { __name__: 'up' }, value: [1000, '1'] }], /* isRange */ false)
+    );
+    const sourceRequest = { headers: { 'encrypted-fas-creds': 'cipher' }, auth: { isAuthenticated: true } } as never;
+    await backend.queryInstant(ctx, ds, 'up', 1000, { sourceRequest });
+    expect((searcher.mock.calls[0][1] as { headers?: unknown }).headers).toEqual({
+      'encrypted-fas-creds': 'cipher',
+    });
+    expect((searcher.mock.calls[0][1] as { auth?: unknown }).auth).toEqual({ isAuthenticated: true });
+
+    // No source request → no headers/auth on the synthetic request (a
+    // header-less fake request is valid for `client.asScoped`).
+    searcher.mockReset();
+    searcher.mockResolvedValueOnce(
+      buildDataFrame([{ metric: { __name__: 'up' }, value: [1000, '1'] }], /* isRange */ false)
+    );
+    await backend.queryInstant(ctx, ds, 'up', 1000);
+    expect((searcher.mock.calls[0][1] as { headers?: unknown }).headers).toBeUndefined();
+    expect((searcher.mock.calls[0][1] as { auth?: unknown }).auth).toBeUndefined();
+  });
+
   // ---- resolveDqName guard ----
   it('throws when datasource has no directQueryName', async () => {
     const noDq = { ...ds, directQueryName: undefined };
@@ -280,6 +320,17 @@ describe('DirectQueryPrometheusBackend', () => {
         { timestamp: 200_000, value: 1 },
       ]);
       expect(byKey['HighCPU|b'].values.map((v) => v.value)).toEqual([0, 1]);
+    });
+
+    it('forwards opts.sourceRequest opaquely onto the search request', async () => {
+      searcher.mockResolvedValueOnce(matrixDF([]));
+      const sourceRequest = { headers: { 'encrypted-fas-creds': 'cipher' }, auth: { isAuthenticated: true } } as never;
+      await backend.queryRangeMatrix(ctx, ds, 'ALERTS', 100, 300, 60, { sourceRequest });
+      const [, request] = searcher.mock.calls[0];
+      expect((request as { headers?: Record<string, unknown> }).headers).toEqual({
+        'encrypted-fas-creds': 'cipher',
+      });
+      expect((request as { auth?: Record<string, unknown> }).auth).toEqual({ isAuthenticated: true });
     });
   });
 

--- a/server/services/alerting/__tests__/directquery_prometheus_backend.test.ts
+++ b/server/services/alerting/__tests__/directquery_prometheus_backend.test.ts
@@ -255,12 +255,17 @@ describe('DirectQueryPrometheusBackend', () => {
     searcher.mockResolvedValueOnce(
       buildDataFrame([{ metric: { __name__: 'up' }, value: [1000, '1'] }], /* isRange */ false)
     );
-    const sourceRequest = { headers: { authorization: 'Bearer tok' }, auth: { isAuthenticated: true } } as never;
+    const sourceRequest = {
+      headers: { authorization: 'Bearer tok' },
+      auth: { isAuthenticated: true },
+    } as never;
     await backend.queryInstant(ctx, ds, 'up', 1000, { sourceRequest });
     expect((searcher.mock.calls[0][1] as { headers?: unknown }).headers).toEqual({
       authorization: 'Bearer tok',
     });
-    expect((searcher.mock.calls[0][1] as { auth?: unknown }).auth).toEqual({ isAuthenticated: true });
+    expect((searcher.mock.calls[0][1] as { auth?: unknown }).auth).toEqual({
+      isAuthenticated: true,
+    });
 
     // No source request → no headers/auth on the synthetic request (a
     // header-less fake request is valid for `client.asScoped`).
@@ -324,13 +329,18 @@ describe('DirectQueryPrometheusBackend', () => {
 
     it('forwards opts.sourceRequest opaquely onto the search request', async () => {
       searcher.mockResolvedValueOnce(matrixDF([]));
-      const sourceRequest = { headers: { authorization: 'Bearer tok' }, auth: { isAuthenticated: true } } as never;
+      const sourceRequest = {
+        headers: { authorization: 'Bearer tok' },
+        auth: { isAuthenticated: true },
+      } as never;
       await backend.queryRangeMatrix(ctx, ds, 'ALERTS', 100, 300, 60, { sourceRequest });
       const [, request] = searcher.mock.calls[0];
       expect((request as { headers?: Record<string, unknown> }).headers).toEqual({
         authorization: 'Bearer tok',
       });
-      expect((request as { auth?: Record<string, unknown> }).auth).toEqual({ isAuthenticated: true });
+      expect((request as { auth?: Record<string, unknown> }).auth).toEqual({
+        isAuthenticated: true,
+      });
     });
   });
 

--- a/server/services/alerting/__tests__/directquery_prometheus_backend.test.ts
+++ b/server/services/alerting/__tests__/directquery_prometheus_backend.test.ts
@@ -235,18 +235,18 @@ describe('DirectQueryPrometheusBackend', () => {
 
   it('queryRange forwards the source request opaquely onto the search request', async () => {
     searcher.mockResolvedValueOnce(matrixDF([]));
-    // A representative inbound request carrying both IAM-style FAS headers and
-    // the IDC-style `auth` object — the backend forwards the whole thing
-    // opaquely, so both survive regardless of auth type.
+    // A representative inbound request carrying arbitrary auth headers and an
+    // `auth` object — the backend forwards the whole thing opaquely, so both
+    // survive regardless of the deployment's auth scheme.
     const sourceRequest = {
-      headers: { 'encrypted-fas-creds': 'cipher', 'fas-kms-key-arn': 'arn:aws:kms:...' },
+      headers: { authorization: 'Bearer tok', 'x-custom-auth': 'abc' },
       auth: { isAuthenticated: true },
     } as never;
     await backend.queryRange(ctx, ds, 'up', 100, 200, 15, { sourceRequest });
     const [, request] = searcher.mock.calls[0];
     expect((request as { headers?: Record<string, unknown> }).headers).toEqual({
-      'encrypted-fas-creds': 'cipher',
-      'fas-kms-key-arn': 'arn:aws:kms:...',
+      authorization: 'Bearer tok',
+      'x-custom-auth': 'abc',
     });
     expect((request as { auth?: Record<string, unknown> }).auth).toEqual({ isAuthenticated: true });
   });
@@ -255,10 +255,10 @@ describe('DirectQueryPrometheusBackend', () => {
     searcher.mockResolvedValueOnce(
       buildDataFrame([{ metric: { __name__: 'up' }, value: [1000, '1'] }], /* isRange */ false)
     );
-    const sourceRequest = { headers: { 'encrypted-fas-creds': 'cipher' }, auth: { isAuthenticated: true } } as never;
+    const sourceRequest = { headers: { authorization: 'Bearer tok' }, auth: { isAuthenticated: true } } as never;
     await backend.queryInstant(ctx, ds, 'up', 1000, { sourceRequest });
     expect((searcher.mock.calls[0][1] as { headers?: unknown }).headers).toEqual({
-      'encrypted-fas-creds': 'cipher',
+      authorization: 'Bearer tok',
     });
     expect((searcher.mock.calls[0][1] as { auth?: unknown }).auth).toEqual({ isAuthenticated: true });
 
@@ -324,11 +324,11 @@ describe('DirectQueryPrometheusBackend', () => {
 
     it('forwards opts.sourceRequest opaquely onto the search request', async () => {
       searcher.mockResolvedValueOnce(matrixDF([]));
-      const sourceRequest = { headers: { 'encrypted-fas-creds': 'cipher' }, auth: { isAuthenticated: true } } as never;
+      const sourceRequest = { headers: { authorization: 'Bearer tok' }, auth: { isAuthenticated: true } } as never;
       await backend.queryRangeMatrix(ctx, ds, 'ALERTS', 100, 300, 60, { sourceRequest });
       const [, request] = searcher.mock.calls[0];
       expect((request as { headers?: Record<string, unknown> }).headers).toEqual({
-        'encrypted-fas-creds': 'cipher',
+        authorization: 'Bearer tok',
       });
       expect((request as { auth?: Record<string, unknown> }).auth).toEqual({ isAuthenticated: true });
     });
@@ -338,6 +338,34 @@ describe('DirectQueryPrometheusBackend', () => {
     beforeEach(() => {
       mockClient.transport.request.mockClear();
       searcher.mockReset();
+    });
+
+    it('threads opts.sourceRequest end-to-end through to the matrix search request', async () => {
+      // Guards the 4th read path: getHistoricalAlerts -> queryRangeMatrix ->
+      // runPromQLRange. endIsNow=false + empty matrix avoids the live-alerts
+      // fallback so the only search call is the matrix read.
+      searcher.mockResolvedValueOnce(matrixDF([]));
+      const sourceRequest = {
+        headers: { authorization: 'Bearer tok' },
+        auth: { isAuthenticated: true },
+      } as never;
+      await backend.getHistoricalAlerts(
+        ctx,
+        mockClient as never,
+        ds,
+        100,
+        400,
+        60,
+        /* endIsNow */ false,
+        { sourceRequest }
+      );
+      const [, request] = searcher.mock.calls[0];
+      expect((request as { headers?: Record<string, unknown> }).headers).toEqual({
+        authorization: 'Bearer tok',
+      });
+      expect((request as { auth?: Record<string, unknown> }).auth).toEqual({
+        isAuthenticated: true,
+      });
     });
 
     it('reconstructs a single contiguous firing block into one episode', async () => {

--- a/server/services/alerting/__tests__/promql_search.test.ts
+++ b/server/services/alerting/__tests__/promql_search.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for the synthetic-request builder used by every server-initiated
+ * PromQL read. The fix forwards the inbound request opaquely so the search
+ * strategy's `client.asScoped(request)` carries the caller's auth; the core
+ * mechanism is `buildSearchRequest` spreading `sourceRequest` and then
+ * overriding `body` / `dataSourceId`. These tests pin that contract:
+ *   - the forwarded request's auth context (`headers`, `auth`) survives,
+ *   - the synthetic `body` and the server-chosen `dataSourceId` always win
+ *     over any same-named field carried on `sourceRequest`,
+ *   - an absent `sourceRequest` yields just `{ body, dataSourceId? }`.
+ *
+ * `buildSearchRequest` is private, so we exercise it through the public
+ * `runPromQLInstant` / `runPromQLRange` entry points and capture the request
+ * object handed to the injected searcher.
+ */
+
+import {
+  runPromQLInstant,
+  runPromQLRange,
+  setPromQLSearcher,
+  resetPromQLSearcherForTests,
+} from '../promql_search';
+import type { PromQLSearcher } from '../promql_search';
+import type { RequestHandlerContext } from '../../../../../../src/core/server';
+
+const ctx = {} as RequestHandlerContext;
+
+/** Capture the request + options the searcher receives. */
+function captureSearcher(): {
+  searcher: PromQLSearcher;
+  calls: () => Array<{ request: Record<string, unknown>; options: { strategy: string } }>;
+} {
+  const recorded: Array<{ request: Record<string, unknown>; options: { strategy: string } }> = [];
+  const searcher = (async (_c, request, options) => {
+    recorded.push({ request: request as Record<string, unknown>, options });
+    // Minimal well-formed empty envelope so rebuildEnvelope doesn't throw.
+    return ({ type: 'data_frame', body: { fields: [] } } as unknown) as never;
+  }) as PromQLSearcher;
+  return { searcher, calls: () => recorded };
+}
+
+beforeEach(() => resetPromQLSearcherForTests());
+afterEach(() => resetPromQLSearcherForTests());
+
+describe('buildSearchRequest (via runPromQLInstant/runPromQLRange)', () => {
+  it('forwards the inbound request auth context (headers AND auth) onto the search request', async () => {
+    const cap = captureSearcher();
+    setPromQLSearcher(cap.searcher);
+    const sourceRequest = {
+      headers: { authorization: 'Bearer tok', 'x-custom-auth': 'abc' },
+      auth: { isAuthenticated: true },
+    } as never;
+
+    await runPromQLInstant(ctx, {
+      dqName: 'conn',
+      query: 'vector(1)',
+      timeSec: 100,
+      sourceRequest,
+    });
+
+    const { request, options } = cap.calls()[0];
+    expect(options.strategy).toBe('promql');
+    expect(request.headers).toEqual({ authorization: 'Bearer tok', 'x-custom-auth': 'abc' });
+    expect(request.auth).toEqual({ isAuthenticated: true });
+    // The synthetic PromQL payload is present alongside the forwarded auth.
+    expect((request.body as { query: { query: string } }).query.query).toBe('vector(1)');
+    expect(request.dataSourceId).toBeUndefined(); // none passed
+  });
+
+  it('overrides body and dataSourceId even if the forwarded request carries its own', async () => {
+    const cap = captureSearcher();
+    setPromQLSearcher(cap.searcher);
+    // A hostile/odd inbound request that happens to carry body + dataSourceId —
+    // the synthetic values must win so datasource routing and the query can't
+    // be hijacked by the caller's request shape.
+    const sourceRequest = {
+      headers: { authorization: 'Bearer tok' },
+      body: { query: { query: 'DROP', language: 'PROMQL' } },
+      dataSourceId: 'attacker-ds',
+    } as never;
+
+    await runPromQLRange(ctx, {
+      dqName: 'conn',
+      query: 'rate(x[5m])',
+      startSec: 1,
+      endSec: 2,
+      stepSec: 1,
+      dataSourceId: 'server-ds',
+      sourceRequest,
+    });
+
+    const { request } = cap.calls()[0];
+    // body is the synthetic PromQL body, NOT the forwarded one.
+    expect((request.body as { query: { query: string } }).query.query).toBe('rate(x[5m])');
+    // dataSourceId is the server-chosen one, NOT the forwarded one.
+    expect(request.dataSourceId).toBe('server-ds');
+    // Auth context still forwarded.
+    expect(request.headers).toEqual({ authorization: 'Bearer tok' });
+  });
+
+  it('yields just { body, dataSourceId? } when no sourceRequest is provided', async () => {
+    const cap = captureSearcher();
+    setPromQLSearcher(cap.searcher);
+
+    await runPromQLInstant(ctx, {
+      dqName: 'conn',
+      query: 'up',
+      timeSec: 100,
+      dataSourceId: 'ds-1',
+      // no sourceRequest
+    });
+
+    const { request } = cap.calls()[0];
+    expect(request.headers).toBeUndefined();
+    expect(request.auth).toBeUndefined();
+    expect(request.dataSourceId).toBe('ds-1');
+    expect((request.body as { query: { query: string } }).query.query).toBe('up');
+    // Only the expected keys are present.
+    expect(Object.keys(request).sort()).toEqual(['body', 'dataSourceId']);
+  });
+});

--- a/server/services/alerting/alert_detail.ts
+++ b/server/services/alerting/alert_detail.ts
@@ -19,7 +19,10 @@
  * flyout no longer surfaces it inline. Alertmanager owns Prom routing
  * and the standalone Routing tab is the canonical place for it.
  */
-import type { RequestHandlerContext } from '../../../../../src/core/server';
+import type {
+  RequestHandlerContext,
+  OpenSearchDashboardsRequest,
+} from '../../../../../src/core/server';
 import {
   ADDetector,
   ADForecaster,
@@ -113,7 +116,8 @@ export async function getRuleDetail(
   dsId: string,
   ruleId: string,
   ctx?: RequestHandlerContext,
-  definitionType?: UnifiedDefinitionType
+  definitionType?: UnifiedDefinitionType,
+  sourceRequest?: OpenSearchDashboardsRequest
 ): Promise<UnifiedRule | null> {
   const ds = await datasourceService.get(dsId);
   if (!ds) return null;
@@ -127,7 +131,7 @@ export async function getRuleDetail(
     const detector = monitor ?? (await getADDetectorDetail(client, ds, ruleId));
     return detector ?? getADForecasterDetail(client, ds, ruleId);
   } else if (ds.type === 'prometheus' && promBackend) {
-    return getPromRuleDetail(promBackend, client, ds, ruleId, ctx);
+    return getPromRuleDetail(promBackend, client, ds, ruleId, ctx, sourceRequest);
   }
   return null;
 }
@@ -292,7 +296,8 @@ export async function getPromRuleDetail(
   client: AlertingOSClient,
   ds: Datasource,
   ruleId: string,
-  ctx?: RequestHandlerContext
+  ctx?: RequestHandlerContext,
+  sourceRequest?: OpenSearchDashboardsRequest
 ): Promise<UnifiedRule | null> {
   const groups = await promBackend.getRuleGroups(client, ds);
 
@@ -331,7 +336,8 @@ export async function getPromRuleDetail(
           ctx,
           ds,
           alertingRule.query,
-          alertingRule
+          alertingRule,
+          sourceRequest
         ),
         notificationRouting: [],
         suppressionRules: [],

--- a/server/services/alerting/alert_preview.ts
+++ b/server/services/alerting/alert_preview.ts
@@ -282,11 +282,11 @@ export async function fetchPromPreviewData(
       const now = Math.floor(Date.now() / 1000);
       const oneHourAgo = now - 3600;
       const step = 60;
-      // Forward the inbound request opaquely so the backend's scoped client
-      // carries the caller's auth to the datasource (same contract the SLO
-      // status aggregator / probe-sli reads use). The datasource client reads
-      // whatever auth context it needs off the request. Without it the read
-      // throws and the preview silently falls back to embedded-alert extraction.
+      // Forward the inbound request opaquely so the backend can derive the
+      // caller's auth to the datasource (same forwarding the SLO status
+      // aggregator / probe-sli reads use). The datasource client reads whatever
+      // auth context it needs off the request. Without it the read throws and
+      // the preview silently falls back to embedded-alert extraction.
       const points = await promBackend.queryRange(ctx, ds, metricQuery, oneHourAgo, now, step, {
         sourceRequest,
       });

--- a/server/services/alerting/alert_preview.ts
+++ b/server/services/alerting/alert_preview.ts
@@ -15,7 +15,10 @@
  *   - `extractDateHistogramPoints` — pull `{timestamp, value}` points from an agg response
  *   - `fetchPromPreviewData` — queryRange (preferred) or fallback to embedded alert data
  */
-import type { RequestHandlerContext } from '../../../../../src/core/server';
+import type {
+  RequestHandlerContext,
+  OpenSearchDashboardsRequest,
+} from '../../../../../src/core/server';
 import {
   AlertingOSClient,
   Datasource,
@@ -270,7 +273,8 @@ export async function fetchPromPreviewData(
   ctx: RequestHandlerContext | undefined,
   ds: Datasource,
   query: string,
-  rule: PromAlertingRule
+  rule: PromAlertingRule,
+  sourceRequest?: OpenSearchDashboardsRequest
 ): Promise<Array<{ timestamp: number; value: number }>> {
   if (promBackend?.queryRange && ctx) {
     try {
@@ -278,7 +282,14 @@ export async function fetchPromPreviewData(
       const now = Math.floor(Date.now() / 1000);
       const oneHourAgo = now - 3600;
       const step = 60;
-      const points = await promBackend.queryRange(ctx, ds, metricQuery, oneHourAgo, now, step);
+      // Forward the inbound request opaquely so the backend's scoped client
+      // carries the caller's auth to the datasource (same contract the SLO
+      // status aggregator / probe-sli reads use). The datasource client reads
+      // whatever auth context it needs off the request. Without it the read
+      // throws and the preview silently falls back to embedded-alert extraction.
+      const points = await promBackend.queryRange(ctx, ds, metricQuery, oneHourAgo, now, step, {
+        sourceRequest,
+      });
       if (points.length > 0) return points;
     } catch {
       // Strategy threw or returned no data — fall through to embedded-alert extraction

--- a/server/services/alerting/alert_service.ts
+++ b/server/services/alerting/alert_service.ts
@@ -15,7 +15,10 @@
  * Preview time-series helpers live in `alert_preview.ts`.
  * Pure utilities and unified-shape mappers live in `alert_utils.ts`.
  */
-import type { RequestHandlerContext } from '../../../../../src/core/server';
+import type {
+  RequestHandlerContext,
+  OpenSearchDashboardsRequest,
+} from '../../../../../src/core/server';
 import {
   AlertingOSClient,
   ADAnomalyResult,
@@ -410,7 +413,8 @@ export class MultiBackendAlertService {
   async getUnifiedAlerts(
     clientOrResolver: AlertingOSClient | ((dsId: string) => Promise<AlertingOSClient>),
     options?: UnifiedFetchOptions,
-    ctx?: RequestHandlerContext
+    ctx?: RequestHandlerContext,
+    sourceRequest?: OpenSearchDashboardsRequest
   ): Promise<ProgressiveResponse<UnifiedAlertSummary>> {
     const datasources = await this.resolveDatasources(options?.dsIds);
     const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -433,7 +437,8 @@ export class MultiBackendAlertService {
           timeoutMs,
           resolvedRange,
           options?.onProgress,
-          ctx
+          ctx,
+          sourceRequest
         );
       })
     );
@@ -658,7 +663,8 @@ export class MultiBackendAlertService {
     dsId: string,
     ruleId: string,
     ctx?: RequestHandlerContext,
-    definitionType?: UnifiedDefinitionType
+    definitionType?: UnifiedDefinitionType,
+    sourceRequest?: OpenSearchDashboardsRequest
   ): Promise<UnifiedRule | null> {
     return getRuleDetailImpl(
       this.datasourceService,
@@ -668,7 +674,8 @@ export class MultiBackendAlertService {
       dsId,
       ruleId,
       ctx,
-      definitionType
+      definitionType,
+      sourceRequest
     );
   }
 
@@ -700,7 +707,8 @@ export class MultiBackendAlertService {
     timeoutMs: number,
     range: ResolvedRange | undefined,
     onProgress?: (result: DatasourceFetchResult<UnifiedAlertSummary>) => void,
-    ctx?: RequestHandlerContext
+    ctx?: RequestHandlerContext,
+    sourceRequest?: OpenSearchDashboardsRequest
   ): Promise<DatasourceFetchResult<UnifiedAlertSummary>> {
     const start = Date.now();
     const makeResult = (
@@ -722,7 +730,7 @@ export class MultiBackendAlertService {
 
     try {
       const raw = await this.withTimeout(
-        this.fetchAlertsRaw(client, ds, range, ctx),
+        this.fetchAlertsRaw(client, ds, range, ctx, sourceRequest),
         timeoutMs,
         `Datasource ${ds.name} timed out after ${timeoutMs}ms`
       );
@@ -802,7 +810,8 @@ export class MultiBackendAlertService {
     client: AlertingOSClient,
     ds: Datasource,
     range?: ResolvedRange,
-    ctx?: RequestHandlerContext
+    ctx?: RequestHandlerContext,
+    sourceRequest?: OpenSearchDashboardsRequest
   ): Promise<FetchAlertsRawResult> {
     if (ds.type === 'opensearch' && this.osBackend) {
       const partialErrors: string[] = [];
@@ -904,7 +913,8 @@ export class MultiBackendAlertService {
             startSec,
             endSec,
             step,
-            range.endIsNow
+            range.endIsNow,
+            { sourceRequest }
           );
           return {
             alerts: historical.alerts,

--- a/server/services/alerting/directquery_prometheus_backend.ts
+++ b/server/services/alerting/directquery_prometheus_backend.ts
@@ -28,7 +28,7 @@
  *   - RestDirectQueryResourcesManagementAction.java
  *   - PrometheusQueryHandler.java / PrometheusClient.java
  */
-import type { RequestHandlerContext } from '../../../../../src/core/server';
+import type { RequestHandlerContext, OpenSearchDashboardsRequest } from '../../../../../src/core/server';
 import {
   AlertingOSClient,
   Datasource,
@@ -578,7 +578,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     start: number,
     end: number,
     step: number,
-    opts: { requestTimeoutMs?: number } = {}
+    opts: { requestTimeoutMs?: number; sourceRequest?: OpenSearchDashboardsRequest } = {}
   ): Promise<PromTimeSeriesPoint[]> {
     try {
       const dqName = this.resolveDqName(ds);
@@ -591,6 +591,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
         stepSec: step,
         dataSourceId: ds.mdsId,
         timeoutSeconds: timeoutSeconds(opts.requestTimeoutMs),
+        sourceRequest: opts.sourceRequest,
       });
       return this.parseRangeQueryResponse((envelope as unknown) as Record<string, unknown>);
     } catch (err) {
@@ -608,7 +609,8 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     query: string,
     startSec: number,
     endSec: number,
-    stepSec: number
+    stepSec: number,
+    opts: { sourceRequest?: OpenSearchDashboardsRequest } = {}
   ): Promise<PromSeriesMatrix[]> {
     const dqName = this.resolveDqName(ds);
     this.logger.debug(`PromQL range matrix query (strategy=PROMQL): ${query.substring(0, 80)}...`);
@@ -620,6 +622,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
       endSec,
       stepSec,
       dataSourceId: ds.mdsId,
+      sourceRequest: opts.sourceRequest,
     });
 
     const promResult = this.extractPrometheusResult(
@@ -681,7 +684,8 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     startEpochSec: number,
     endEpochSec: number,
     stepSec: number,
-    endIsNow: boolean
+    endIsNow: boolean,
+    opts: { sourceRequest?: OpenSearchDashboardsRequest } = {}
   ): Promise<{
     alerts: UnifiedAlertSummary[];
     fallback?: 'prometheus-alerts-current-only';
@@ -699,7 +703,8 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
       'ALERTS{alertstate="firing"}',
       startEpochSec,
       endEpochSec,
-      stepSec
+      stepSec,
+      { sourceRequest: opts.sourceRequest }
     );
     const liveSettled: Promise<
       { ok: true; alerts: PromAlert[] } | { ok: false; error: string }
@@ -845,7 +850,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
     ds: Datasource,
     query: string,
     time?: number,
-    opts: { requestTimeoutMs?: number } = {}
+    opts: { requestTimeoutMs?: number; sourceRequest?: OpenSearchDashboardsRequest } = {}
   ): Promise<PromTimeSeriesPoint[]> {
     try {
       const dqName = this.resolveDqName(ds);
@@ -856,6 +861,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
         timeSec: time ?? Math.floor(Date.now() / 1000),
         dataSourceId: ds.mdsId,
         timeoutSeconds: timeoutSeconds(opts.requestTimeoutMs),
+        sourceRequest: opts.sourceRequest,
       });
       return this.parseInstantQueryResponse((envelope as unknown) as Record<string, unknown>);
     } catch (err) {

--- a/server/services/alerting/directquery_prometheus_backend.ts
+++ b/server/services/alerting/directquery_prometheus_backend.ts
@@ -28,7 +28,10 @@
  *   - RestDirectQueryResourcesManagementAction.java
  *   - PrometheusQueryHandler.java / PrometheusClient.java
  */
-import type { RequestHandlerContext, OpenSearchDashboardsRequest } from '../../../../../src/core/server';
+import type {
+  RequestHandlerContext,
+  OpenSearchDashboardsRequest,
+} from '../../../../../src/core/server';
 import {
   AlertingOSClient,
   Datasource,

--- a/server/services/alerting/promql_search.ts
+++ b/server/services/alerting/promql_search.ts
@@ -81,18 +81,23 @@ export interface PromQLSearchOptions {
   timeoutSeconds?: number;
   /**
    * The originating inbound request, forwarded opaquely so the `promql`
-   * strategy's `client.asScoped(request)` produces a scoped client carrying
-   * the caller's auth. Server-initiated reads (SLO status aggregator,
-   * probe-sli, alert preview, historical-alert matrix) construct a *synthetic*
-   * request to hold the PromQL `body`; the synthetic request alone has none of
-   * the auth context a scoped client needs. We don't inspect this — whatever
-   * the datasource client reads off the request (auth headers, `request.auth`,
-   * etc.) travels untouched. Forwarding the whole request (rather than
-   * cherry-picking `headers`) keeps every field the client might need present,
-   * so we don't regress as that client evolves. `buildSearchRequest` spreads
-   * this and overrides only
-   * `body` / `dataSourceId`. Omit for callers (tests / non-scoped deployments)
-   * that have no request to forward — `asScoped` accepts a header-less fake.
+   * strategy's datasource client can derive the caller's auth from it.
+   * Server-initiated reads (SLO status aggregator, probe-sli, alert preview,
+   * historical-alert matrix) construct a *synthetic* request to hold the
+   * PromQL `body`; the synthetic request alone has none of the inbound auth
+   * context. We don't inspect this — whatever the datasource client reads off
+   * the request (auth `headers`, `request.auth`, etc.) travels untouched.
+   *
+   * Note: `buildSearchRequest` shallow-spreads this into a plain object, so the
+   * result is not an `instanceof OpenSearchDashboardsRequest`. The request's
+   * own-enumerable fields (`headers`, `auth`, …) are preserved, which is what
+   * the DirectQuery datasource client reads; but core's `asScoped` treats a
+   * non-branded request as header-less and won't re-run `getAuthHeaders`. That
+   * is acceptable here: the forwarded raw `headers`/`auth` are what the
+   * datasource client needs, and forwarding the whole request (rather than
+   * cherry-picking `headers`) keeps every field present so we don't regress as
+   * that client evolves. Override is limited to `body` / `dataSourceId`. Omit
+   * for callers (tests / non-scoped deployments) with no request to forward.
    */
   sourceRequest?: OpenSearchDashboardsRequest;
 }

--- a/server/services/alerting/promql_search.ts
+++ b/server/services/alerting/promql_search.ts
@@ -79,6 +79,22 @@ export interface PromQLSearchOptions {
   dataSourceId?: string;
   /** Maps to the strategy's `timeout` (seconds) per-query budget. */
   timeoutSeconds?: number;
+  /**
+   * The originating inbound request, forwarded opaquely so the `promql`
+   * strategy's `client.asScoped(request)` produces a scoped client carrying
+   * the caller's auth. Server-initiated reads (SLO status aggregator,
+   * probe-sli, alert preview, historical-alert matrix) construct a *synthetic*
+   * request to hold the PromQL `body`; the synthetic request alone has none of
+   * the auth context a scoped client needs. We don't inspect this — whatever
+   * the datasource client reads off the request (auth headers, `request.auth`,
+   * etc.) travels untouched. Forwarding the whole request (rather than
+   * cherry-picking `headers`) keeps every field the client might need present,
+   * so we don't regress as that client evolves. `buildSearchRequest` spreads
+   * this and overrides only
+   * `body` / `dataSourceId`. Omit for callers (tests / non-scoped deployments)
+   * that have no request to forward — `asScoped` accepts a header-less fake.
+   */
+  sourceRequest?: OpenSearchDashboardsRequest;
 }
 
 export interface PromQLInstantArgs extends PromQLSearchOptions {
@@ -130,7 +146,13 @@ let cachedSearcher: PromQLSearcher | undefined;
 /** Function shape that matches `data.search.search`. */
 export type PromQLSearcher = (
   context: RequestHandlerContext,
-  request: OpenSearchDashboardsRequest | { dataSourceId?: string; body: unknown },
+  request:
+    | OpenSearchDashboardsRequest
+    | {
+        dataSourceId?: string;
+        body: unknown;
+        [k: string]: unknown;
+      },
   options: { strategy: string }
 ) => Promise<IDataFrameResponse>;
 
@@ -186,6 +208,7 @@ export async function runPromQLInstant(
   const request = buildSearchRequest(args.dqName, args.query, args.dataSourceId, {
     options: { queryType: 'INSTANT', time: args.timeSec.toString() },
     timeoutSeconds: args.timeoutSeconds,
+    sourceRequest: args.sourceRequest,
   });
   const response = await getSearcher()(ctx, request, { strategy: PROMQL_STRATEGY });
   return rebuildEnvelope(response, args.dqName, /* isRange */ false);
@@ -199,6 +222,7 @@ export async function runPromQLRange(
     options: { step: args.stepSec },
     timeRange: { from: args.startSec.toString(), to: args.endSec.toString() },
     timeoutSeconds: args.timeoutSeconds,
+    sourceRequest: args.sourceRequest,
   });
   const response = await getSearcher()(ctx, request, { strategy: PROMQL_STRATEGY });
   return rebuildEnvelope(response, args.dqName, /* isRange */ true);
@@ -216,8 +240,13 @@ function buildSearchRequest(
     options?: Record<string, unknown>;
     timeRange?: { from: string; to: string };
     timeoutSeconds?: number;
+    sourceRequest?: OpenSearchDashboardsRequest;
   }
-): { dataSourceId?: string; body: Record<string, unknown> } {
+): {
+  dataSourceId?: string;
+  body: Record<string, unknown>;
+  [k: string]: unknown;
+} {
   const body: Record<string, unknown> = {
     query: {
       query,
@@ -235,7 +264,18 @@ function buildSearchRequest(
   if (extras.timeoutSeconds !== undefined) {
     (body.query as Record<string, unknown>).timeout = extras.timeoutSeconds;
   }
-  const request: { dataSourceId?: string; body: Record<string, unknown> } = { body };
+  // Spread the originating request first so all of its scoped-client context
+  // (`headers`, `auth`, and anything else the deployment's client wrapper
+  // reads) is present, then override `body` / `dataSourceId` with the
+  // synthetic PromQL payload. The strategy reads `body` + `dataSourceId`; the
+  // DirectQuery client wrapper reads `headers` + `auth` off the same object.
+  // When no source request is supplied (tests / non-scoped deployments) the
+  // result is just `{ body, dataSourceId? }` — `asScoped` tolerates a
+  // header-less fake request.
+  const request: { dataSourceId?: string; body: Record<string, unknown>; [k: string]: unknown } = {
+    ...((extras.sourceRequest as unknown) as Record<string, unknown>),
+    body,
+  };
   if (dataSourceId) request.dataSourceId = dataSourceId;
   return request;
 }

--- a/server/services/slo/__tests__/status_aggregator.test.ts
+++ b/server/services/slo/__tests__/status_aggregator.test.ts
@@ -810,12 +810,12 @@ describe('rule-health priority merge', () => {
     expect(status.objectives[0].state).toBe('breached');
   });
 
-  it('health=ruler_unreachable → top-level state becomes no_data', async () => {
+  it('health=ruler_unreachable WITH no sample data → top-level state becomes no_data', async () => {
     const doc = makeDoc();
-    const { client } = mockClient({
-      query: () =>
-        instantResponse([{ objective: 'availability-99-9', sloId: 'slo-1', ratio: 0.0002 }]),
-    });
+    // No query rows → the objective has no sample → no_data. The
+    // ruler_unreachable overlay then surfaces as no_data (nothing real to
+    // preserve).
+    const { client } = mockClient({ query: () => instantResponse([]) });
     const { checker } = checkerReturning({
       state: 'ruler_unreachable',
       rulerErrorCode: 'TIMEOUT',
@@ -824,10 +824,30 @@ describe('rule-health priority merge', () => {
     const agg = new DirectQueryStatusAggregator(logger);
     const [status] = await agg.aggregate([doc], ctxWith(promDatasource(), client, checker));
     expect(status.state).toBe('no_data');
-    // Debug log is emitted with the error code so operators can follow up.
     expect(logger.debug).toHaveBeenCalledWith(
       expect.stringContaining('ruler unreachable for slo=slo-1 code=TIMEOUT')
     );
+  });
+
+  it('health=ruler_unreachable WITH sample data → sample-derived state is preserved', async () => {
+    // Regression: the health checker and the PromQL read can travel different
+    // transports, so the health check can report ruler_unreachable even when
+    // the PromQL read succeeded. Since we have real sample data, the ruler is
+    // reachable for reads and we must NOT downgrade the true state to no_data.
+    const doc = makeDoc();
+    const { client } = mockClient({
+      // ratio 0.002 vs target 0.999 → breached
+      query: () =>
+        instantResponse([{ objective: 'availability-99-9', sloId: 'slo-1', ratio: 0.002 }]),
+    });
+    const { checker } = checkerReturning({
+      state: 'ruler_unreachable',
+      rulerErrorCode: 'TIMEOUT',
+    });
+    const agg = new DirectQueryStatusAggregator(noopLogger());
+    const [status] = await agg.aggregate([doc], ctxWith(promDatasource(), client, checker));
+    expect(status.state).toBe('breached');
+    expect(status.objectives[0].state).toBe('breached');
   });
 
   it('health=ok → state is the sample-derived one', async () => {

--- a/server/services/slo/__tests__/status_aggregator.test.ts
+++ b/server/services/slo/__tests__/status_aggregator.test.ts
@@ -492,6 +492,30 @@ describe('DirectQueryStatusAggregator.aggregate — happy paths', () => {
     );
   });
 
+  it('forwards ctx.sourceRequest opaquely onto the aggregator PromQL read', async () => {
+    // The aggregator's queryInstant passes ctx.sourceRequest into
+    // runPromQLInstant so the scoped client carries the caller's auth.
+    const doc = makeDoc();
+    const { client, searcherMock } = mockClient({
+      query: () =>
+        instantResponse([{ objective: 'availability-99-9', sloId: 'slo-1', ratio: 0.0002 }]),
+    });
+    const sourceRequest = {
+      headers: { authorization: 'Bearer tok' },
+      auth: { isAuthenticated: true },
+    } as never;
+    const ctx = { ...ctxFor(promDatasource(), client), sourceRequest };
+    const agg = new DirectQueryStatusAggregator(noopLogger());
+    await agg.aggregate([doc], ctx);
+
+    expect(searcherMock).toHaveBeenCalled();
+    const [, request] = searcherMock.mock.calls[0];
+    expect((request as { headers?: Record<string, unknown> }).headers).toEqual({
+      authorization: 'Bearer tok',
+    });
+    expect((request as { auth?: Record<string, unknown> }).auth).toEqual({ isAuthenticated: true });
+  });
+
   it('warning SLO (errorRatio=0.0006, budget=40%) → warning', async () => {
     const doc = makeDoc();
     const { client } = mockClient({
@@ -847,6 +871,57 @@ describe('rule-health priority merge', () => {
     const agg = new DirectQueryStatusAggregator(noopLogger());
     const [status] = await agg.aggregate([doc], ctxWith(promDatasource(), client, checker));
     expect(status.state).toBe('breached');
+    expect(status.objectives[0].state).toBe('breached');
+  });
+
+  it('health=ruler_unreachable WITH only source_idle (NaN) data → downgrades to no_data', async () => {
+    // `baseHasData` counts only ok/warning/breached objectives, so a
+    // source_idle (recorded NaN — source metric idle) objective is treated as
+    // "no real signal". When the ruler is also unreachable we surface no_data:
+    // there's no live signal to preserve and the ruler status is unknown. This
+    // pins that intended behavior (source_idle alone, without ruler trouble,
+    // still surfaces as source_idle — see the dedicated NaN test above).
+    const doc = makeDoc();
+    const { client } = mockClient({
+      query: () => ({
+        resultType: 'vector',
+        result: [
+          {
+            metric: {
+              __name__: 'slo:sli_error:ratio_rate_3d:checkout_availability_xxxx',
+              slo_id: 'slo-1',
+              slo_objective: 'availability-99-9',
+            },
+            value: [Math.floor(Date.now() / 1000), 'NaN'],
+          },
+        ],
+      }),
+    });
+    const { checker } = checkerReturning({
+      state: 'ruler_unreachable',
+      rulerErrorCode: 'TIMEOUT',
+    });
+    const agg = new DirectQueryStatusAggregator(noopLogger());
+    const [status] = await agg.aggregate([doc], ctxWith(promDatasource(), client, checker));
+    expect(status.state).toBe('no_data');
+  });
+
+  it('health=rules_missing overlays even WHEN sample data is present (not gated by hasSampleData)', async () => {
+    // Regression guard: the hasSampleData gate is specific to the
+    // ruler_unreachable branch. `rules_missing` is a definitive "rules were
+    // deleted" signal and must still overlay on top of a real breached sample,
+    // so a future edit can't accidentally copy the hasSampleData check up to
+    // the rules_missing branch and hide deleted rules behind stale data.
+    const doc = makeDoc();
+    const { client } = mockClient({
+      query: () =>
+        instantResponse([{ objective: 'availability-99-9', sloId: 'slo-1', ratio: 0.002 }]),
+    });
+    const { checker } = checkerReturning({ state: 'rules_missing' });
+    const agg = new DirectQueryStatusAggregator(noopLogger());
+    const [status] = await agg.aggregate([doc], ctxWith(promDatasource(), client, checker));
+    expect(status.state).toBe('rules_missing');
+    // Per-objective still reflects the breached sample.
     expect(status.objectives[0].state).toBe('breached');
   });
 

--- a/server/services/slo/__tests__/status_aggregator_circuit_breaker.test.ts
+++ b/server/services/slo/__tests__/status_aggregator_circuit_breaker.test.ts
@@ -134,7 +134,7 @@ describe('status aggregator + circuit breaker', () => {
     ).toBe(true);
   });
 
-  it('a successful alerts fetch closes a previously open breaker', async () => {
+  it('a successful status read closes a previously open breaker', async () => {
     let now = 0;
     const cb = new DatasourceCircuitBreaker({
       now: () => now,
@@ -157,15 +157,22 @@ describe('status aggregator + circuit breaker', () => {
     const ctx = ctxFor({ 'ds-1': dsFor('ds-1') }, client);
     await agg.aggregate(docs, ctx);
 
-    // Successful trial → closed; subsequent calls don't fast-fail.
+    // The PromQL read returned (empty but no throw) → success → closed;
+    // subsequent calls don't fast-fail.
     expect(cb.isOpen('ds-1')).toBe(false);
   });
 
-  it('records a failure when the alerts fetch throws and re-opens after threshold', async () => {
+  it('records a failure when the status READ throws and re-opens after threshold', async () => {
+    // The breaker is driven by the PromQL read path, NOT the optional alerts
+    // fetch. Make the searcher (read) throw to trip it; the alerts transport is
+    // irrelevant to the breaker now.
+    setPromQLSearcher(
+      (async () => {
+        throw new Error('search strategy unreachable');
+      }) as PromQLSearcher
+    );
     const cb = new DatasourceCircuitBreaker({ now: () => 0, failureThreshold: 2 });
-    const transport = jest.fn(async () => {
-      throw new Error('connection refused');
-    });
+    const transport = jest.fn(async () => ({ statusCode: 200, body: { data: { alerts: [] } } }));
     const client = ({ transport: { request: transport } } as unknown) as AlertingOSClient;
     const agg = new DirectQueryStatusAggregator(noopLogger(), cb);
     const docs = [makeDoc('a', 'ds-1')];
@@ -175,6 +182,26 @@ describe('status aggregator + circuit breaker', () => {
     expect(cb.isOpen('ds-1')).toBe(false);
     await agg.aggregate(docs, ctx);
     expect(cb.isOpen('ds-1')).toBe(true);
+  });
+
+  it('a failing alerts fetch alone does NOT trip the breaker when the read succeeds', async () => {
+    // Regression: previously the alerts-fetch failure recorded a breaker
+    // failure, which tripped a healthy datasource and masked working PromQL
+    // status reads as no_data. The read here succeeds (empty searcher), so the
+    // breaker must stay closed even though the alerts transport throws.
+    const cb = new DatasourceCircuitBreaker({ now: () => 0, failureThreshold: 1 });
+    const transport = jest.fn(async () => {
+      throw new Error('connection refused'); // alerts fetch fails
+    });
+    const client = ({ transport: { request: transport } } as unknown) as AlertingOSClient;
+    const agg = new DirectQueryStatusAggregator(noopLogger(), cb);
+    const docs = [makeDoc('a', 'ds-1')];
+    const ctx = ctxFor({ 'ds-1': dsFor('ds-1') }, client);
+
+    const results = await agg.aggregate(docs, ctx);
+    expect(cb.isOpen('ds-1')).toBe(false);
+    // And the SLO is not forced to no_data by the breaker.
+    expect(results.find((r) => r.sloId === 'a')?.firingCount).toBe(0);
   });
 
   it('a bad datasource does not affect other datasources isolation', async () => {
@@ -211,9 +238,14 @@ describe('status aggregator + circuit breaker', () => {
       cooldownMs: 60_000,
       onTransition: (id, kind) => events.push([id, kind]),
     });
-    const transport = jest.fn(async () => {
-      throw new Error('boom');
-    });
+    // Breaker is driven by the read path — make the searcher throw so the
+    // status read fails and trips the breaker.
+    setPromQLSearcher(
+      (async () => {
+        throw new Error('boom');
+      }) as PromQLSearcher
+    );
+    const transport = jest.fn(async () => ({ statusCode: 200, body: { data: { alerts: [] } } }));
     const client = ({ transport: { request: transport } } as unknown) as AlertingOSClient;
     const agg = new DirectQueryStatusAggregator(noopLogger(), cb);
     const docs = [makeDoc('a', 'ds-1')];

--- a/server/services/slo/__tests__/status_aggregator_circuit_breaker.test.ts
+++ b/server/services/slo/__tests__/status_aggregator_circuit_breaker.test.ts
@@ -166,11 +166,9 @@ describe('status aggregator + circuit breaker', () => {
     // The breaker is driven by the PromQL read path, NOT the optional alerts
     // fetch. Make the searcher (read) throw to trip it; the alerts transport is
     // irrelevant to the breaker now.
-    setPromQLSearcher(
-      (async () => {
-        throw new Error('search strategy unreachable');
-      }) as PromQLSearcher
-    );
+    setPromQLSearcher((async () => {
+      throw new Error('search strategy unreachable');
+    }) as PromQLSearcher);
     const cb = new DatasourceCircuitBreaker({ now: () => 0, failureThreshold: 2 });
     const transport = jest.fn(async () => ({ statusCode: 200, body: { data: { alerts: [] } } }));
     const client = ({ transport: { request: transport } } as unknown) as AlertingOSClient;
@@ -228,7 +226,7 @@ describe('status aggregator + circuit breaker', () => {
     // its own queryInstant where we can give it a per-id outcome.
     const queryAwareSearcher = (async (_c: unknown, request: unknown) => {
       const q = String(
-        ((request as { body?: { query?: { query?: unknown } } }).body?.query?.query ?? '')
+        (request as { body?: { query?: { query?: unknown } } }).body?.query?.query ?? ''
       );
       if (q.includes('slo_id=~')) throw new Error('batch prefetch unreachable'); // force fallback
       if (q.includes('slo_id="a"')) throw new Error('read a unreachable'); // a throws
@@ -296,11 +294,9 @@ describe('status aggregator + circuit breaker', () => {
     });
     // Breaker is driven by the read path — make the searcher throw so the
     // status read fails and trips the breaker.
-    setPromQLSearcher(
-      (async () => {
-        throw new Error('boom');
-      }) as PromQLSearcher
-    );
+    setPromQLSearcher((async () => {
+      throw new Error('boom');
+    }) as PromQLSearcher);
     const transport = jest.fn(async () => ({ statusCode: 200, body: { data: { alerts: [] } } }));
     const client = ({ transport: { request: transport } } as unknown) as AlertingOSClient;
     const agg = new DirectQueryStatusAggregator(noopLogger(), cb);

--- a/server/services/slo/__tests__/status_aggregator_circuit_breaker.test.ts
+++ b/server/services/slo/__tests__/status_aggregator_circuit_breaker.test.ts
@@ -219,6 +219,62 @@ describe('status aggregator + circuit breaker', () => {
     expect(cb.isOpen('ds-good')).toBe(false);
   });
 
+  it('mixed reads on one datasource (one throws, one succeeds) → breaker stays closed', async () => {
+    // The breaker records a failure only when EVERY enabled SLO read on the
+    // datasource throws (anyReadOk gate). Here SLO "a" read throws and SLO "b"
+    // read succeeds, so anyReadOk wins → recordSuccess → breaker stays closed.
+    // The searcher is keyed on the per-SLO `slo_id="..."` selector; the batched
+    // prefetch (`slo_id=~"..."`) is forced to throw so each SLO falls back to
+    // its own queryInstant where we can give it a per-id outcome.
+    const queryAwareSearcher = (async (_c: unknown, request: unknown) => {
+      const q = String(
+        ((request as { body?: { query?: { query?: unknown } } }).body?.query?.query ?? '')
+      );
+      if (q.includes('slo_id=~')) throw new Error('batch prefetch unreachable'); // force fallback
+      if (q.includes('slo_id="a"')) throw new Error('read a unreachable'); // a throws
+      return ({ series: [], fields: [] } as unknown) as never; // b succeeds (empty)
+    }) as PromQLSearcher;
+    setPromQLSearcher(queryAwareSearcher);
+
+    const cb = new DatasourceCircuitBreaker({ now: () => 0, failureThreshold: 1 });
+    const transport = jest.fn(async () => ({ statusCode: 200, body: { data: { alerts: [] } } }));
+    const client = ({ transport: { request: transport } } as unknown) as AlertingOSClient;
+    const agg = new DirectQueryStatusAggregator(noopLogger(), cb);
+    const docs = [makeDoc('a', 'ds-1'), makeDoc('b', 'ds-1')];
+    const ctx = ctxFor({ 'ds-1': dsFor('ds-1') }, client);
+    await agg.aggregate(docs, ctx);
+
+    expect(cb.isOpen('ds-1')).toBe(false);
+  });
+
+  it('all-disabled SLOs on a datasource leave the breaker untouched (no success or failure recorded)', async () => {
+    // Disabled SLOs short-circuit before any read, so neither anyReadOk nor
+    // anyReadThrew is set → the breaker must be neither tripped NOR reset.
+    // Prove "not reset" by pre-loading one failure (threshold 2, not yet open);
+    // if aggregate wrongly called recordSuccess it would clear that failure and
+    // the subsequent single failure wouldn't open the breaker.
+    const cb = new DatasourceCircuitBreaker({ now: () => 0, failureThreshold: 2 });
+    cb.recordFailure('ds-1');
+    expect(cb.isOpen('ds-1')).toBe(false);
+
+    const transport = jest.fn(async () => ({ statusCode: 200, body: { data: { alerts: [] } } }));
+    const client = ({ transport: { request: transport } } as unknown) as AlertingOSClient;
+    const agg = new DirectQueryStatusAggregator(noopLogger(), cb);
+    const docs = [makeDoc('a', 'ds-1'), makeDoc('b', 'ds-1')].map((d) => ({
+      ...d,
+      spec: { ...d.spec, enabled: false },
+    }));
+    const ctx = ctxFor({ 'ds-1': dsFor('ds-1') }, client);
+    await agg.aggregate(docs, ctx);
+
+    // Breaker not tripped during aggregate.
+    expect(cb.isOpen('ds-1')).toBe(false);
+    // And the prior failure was NOT reset: one more failure now reaches the
+    // threshold and opens it.
+    cb.recordFailure('ds-1');
+    expect(cb.isOpen('ds-1')).toBe(true);
+  });
+
   it('without a breaker (legacy path), behavior is unchanged', async () => {
     const transport = jest.fn(async () => ({ statusCode: 200, body: { data: { alerts: [] } } }));
     const client = ({ transport: { request: transport } } as unknown) as AlertingOSClient;

--- a/server/services/slo/status_aggregator.ts
+++ b/server/services/slo/status_aggregator.ts
@@ -139,12 +139,12 @@ export interface SloStatusAggregationContext {
   ruleDedupEnabled?: boolean;
   /**
    * The originating inbound request, forwarded opaquely onto the PromQL search
-   * request so its scoped client carries the caller's auth — the standard OSD
-   * `client.asScoped(request)` contract. Server-initiated reads build a
-   * synthetic search request to hold the PromQL body; the synthetic request
-   * alone has none of the auth context (headers, `auth`, …) a scoped client
-   * needs, and the datasource client reads those off the request. The
-   * aggregator does not inspect this. Leave undefined in offline / tests.
+   * request so the datasource client can derive the caller's auth from it.
+   * Server-initiated reads build a synthetic search request to hold the PromQL
+   * body; the synthetic request alone has none of the inbound auth context
+   * (headers, `auth`, …) the datasource client reads off the request. The
+   * aggregator does not inspect this. See `PromQLSearchOptions.sourceRequest`
+   * for how the forwarding works. Leave undefined in offline / tests.
    */
   sourceRequest?: OpenSearchDashboardsRequest;
 }

--- a/server/services/slo/status_aggregator.ts
+++ b/server/services/slo/status_aggregator.ts
@@ -272,23 +272,29 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
       }
 
       // Firing-alerts: one fetch per datasource, keyed by slo_id.
+      //
+      // This fetch is NON-CRITICAL: it only supplies the firing-alert count
+      // badge. It uses the raw OSD resource-proxy transport
+      // (`ctx.client.transport`), a different path from the PromQL status read
+      // (which goes through the data plugin's search strategy). The alerts
+      // endpoint can be unreachable while `/query` is fine, so this fetch's
+      // failure must NOT drive the datasource circuit breaker — doing so trips
+      // the breaker on a healthy datasource and short-circuits the *working*
+      // PromQL status reads to `no_data` for every SLO. Failure here only zeroes
+      // the firing count; the breaker is recorded by the status read below,
+      // which reflects the path that actually determines health.
       let alertCountBySloId = new Map<string, number>();
-      let alertsFetchOk = true;
       try {
         alertCountBySloId = await this.fetchFiringAlertsBySlo(ctx.client, ds);
       } catch (err) {
-        alertsFetchOk = false;
-        this.circuitBreaker?.recordFailure(dsId);
-        // Graceful: treat as zero firing alerts for this datasource and keep
-        // computing attainment — a ruler that can't serve /alerts might still
-        // serve /query.
+        // Graceful: treat as zero firing alerts and keep computing attainment.
         this.logger.warn(
           `StatusAggregator: alerts fetch failed for datasource ${ds.id} (${
             ds.directQueryName
-          }): ${errMsg(err)}. firingCount will be 0 for affected SLOs.`
+          }): ${errMsg(err)}. firingCount will be 0 for affected SLOs (non-critical; ` +
+            `circuit breaker not affected).`
         );
       }
-      if (alertsFetchOk) this.circuitBreaker?.recordSuccess(dsId);
 
       // Pre-fetch the long-window recording samples for every non-dedup SLO
       // on this datasource in a single PromQL call per (datasource ×
@@ -308,6 +314,14 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
       // listing poll.
       const PER_SLO_CONCURRENCY = 8;
       let cursor = 0;
+      // Drive the circuit breaker off the PromQL *read* path (the thing that
+      // actually determines health), not the optional alerts fetch above.
+      // `statusForSlo` throwing means the read transport is broken for this
+      // datasource; a clean return (even `no_data` from an empty vector) means
+      // it's reachable. We only trip the breaker when every enabled SLO's read
+      // throws — one bad query shouldn't fast-fail the whole datasource.
+      let anyReadOk = false;
+      let anyReadThrew = false;
       const runOne = async (doc: SloDocument): Promise<void> => {
         // Priority 1: `disabled` beats everything — don't even call the
         // ruler or the health checker for a disabled SLO.
@@ -325,7 +339,9 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
             alertCountBySloId.get(doc.id) ?? 0,
             prefetch
           );
+          anyReadOk = true;
         } catch (err) {
+          anyReadThrew = true;
           this.logger.warn(
             `StatusAggregator: statusForSlo failed for ${doc.id}: ${errMsg(
               err
@@ -349,6 +365,15 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
         }
       );
       await Promise.all(workers);
+
+      // Record breaker health from the read path: any successful read closes /
+      // resets the breaker; only an all-reads-threw group (with at least one
+      // enabled SLO attempted) records a failure toward tripping it.
+      if (anyReadOk) {
+        this.circuitBreaker?.recordSuccess(dsId);
+      } else if (anyReadThrew) {
+        this.circuitBreaker?.recordFailure(dsId);
+      }
     }
 
     // Preserve input order.

--- a/server/services/slo/status_aggregator.ts
+++ b/server/services/slo/status_aggregator.ts
@@ -352,7 +352,7 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
         // Priority 2/3: overlay rule-health state on top of the sample
         // derivation. Health-checker errors never escape (see
         // applyRuleHealthMerge) — the listing must stay available.
-        const merged = await this.applyRuleHealthMerge(doc, ds!, ctx, base);
+        const merged = await this.applyRuleHealthMerge(doc, ds!, ctx, base, baseHasData(base));
         perSloStatus.set(doc.id, merged);
       };
       const workers = Array.from(
@@ -404,7 +404,8 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
     doc: SloDocument,
     ds: Datasource,
     ctx: SloStatusAggregationContext,
-    base: SloLiveStatus
+    base: SloLiveStatus,
+    hasSampleData: boolean
   ): Promise<SloLiveStatus> {
     if (!ctx.healthChecker) return base;
 
@@ -436,6 +437,22 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
       return { ...base, state: 'rules_missing' };
     }
     if (result.state === 'ruler_unreachable') {
+      // Only surface `ruler_unreachable` as `no_data` when we have NO
+      // sample-derived data. If the SLI read returned real samples, the ruler
+      // is demonstrably reachable for reads, and a `ruler_unreachable` here is
+      // a health-check transport mismatch (the health checker and the PromQL
+      // read can travel different paths, so the health check can transiently
+      // fail while reads succeed). Downgrading a real `breached`/`warning`/`ok`
+      // to `no_data` in that case would hide the true status, so leave the
+      // sample-derived state intact.
+      if (hasSampleData) {
+        this.logger.debug(
+          `ruler unreachable for slo=${doc.id} code=${
+            result.rulerErrorCode ?? 'unknown'
+          }, but sample data is present — keeping sample-derived state ${base.state}`
+        );
+        return base;
+      }
       this.logger.debug(
         `ruler unreachable for slo=${doc.id} code=${result.rulerErrorCode ?? 'unknown'}`
       );
@@ -956,6 +973,19 @@ function emptyObjectiveStatus(objective: Objective, doc: SloDocument): Objective
     errorBudgetRemaining: 1,
     state: 'no_data',
   };
+}
+
+/**
+ * True when at least one objective carries a sample-derived state
+ * (`ok` / `warning` / `breached`) — i.e. the SLI read returned real data.
+ * `no_data` / `source_idle` / `disabled` objectives don't count. Used to
+ * decide whether a `ruler_unreachable` health-check result should downgrade
+ * the status to `no_data` (only when there's no real data to preserve).
+ */
+function baseHasData(status: SloLiveStatus): boolean {
+  return status.objectives.some(
+    (o) => o.state === 'ok' || o.state === 'warning' || o.state === 'breached'
+  );
 }
 
 /**

--- a/server/services/slo/status_aggregator.ts
+++ b/server/services/slo/status_aggregator.ts
@@ -42,7 +42,10 @@
 
 /* eslint-disable max-classes-per-file */
 
-import type { RequestHandlerContext } from '../../../../../src/core/server';
+import type {
+  RequestHandlerContext,
+  OpenSearchDashboardsRequest,
+} from '../../../../../src/core/server';
 import type {
   AlertingOSClient,
   Datasource,
@@ -134,6 +137,16 @@ export interface SloStatusAggregationContext {
    * the single-group `{slo_id="X"}` selector is used.
    */
   ruleDedupEnabled?: boolean;
+  /**
+   * The originating inbound request, forwarded opaquely onto the PromQL search
+   * request so its scoped client carries the caller's auth — the standard OSD
+   * `client.asScoped(request)` contract. Server-initiated reads build a
+   * synthetic search request to hold the PromQL body; the synthetic request
+   * alone has none of the auth context (headers, `auth`, …) a scoped client
+   * needs, and the datasource client reads those off the request. The
+   * aggregator does not inspect this. Leave undefined in offline / tests.
+   */
+  sourceRequest?: OpenSearchDashboardsRequest;
 }
 
 export interface SloStatusAggregator {
@@ -791,6 +804,7 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
       query,
       timeSec: Math.floor(Date.now() / 1000),
       dataSourceId: ds.mdsId,
+      sourceRequest: ctx.sourceRequest,
     });
     return parseInstantResponseWithNonFinite((envelope as unknown) as Record<string, unknown>);
   }


### PR DESCRIPTION
### Description

This PR fixes three related defects that cause SLO status to incorrectly degrade to **"no data"** on the SLO listing. Each is a provider-agnostic correctness bug in the status-aggregation path; the commits are split so they can be reviewed independently. (They all touch `status_aggregator.ts`, so they're grouped into one PR rather than three conflicting ones.)

#### 1. Don't let an optional alerts-fetch failure trip the datasource circuit breaker
The per-datasource `DatasourceCircuitBreaker` was driven off the optional firing-alerts fetch (`fetchFiringAlertsBySlo`), which uses a different transport than the PromQL status read. The alerts endpoint can be unreachable while `/query` is fine. When the alerts fetch failed it called `recordFailure`, opening the breaker and short-circuiting **every** SLO on that datasource to `no_data` — even when the PromQL status reads were succeeding.

Fix: drive the breaker off the PromQL **read** outcome (the path that actually determines health). A successful `statusForSlo` read resets the breaker; only an all-reads-threw group records a failure. A failing alerts fetch alone now only zeroes the firing-alert count. Adds a regression test.

#### 2. Don't let `ruler_unreachable` mask a real sample-derived SLO state
`applyRuleHealthMerge` overlaid rule-health on top of the sample-derived status and, on `ruler_unreachable`, unconditionally mapped the status to `no_data` — clobbering a correct `ok` / `warning` / `breached` derived from real samples. The health checker and the PromQL read can travel different transports, so a transient health-check failure could wrongly downgrade a correctly-read status.

Fix: only map `ruler_unreachable` → `no_data` when there is no sample data to preserve (new `baseHasData()` helper). If the SLI read returned real samples, the ruler is demonstrably reachable for reads, so keep the sample-derived state. `rules_missing` (a definitive "rules deleted" signal) still overlays. Adds tests for both paths.

#### 3. Forward the inbound request on server-initiated PromQL reads
Server-initiated PromQL reads build a *synthetic* search request to hold the PromQL body but did not forward the originating inbound request. The data plugin's `promql` search strategy does `client.asScoped(request)`, so the scoped client derives the caller's auth from that request. Without it, an auth-enabled datasource read fails and is swallowed — surfacing as `no_data` on the SLO listing and as a silent fallback in the rule-detail condition preview.

Fix: thread the inbound `OpenSearchDashboardsRequest` opaquely (`sourceRequest`) through every server-initiated read path — SLO status aggregator `queryInstant`, probe-sli `queryInstant`/`queryRange`, rule-detail preview `fetchPromPreviewData` `queryRange`, and historical-alerts `getHistoricalAlerts` → `queryRangeMatrix`. `buildSearchRequest` spreads the forwarded request and overrides only `body`/`dataSourceId`, so all auth context survives. The request is never inspected by this plugin — whatever the deployment's datasource client reads off it travels untouched — so the change is auth-mechanism-agnostic. Callers with no request (offline/tests) omit it.

### Issues Resolved

N/A

### Check List
- [x] All tests pass (`status_aggregator`, `status_aggregator_circuit_breaker`, `handlers`, `directquery_prometheus_backend` suites).
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
