### PR TITLE
refactor: replace `import _ from 'lodash'` with path-based imports for tree-shaking

### DIFF
--- a/public/components/event_analytics/explorer/timechart/timechart.tsx
+++ b/public/components/event_analytics/explorer/timechart/timechart.tsx
@@ -4,7 +4,7 @@
  */
 
 import { EuiSpacer } from '@elastic/eui';
-import _ from 'lodash';
+import sum from 'lodash/sum';
 import React from 'react';
 import { selectCountDistribution } from '../../redux/slices/count_distribution_slice';
 import { CountDistribution } from '../visualizations/count_distribution';
@@ -24,7 +24,7 @@ export const Timechart: React.FC<TimechartProps> = (props) => {
   return (
     <>
       <HitsCounter
-        hits={_.sum(props.countDistribution.data?.['count()'])}
+        hits={sum(props.countDistribution.data?.['count()'])}
         showResetButton={false}
         onResetQuery={() => {}}
       />

--- a/public/components/metrics/helpers/__tests__/utils.test.tsx
+++ b/public/components/metrics/helpers/__tests__/utils.test.tsx
@@ -10,15 +10,15 @@ import {
   sampleMetricsVisualizations,
   sampleVisualizationsList,
 } from '../../../../../test/metrics_constants';
-import _ from 'lodash';
+import shuffle from 'lodash/shuffle';
 
 describe('Utils helper functions', () => {
   it('validates sortMetricLayout function', () => {
-    expect(sortMetricLayout(_.shuffle(sampleMetricsVisualizations))).toStrictEqual(
+    expect(sortMetricLayout(shuffle(sampleMetricsVisualizations))).toStrictEqual(
       sampleMetricsVisualizations
     );
 
-    expect(sortMetricLayout(_.shuffle(sampleMetricsVisualizations))).toStrictEqual(
+    expect(sortMetricLayout(shuffle(sampleMetricsVisualizations))).toStrictEqual(
       sampleMetricsVisualizations
     );
   });

--- a/server/adaptors/ppl_datasource.ts
+++ b/server/adaptors/ppl_datasource.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import _ from 'lodash';
+import forEach from 'lodash/forEach';
 import { IPPLEventsDataSource, IPPLVisualizationDataSource } from '../common/types';
 
 type PPLResponse = IPPLEventsDataSource & IPPLVisualizationDataSource;
@@ -60,7 +60,7 @@ export class PPLDataSource {
 
     const data: any[] = [];
 
-    _.forEach(pplRes.datarows, (row) => {
+    forEach(pplRes.datarows, (row) => {
       const record: any = {};
 
       for (let i = 0; i < pplRes.schema.length; i++) {

--- a/server/common/metrics/metrics_helper.ts
+++ b/server/common/metrics/metrics_helper.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import get from 'lodash/get';
+import merge from 'lodash/merge';
+import set from 'lodash/set';
 import {
   CAPACITY,
   COMPONENTS,
@@ -22,16 +25,16 @@ export function addClickToMetric(element: string, counter: CounterNameType = 'co
   trim();
 
   const timeKey = getKey(Date.now());
-  const rollingCounter = time2CountWin.get(timeKey) || _.cloneDeep(DEFAULT_ROLLING_COUNTER);
+  const rollingCounter = time2CountWin.get(timeKey) || cloneDeep(DEFAULT_ROLLING_COUNTER);
   const key = `click.${element}.${counter}`;
 
-  _.set(rollingCounter, key, (_.get(rollingCounter, key, 0) as number) + 1);
+  set(rollingCounter, key, (get(rollingCounter, key, 0) as number) + 1);
   if (counter === 'count') {
     const basicCounterKey = `click.${element}.total`;
-    _.set(
+    set(
       GLOBAL_BASIC_COUNTER,
       basicCounterKey,
-      (_.get(GLOBAL_BASIC_COUNTER, basicCounterKey, 0) as number) + 1
+      (get(GLOBAL_BASIC_COUNTER, basicCounterKey, 0) as number) + 1
     );
   }
 
@@ -64,7 +67,7 @@ export function addRequestToMetric(
   trim();
 
   const timeKey = getKey(Date.now());
-  const rollingCounter = time2CountWin.get(timeKey) || _.cloneDeep(DEFAULT_ROLLING_COUNTER);
+  const rollingCounter = time2CountWin.get(timeKey) || cloneDeep(DEFAULT_ROLLING_COUNTER);
 
   rollingCounter[component][request][counter]!++;
   if (counter === 'count') {
@@ -115,7 +118,7 @@ const buildMetrics = (rollingCounters?: CounterType) => {
   if (!rollingCounters) {
     rollingCounters = DEFAULT_ROLLING_COUNTER;
   }
-  const basicMetrics = _.merge(rollingCounters, GLOBAL_BASIC_COUNTER);
+  const basicMetrics = merge(rollingCounters, GLOBAL_BASIC_COUNTER);
   const overallActionMetrics = {
     request_total: 0,
     request_count: 0,

--- a/server/services/facets/dsl_facet.ts
+++ b/server/services/facets/dsl_facet.ts
@@ -3,14 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import _ from 'lodash';
-
 export class DSLFacet {
   constructor(private client: any) {
     this.client = client;
   }
 
-  private fetch = async (request: any, format: string, responseFormat: string) => {
+  private fetch = async (request: any, format: string, _responseFormat: string) => {
     const res = {
       success: false,
       data: {},

--- a/server/services/queryService.ts
+++ b/server/services/queryService.ts
@@ -4,7 +4,7 @@
  */
 
 import 'core-js/stable';
-import _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 import 'regenerator-runtime/runtime';
 import { Logger } from '../../../../src/core/server';
 
@@ -41,7 +41,7 @@ export class QueryService {
       return {
         data: {
           ok: true,
-          resp: _.isEqual(responseFormat, 'json') ? JSON.stringify(queryResponse) : queryResponse,
+          resp: isEqual(responseFormat, 'json') ? JSON.stringify(queryResponse) : queryResponse,
         },
       };
     } catch (err) {


### PR DESCRIPTION
### Description
Replaces full-library `import _ from 'lodash'` with path-based imports (`import sum from 'lodash/sum'`, etc.) across 6 files. Path imports are tree-shakable, so only the used functions are bundled instead of all of lodash. Behavior is unchanged.
- `timechart.tsx` — `sum`
- `metrics/helpers/__tests__/utils.test.tsx` — `shuffle`
- `server/adaptors/ppl_datasource.ts` — `forEach`
- `server/common/metrics/metrics_helper.ts` — `cloneDeep`, `get`, `merge`, `set`
- `server/services/facets/dsl_facet.ts` — removed unused import
- `server/services/queryService.ts` — `isEqual`

### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
