### PR TITLE
[CVE] Pin picomatch and brace-expansion; regenerate yarn.lock for CVE remediation

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "tough-cookie": "^4.1.3",
     "semver": "^7.5.2",
     "braces": "^3.0.3",
-    "ws": "^8.18.0",
+    "ws": "^8.21.0",
     "nanoid": "3.3.8",
     "serialize-javascript": "^7.0.3",
     "@babel/runtime": "^7.26.10",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "ansi-regex": "^5.0.1",
     "json-schema": "^0.4.0",
     "minimatch": "^3.0.5",
+    "picomatch": "^2.3.2",
+    "brace-expansion": "^1.1.14",
     "debug": "^3.1.0",
     "yaml": "^2.2.2",
     "tough-cookie": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -414,10 +414,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
-brace-expansion@^1.1.7:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.14.tgz#d9de602370d91347cd9ddad1224d4fd701eb348b"
-  integrity sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==
+brace-expansion@^1.1.14, brace-expansion@^1.1.7:
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
+  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -1810,7 +1810,7 @@ picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1, picomatch@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,10 +2582,10 @@ wrap-ansi@^9.0.0:
     string-width "^7.0.0"
     strip-ansi "^7.1.0"
 
-ws@8.18.3, ws@^8.18.0, ws@^8.18.3:
-  version "8.20.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
-  integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
+ws@8.18.3, ws@^8.18.3, ws@^8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 x-is-string@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
### Description

Hardens the `observability-dashboards` plugin against the Mend-flagged dependency CVEs on **main**.

The committed `yarn.lock` already resolved every in-scope CVE to a fixed version, but `picomatch` and `brace-expansion` were satisfied only by incidental resolution — not pinned in `resolutions`. A future lockfile regeneration could silently regress them (which is why Mend kept flagging the plugin). This PR adds explicit pins and regenerates `yarn.lock` via `yarn osd bootstrap` against OpenSearch-Dashboards core `main` (3.8.0, node 22.22.3).

| CVE / GHSA | Package | Status on main |
|---|---|---|
| CVE-2026-33671, CVE-2026-33672 | picomatch | **pinned** `^2.3.2` → 2.3.2 |
| CVE-2026-33750 | brace-expansion | **pinned** `^1.1.14` → 1.1.15 |
| CVE-2026-4800, CVE-2025-13465, CVE-2026-2950 | lodash | already 4.18.1 (pinned) |
| CVE-2026-27904, CVE-2026-27903, CVE-2026-26996 | minimatch | already 3.1.5 (pinned `^3.0.5`) |
| GHSA-5c6j-r48x-rmvq, CVE-2026-34043 | serialize-javascript | already 7.0.5 (pinned `^7.0.3`) |
| CVE-2026-33532 | yaml | already 2.8.3 (pinned `^2.2.2`) |
| CVE-2025-69873 | ajv | already 8.20.0 (direct dep `^8.18.0`) |
| CVE-2026-33228, CVE-2026-32141 | flatted | **not in this plugin's tree** — routed to OSD core |

Note on flatted: on `main` the plugin does not bundle eslint (lint runs from OSD core via `../../scripts/eslint`), so `flatted` is absent from this plugin's dependency tree. These two CVEs must be remediated in `OpenSearch-Dashboards` core and are out of scope here. (On the 2.19 line the plugin does bundle its own eslint, so flatted is fixed in the companion 2.19 PR.)

### Verification
- `yarn osd bootstrap` against OSD core main completes successfully.
- Plugin Jest suite passes.

### Check List
- [x] All tests pass
- [x] New functionality does not require documentation
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
