### PR TITLE
Feature/alerting business metrics

### DIFF
--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -60,6 +60,7 @@ import { transformPplFormToPayload } from '../../../common/services/alerting/for
 import { PPL_MONITOR_NAME_MAX } from '../../../common/services/alerting/validators';
 import { showMonitorCreatedToast } from './toast_helpers';
 import './alerting.scss';
+import { alertingTelemetry } from './alerting_telemetry';
 import type { OpenSearchFormState } from './create_monitor/create_monitor_types';
 import {
   extractPplValidationError,
@@ -256,6 +257,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   // flyout's "Open monitor") still re-apply.
   const lastAppliedDsRef = useRef<string | undefined>(undefined);
   const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wizardOpenTimeRef = useRef<number>(0);
   useEffect(() => {
     return () => {
       if (refetchTimerRef.current) clearTimeout(refetchTimerRef.current);
@@ -564,6 +566,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           defaultMessage: 'Alert acknowledged',
         })
       );
+      alertingTelemetry.alertAcknowledged({
+        alertCount: 1,
+        dsType: (alert?.datasourceType as any) || 'opensearch',
+      });
       // Layer an optimistic override so the row flips to "acknowledged"
       // immediately. The override is dropped once the refetch's response
       // either confirms the ack or removes the row.
@@ -932,6 +938,15 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         await mutations.createMonitor(buildPayload(formState), dsId);
       }
       showMonitorCreatedToast({ monitorName: formState.name, dsId });
+      alertingTelemetry.ruleCreated({
+        ruleType: formState.datasourceType === 'prometheus' ? 'promql' : 'ppl',
+        dsType: formState.datasourceType as any,
+        dsId,
+      });
+      alertingTelemetry.wizardCompleted({
+        ruleType: formState.datasourceType === 'prometheus' ? 'promql' : 'ppl',
+        durationMs: wizardOpenTimeRef.current ? Date.now() - wizardOpenTimeRef.current : 0,
+      });
       setShowCreateMonitor(false);
       setCreateBackendType(null);
       setPplSubmitError(null);
@@ -1131,9 +1146,11 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             if (type === 'logs') {
               setCreateBackendType('opensearch');
               setShowCreateMonitor(true);
+              wizardOpenTimeRef.current = Date.now(); alertingTelemetry.wizardStarted({ entryPoint: 'button' });
             } else if (type === 'metrics') {
               setCreateBackendType('prometheus');
               setShowCreateMonitor(true);
+              wizardOpenTimeRef.current = Date.now(); alertingTelemetry.wizardStarted({ entryPoint: 'button' });
             }
           }}
           selectedDsIds={selectedDsIds}

--- a/public/components/alerting/alerting_telemetry.test.ts
+++ b/public/components/alerting/alerting_telemetry.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { alertingTelemetry } from './alerting_telemetry';
+import { coreRefs } from '../../framework/core_refs';
+
+describe('alertingTelemetry', () => {
+  const mockRecordEvent = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (coreRefs as any).core = {
+      telemetry: {
+        isEnabled: () => true,
+        getPluginRecorder: () => ({
+          recordEvent: mockRecordEvent,
+          recordMetric: jest.fn(),
+          recordError: jest.fn(),
+        }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    (coreRefs as any).core = undefined;
+  });
+
+  it('emits alerting.rule.created event', () => {
+    alertingTelemetry.ruleCreated({ ruleType: 'promql', dsType: 'prometheus', dsId: 'ds-1' });
+    expect(mockRecordEvent).toHaveBeenCalledWith({
+      name: 'alerting.rule.created',
+      data: { ruleType: 'promql', dsType: 'prometheus', dsId: 'ds-1' },
+    });
+  });
+
+  it('emits alerting.alert.acknowledged event', () => {
+    alertingTelemetry.alertAcknowledged({ alertCount: 3, dsType: 'opensearch' });
+    expect(mockRecordEvent).toHaveBeenCalledWith({
+      name: 'alerting.alert.acknowledged',
+      data: { alertCount: 3, dsType: 'opensearch' },
+    });
+  });
+
+  it('emits alerting.slo.created event', () => {
+    alertingTelemetry.sloCreated({ template: 'apm-availability', dsId: 'ds-2' });
+    expect(mockRecordEvent).toHaveBeenCalledWith({
+      name: 'alerting.slo.created',
+      data: { template: 'apm-availability', dsId: 'ds-2' },
+    });
+  });
+
+  it('emits alerting.wizard.started event', () => {
+    alertingTelemetry.wizardStarted({ entryPoint: 'button' });
+    expect(mockRecordEvent).toHaveBeenCalledWith({
+      name: 'alerting.wizard.started',
+      data: { entryPoint: 'button' },
+    });
+  });
+
+  it('emits alerting.wizard.completed event', () => {
+    alertingTelemetry.wizardCompleted({ ruleType: 'ppl', durationMs: 5000 });
+    expect(mockRecordEvent).toHaveBeenCalledWith({
+      name: 'alerting.wizard.completed',
+      data: { ruleType: 'ppl', durationMs: 5000 },
+    });
+  });
+
+  it('is a no-op when telemetry is disabled', () => {
+    (coreRefs as any).core = {
+      telemetry: { isEnabled: () => false, getPluginRecorder: jest.fn() },
+    };
+    alertingTelemetry.ruleCreated({ ruleType: 'ppl', dsType: 'opensearch', dsId: 'ds-1' });
+    expect(mockRecordEvent).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when core is not initialized', () => {
+    (coreRefs as any).core = undefined;
+    alertingTelemetry.ruleCreated({ ruleType: 'ppl', dsType: 'opensearch', dsId: 'ds-1' });
+    expect(mockRecordEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when telemetry throws internally', () => {
+    (coreRefs as any).core = {
+      telemetry: {
+        isEnabled: () => { throw new Error('boom'); },
+      },
+    };
+    expect(() => {
+      alertingTelemetry.ruleCreated({ ruleType: 'ppl', dsType: 'opensearch', dsId: 'ds-1' });
+    }).not.toThrow();
+  });
+});

--- a/public/components/alerting/alerting_telemetry.ts
+++ b/public/components/alerting/alerting_telemetry.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Alerting Business Metrics — telemetry event helpers.
+ *
+ * Uses the OSD core TelemetryService (Neo browser telemetry) to emit
+ * custom events for the Unified Alerting feature. Events are batched
+ * and forwarded to the Neo telemetry pipeline automatically.
+ *
+ * Usage:
+ *   import { alertingTelemetry } from './alerting_telemetry';
+ *   alertingTelemetry.ruleCreated({ ruleType: 'promql', dsType: 'prometheus', dsId: 'ds-123' });
+ */
+
+import { coreRefs } from '../../framework/core_refs';
+import type { PluginTelemetryRecorder } from '../../../../../src/core/public';
+
+const PLUGIN_ID = 'dashboards-observability';
+
+/** Lazily get the telemetry recorder — safe to call before core is ready. */
+function getRecorder(): PluginTelemetryRecorder | undefined {
+  try {
+    const telemetry = (coreRefs.core as any)?.telemetry;
+    if (!telemetry || !telemetry.isEnabled()) return undefined;
+    return telemetry.getPluginRecorder(PLUGIN_ID);
+  } catch {
+    return undefined;
+  }
+}
+
+// =========================================================================
+// P0 Events
+// =========================================================================
+
+/**
+ * Emit when a rule is successfully created (POST returns 200).
+ */
+export function ruleCreated(data: {
+  ruleType: 'ppl' | 'promql';
+  dsType: 'opensearch' | 'prometheus' | 'mustang' | 'serverless';
+  dsId: string;
+}): void {
+  getRecorder()?.recordEvent({
+    name: 'alerting.rule.created',
+    data,
+  });
+}
+
+/**
+ * Emit when an alert is acknowledged (POST acknowledge returns 200).
+ */
+export function alertAcknowledged(data: {
+  alertCount: number;
+  dsType: 'opensearch' | 'prometheus';
+}): void {
+  getRecorder()?.recordEvent({
+    name: 'alerting.alert.acknowledged',
+    data,
+  });
+}
+
+/**
+ * Emit when an SLO is successfully created (POST returns 200).
+ */
+export function sloCreated(data: {
+  template?: string;
+  dsId: string;
+}): void {
+  getRecorder()?.recordEvent({
+    name: 'alerting.slo.created',
+    data,
+  });
+}
+
+/**
+ * Emit when the Create Monitor/Rule wizard is opened.
+ */
+export function wizardStarted(data: {
+  entryPoint: 'button' | 'metricsPage' | 'sloPage' | 'rulesTab';
+}): void {
+  getRecorder()?.recordEvent({
+    name: 'alerting.wizard.started',
+    data,
+  });
+}
+
+/**
+ * Emit when the Create Monitor/Rule wizard submission succeeds.
+ */
+export function wizardCompleted(data: {
+  ruleType: 'ppl' | 'promql';
+  durationMs: number;
+}): void {
+  getRecorder()?.recordEvent({
+    name: 'alerting.wizard.completed',
+    data,
+  });
+}
+
+// =========================================================================
+// P1 Events (stubs ready for future sprints)
+// =========================================================================
+
+export function ruleDeleted(data: { ruleType: string; dsType: string }): void {
+  getRecorder()?.recordEvent({ name: 'alerting.rule.deleted', data });
+}
+
+export function ruleEdited(data: { ruleType: string; dsType: string; fieldsChanged?: string[] }): void {
+  getRecorder()?.recordEvent({ name: 'alerting.rule.edited', data });
+}
+
+export function sloToggled(data: { action: 'enable' | 'disable' }): void {
+  getRecorder()?.recordEvent({ name: 'alerting.slo.toggled', data });
+}
+
+export function silenceCreated(data: { duration: string; matcherCount: number }): void {
+  getRecorder()?.recordEvent({ name: 'alerting.silence.created', data });
+}
+
+export function wizardAbandoned(data: { step: number; durationMs: number }): void {
+  getRecorder()?.recordEvent({ name: 'alerting.wizard.abandoned', data });
+}
+
+export function detailOpened(data: { detailType: 'alert' | 'rule' | 'anomaly'; dsType: string }): void {
+  getRecorder()?.recordEvent({ name: 'alerting.detail.opened', data });
+}
+
+export function deepLinkFromMcp(data: { sourceWidget: string }): void {
+  getRecorder()?.recordEvent({ name: 'alerting.deeplink.from_mcp', data });
+}
+
+// =========================================================================
+// Convenience namespace export
+// =========================================================================
+
+export const alertingTelemetry = {
+  ruleCreated,
+  alertAcknowledged,
+  sloCreated,
+  wizardStarted,
+  wizardCompleted,
+  ruleDeleted,
+  ruleEdited,
+  sloToggled,
+  silenceCreated,
+  wizardAbandoned,
+  detailOpened,
+  deepLinkFromMcp,
+};

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -64,6 +64,7 @@ import { WIZARD_SECTIONS } from './wizard_sections';
 import type { WizardSectionId } from './wizard_sections';
 import { WizardValidationSummary } from './wizard_validation_summary';
 import { WizardKeyValueGrid } from './wizard_key_value_grid';
+import { alertingTelemetry } from '../../../alerting/alerting_telemetry';
 
 function sectionAnchorId(id: WizardSectionId): string {
   return WIZARD_SECTIONS.find((s) => s.id === id)!.anchorId;
@@ -291,6 +292,7 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
         }),
       });
       history.push(`/slos/${encodeURIComponent(doc.id)}`);
+      alertingTelemetry.sloCreated({ template: template?.id, dsId: state.datasourceId || '' });
     } catch (e) {
       // Ruler dual-write envelope: surface the raw upstream message inline.
       // `rawBody` is the user-actionable diagnostic (e.g. "invalid PromQL:


### PR DESCRIPTION
Add alerting_telemetry.ts helper module using OSD core TelemetryService (Neo browser telemetry) to emit custom events for business metrics.

P0 events instrumented:
- alerting.rule.created: after successful monitor/rule creation
- alerting.alert.acknowledged: after successful alert acknowledge
- alerting.slo.created: after successful SLO creation
- alerting.wizard.started: when create wizard opens
- alerting.wizard.completed: when wizard submission succeeds (with duration)

P1 event stubs included for future:
- alerting.rule.deleted, alerting.rule.edited
- alerting.slo.toggled, alerting.silence.created
- alerting.wizard.abandoned, alerting.detail.opened
- alerting.deeplink.from_mcp

Wired into:
- alarms_page.tsx: rule creation, acknowledge, wizard open
- slo_wizard_page.tsx: SLO creation

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
