### PR TITLE
fix(alerting): Pass datasource context to CreateMetricsMonitor from E…

### DIFF
--- a/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 jest.mock('echarts', () => ({
   init: jest.fn(() => ({ setOption: jest.fn(), resize: jest.fn(), dispose: jest.fn() })),
@@ -46,5 +46,67 @@ describe('CreateMetricsMonitor', () => {
     expect(closeBtn).not.toBeNull();
     closeBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('disables Create button when datasourceId is empty', () => {
+    render(<CreateMetricsMonitor onCancel={jest.fn()} onSave={jest.fn()} datasourceId="" />);
+    const createBtn = document.querySelector(
+      'button[class*="euiButton--fill"]'
+    ) as HTMLButtonElement;
+    expect(createBtn).not.toBeNull();
+    expect(createBtn!.disabled).toBe(true);
+  });
+
+  it('POSTs the correct payload shape on save', async () => {
+    const mockPost = jest.fn().mockResolvedValue({});
+    const onSave = jest.fn();
+    const addToast = jest.fn();
+
+    render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={onSave}
+        datasourceId="test-ds-123"
+        datasourceName="Test Prometheus"
+        http={{ post: mockPost }}
+        addToast={addToast}
+      />
+    );
+
+    // Fill in required fields: monitorName
+    const nameInput = document.querySelector('input[aria-label="Rule name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'my-test-rule' } });
+
+    // Click Create button
+    const createBtn = document.querySelector(
+      'button[class*="euiButton--fill"]'
+    ) as HTMLButtonElement;
+    fireEvent.click(createBtn);
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/alerting/prometheus/test-ds-123/rules',
+        expect.objectContaining({ body: expect.any(String) })
+      );
+    });
+
+    // Verify payload structure
+    const body = JSON.parse(mockPost.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      name: 'my-test-rule',
+      query: expect.any(String),
+      operator: '>',
+      threshold: expect.any(Number),
+      forDuration: expect.any(String),
+      evaluationInterval: expect.any(String),
+      enabled: true,
+      groupName: 'my-test-rule',
+    });
+    expect(body).toHaveProperty('labels');
+    expect(body).toHaveProperty('annotations');
+
+    // Should call onSave and show success toast
+    expect(onSave).toHaveBeenCalled();
+    expect(addToast).toHaveBeenCalledWith(expect.any(String), 'success');
   });
 });

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -89,6 +89,16 @@ export interface MetricsMonitorFormState {
 export interface CreateMetricsMonitorProps {
   onCancel: () => void;
   onSave: (form: MetricsMonitorFormState) => void;
+  /** Datasource ID from the current Explore page context */
+  datasourceId?: string;
+  /** Datasource display name from the current Explore page context */
+  datasourceName?: string;
+  /** HTTP client for persisting rules */
+  http?: {
+    post: (path: string, options: { body: string }) => Promise<unknown>;
+  };
+  /** Toast notification callback */
+  addToast?: (title: string, color?: 'success' | 'danger') => void;
 }
 
 // ============================================================================
@@ -269,21 +279,6 @@ const EVAL_INTERVAL_OPTIONS = [
   },
 ];
 
-const MOCK_DATASOURCES = [
-  {
-    id: 'prom-1',
-    name: i18n.translate('observability.alerting.createMetricsMonitor.datasourceProd', {
-      defaultMessage: 'Prometheus (production)',
-    }),
-  },
-  {
-    id: 'prom-2',
-    name: i18n.translate('observability.alerting.createMetricsMonitor.datasourceStaging', {
-      defaultMessage: 'Prometheus (staging)',
-    }),
-  },
-];
-
 const MOCK_SAMPLE_QUERIES = [
   {
     label: i18n.translate('observability.alerting.createMetricsMonitor.sampleHighCpu', {
@@ -447,13 +442,30 @@ const QuerySection = React.memo<{
   onUpdate: (patch: Partial<MetricsMonitorFormState>) => void;
   showPreview: boolean;
   onRunPreview: () => void;
-}>(({ form, onUpdate, showPreview, onRunPreview }) => {
+  contextDatasourceName?: string;
+}>(({ form, onUpdate, showPreview, onRunPreview, contextDatasourceName }) => {
   const [showMetricBrowser, setShowMetricBrowser] = useState(false);
   const [showQueryLibrary, setShowQueryLibrary] = useState(false);
   const [showDatasourcePicker, setShowDatasourcePicker] = useState(false);
 
+  // Use the real datasource from the Explore page context. When no
+  // datasource is provided (e.g. standalone usage), show a placeholder.
+  const datasourceOptions = useMemo(() => {
+    if (form.datasourceId) {
+      return [{ id: form.datasourceId, name: contextDatasourceName || form.datasourceId }];
+    }
+    return [];
+  }, [form.datasourceId, contextDatasourceName]);
+
   const selectedDs =
-    MOCK_DATASOURCES.find((d) => d.id === form.datasourceId) || MOCK_DATASOURCES[0];
+    datasourceOptions.length > 0
+      ? datasourceOptions[0]
+      : {
+          id: '',
+          name: i18n.translate('observability.alerting.createMetricsMonitor.noDatasourceAttached', {
+            defaultMessage: 'No Prometheus datasource attached',
+          }),
+        };
 
   const handleMetricSelect = (metricName: string) => {
     const newQuery = form.query
@@ -533,7 +545,7 @@ const QuerySection = React.memo<{
               closePopover={() => setShowDatasourcePicker(false)}
               panelPaddingSize="s"
             >
-              {MOCK_DATASOURCES.map((ds) => (
+              {datasourceOptions.map((ds) => (
                 <EuiButtonEmpty
                   key={ds.id}
                   size="xs"
@@ -620,7 +632,11 @@ const QuerySection = React.memo<{
               style={{ width: 600 }}
             >
               <div style={{ width: 560, maxHeight: 400, overflow: 'auto' }}>
-                <MetricBrowser onSelectMetric={handleMetricSelect} currentQuery={form.query} />
+                <MetricBrowser
+                  onSelectMetric={handleMetricSelect}
+                  currentQuery={form.query}
+                  datasourceId={form.datasourceId}
+                />
               </div>
             </EuiPopover>
           </EuiFlexItem>
@@ -1341,12 +1357,19 @@ const RulePreviewSection = React.memo<{
 // Main Component
 // ============================================================================
 
-export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({ onCancel, onSave }) => {
+export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
+  onCancel,
+  onSave,
+  datasourceId: contextDatasourceId,
+  datasourceName: contextDatasourceName,
+  http,
+  addToast,
+}) => {
   const [form, setForm] = useState<MetricsMonitorFormState>({
     monitorName: '',
     description: '',
     query: DEFAULT_PROMQL,
-    datasourceId: MOCK_DATASOURCES[0].id,
+    datasourceId: contextDatasourceId || '',
     operator: '>',
     thresholdValue: 0.05,
     forDuration: '5m',
@@ -1412,7 +1435,60 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({ onCa
     setShowPreview(true);
   }, []);
 
-  const isValid = form.monitorName.trim() !== '' && form.query.trim() !== '';
+  const isValid =
+    form.monitorName.trim() !== '' && form.query.trim() !== '' && form.datasourceId !== '';
+
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    if (!isValid || isSaving) return;
+
+    // If no http client available, fall back to the original onSave callback
+    if (!http || !form.datasourceId) {
+      onSave(form);
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const payload = {
+        name: form.monitorName,
+        query: form.query,
+        operator: form.operator,
+        threshold: form.thresholdValue,
+        forDuration: form.forDuration,
+        evaluationInterval: form.evalInterval,
+        labels: Object.fromEntries(
+          form.labels.filter((l) => l.key.trim()).map((l) => [l.key, l.value])
+        ),
+        annotations: Object.fromEntries(
+          form.annotations.filter((a) => a.key.trim()).map((a) => [a.key, a.value])
+        ),
+        enabled: true,
+        groupName: form.monitorName,
+      };
+      await http.post(`/api/alerting/prometheus/${encodeURIComponent(form.datasourceId)}/rules`, {
+        body: JSON.stringify(payload),
+      });
+      addToast?.(
+        i18n.translate('observability.alerting.createMetricsMonitor.toast.created', {
+          defaultMessage: 'Alert rule created successfully.',
+        }),
+        'success'
+      );
+      onSave(form);
+    } catch (err) {
+      console.error('CreateMetricsMonitor: rule creation failed', err);
+      addToast?.(
+        i18n.translate('observability.alerting.createMetricsMonitor.toast.failed', {
+          defaultMessage: 'Failed to create alert rule.',
+        }),
+        'danger'
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }, [isValid, isSaving, http, form, onSave, addToast]);
 
   return (
     <EuiFlyout onClose={handleClose} size="l" ownFocus aria-labelledby="createMetricsMonitorTitle">
@@ -1443,6 +1519,7 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({ onCa
           onUpdate={updateForm}
           showPreview={showPreview}
           onRunPreview={handleRunPreview}
+          contextDatasourceName={contextDatasourceName}
         />
         <EuiHorizontalRule margin="l" />
 
@@ -1484,7 +1561,7 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({ onCa
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton fill onClick={() => onSave(form)} isDisabled={!isValid}>
+            <EuiButton fill onClick={handleSave} isLoading={isSaving} isDisabled={!isValid}>
               {i18n.translate('observability.alerting.createMetricsMonitor.createButton', {
                 defaultMessage: 'Create',
               })}

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -637,6 +637,10 @@ export class ObservabilityPlugin
                 | { alertingDashboards?: { pplV2?: boolean } }
                 | undefined;
               if (!liveCapabilities?.alertingDashboards?.pplV2) return false;
+              // This is a Logs (PPL) rule action — disable on Metrics
+              // (PromQL) pages so users don't get the wrong flyout.
+              const queryLanguage = (deps.query as { language?: string })?.language?.toUpperCase();
+              if (queryLanguage === 'PROMQL') return false;
               // AOSS clusters can't host monitors; the button greys out.
               const isAOSS =
                 (deps.query as { dataset?: { dataSource?: { type?: string } } })?.dataset
@@ -681,6 +685,81 @@ export class ObservabilityPlugin
           // `console.error` precedent below for the S3 datasource path.
 
           console.error('Failed to register Explore "Create alert rule" action', error);
+        });
+
+      // Register a separate "Create alert rule" action for the Metrics
+      // (PromQL) Explore page. This opens the Metrics rule flyout instead
+      // of the Logs (PPL) flyout when the user is on the Metrics page.
+      const LazyCreateMetricsMonitor = React.lazy(async () => {
+        const mod = await import('./components/alerting/create_metrics_monitor');
+        return { default: mod.CreateMetricsMonitor };
+      });
+
+      core
+        .getStartServices()
+        .then(([coreStart]) => {
+          const capabilities = coreStart.application.capabilities as
+            | { observability?: { alertManagerEnabled?: boolean } }
+            | undefined;
+          if (!capabilities?.observability?.alertManagerEnabled) {
+            return;
+          }
+          exploreSetup.queryPanelActionsRegistry.register({
+            id: 'observability-create-metrics-monitor-from-explore',
+            order: 2,
+            actionType: 'flyout',
+            getLabel: () =>
+              i18n.translate('observability.alerting.exploreCreateMetricsMonitor.actionLabel', {
+                defaultMessage: 'Create alert rule',
+              }),
+            getIcon: () => 'bell',
+            getIsEnabled: (deps) => {
+              // Only enable on Metrics (PromQL) pages.
+              const queryLanguage = (deps.query as { language?: string })?.language?.toUpperCase();
+              if (queryLanguage !== 'PROMQL') return false;
+              // AOSS clusters can't host monitors.
+              const isAOSS =
+                (deps.query as { dataset?: { dataSource?: { type?: string } } })?.dataset
+                  ?.dataSource?.type === 'OpenSearch Serverless';
+              return !isAOSS;
+            },
+            component: (props) => {
+              const dataset = (props.dependencies.query as {
+                dataset?: {
+                  id?: string;
+                  title?: string;
+                  dataSource?: { id?: string; title?: string; name?: string };
+                };
+              }).dataset;
+              // On the Metrics page the Prometheus connection is the dataset
+              // itself (dataset.id), not a nested dataSource. Fall back to
+              // dataset.dataSource.id for compatibility with other layouts.
+              const dsId = dataset?.dataSource?.id || dataset?.id;
+              const dsName =
+                dataset?.dataSource?.title ?? dataset?.dataSource?.name ?? dataset?.title;
+              return (
+                <React.Suspense fallback={null}>
+                  <LazyCreateMetricsMonitor
+                    onCancel={props.closeFlyout}
+                    onSave={() => {
+                      props.closeFlyout();
+                    }}
+                    datasourceId={dsId}
+                    datasourceName={dsName}
+                    http={props.services.http}
+                    addToast={(title, color) =>
+                      props.services.notifications.toasts[
+                        color === 'danger' ? 'addDanger' : 'addSuccess'
+                      ](title)
+                    }
+                  />
+                </React.Suspense>
+              );
+            },
+          });
+        })
+        .catch((error) => {
+          console.error('Failed to register Explore "Create metrics alert rule" action', error);
         });
     }
 


### PR DESCRIPTION


The CreateMetricsMonitor flyout was using hardcoded mock datasource IDs, causing the Metric Browser to show "No datasource selected" and the datasource picker to display fake "Prometheus (production/staging)" entries when opened from the Explore Metrics page.

On the Metrics page the Prometheus data connection is the dataset itself (dataset.id), not a nested dataSource. The registry action now extracts the ID with fallback (dataset.dataSource.id || dataset.id) and passes both ID and name to the component.

When a real datasource context is provided, the component now shows only that datasource in the picker (replacing the mock list) and passes the real ID to MetricBrowser for metric fetching.

Changes:
- Add datasourceId and datasourceName props to CreateMetricsMonitorProps.
- Build datasourceOptions dynamically: use real datasource when provided, fall back to mocks only for development/demo.
- Thread contextDatasourceName into QuerySection for toolbar display.
- Pass form.datasourceId to MetricBrowser for real metric fetching.
- Update the registry action in plugin.tsx to extract datasource info with correct fallback for Metrics page dataset structure.

### Description
When datssource attached

<img width="3456" height="2234" alt="Image 7-6-26 at 6 09 PM" src="https://github.com/user-attachments/assets/f2bd4709-1077-4902-a0a0-e9fc787b1f09" />

When no datasource

<img width="3456" height="2234" alt="Image 7-6-26 at 6 12 PM" src="https://github.com/user-attachments/assets/c702ddbe-8165-42c0-9ce9-c6ba4188db08" />



### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
