### PR TITLE
[SLO] Refine suggest page

### DIFF
--- a/common/slo/classifier.ts
+++ b/common/slo/classifier.ts
@@ -52,7 +52,13 @@ export function classifySloKind(slo: SloSummary): CanonicalKind | undefined {
   return undefined;
 }
 
-function kindSide(kind: CanonicalKind | undefined): 'availability' | 'latency' | undefined {
+/**
+ * Map a canonical kind to the side of the availability+latency pair it
+ * satisfies. Exported so the Suggest page can decide per-draft coverage from
+ * the same rule the rollup uses (any `-availability` kind covers the
+ * availability side, any `-latency` kind the latency side).
+ */
+export function kindSide(kind: CanonicalKind | undefined): 'availability' | 'latency' | undefined {
   if (!kind) return undefined;
   if (kind.endsWith('-availability')) return 'availability';
   if (kind.endsWith('-latency')) return 'latency';

--- a/public/components/apm/pages/services_home/__tests__/slo_health_panel.test.tsx
+++ b/public/components/apm/pages/services_home/__tests__/slo_health_panel.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 // Stub coreRefs so the navigate helpers don't explode on mount. `jest.mock`
 // is hoisted above imports, so the captured variable has to be `mock`-
@@ -17,6 +17,64 @@ jest.mock('../../../../../framework/core_refs', () => ({
     http: { basePath: { prepend: (p: string) => p } },
   },
 }));
+
+// EuiSelectable virtualizes its option list (react-window + AutoSizer), which
+// measures 0×0 in jsdom and renders no rows — so its options can't be queried
+// or clicked in tests. Stub it with a plain checkbox list that preserves the
+// same option/onChange contract our picker relies on, leaving every other EUI
+// component real.
+interface StubOption {
+  label: string;
+  checked?: 'on';
+  disabled?: boolean;
+  append?: React.ReactNode;
+}
+jest.mock('@elastic/eui', () => {
+  const actual = jest.requireActual('@elastic/eui');
+  const ReactLib = jest.requireActual('react');
+  return {
+    ...actual,
+    EuiSelectable: ({
+      options,
+      onChange,
+    }: {
+      options: StubOption[];
+      onChange: (next: StubOption[]) => void;
+    }) =>
+      ReactLib.createElement(
+        'ul',
+        { role: 'listbox' },
+        options.map((opt) =>
+          ReactLib.createElement(
+            'li',
+            {
+              key: opt.label,
+              role: 'option',
+              'aria-selected': opt.checked === 'on',
+              'aria-disabled': opt.disabled ? 'true' : undefined,
+            },
+            ReactLib.createElement(
+              'button',
+              {
+                type: 'button',
+                disabled: opt.disabled,
+                onClick: () =>
+                  onChange(
+                    options.map((o) =>
+                      o.label === opt.label
+                        ? { ...o, checked: o.checked === 'on' ? undefined : ('on' as const) }
+                        : o
+                    )
+                  ),
+              },
+              opt.label
+            ),
+            opt.append
+          )
+        )
+      ),
+  };
+});
 
 import { SloHealthCell, SloHealthPanel } from '../slo_health_panel';
 import { navigateToSloListing, navigateToSloSuggest } from '../../../shared/utils/navigation_utils';
@@ -152,7 +210,7 @@ describe('SloHealthPanel', () => {
     expect(screen.queryByTestId('sloHealthPanelChip-breached')).toBeNull();
   });
 
-  it('primary CTA scopes to services with missingCanonicalPair=true only', () => {
+  it('opens a picker (nothing pre-checked) and scopes to the services the user picks', async () => {
     const bySvc = new Map<string, SloHealthBucket>();
     bySvc.set('foo', makeBucket({ missingCanonicalPair: true }));
     bySvc.set('bar', makeBucket({ missingCanonicalPair: false }));
@@ -169,11 +227,126 @@ describe('SloHealthPanel', () => {
       />
     );
     const cta = screen.getByTestId('sloHealthPanelCta');
-    expect(cta).toHaveTextContent('Suggest SLOs for 2 services');
+    // Default label — nothing picked yet.
+    expect(cta).toHaveTextContent('Suggest SLOs');
+    expect(cta).not.toHaveTextContent('service');
+
+    // Open the popover and pick a subset. `bar` is covered (disabled).
     fireEvent.click(cta);
+    const foo = await screen.findByText('foo');
+    fireEvent.click(foo);
+    fireEvent.click(screen.getByText('baz'));
+
+    // The confirm button reflects the picked count and navigates scoped to it.
+    const confirm = screen.getByTestId('sloHealthPanelCtaConfirm');
+    await waitFor(() => expect(confirm).toHaveTextContent('Suggest SLOs for 2 services'));
+    fireEvent.click(confirm);
     expect(mockNavigateToApp).toHaveBeenLastCalledWith('observability-apm-slo', {
       path: '#/slos/suggest?source=apm&services=foo%2Cbaz',
     });
+  });
+
+  it('floats checked services to the top of the list', async () => {
+    const bySvc = new Map<string, SloHealthBucket>();
+    for (const s of ['ad', 'cart', 'checkout', 'currency']) {
+      bySvc.set(s, makeBucket({ missingCanonicalPair: true }));
+    }
+
+    render(
+      <SloHealthPanel
+        aggregate={makeBucket({ total: 4, ok: 4 })}
+        bySvc={bySvc}
+        allServices={['ad', 'cart', 'checkout', 'currency']}
+        isLoading={false}
+        error={undefined}
+        onRetry={jest.fn()}
+      />
+    );
+    fireEvent.click(screen.getByTestId('sloHealthPanelCta'));
+    // Check two services that aren't first alphabetically.
+    fireEvent.click(await screen.findByText('checkout'));
+    fireEvent.click(screen.getByText('currency'));
+
+    // After selection they sort above the unchecked ones (each group keeps
+    // original order): checkout, currency, then ad, cart.
+    await waitFor(() => {
+      const labels = screen.getAllByRole('option').map((li) => li.textContent);
+      expect(labels).toEqual(['checkout', 'currency', 'ad', 'cart']);
+    });
+  });
+
+  it('clears all picks via the Clear button', async () => {
+    const bySvc = new Map<string, SloHealthBucket>();
+    bySvc.set('foo', makeBucket({ missingCanonicalPair: true }));
+    bySvc.set('baz', makeBucket({ missingCanonicalPair: true }));
+
+    render(
+      <SloHealthPanel
+        aggregate={makeBucket({ total: 2, ok: 2 })}
+        bySvc={bySvc}
+        allServices={['foo', 'baz']}
+        isLoading={false}
+        error={undefined}
+        onRetry={jest.fn()}
+      />
+    );
+    fireEvent.click(screen.getByTestId('sloHealthPanelCta'));
+    fireEvent.click(await screen.findByText('foo'));
+    fireEvent.click(screen.getByText('baz'));
+
+    const clear = screen.getByTestId('sloHealthPanelCtaClear');
+    const confirm = screen.getByTestId('sloHealthPanelCtaConfirm');
+    await waitFor(() => expect(confirm).toHaveTextContent('Suggest SLOs for 2 services'));
+    expect(clear).not.toBeDisabled();
+
+    // Clearing resets the count and disables both the confirm and clear actions.
+    fireEvent.click(clear);
+    await waitFor(() => expect(confirm).toHaveTextContent('Suggest SLOs'));
+    expect(confirm).not.toHaveTextContent('service');
+    expect(confirm).toBeDisabled();
+    expect(clear).toBeDisabled();
+  });
+
+  it('shows a filled (primary) trigger when closed and a neutral one when open', async () => {
+    render(
+      <SloHealthPanel
+        aggregate={makeBucket({ total: 1, ok: 1 })}
+        bySvc={new Map([['foo', makeBucket({ missingCanonicalPair: true })]])}
+        allServices={['foo']}
+        isLoading={false}
+        error={undefined}
+        onRetry={jest.fn()}
+      />
+    );
+    const cta = screen.getByTestId('sloHealthPanelCta');
+    // Closed → primary/filled to draw attention to opening the picker.
+    expect(cta.className).toContain('euiButton--fill');
+    fireEvent.click(cta);
+    // Open → neutral so the footer confirm is the only primary action in view.
+    await waitFor(() => expect(cta.className).not.toContain('euiButton--fill'));
+    expect(screen.getByTestId('sloHealthPanelCtaConfirm').className).toContain('euiButton--fill');
+  });
+
+  it('disables covered services in the picker so they cannot be scoped', async () => {
+    const bySvc = new Map<string, SloHealthBucket>();
+    bySvc.set('foo', makeBucket({ missingCanonicalPair: true }));
+    bySvc.set('bar', makeBucket({ missingCanonicalPair: false }));
+
+    render(
+      <SloHealthPanel
+        aggregate={makeBucket({ total: 2, ok: 2 })}
+        bySvc={bySvc}
+        allServices={['foo', 'bar']}
+        isLoading={false}
+        error={undefined}
+        onRetry={jest.fn()}
+      />
+    );
+    fireEvent.click(screen.getByTestId('sloHealthPanelCta'));
+    // The covered service renders a disabled option carrying the "covered" tag.
+    const barOption = (await screen.findByText('bar')).closest('li');
+    expect(barOption).toHaveAttribute('aria-disabled', 'true');
+    expect(within(barOption as HTMLElement).getByText('covered')).toBeInTheDocument();
   });
 
   it('secondary CTA carries the full service list currently shown', () => {
@@ -209,6 +382,7 @@ describe('SloHealthPanel', () => {
         onRetry={jest.fn()}
       />
     );
+    // Every service is covered → nothing to suggest → the trigger is disabled.
     expect(screen.getByTestId('sloHealthPanelCta')).toBeDisabled();
   });
 

--- a/public/components/apm/pages/services_home/__tests__/slo_health_panel.test.tsx
+++ b/public/components/apm/pages/services_home/__tests__/slo_health_panel.test.tsx
@@ -307,6 +307,51 @@ describe('SloHealthPanel', () => {
     expect(clear).toBeDisabled();
   });
 
+  it('prunes a pick that becomes covered before confirm (no stale/inflated selection)', async () => {
+    const uncovered = ['foo', 'baz'].reduce((m, s) => {
+      m.set(s, makeBucket({ missingCanonicalPair: true }));
+      return m;
+    }, new Map<string, SloHealthBucket>());
+
+    const { rerender } = render(
+      <SloHealthPanel
+        aggregate={makeBucket({ total: 2, ok: 2 })}
+        bySvc={uncovered}
+        allServices={['foo', 'baz']}
+        isLoading={false}
+        error={undefined}
+        onRetry={jest.fn()}
+      />
+    );
+    fireEvent.click(screen.getByTestId('sloHealthPanelCta'));
+    fireEvent.click(await screen.findByText('foo'));
+    fireEvent.click(screen.getByText('baz'));
+    const confirm = screen.getByTestId('sloHealthPanelCtaConfirm');
+    await waitFor(() => expect(confirm).toHaveTextContent('Suggest SLOs for 2 services'));
+
+    // A health refresh marks `foo` as now covered (owns its canonical pair).
+    const refreshed = new Map<string, SloHealthBucket>(uncovered);
+    refreshed.set('foo', makeBucket({ missingCanonicalPair: false }));
+    rerender(
+      <SloHealthPanel
+        aggregate={makeBucket({ total: 2, ok: 2 })}
+        bySvc={refreshed}
+        allServices={['foo', 'baz']}
+        isLoading={false}
+        error={undefined}
+        onRetry={jest.fn()}
+      />
+    );
+
+    // `foo` is pruned from the selection — count drops to 1 and confirm
+    // navigates with only the still-valid pick, never the covered service.
+    await waitFor(() => expect(confirm).toHaveTextContent('Suggest SLOs for 1 service'));
+    fireEvent.click(confirm);
+    expect(mockNavigateToApp).toHaveBeenLastCalledWith('observability-apm-slo', {
+      path: '#/slos/suggest?source=apm&services=baz',
+    });
+  });
+
   it('shows a filled (primary) trigger when closed and a neutral one when open', async () => {
     render(
       <SloHealthPanel
@@ -388,23 +433,26 @@ describe('SloHealthPanel', () => {
 
   it('does not show the skeleton before the 150ms grace timer elapses', () => {
     jest.useFakeTimers();
-    render(
-      <SloHealthPanel
-        aggregate={makeBucket()}
-        bySvc={new Map()}
-        allServices={[]}
-        isLoading
-        error={undefined}
-        onRetry={jest.fn()}
-      />
-    );
-    expect(screen.queryByTestId('sloHealthPanelSkeleton')).toBeNull();
-    expect(screen.getByTestId('sloHealthPanelLoadingPlaceholder')).toBeInTheDocument();
-    act(() => {
-      jest.advanceTimersByTime(160);
-    });
-    expect(screen.getByTestId('sloHealthPanelSkeleton')).toBeInTheDocument();
-    jest.useRealTimers();
+    try {
+      render(
+        <SloHealthPanel
+          aggregate={makeBucket()}
+          bySvc={new Map()}
+          allServices={[]}
+          isLoading
+          error={undefined}
+          onRetry={jest.fn()}
+        />
+      );
+      expect(screen.queryByTestId('sloHealthPanelSkeleton')).toBeNull();
+      expect(screen.getByTestId('sloHealthPanelLoadingPlaceholder')).toBeInTheDocument();
+      act(() => {
+        jest.advanceTimersByTime(160);
+      });
+      expect(screen.getByTestId('sloHealthPanelSkeleton')).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('renders an inline error with retry link on generic failure', () => {

--- a/public/components/apm/pages/services_home/slo_health_panel.scss
+++ b/public/components/apm/pages/services_home/slo_health_panel.scss
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Width shared by the suggest-picker popover panel and its empty message.
+$sloHealthPickerWidth: 300px;
+
+.sloHealthPicker {
+  &__panel {
+    width: $sloHealthPickerWidth;
+  }
+
+  &__empty {
+    width: $sloHealthPickerWidth;
+    padding: 12px;
+  }
+
+  // Padding around the EuiSelectable search box inside the popover.
+  &__search {
+    padding: 8px 8px 0;
+  }
+}
+
+// Reserve height so the header doesn't reflow when the skeleton appears.
+.sloHealthPanel__loadingPlaceholder {
+  height: 20px;
+}
+
+// Fixed width for the per-row loading skeleton so the column doesn't jump.
+.sloHealthCell__loading {
+  width: 80px;
+}

--- a/public/components/apm/pages/services_home/slo_health_panel.scss
+++ b/public/components/apm/pages/services_home/slo_health_panel.scss
@@ -3,31 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Width shared by the suggest-picker popover panel and its empty message.
-$sloHealthPickerWidth: 300px;
-
-.sloHealthPicker {
+.slo-health-picker {
   &__panel {
-    width: $sloHealthPickerWidth;
+    width: 300px;
   }
 
   &__empty {
-    width: $sloHealthPickerWidth;
-    padding: 12px;
-  }
-
-  // Padding around the EuiSelectable search box inside the popover.
-  &__search {
-    padding: 8px 8px 0;
+    width: 300px;
+    padding: $euiSizeM;
   }
 }
 
 // Reserve height so the header doesn't reflow when the skeleton appears.
-.sloHealthPanel__loadingPlaceholder {
+.slo-health-panel__loading-placeholder {
   height: 20px;
 }
 
 // Fixed width for the per-row loading skeleton so the column doesn't jump.
-.sloHealthCell__loading {
+.slo-health-cell__loading {
   width: 80px;
 }

--- a/public/components/apm/pages/services_home/slo_health_panel.tsx
+++ b/public/components/apm/pages/services_home/slo_health_panel.tsx
@@ -25,6 +25,8 @@ import {
   EuiLink,
   EuiLoadingContent,
   EuiPanel,
+  EuiPopover,
+  EuiSelectable,
   EuiSpacer,
   EuiText,
   EuiToolTip,
@@ -33,7 +35,9 @@ import { i18n } from '@osd/i18n';
 import { navigateToSloListing, navigateToSloSuggest } from '../../shared/utils/navigation_utils';
 import type { SloHealthAccessError, SloHealthBucket } from '../slos/slo_health_summary';
 import { ChipRow } from '../slos/slo_health_chip_row';
+import { buildServiceFilterOptions } from '../slos/service_filter_options';
 import { SloBudgetSparkline } from './slo_budget_sparkline';
+import './slo_health_panel.scss';
 
 export interface SloHealthPanelProps {
   aggregate: SloHealthBucket;
@@ -76,6 +80,22 @@ const t = {
       defaultMessage: 'Suggest SLOs for {count, plural, one {# service} other {# services}}',
       values: { count },
     }),
+  suggestPick: i18n.translate('observability.apm.services.sloHealth.suggestPick', {
+    defaultMessage: 'Suggest SLOs',
+  }),
+  suggestPickPlaceholder: i18n.translate(
+    'observability.apm.services.sloHealth.suggestPickPlaceholder',
+    { defaultMessage: 'Filter services' }
+  ),
+  suggestPickCovered: i18n.translate('observability.apm.services.sloHealth.suggestPickCovered', {
+    defaultMessage: 'covered',
+  }),
+  suggestPickEmpty: i18n.translate('observability.apm.services.sloHealth.suggestPickEmpty', {
+    defaultMessage: 'No services to suggest SLOs for.',
+  }),
+  suggestPickClear: i18n.translate('observability.apm.services.sloHealth.suggestPickClear', {
+    defaultMessage: 'Clear',
+  }),
   suggestDisabledTip: i18n.translate('observability.apm.services.sloHealth.suggestDisabledTip', {
     defaultMessage: 'All services have an availability and latency SLO.',
   }),
@@ -143,6 +163,137 @@ function useDelayedLoading(isLoading: boolean, delayMs = 150): boolean {
   return delayed;
 }
 
+/**
+ * Dropdown picker for the SLO-suggest CTA. Lists every service in the table,
+ * disabling the ones whose canonical availability+latency pair already exists
+ * ("covered"). Nothing is checked on open — the user opts services in — and
+ * confirming navigates to the Suggest SLOs page scoped to the picks.
+ */
+const SloSuggestPicker: React.FC<{
+  allServices: string[];
+  coveredSet: Set<string>;
+  isLoading: boolean;
+}> = ({ allServices, coveredSet, isLoading }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [picked, setPicked] = useState<Set<string>>(new Set());
+
+  const options = useMemo(
+    () =>
+      // Shared builder: covered services disabled, checked services floated to
+      // the top so the current selection stays visible as the list scrolls.
+      buildServiceFilterOptions(allServices, picked, coveredSet).map((opt) => ({
+        label: opt.label,
+        checked: opt.checked,
+        disabled: opt.disabled,
+        append: opt.covered ? (
+          <EuiText size="xs" color="success">
+            {t.suggestPickCovered}
+          </EuiText>
+        ) : undefined,
+      })),
+    [allServices, coveredSet, picked]
+  );
+
+  const onChange = useCallback(
+    (newOptions: Array<{ label: string; checked?: 'on'; disabled?: boolean }>) => {
+      const next = new Set<string>();
+      for (const o of newOptions) {
+        if (o.checked === 'on' && !coveredSet.has(o.label)) next.add(o.label);
+      }
+      setPicked(next);
+    },
+    [coveredSet]
+  );
+
+  const onConfirm = useCallback(() => {
+    if (picked.size === 0) return;
+    setIsOpen(false);
+    navigateToSloSuggest([...picked]);
+  }, [picked]);
+
+  const clearAll = useCallback(() => setPicked(new Set()), []);
+
+  const allCovered = allServices.length > 0 && allServices.every((s) => coveredSet.has(s));
+
+  return (
+    <EuiPopover
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      panelPaddingSize="none"
+      anchorPosition="downRight"
+      button={
+        <EuiToolTip content={allCovered && !isLoading ? t.suggestDisabledTip : undefined}>
+          <EuiButton
+            // Fill (primary) while closed to draw attention to opening it; once
+            // open, drop to a neutral trigger so the footer's "Suggest SLOs for
+            // N" button is the single primary action in view.
+            fill={!isOpen}
+            iconType="arrowDown"
+            iconSide="right"
+            size="s"
+            isLoading={isLoading}
+            isDisabled={!isLoading && allCovered}
+            onClick={() => setIsOpen((prev) => !prev)}
+            data-test-subj="sloHealthPanelCta"
+          >
+            {picked.size === 0 ? t.suggestPick : t.suggestCta(picked.size)}
+          </EuiButton>
+        </EuiToolTip>
+      }
+    >
+      {allServices.length === 0 ? (
+        <EuiText size="s" color="subdued" className="sloHealthPicker__empty">
+          {t.suggestPickEmpty}
+        </EuiText>
+      ) : (
+        <div className="sloHealthPicker__panel">
+          <EuiSelectable
+            searchable
+            searchProps={{ compressed: true, placeholder: t.suggestPickPlaceholder }}
+            options={options}
+            onChange={onChange}
+            listProps={{ bordered: false }}
+            height={240}
+          >
+            {(list, search) => (
+              <>
+                <div className="sloHealthPicker__search">{search}</div>
+                {list}
+              </>
+            )}
+          </EuiSelectable>
+          <EuiPanel color="transparent" paddingSize="s">
+            <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  size="s"
+                  onClick={clearAll}
+                  isDisabled={picked.size === 0}
+                  data-test-subj="sloHealthPanelCtaClear"
+                >
+                  {t.suggestPickClear}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={true}>
+                <EuiButton
+                  fullWidth
+                  size="s"
+                  fill
+                  onClick={onConfirm}
+                  isDisabled={picked.size === 0}
+                  data-test-subj="sloHealthPanelCtaConfirm"
+                >
+                  {picked.size === 0 ? t.suggestPick : t.suggestCta(picked.size)}
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
+        </div>
+      )}
+    </EuiPopover>
+  );
+};
+
 export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
   aggregate,
   bySvc,
@@ -154,21 +305,18 @@ export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
 }) => {
   const showSkeleton = useDelayedLoading(isLoading);
 
-  const missingPairServices = useMemo(() => {
-    const out: string[] = [];
-    // Only include services we actually have data for — stale `allServices`
-    // entries that are missing from `bySvc` aren't "known to be missing", so
-    // don't silently seed the CTA CSV with them.
+  // Services whose canonical availability+latency pair already exists. These
+  // are shown but disabled in the picker so the user can't request duplicate
+  // suggestions. A service missing from `bySvc` isn't known to be covered, so
+  // it stays enabled (pickable).
+  const coveredSet = useMemo(() => {
+    const set = new Set<string>();
     for (const name of allServices) {
       const bucket = bySvc.get(name);
-      if (bucket?.missingCanonicalPair) out.push(name);
+      if (bucket && !bucket.missingCanonicalPair) set.add(name);
     }
-    return out;
+    return set;
   }, [allServices, bySvc]);
-
-  const onClickSuggest = useCallback(() => {
-    navigateToSloSuggest(missingPairServices);
-  }, [missingPairServices]);
 
   const onClickViewAll = useCallback(() => {
     navigateToSloListing(allServices);
@@ -179,6 +327,7 @@ export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
       <>
         <EuiPanel hasBorder paddingSize="m" data-test-subj="sloHealthPanel">
           <EuiCallOut
+            announceOnMount
             size="s"
             color="warning"
             iconType="lock"
@@ -225,7 +374,10 @@ export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
                   ) : (
                     // Reserve vertical height so the panel doesn't reflow when
                     // the skeleton appears at t=150ms.
-                    <div style={{ height: 20 }} data-test-subj="sloHealthPanelLoadingPlaceholder" />
+                    <div
+                      className="sloHealthPanel__loadingPlaceholder"
+                      data-test-subj="sloHealthPanelLoadingPlaceholder"
+                    />
                   )
                 ) : aggregate.total === 0 ? (
                   <EuiText size="s" color="subdued" data-test-subj="sloHealthPanelEmpty">
@@ -242,25 +394,11 @@ export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
             <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
               {!error && (
                 <EuiFlexItem grow={false}>
-                  <EuiToolTip
-                    content={
-                      missingPairServices.length === 0 && !isLoading
-                        ? t.suggestDisabledTip
-                        : undefined
-                    }
-                  >
-                    <EuiButton
-                      fill
-                      iconType="wand"
-                      size="s"
-                      isLoading={isLoading}
-                      isDisabled={!isLoading && missingPairServices.length === 0}
-                      onClick={onClickSuggest}
-                      data-test-subj="sloHealthPanelCta"
-                    >
-                      {t.suggestCta(missingPairServices.length)}
-                    </EuiButton>
-                  </EuiToolTip>
+                  <SloSuggestPicker
+                    allServices={allServices}
+                    coveredSet={coveredSet}
+                    isLoading={isLoading}
+                  />
                 </EuiFlexItem>
               )}
               <EuiFlexItem grow={false}>
@@ -404,6 +542,7 @@ const SloHealthCellUI: React.FC<SloHealthCellProps> = ({
           type="lock"
           color="subdued"
           data-test-subj={`sloHealthCellForbidden-${serviceName}`}
+          aria-hidden={true}
         />
       </EuiToolTip>
     );
@@ -411,13 +550,21 @@ const SloHealthCellUI: React.FC<SloHealthCellProps> = ({
   if (error) {
     return (
       <EuiToolTip content={t.cellLoadError}>
-        <EuiIcon type="alert" color="danger" data-test-subj={`sloHealthCellError-${serviceName}`} />
+        <EuiIcon
+          type="alert"
+          color="danger"
+          data-test-subj={`sloHealthCellError-${serviceName}`}
+          aria-hidden={true}
+        />
       </EuiToolTip>
     );
   }
   if (isLoading && !bucket) {
     return (
-      <div style={{ width: 80 }} data-test-subj={`sloHealthCellLoading-${serviceName}`}>
+      <div
+        className="sloHealthCell__loading"
+        data-test-subj={`sloHealthCellLoading-${serviceName}`}
+      >
         <EuiLoadingContent lines={1} />
       </div>
     );
@@ -477,6 +624,7 @@ const SloHealthCellUI: React.FC<SloHealthCellProps> = ({
               type="alert"
               color="warning"
               data-test-subj={`sloHealthMissingPairIcon-${serviceName}`}
+              aria-hidden={true}
             />
           </EuiToolTip>
         </EuiFlexItem>

--- a/public/components/apm/pages/services_home/slo_health_panel.tsx
+++ b/public/components/apm/pages/services_home/slo_health_panel.tsx
@@ -26,7 +26,6 @@ import {
   EuiLoadingContent,
   EuiPanel,
   EuiPopover,
-  EuiSelectable,
   EuiSpacer,
   EuiText,
   EuiToolTip,
@@ -35,7 +34,7 @@ import { i18n } from '@osd/i18n';
 import { navigateToSloListing, navigateToSloSuggest } from '../../shared/utils/navigation_utils';
 import type { SloHealthAccessError, SloHealthBucket } from '../slos/slo_health_summary';
 import { ChipRow } from '../slos/slo_health_chip_row';
-import { buildServiceFilterOptions } from '../slos/service_filter_options';
+import { ServiceFilterSelectable } from '../slos/service_filter_selectable';
 import { SloBudgetSparkline } from './slo_budget_sparkline';
 import './slo_health_panel.scss';
 
@@ -82,13 +81,6 @@ const t = {
     }),
   suggestPick: i18n.translate('observability.apm.services.sloHealth.suggestPick', {
     defaultMessage: 'Suggest SLOs',
-  }),
-  suggestPickPlaceholder: i18n.translate(
-    'observability.apm.services.sloHealth.suggestPickPlaceholder',
-    { defaultMessage: 'Filter services' }
-  ),
-  suggestPickCovered: i18n.translate('observability.apm.services.sloHealth.suggestPickCovered', {
-    defaultMessage: 'covered',
   }),
   suggestPickEmpty: i18n.translate('observability.apm.services.sloHealth.suggestPickEmpty', {
     defaultMessage: 'No services to suggest SLOs for.',
@@ -177,33 +169,20 @@ const SloSuggestPicker: React.FC<{
   const [isOpen, setIsOpen] = useState(false);
   const [picked, setPicked] = useState<Set<string>>(new Set());
 
-  const options = useMemo(
-    () =>
-      // Shared builder: covered services disabled, checked services floated to
-      // the top so the current selection stays visible as the list scrolls.
-      buildServiceFilterOptions(allServices, picked, coveredSet).map((opt) => ({
-        label: opt.label,
-        checked: opt.checked,
-        disabled: opt.disabled,
-        append: opt.covered ? (
-          <EuiText size="xs" color="success">
-            {t.suggestPickCovered}
-          </EuiText>
-        ) : undefined,
-      })),
-    [allServices, coveredSet, picked]
-  );
+  // Prune picks that no longer make sense as the data refreshes: a service that
+  // dropped out of discovery, or one that became covered while the popover was
+  // open, must not linger in `picked` — otherwise the CTA count inflates and
+  // `onConfirm` would navigate with a stale/covered service. Runs on every
+  // props change; only rebuilds the set when something actually falls out.
+  useEffect(() => {
+    setPicked((prev) => {
+      const allServiceSet = new Set(allServices);
+      const next = new Set([...prev].filter((s) => allServiceSet.has(s) && !coveredSet.has(s)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [allServices, coveredSet]);
 
-  const onChange = useCallback(
-    (newOptions: Array<{ label: string; checked?: 'on'; disabled?: boolean }>) => {
-      const next = new Set<string>();
-      for (const o of newOptions) {
-        if (o.checked === 'on' && !coveredSet.has(o.label)) next.add(o.label);
-      }
-      setPicked(next);
-    },
-    [coveredSet]
-  );
+  const onSelectionChange = useCallback((sel: string[]) => setPicked(new Set(sel)), []);
 
   const onConfirm = useCallback(() => {
     if (picked.size === 0) return;
@@ -242,26 +221,17 @@ const SloSuggestPicker: React.FC<{
       }
     >
       {allServices.length === 0 ? (
-        <EuiText size="s" color="subdued" className="sloHealthPicker__empty">
+        <EuiText size="s" color="subdued" className="slo-health-picker__empty">
           {t.suggestPickEmpty}
         </EuiText>
       ) : (
-        <div className="sloHealthPicker__panel">
-          <EuiSelectable
-            searchable
-            searchProps={{ compressed: true, placeholder: t.suggestPickPlaceholder }}
-            options={options}
-            onChange={onChange}
-            listProps={{ bordered: false }}
-            height={240}
-          >
-            {(list, search) => (
-              <>
-                <div className="sloHealthPicker__search">{search}</div>
-                {list}
-              </>
-            )}
-          </EuiSelectable>
+        <div className="slo-health-picker__panel">
+          <ServiceFilterSelectable
+            serviceNames={allServices}
+            selectedSet={picked}
+            coveredSet={coveredSet}
+            onSelectionChange={onSelectionChange}
+          />
           <EuiPanel color="transparent" paddingSize="s">
             <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
               <EuiFlexItem grow={false}>
@@ -375,7 +345,7 @@ export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
                     // Reserve vertical height so the panel doesn't reflow when
                     // the skeleton appears at t=150ms.
                     <div
-                      className="sloHealthPanel__loadingPlaceholder"
+                      className="slo-health-panel__loading-placeholder"
                       data-test-subj="sloHealthPanelLoadingPlaceholder"
                     />
                   )
@@ -562,7 +532,7 @@ const SloHealthCellUI: React.FC<SloHealthCellProps> = ({
   if (isLoading && !bucket) {
     return (
       <div
-        className="sloHealthCell__loading"
+        className="slo-health-cell__loading"
         data-test-subj={`sloHealthCellLoading-${serviceName}`}
       >
         <EuiLoadingContent lines={1} />

--- a/public/components/apm/pages/services_home/slo_health_panel.tsx
+++ b/public/components/apm/pages/services_home/slo_health_panel.tsx
@@ -307,7 +307,6 @@ export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
       <>
         <EuiPanel hasBorder paddingSize="m" data-test-subj="sloHealthPanel">
           <EuiCallOut
-            announceOnMount
             size="s"
             color="warning"
             iconType="lock"

--- a/public/components/apm/pages/slos/__tests__/slo_suggest_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_suggest_page.test.tsx
@@ -32,6 +32,7 @@ jest.mock('../../../shared/hooks/use_services', () => ({
 }));
 
 import { SloSuggestPage } from '../slo_suggest_page';
+import { buildServiceFilterOptions } from '../service_filter_options';
 import type { SloApiClient } from '../slo_api_client';
 import type {
   ChromeStart,
@@ -42,21 +43,21 @@ import type {
 function makeHttp(): HttpStart {
   // The discovery effect fires probes + ruler fetch; resolve them all to
   // empty so the page renders without loading-spinner getting stuck.
-  return ({
+  return {
     get: jest.fn().mockImplementation((url: string) => {
       if (url.includes('/metadata/label-values/')) return Promise.resolve({ values: [] });
       if (url.includes('/rules')) return Promise.resolve({ data: { groups: [] } });
       return Promise.resolve({});
     }),
-  } as unknown) as HttpStart;
+  } as unknown as HttpStart;
 }
 
 function makeChrome(): ChromeStart {
-  return ({ setBreadcrumbs: jest.fn() } as unknown) as ChromeStart;
+  return { setBreadcrumbs: jest.fn() } as unknown as ChromeStart;
 }
 
 function makeNotifications(): NotificationsStart {
-  return ({
+  return {
     toasts: {
       addSuccess: jest.fn(),
       addDanger: jest.fn(),
@@ -64,19 +65,25 @@ function makeNotifications(): NotificationsStart {
       addInfo: jest.fn(),
       addError: jest.fn(),
     },
-  } as unknown) as NotificationsStart;
+  } as unknown as NotificationsStart;
 }
 
 function makeApiClient(): SloApiClient {
-  return ({
+  return {
     create: jest.fn().mockResolvedValue(undefined),
     preview: jest.fn().mockResolvedValue({ groupName: 'g', interval: 30, rules: [], yaml: '' }),
-  } as unknown) as SloApiClient;
+  } as unknown as SloApiClient;
 }
 
 function renderPage(
   opts: {
     rulerFails?: boolean;
+    /**
+     * URL the page mounts at. Drafts are only generated for services named in
+     * the `?services=` scope, so interactive tests that need a populated draft
+     * view pass an explicit scope. Defaults to unscoped (the empty landing).
+     */
+    initialEntry?: string;
   } = {}
 ) {
   mockUseApmConfig.mockReturnValue({
@@ -93,20 +100,20 @@ function renderPage(
     refetch: jest.fn(),
   });
   const http = opts.rulerFails
-    ? (({
+    ? ({
         get: jest.fn().mockImplementation((url: string) => {
           if (url.includes('/rules')) return Promise.reject(new Error('ruler down'));
           if (url.includes('/metadata/label-values/')) return Promise.resolve({ values: [] });
           return Promise.resolve({});
         }),
-      } as unknown) as HttpStart)
+      } as unknown as HttpStart)
     : makeHttp();
   // Suppress per-probe / ruler failure console.warn / .error so they don't
   // pollute the test report.
   jest.spyOn(console, 'warn').mockImplementation(() => {});
   const apiClient = makeApiClient();
   const result = render(
-    <MemoryRouter initialEntries={['/slos/suggest']}>
+    <MemoryRouter initialEntries={[opts.initialEntry ?? '/slos/suggest']}>
       <SloSuggestPage
         apiClient={apiClient}
         http={http}
@@ -119,6 +126,10 @@ function renderPage(
   return { ...result, apiClient };
 }
 
+// Scope both mocked services so drafts are generated (unscoped renders the
+// "pick services" empty state instead).
+const SCOPED_ENTRY = '/slos/suggest?source=apm&services=cart,checkout';
+
 describe('SloSuggestPage', () => {
   afterEach(() => {
     mockUseApmConfig.mockReset();
@@ -129,7 +140,7 @@ describe('SloSuggestPage', () => {
   it('mounts with mocked services and renders the page chrome', async () => {
     renderPage();
     expect(await screen.findByTestId('slosSuggestPage')).toBeInTheDocument();
-    expect(screen.getByTestId('slosSuggestDiscover')).toBeInTheDocument();
+    expect(screen.getByTestId('slosSuggestPreviewToggle')).toBeInTheDocument();
     expect(screen.getByTestId('slosSuggestCreate')).toBeInTheDocument();
   });
 
@@ -138,34 +149,81 @@ describe('SloSuggestPage', () => {
     expect(await screen.findByTestId('slosSuggestRulerFetchFailed')).toBeInTheDocument();
   });
 
-  it('disables the create button when no rows are selected', async () => {
+  it('shows the "pick services" empty state (and no drafts) when unscoped', async () => {
     renderPage();
-    // Click "Clear" to reset the default selection (Suggest defaults to all
-    // selected) so the create button drops to disabled.
+    await screen.findByTestId('slosSuggestPage');
+    // The service picker is available so the user can scope, but no drafts
+    // (and no stats strip) are rendered until they pick.
+    expect(await screen.findByTestId('slosSuggestPickServices')).toBeInTheDocument();
+    expect(screen.getByTestId('slosSuggestServiceFilter')).toBeInTheDocument();
+    expect(screen.getByText('Select services')).toBeInTheDocument();
+    expect(screen.queryByTestId('slosSuggestHeaderStrip')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slosSuggestTable')).not.toBeInTheDocument();
+  });
+
+  it('generates drafts and shows the stats strip when a scope is present', async () => {
+    renderPage({ initialEntry: SCOPED_ENTRY });
+    await screen.findByTestId('slosSuggestPage');
+    expect(await screen.findByTestId('slosSuggestHeaderStrip')).toBeInTheDocument();
+    expect(screen.getByTestId('slosSuggestTable')).toBeInTheDocument();
+    expect(screen.queryByTestId('slosSuggestPickServices')).not.toBeInTheDocument();
+    // Button reflects the scoped count, not "Select services" or "0 services".
+    expect(screen.getByText('Suggest SLOs for 2 services')).toBeInTheDocument();
+  });
+
+  it('defaults scoped drafts to selected so the create button is enabled', async () => {
+    renderPage({ initialEntry: SCOPED_ENTRY });
     await screen.findByTestId('slosSuggestPage');
     await waitFor(() => expect(screen.getByTestId('slosSuggestHeaderStrip')).toBeInTheDocument());
-    fireEvent.click(screen.getByText('Clear'));
+    // A scoped page lands with every uncovered draft selected — no top-level
+    // Select all / Clear links exist anymore.
+    expect(screen.queryByText('Select all')).not.toBeInTheDocument();
+    expect(screen.getByTestId('slosSuggestCreate')).not.toBeDisabled();
+  });
+
+  it('disables the create button when every service is deselected', async () => {
+    renderPage({ initialEntry: SCOPED_ENTRY });
+    await screen.findByTestId('slosSuggestPage');
+    await waitFor(() => expect(screen.getByTestId('slosSuggestHeaderStrip')).toBeInTheDocument());
+    // Uncheck each service's master checkbox to clear the default selection.
+    fireEvent.click(screen.getByTestId('slosSuggestServiceSelect-cart'));
+    fireEvent.click(screen.getByTestId('slosSuggestServiceSelect-checkout'));
     await waitFor(() => expect(screen.getByTestId('slosSuggestCreate')).toBeDisabled());
   });
 
   it('opens and closes the confirm modal', async () => {
-    renderPage();
+    renderPage({ initialEntry: SCOPED_ENTRY });
     await screen.findByTestId('slosSuggestPage');
     await waitFor(() => expect(screen.getByTestId('slosSuggestHeaderStrip')).toBeInTheDocument());
+    // Drafts default to selected, so create is immediately actionable.
+    await waitFor(() => expect(screen.getByTestId('slosSuggestCreate')).not.toBeDisabled());
     fireEvent.click(screen.getByTestId('slosSuggestCreate'));
     expect(await screen.findByTestId('slosSuggestConfirmModal')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Cancel'));
+    fireEvent.click(screen.getByTestId('confirmModalCancelButton'));
     await waitFor(() =>
       expect(screen.queryByTestId('slosSuggestConfirmModal')).not.toBeInTheDocument()
     );
   });
 
   it('renders the preview flyout when "Preview" is clicked', async () => {
-    renderPage();
+    renderPage({ initialEntry: SCOPED_ENTRY });
     await screen.findByTestId('slosSuggestPage');
     await waitFor(() => expect(screen.getByTestId('slosSuggestPreviewToggle')).toBeInTheDocument());
+    // Preview is enabled because scoped drafts default to selected.
+    await waitFor(() => expect(screen.getByTestId('slosSuggestPreviewToggle')).not.toBeDisabled());
     fireEvent.click(screen.getByTestId('slosSuggestPreviewToggle'));
     expect(await screen.findByTestId('slosSuggestPreviewFlyout')).toBeInTheDocument();
+  });
+
+  it('clears the service scope from the filter dropdown, returning to the empty state', async () => {
+    renderPage({ initialEntry: SCOPED_ENTRY });
+    await screen.findByTestId('slosSuggestPage');
+    await waitFor(() => expect(screen.getByTestId('slosSuggestHeaderStrip')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('slosSuggestServiceFilter'));
+    fireEvent.click(await screen.findByTestId('slosSuggestServiceFilterClear'));
+    // Scope cleared → drafts gone → the "pick services" empty state returns.
+    expect(await screen.findByTestId('slosSuggestPickServices')).toBeInTheDocument();
+    expect(screen.queryByTestId('slosSuggestHeaderStrip')).not.toBeInTheDocument();
   });
 
   it('renders the no-datasource warning when prometheusDataSource is missing', async () => {
@@ -192,5 +250,50 @@ describe('SloSuggestPage', () => {
       </MemoryRouter>
     );
     expect(await screen.findByText(/No Prometheus datasource configured/)).toBeInTheDocument();
+  });
+});
+
+describe('buildServiceFilterOptions', () => {
+  it('checks in-scope services and leaves the rest unchecked', () => {
+    const opts = buildServiceFilterOptions(
+      ['cart', 'checkout', 'payments'],
+      new Set(['cart']),
+      new Set()
+    );
+    const byLabel = Object.fromEntries(opts.map((o) => [o.label, o]));
+    expect(byLabel.cart.checked).toBe('on');
+    expect(byLabel.checkout.checked).toBeUndefined();
+    expect(byLabel.payments.checked).toBeUndefined();
+  });
+
+  it('disables covered services and never checks them, even if in scope', () => {
+    const opts = buildServiceFilterOptions(
+      ['cart', 'payments'],
+      new Set(['cart', 'payments']),
+      new Set(['payments'])
+    );
+    const byLabel = Object.fromEntries(opts.map((o) => [o.label, o]));
+    expect(byLabel.payments.disabled).toBe(true);
+    expect(byLabel.payments.covered).toBe(true);
+    expect(byLabel.payments.checked).toBeUndefined();
+    expect(byLabel.cart.disabled).toBe(false);
+    expect(byLabel.cart.checked).toBe('on');
+  });
+
+  it('floats checked services to the top, preserving order within each group', () => {
+    const opts = buildServiceFilterOptions(
+      ['ad', 'cart', 'checkout', 'currency', 'email'],
+      new Set(['checkout', 'email']),
+      new Set()
+    );
+    expect(opts.map((o) => o.label)).toEqual([
+      // checked, in original order…
+      'checkout',
+      'email',
+      // …then unchecked, in original order.
+      'ad',
+      'cart',
+      'currency',
+    ]);
   });
 });

--- a/public/components/apm/pages/slos/__tests__/slo_suggest_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_suggest_page.test.tsx
@@ -56,6 +56,7 @@ function fakeDraft(key: string, service: string, existingRuleMatch = false) {
       spec: {
         service,
         name: key,
+        owner: { teams: ['t'] },
         objectives: [{ name: 'o', target: 0.99 }],
         sli: {
           type: 'single',
@@ -165,6 +166,40 @@ function renderPage(
 // Scope both mocked services so drafts are generated (unscoped renders the
 // "pick services" empty state instead).
 const SCOPED_ENTRY = '/slos/suggest?source=apm&services=cart,checkout';
+
+/** Seed the config + services hooks the page reads (for tests that render the
+ *  page directly, e.g. to drive rerenders, rather than via `renderPage`). */
+function seedPageMocks() {
+  mockUseApmConfig.mockReturnValue({
+    config: { prometheusDataSource: { name: 'prom-1' } },
+    loading: false,
+  });
+  mockUseServices.mockReturnValue({
+    data: [
+      { serviceName: 'cart', environment: 'prod' },
+      { serviceName: 'checkout', environment: 'prod' },
+    ],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  });
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+}
+
+/** The scoped page element, for render + rerender in state-machine tests. */
+function scopedPage() {
+  return (
+    <MemoryRouter initialEntries={[SCOPED_ENTRY]}>
+      <SloSuggestPage
+        apiClient={makeApiClient()}
+        http={makeHttp()}
+        chrome={makeChrome()}
+        notifications={makeNotifications()}
+        parentBreadcrumb={{ text: 'APM', href: '#/' }}
+      />
+    </MemoryRouter>
+  );
+}
 
 describe('SloSuggestPage', () => {
   beforeEach(() => {
@@ -343,6 +378,62 @@ describe('SloSuggestPage', () => {
     // The covered draft is called out in the subline.
     expect(screen.getByTestId('slosSuggestHeaderSubline')).toHaveTextContent(
       '1 draft already covered by existing rules'
+    );
+  });
+
+  it('deselects an untouched draft when coverage resolves late', async () => {
+    seedPageMocks();
+    // First paint: both drafts uncovered (ruler not yet resolved) → both selected.
+    mockGenerateSuggestions.mockReturnValue([
+      fakeDraft('cart-avail', 'cart', false),
+      fakeDraft('cart-lat', 'cart', false),
+    ]);
+    const { rerender } = render(scopedPage());
+    await screen.findByTestId('slosSuggestPage');
+    await waitFor(() =>
+      expect(screen.getByTestId('slosSuggestCreate')).toHaveTextContent('Create 2 SLOs')
+    );
+
+    // Ruler resolves: cart-avail now matches an existing rule. The user never
+    // touched it, so the late coverage signal must deselect it.
+    mockGenerateSuggestions.mockReturnValue([
+      fakeDraft('cart-avail', 'cart', true),
+      fakeDraft('cart-lat', 'cart', false),
+    ]);
+    rerender(scopedPage());
+    await waitFor(() =>
+      expect(screen.getByTestId('slosSuggestCreate')).toHaveTextContent('Create 1 SLO')
+    );
+  });
+
+  it('preserves a manual toggle when the draft set recomputes', async () => {
+    seedPageMocks();
+    mockGenerateSuggestions.mockReturnValue([
+      fakeDraft('cart-avail', 'cart', false),
+      fakeDraft('cart-lat', 'cart', false),
+    ]);
+    const { rerender } = render(scopedPage());
+    await screen.findByTestId('slosSuggestPage');
+    await waitFor(() =>
+      expect(screen.getByTestId('slosSuggestCreate')).toHaveTextContent('Create 2 SLOs')
+    );
+
+    // User expands cart and unchecks the latency draft themselves.
+    fireEvent.click(screen.getByTestId('slosSuggestServiceExpand-cart'));
+    fireEvent.click(await screen.findByTestId('slosSuggestSelect-cart-lat'));
+    await waitFor(() =>
+      expect(screen.getByTestId('slosSuggestCreate')).toHaveTextContent('Create 1 SLO')
+    );
+
+    // A metadata-only recompute (same keys) must NOT re-check the user's draft.
+    mockGenerateSuggestions.mockReturnValue([
+      fakeDraft('cart-avail', 'cart', false),
+      fakeDraft('cart-lat', 'cart', false),
+    ]);
+    rerender(scopedPage());
+    // Still 1 — the manual deselection survived the recompute.
+    await waitFor(() =>
+      expect(screen.getByTestId('slosSuggestCreate')).toHaveTextContent('Create 1 SLO')
     );
   });
 });

--- a/public/components/apm/pages/slos/__tests__/slo_suggest_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_suggest_page.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 // HeaderControlledComponentsWrapper hits the chrome service; stub it.
@@ -30,6 +30,42 @@ jest.mock('../../../config/apm_config_context', () => ({
 jest.mock('../../../shared/hooks/use_services', () => ({
   useServices: (...args: unknown[]) => mockUseServices(...args),
 }));
+
+// Let individual tests control the drafts the engine returns (e.g. to inject a
+// draft already covered by an existing recording rule) without exercising the
+// full detector pipeline. Defaults to the real implementation.
+const actualEngine = jest.requireActual('../suggest_engine');
+const mockGenerateSuggestions = jest.fn();
+jest.mock('../suggest_engine', () => ({
+  ...jest.requireActual('../suggest_engine'),
+  generateSuggestionsForServices: (...args: unknown[]) => mockGenerateSuggestions(...args),
+}));
+
+/** Minimal covered/uncovered draft fixture shaped like a real Suggestion. */
+function fakeDraft(key: string, service: string, existingRuleMatch = false) {
+  return {
+    key,
+    kindId: 'apm-availability',
+    kind: 'APM availability',
+    reason: '',
+    sourceMetric: 'request',
+    detected: { service },
+    estimatedRuleCount: 13,
+    existingRuleMatch: existingRuleMatch ? { ruleName: 'r', groupName: 'g' } : undefined,
+    input: {
+      spec: {
+        service,
+        name: key,
+        objectives: [{ name: 'o', target: 0.99 }],
+        sli: {
+          type: 'single',
+          definition: { backend: 'prometheus', type: 'availability', calcMethod: 'events' },
+          dimensions: [],
+        },
+      },
+    },
+  };
+}
 
 import { SloSuggestPage } from '../slo_suggest_page';
 import { buildServiceFilterOptions } from '../service_filter_options';
@@ -131,9 +167,16 @@ function renderPage(
 const SCOPED_ENTRY = '/slos/suggest?source=apm&services=cart,checkout';
 
 describe('SloSuggestPage', () => {
+  beforeEach(() => {
+    // Default: delegate to the real detector pipeline. Tests that need a
+    // specific draft set override this per-test.
+    mockGenerateSuggestions.mockImplementation(actualEngine.generateSuggestionsForServices);
+  });
+
   afterEach(() => {
     mockUseApmConfig.mockReset();
     mockUseServices.mockReset();
+    mockGenerateSuggestions.mockReset();
     jest.restoreAllMocks();
   });
 
@@ -215,6 +258,39 @@ describe('SloSuggestPage', () => {
     expect(await screen.findByTestId('slosSuggestPreviewFlyout')).toBeInTheDocument();
   });
 
+  it('resizes the preview flyout by dragging the handle and cleans up on mouse up', async () => {
+    renderPage({ initialEntry: SCOPED_ENTRY });
+    await screen.findByTestId('slosSuggestPage');
+    await waitFor(() => expect(screen.getByTestId('slosSuggestPreviewToggle')).not.toBeDisabled());
+    fireEvent.click(screen.getByTestId('slosSuggestPreviewToggle'));
+    const flyout = await screen.findByTestId('slosSuggestPreviewFlyout');
+    const handle = screen.getByTestId('slosSuggestPreviewFlyoutResizeHandle');
+
+    const widthBefore = flyout.getBoundingClientRect().width || parseFloat(flyout.style.width) || 0;
+
+    // Press on the handle → cursor + user-select locked globally while dragging.
+    fireEvent.mouseDown(handle, { clientX: 800 });
+    expect(document.body.style.cursor).toBe('col-resize');
+    expect(document.body.style.userSelect).toBe('none');
+
+    // Drag left (smaller clientX) → the flyout, docked right, grows wider.
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 600 }));
+    });
+    await waitFor(() => {
+      const widthAfter =
+        flyout.getBoundingClientRect().width || parseFloat(flyout.style.width) || 0;
+      expect(widthAfter).toBeGreaterThan(widthBefore);
+    });
+
+    // Releasing clears the global cursor/user-select locks.
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mouseup'));
+    });
+    expect(document.body.style.cursor).toBe('');
+    expect(document.body.style.userSelect).toBe('');
+  });
+
   it('clears the service scope from the filter dropdown, returning to the empty state', async () => {
     renderPage({ initialEntry: SCOPED_ENTRY });
     await screen.findByTestId('slosSuggestPage');
@@ -250,6 +326,24 @@ describe('SloSuggestPage', () => {
       </MemoryRouter>
     );
     expect(await screen.findByText(/No Prometheus datasource configured/)).toBeInTheDocument();
+  });
+
+  it('leaves already-covered drafts unchecked and surfaces the covered subline', async () => {
+    // cart yields two drafts: one already covered by an existing rule, one not.
+    mockGenerateSuggestions.mockReturnValue([
+      fakeDraft('cart-avail', 'cart', true),
+      fakeDraft('cart-lat', 'cart', false),
+    ]);
+    renderPage({ initialEntry: SCOPED_ENTRY });
+    await screen.findByTestId('slosSuggestPage');
+    await waitFor(() => expect(screen.getByTestId('slosSuggestHeaderStrip')).toBeInTheDocument());
+
+    // Only the uncovered draft is selected by default → "Create 1 SLO".
+    expect(screen.getByTestId('slosSuggestCreate')).toHaveTextContent('Create 1 SLO');
+    // The covered draft is called out in the subline.
+    expect(screen.getByTestId('slosSuggestHeaderSubline')).toHaveTextContent(
+      '1 draft already covered by existing rules'
+    );
   });
 });
 

--- a/public/components/apm/pages/slos/__tests__/suggest_batch_preview.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/suggest_batch_preview.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 
 const mockExecuteInstantQuery = jest.fn();
 jest.mock('../../../query_services/promql_search_service', () => ({
@@ -18,8 +18,8 @@ import type { Suggestion } from '../suggest_engine';
 import type { SloApiClient } from '../slo_api_client';
 import type { GeneratedRuleGroup } from '../../../../../../common/slo/slo_types';
 
-function fakeSuggestion(key: string): Suggestion {
-  return ({
+function fakeSuggestion(key: string, service = 'cart'): Suggestion {
+  return {
     key,
     kindId: 'http-availability',
     kind: 'HTTP availability',
@@ -33,7 +33,7 @@ function fakeSuggestion(key: string): Suggestion {
         name: key,
         enabled: true,
         mode: 'active',
-        service: 'cart',
+        service,
         owner: { teams: ['t'] },
         sli: {
           type: 'single',
@@ -61,7 +61,7 @@ function fakeSuggestion(key: string): Suggestion {
         annotations: {},
       },
     },
-  } as unknown) as Suggestion;
+  } as unknown as Suggestion;
 }
 
 const fakeGroup: GeneratedRuleGroup = {
@@ -85,14 +85,14 @@ describe('SuggestBatchPreview', () => {
   });
 
   it('renders an empty-state message when no suggestions are selected', () => {
-    const apiClient = ({ preview: jest.fn() } as unknown) as Pick<SloApiClient, 'preview'>;
+    const apiClient = { preview: jest.fn() } as unknown as Pick<SloApiClient, 'preview'>;
     render(<SuggestBatchPreview apiClient={apiClient} selectedSuggestions={[]} />);
     expect(screen.getByText('Select at least one draft to preview.')).toBeInTheDocument();
   });
 
   it('renders a SuggestPreviewRow per suggestion after preview resolves', async () => {
     const preview = jest.fn().mockResolvedValue(fakeGroup);
-    const apiClient = ({ preview } as unknown) as Pick<SloApiClient, 'preview'>;
+    const apiClient = { preview } as unknown as Pick<SloApiClient, 'preview'>;
 
     render(
       <SuggestBatchPreview
@@ -109,7 +109,7 @@ describe('SuggestBatchPreview', () => {
   });
 
   it('exposes the SLI evaluation window selector', async () => {
-    const apiClient = ({ preview: jest.fn().mockResolvedValue(fakeGroup) } as unknown) as Pick<
+    const apiClient = { preview: jest.fn().mockResolvedValue(fakeGroup) } as unknown as Pick<
       SloApiClient,
       'preview'
     >;
@@ -126,7 +126,7 @@ describe('SuggestBatchPreview', () => {
 
   it('shows aggregate rule count after every preview resolves', async () => {
     const preview = jest.fn().mockResolvedValue(fakeGroup);
-    const apiClient = ({ preview } as unknown) as Pick<SloApiClient, 'preview'>;
+    const apiClient = { preview } as unknown as Pick<SloApiClient, 'preview'>;
     render(
       <SuggestBatchPreview
         apiClient={apiClient}
@@ -136,5 +136,34 @@ describe('SuggestBatchPreview', () => {
     await waitFor(() => {
       expect(screen.getByText(/2 rules total/)).toBeInTheDocument();
     });
+  });
+
+  it('renders one accordion group per service even when drafts are non-contiguous', async () => {
+    const preview = jest.fn().mockResolvedValue(fakeGroup);
+    const apiClient = { preview } as unknown as Pick<SloApiClient, 'preview'>;
+    // Interleave services (cart, checkout, cart) — mirrors the engine emitting
+    // detector-first, so a service's drafts aren't adjacent in the list. The
+    // grouping must still coalesce them into a single per-service accordion.
+    render(
+      <SuggestBatchPreview
+        apiClient={apiClient}
+        selectedSuggestions={[
+          fakeSuggestion('cart-avail', 'cart'),
+          fakeSuggestion('checkout-avail', 'checkout'),
+          fakeSuggestion('cart-http', 'cart'),
+        ]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('slosSuggestPreviewRow-cart-http')).toBeInTheDocument();
+    });
+    // Exactly one group per distinct service — no duplicate 'cart' group.
+    expect(screen.getAllByTestId('slosSuggestPreviewGroup-cart')).toHaveLength(1);
+    expect(screen.getAllByTestId('slosSuggestPreviewGroup-checkout')).toHaveLength(1);
+    // Both of cart's non-contiguous drafts land in the single cart group.
+    const cartGroup = screen.getByTestId('slosSuggestPreviewGroup-cart');
+    expect(within(cartGroup).getByTestId('slosSuggestPreviewRow-cart-avail')).toBeInTheDocument();
+    expect(within(cartGroup).getByTestId('slosSuggestPreviewRow-cart-http')).toBeInTheDocument();
   });
 });

--- a/public/components/apm/pages/slos/__tests__/suggest_batch_preview.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/suggest_batch_preview.test.tsx
@@ -166,4 +166,42 @@ describe('SuggestBatchPreview', () => {
     expect(within(cartGroup).getByTestId('slosSuggestPreviewRow-cart-avail')).toBeInTheDocument();
     expect(within(cartGroup).getByTestId('slosSuggestPreviewRow-cart-http')).toBeInTheDocument();
   });
+
+  /** Data-frame scalar as the PromQL search service returns it. */
+  function valueFrame(n: number) {
+    return { fields: [{ name: 'Value', values: [n] }] };
+  }
+
+  it('shows the breaching badge when the live SLI is below target', async () => {
+    const preview = jest.fn().mockResolvedValue(fakeGroup);
+    const apiClient = { preview } as unknown as Pick<SloApiClient, 'preview'>;
+    // Availability draft (target 0.99): ratio query → 0.5 (below target),
+    // samples query → 100 (>0 so the comparison runs), p99 unused.
+    mockExecuteInstantQuery.mockImplementation(({ query }: { query: string }) => {
+      if (query.includes('http_response_status_code')) return Promise.resolve(valueFrame(0.5));
+      if (query.includes('increase(')) return Promise.resolve(valueFrame(100));
+      return Promise.resolve(valueFrame(NaN));
+    });
+
+    render(
+      <SuggestBatchPreview
+        apiClient={apiClient}
+        selectedSuggestions={[fakeSuggestion('a')]}
+        prometheusConnectionId="prom-1"
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('1 breaching')).toBeInTheDocument());
+  });
+
+  it('shows the failed badge when a preview request rejects', async () => {
+    const preview = jest.fn().mockRejectedValue(new Error('preview boom'));
+    const apiClient = { preview } as unknown as Pick<SloApiClient, 'preview'>;
+
+    render(
+      <SuggestBatchPreview apiClient={apiClient} selectedSuggestions={[fakeSuggestion('a')]} />
+    );
+
+    await waitFor(() => expect(screen.getByText('1 failed')).toBeInTheDocument());
+  });
 });

--- a/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
@@ -4,12 +4,12 @@
  */
 
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ServiceRowShape, ServiceTreeTable } from '../suggest_service_tree_table';
 import type { Suggestion } from '../suggest_engine';
 
 function fakeSuggestion(key: string, kind = 'HTTP availability'): Suggestion {
-  return ({
+  return {
     key,
     kindId: 'http-availability',
     kind,
@@ -51,7 +51,7 @@ function fakeSuggestion(key: string, kind = 'HTTP availability'): Suggestion {
         annotations: {},
       },
     },
-  } as unknown) as Suggestion;
+  } as unknown as Suggestion;
 }
 
 function row(overrides: Partial<ServiceRowShape> = {}): ServiceRowShape {
@@ -151,10 +151,10 @@ describe('ServiceTreeTable', () => {
         onOverrideChange={jest.fn()}
       />
     );
-    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('3 covered')).toBeInTheDocument();
   });
 
-  it('renders the selection badge with the correct counts', () => {
+  it('renders the selection count with the correct values', () => {
     render(
       <ServiceTreeTable
         serviceRows={[row({ selectedCount: 1 })]}
@@ -167,8 +167,7 @@ describe('ServiceTreeTable', () => {
         onOverrideChange={jest.fn()}
       />
     );
-    const badge = screen.getByTestId('slosSuggestSelectionBadge-cart');
-    expect(badge).toHaveTextContent('1 / 2 selected');
+    expect(screen.getByText('1/2 SLOs selected')).toBeInTheDocument();
   });
 
   it('caps SLI mix badges and renders an overflow badge', () => {
@@ -198,5 +197,42 @@ describe('ServiceTreeTable', () => {
       />
     );
     expect(screen.getByText('+2 more')).toBeInTheDocument();
+  });
+
+  it('clears the SLI-mix popover close timer on unmount without a setState warning', () => {
+    jest.useFakeTimers();
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const { unmount } = render(
+        <ServiceTreeTable
+          serviceRows={[row()]}
+          expandedMap={{}}
+          onToggleExpand={jest.fn()}
+          onToggleServiceSelection={jest.fn()}
+          selected={new Set()}
+          overrides={{}}
+          onToggleDraft={jest.fn()}
+          onOverrideChange={jest.fn()}
+        />
+      );
+      // Open a badge popover (hover), then leave to arm the 150ms close timer.
+      const badge = screen.getAllByText('HTTP availability')[0];
+      fireEvent.mouseEnter(badge);
+      fireEvent.mouseLeave(badge);
+      // Unmount with the timer still pending, then let it fire.
+      unmount();
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(errSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('not wrapped in act'),
+        expect.anything(),
+        expect.anything()
+      );
+      expect(errSpy).not.toHaveBeenCalledWith(expect.stringContaining('unmounted component'));
+    } finally {
+      errSpy.mockRestore();
+      jest.useRealTimers();
+    }
   });
 });

--- a/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
@@ -235,4 +235,45 @@ describe('ServiceTreeTable', () => {
       jest.useRealTimers();
     }
   });
+
+  it('opens the SLI-mix popover on hover and holds it open through the grace delay', () => {
+    jest.useFakeTimers();
+    try {
+      render(
+        <ServiceTreeTable
+          serviceRows={[row({ drafts: [fakeSuggestion('a', 'HTTP availability')] })]}
+          expandedMap={{}}
+          onToggleExpand={jest.fn()}
+          onToggleServiceSelection={jest.fn()}
+          selected={new Set()}
+          overrides={{}}
+          onToggleDraft={jest.fn()}
+          onOverrideChange={jest.fn()}
+        />
+      );
+      const badge = screen.getByText('HTTP availability');
+
+      // Not open until hovered.
+      expect(screen.queryByText('Metric:')).not.toBeInTheDocument();
+
+      // Hover opens the popover — its draft detail (the "Metric:" line) appears.
+      act(() => {
+        fireEvent.mouseEnter(badge);
+      });
+      expect(screen.getByText('Metric:')).toBeInTheDocument();
+
+      // Leaving arms the close timer; the grace delay keeps it open just before
+      // the delay elapses so moving the pointer into the panel doesn't dismiss
+      // it. (The close firing + timer cleanup is covered by the unmount test.)
+      act(() => {
+        fireEvent.mouseLeave(badge);
+        jest.advanceTimersByTime(HOVER_CLOSE_DELAY_MS - 1);
+      });
+      expect(screen.getByText('Metric:')).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });
+
+const HOVER_CLOSE_DELAY_MS = 150;

--- a/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
@@ -55,10 +55,13 @@ function fakeSuggestion(key: string, kind = 'HTTP availability'): Suggestion {
 }
 
 function row(overrides: Partial<ServiceRowShape> = {}): ServiceRowShape {
+  const drafts = overrides.drafts ?? [fakeSuggestion('a'), fakeSuggestion('b')];
   return {
     serviceName: overrides.serviceName ?? 'cart',
-    drafts: overrides.drafts ?? [fakeSuggestion('a'), fakeSuggestion('b')],
+    drafts,
     selectedCount: overrides.selectedCount ?? 1,
+    // Default every draft to selectable (nothing covered) unless overridden.
+    selectableCount: overrides.selectableCount ?? drafts.length,
     totalRules: overrides.totalRules ?? 26,
     coveredCount: overrides.coveredCount ?? 0,
     kinds: overrides.kinds ?? ['HTTP availability', 'HTTP latency'],
@@ -152,6 +155,41 @@ describe('ServiceTreeTable', () => {
       />
     );
     expect(screen.getByText('3 covered')).toBeInTheDocument();
+  });
+
+  it('disables the master checkbox when the service has no selectable drafts', () => {
+    render(
+      <ServiceTreeTable
+        serviceRows={[row({ selectableCount: 0, selectedCount: 0, coveredCount: 2 })]}
+        expandedMap={{}}
+        onToggleExpand={jest.fn()}
+        onToggleServiceSelection={jest.fn()}
+        selected={new Set()}
+        overrides={{}}
+        onToggleDraft={jest.fn()}
+        onOverrideChange={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('slosSuggestServiceSelect-cart')).toBeDisabled();
+  });
+
+  it('disables the inline checkbox for drafts named in coveredKeys', () => {
+    render(
+      <ServiceTreeTable
+        serviceRows={[row({ selectableCount: 1 })]}
+        expandedMap={{ cart: true }}
+        onToggleExpand={jest.fn()}
+        onToggleServiceSelection={jest.fn()}
+        selected={new Set()}
+        overrides={{}}
+        onToggleDraft={jest.fn()}
+        onOverrideChange={jest.fn()}
+        coveredKeys={new Set(['a'])}
+      />
+    );
+    // Draft 'a' is covered → its checkbox is disabled; 'b' stays enabled.
+    expect(screen.getByTestId('slosSuggestSelect-a')).toBeDisabled();
+    expect(screen.getByTestId('slosSuggestSelect-b')).not.toBeDisabled();
   });
 
   it('renders the selection count with the correct values', () => {

--- a/public/components/apm/pages/slos/__tests__/suggest_use_discovery_probes.test.ts
+++ b/public/components/apm/pages/slos/__tests__/suggest_use_discovery_probes.test.ts
@@ -110,16 +110,19 @@ describe('useDiscoveryProbes', () => {
 
   it('does not setState after unmount', async () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    const http = makeHttp({
-      labelValues: { http_server_request_duration_seconds_count: { service_name: ['x'] } },
-    });
-    const { unmount } = renderHook(() => useDiscoveryProbes({ http, datasourceId: 'prom-1' }));
-    unmount();
-    // Drain microtasks so the in-flight effect's `.then` resolves and would
-    // attempt a setState if cancellation weren't honored.
-    await new Promise((r) => setImmediate(r));
-    // Any state-update-after-unmount would trigger React's act warning here.
-    expect(errSpy).not.toHaveBeenCalledWith(expect.stringContaining('not wrapped in act'));
-    errSpy.mockRestore();
+    try {
+      const http = makeHttp({
+        labelValues: { http_server_request_duration_seconds_count: { service_name: ['x'] } },
+      });
+      const { unmount } = renderHook(() => useDiscoveryProbes({ http, datasourceId: 'prom-1' }));
+      unmount();
+      // Drain microtasks so the in-flight effect's `.then` resolves and would
+      // attempt a setState if cancellation weren't honored.
+      await new Promise((r) => setImmediate(r));
+      // Any state-update-after-unmount would trigger React's act warning here.
+      expect(errSpy).not.toHaveBeenCalledWith(expect.stringContaining('not wrapped in act'));
+    } finally {
+      errSpy.mockRestore();
+    }
   });
 });

--- a/public/components/apm/pages/slos/__tests__/suggest_use_discovery_probes.test.ts
+++ b/public/components/apm/pages/slos/__tests__/suggest_use_discovery_probes.test.ts
@@ -27,7 +27,7 @@ function makeHttp(implementations: {
     }
     return {};
   });
-  return ({ get } as unknown) as HttpStart;
+  return { get } as unknown as HttpStart;
 }
 
 describe('useDiscoveryProbes', () => {
@@ -43,7 +43,7 @@ describe('useDiscoveryProbes', () => {
 
   it('returns empty defaults and never fetches when datasourceId is empty', () => {
     const http = makeHttp({});
-    const { result } = renderHook(() => useDiscoveryProbes({ http, datasourceId: '', epoch: 0 }));
+    const { result } = renderHook(() => useDiscoveryProbes({ http, datasourceId: '' }));
     expect(result.current.metricNames).toEqual([]);
     expect(result.current.labelValuesByMetric).toEqual({});
     expect(result.current.existingRuleGroups).toEqual([]);
@@ -62,9 +62,7 @@ describe('useDiscoveryProbes', () => {
       },
       ruler: { groups: [{ name: 'g', file: 'f', interval: 30, rules: [] }] },
     });
-    const { result } = renderHook(() =>
-      useDiscoveryProbes({ http, datasourceId: 'prom-1', epoch: 0 })
-    );
+    const { result } = renderHook(() => useDiscoveryProbes({ http, datasourceId: 'prom-1' }));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.metricNames).toContain('http_server_request_duration_seconds_count');
@@ -79,9 +77,7 @@ describe('useDiscoveryProbes', () => {
     const http = makeHttp({
       ruler: new Error('ruler down'),
     });
-    const { result } = renderHook(() =>
-      useDiscoveryProbes({ http, datasourceId: 'prom-1', epoch: 0 })
-    );
+    const { result } = renderHook(() => useDiscoveryProbes({ http, datasourceId: 'prom-1' }));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.rulerFetchFailed).toBe(true);
@@ -99,9 +95,7 @@ describe('useDiscoveryProbes', () => {
         http_server_request_duration_seconds_count: { service_name: ['cart'] },
       },
     });
-    const { result } = renderHook(() =>
-      useDiscoveryProbes({ http, datasourceId: 'prom-1', epoch: 0 })
-    );
+    const { result } = renderHook(() => useDiscoveryProbes({ http, datasourceId: 'prom-1' }));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.metricNames).toContain('http_server_request_duration_seconds_count');
@@ -114,33 +108,12 @@ describe('useDiscoveryProbes', () => {
     );
   });
 
-  it('refetches when epoch bumps', async () => {
-    const http = makeHttp({
-      labelValues: { http_server_request_duration_seconds_count: { service_name: ['cart'] } },
-    });
-    const { result, rerender } = renderHook(
-      ({ epoch }) => useDiscoveryProbes({ http, datasourceId: 'prom-1', epoch }),
-      { initialProps: { epoch: 0 } }
-    );
-
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    const firstCount = ((http as unknown) as { get: jest.Mock }).get.mock.calls.length;
-    rerender({ epoch: 1 });
-    await waitFor(() => {
-      expect(((http as unknown) as { get: jest.Mock }).get.mock.calls.length).toBeGreaterThan(
-        firstCount
-      );
-    });
-  });
-
   it('does not setState after unmount', async () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const http = makeHttp({
       labelValues: { http_server_request_duration_seconds_count: { service_name: ['x'] } },
     });
-    const { unmount } = renderHook(() =>
-      useDiscoveryProbes({ http, datasourceId: 'prom-1', epoch: 0 })
-    );
+    const { unmount } = renderHook(() => useDiscoveryProbes({ http, datasourceId: 'prom-1' }));
     unmount();
     // Drain microtasks so the in-flight effect's `.then` resolves and would
     // attempt a setState if cancellation weren't honored.

--- a/public/components/apm/pages/slos/service_filter_options.ts
+++ b/public/components/apm/pages/slos/service_filter_options.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared option-list builder for the two service-picker popovers (Suggest SLOs
+ * page filter + Services Home suggest CTA). Keeping one implementation means
+ * both pickers agree on how covered/checked services render and sort.
+ */
+
+export interface ServiceFilterOption {
+  label: string;
+  checked?: 'on';
+  disabled: boolean;
+  covered: boolean;
+}
+
+/**
+ * Build the service-filter option list: fully-covered services are disabled
+ * (they already own their canonical pair), selected services are checked, and
+ * checked services float to the top so the current selection is visible at a
+ * glance. Each partition keeps the original service order. Pure so the sort +
+ * checked/covered logic is unit-testable without EUI's virtualized list.
+ */
+export function buildServiceFilterOptions(
+  serviceNames: string[],
+  selectedSet: Set<string>,
+  coveredSet: Set<string>
+): ServiceFilterOption[] {
+  return serviceNames
+    .map((label, idx) => {
+      const covered = coveredSet.has(label);
+      return {
+        label,
+        checked: !covered && selectedSet.has(label) ? ('on' as const) : undefined,
+        disabled: covered,
+        covered,
+        idx,
+      };
+    })
+    .sort((a, b) => {
+      const aChecked = a.checked === 'on' ? 0 : 1;
+      const bChecked = b.checked === 'on' ? 0 : 1;
+      return aChecked - bChecked || a.idx - b.idx;
+    })
+    .map(({ idx: _idx, ...opt }) => opt);
+}

--- a/public/components/apm/pages/slos/service_filter_selectable.scss
+++ b/public/components/apm/pages/slos/service_filter_selectable.scss
@@ -1,0 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Padding around the EuiSelectable search box inside the picker popovers.
+.service-filter__search {
+  padding: $euiSizeS $euiSizeS 0;
+}

--- a/public/components/apm/pages/slos/service_filter_selectable.tsx
+++ b/public/components/apm/pages/slos/service_filter_selectable.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared presentational body for the two service-picker popovers (Suggest SLOs
+ * page filter + Services Home suggest CTA). Owns the option list, the searchable
+ * EuiSelectable, and the "covered" append badge; callers own the popover
+ * trigger, the footer buttons, and what committing a selection does (URL scope
+ * vs. navigate). Keeping this here means both pickers agree on look, ordering,
+ * covered-disabling, and the covered-exclusion guard in one place.
+ */
+
+import React, { useMemo } from 'react';
+import { EuiSelectable, EuiText } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { buildServiceFilterOptions } from './service_filter_options';
+import './service_filter_selectable.scss';
+
+/** Fixed pixel height of the service list inside the popover. */
+export const SERVICE_FILTER_LIST_HEIGHT = 240;
+
+const t = {
+  searchPlaceholder: i18n.translate('observability.apm.slo.serviceFilter.searchPlaceholder', {
+    defaultMessage: 'Filter services',
+  }),
+  covered: i18n.translate('observability.apm.slo.serviceFilter.covered', {
+    defaultMessage: 'covered',
+  }),
+};
+
+export interface ServiceFilterSelectableProps {
+  /** Every service the picker can offer (already de-duped by the caller). */
+  serviceNames: string[];
+  /** Services currently selected/scoped — rendered checked and floated to top. */
+  selectedSet: Set<string>;
+  /** Services whose canonical pair already exists — rendered disabled. */
+  coveredSet: Set<string>;
+  /**
+   * Called with the next selection (covered services already excluded) whenever
+   * the user toggles a row. Callers decide what a selection commits to.
+   */
+  onSelectionChange: (labels: string[]) => void;
+}
+
+export const ServiceFilterSelectable: React.FC<ServiceFilterSelectableProps> = ({
+  serviceNames,
+  selectedSet,
+  coveredSet,
+  onSelectionChange,
+}) => {
+  const options = useMemo(
+    () =>
+      buildServiceFilterOptions(serviceNames, selectedSet, coveredSet).map((opt) => ({
+        label: opt.label,
+        checked: opt.checked,
+        disabled: opt.disabled,
+        append: opt.covered ? (
+          <EuiText size="xs" color="success">
+            {t.covered}
+          </EuiText>
+        ) : undefined,
+      })),
+    [serviceNames, selectedSet, coveredSet]
+  );
+
+  const onChange = (newOptions: Array<{ label: string; checked?: 'on' }>) => {
+    // Guard against a covered label ever reaching the selection — covered rows
+    // render disabled, but keep the filter so callers never get a covered svc.
+    const sel = newOptions
+      .filter((o) => o.checked === 'on' && !coveredSet.has(o.label))
+      .map((o) => o.label);
+    onSelectionChange(sel);
+  };
+
+  return (
+    <EuiSelectable
+      searchable
+      searchProps={{ compressed: true, placeholder: t.searchPlaceholder }}
+      options={options}
+      onChange={onChange}
+      listProps={{ bordered: false }}
+      height={SERVICE_FILTER_LIST_HEIGHT}
+    >
+      {(list, search) => (
+        <>
+          <div className="service-filter__search">{search}</div>
+          {list}
+        </>
+      )}
+    </EuiSelectable>
+  );
+};

--- a/public/components/apm/pages/slos/service_filter_selectable.tsx
+++ b/public/components/apm/pages/slos/service_filter_selectable.tsx
@@ -25,6 +25,9 @@ const t = {
   searchPlaceholder: i18n.translate('observability.apm.slo.serviceFilter.searchPlaceholder', {
     defaultMessage: 'Filter services',
   }),
+  ariaLabel: i18n.translate('observability.apm.slo.serviceFilter.ariaLabel', {
+    defaultMessage: 'Select services to suggest SLOs for',
+  }),
   covered: i18n.translate('observability.apm.slo.serviceFilter.covered', {
     defaultMessage: 'covered',
   }),
@@ -76,8 +79,13 @@ export const ServiceFilterSelectable: React.FC<ServiceFilterSelectableProps> = (
 
   return (
     <EuiSelectable
+      aria-label={t.ariaLabel}
       searchable
-      searchProps={{ compressed: true, placeholder: t.searchPlaceholder }}
+      searchProps={{
+        compressed: true,
+        placeholder: t.searchPlaceholder,
+        'aria-label': t.ariaLabel,
+      }}
       options={options}
       onChange={onChange}
       listProps={{ bordered: false }}

--- a/public/components/apm/pages/slos/slo_health_summary.ts
+++ b/public/components/apm/pages/slos/slo_health_summary.ts
@@ -20,7 +20,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SloApiClient } from './slo_api_client';
-import { classifySloKind, rollupSloHealth } from '../../../../../common/slo/classifier';
+import { classifySloKind, kindSide, rollupSloHealth } from '../../../../../common/slo/classifier';
 import type { CanonicalKind, SloHealthBucket } from '../../../../../common/slo/classifier';
 import type {
   SloAggregateResponse,
@@ -30,7 +30,7 @@ import type {
 
 // Re-export so existing callers (ChipRow, ServiceSloTab, tests) keep working
 // against the hook's module without reaching into `common/slo/`.
-export { classifySloKind, rollupSloHealth };
+export { classifySloKind, kindSide, rollupSloHealth };
 export type { CanonicalKind, SloHealthBucket };
 
 export interface UseServiceSloHealthResult {

--- a/public/components/apm/pages/slos/slo_suggest_page.scss
+++ b/public/components/apm/pages/slos/slo_suggest_page.scss
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Width shared by the service-filter popover panel and its search row.
+$sloSuggestFilterPanelWidth: 300px;
+
+.sloSuggestFilter {
+  &__panel {
+    width: $sloSuggestFilterPanelWidth;
+  }
+
+  // Padding around the EuiSelectable search box inside the popover.
+  &__search {
+    padding: 8px 8px 0;
+  }
+}
+
+// Draggable grip on the left edge of the preview flyout. The flyout width
+// itself stays inline (it is driven by the drag state), but the handle's
+// presentation lives here so the themed color + hover state are declarative.
+.sloSuggestFlyout {
+  &__resizeHandle {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: col-resize;
+    z-index: 1000;
+  }
+
+  &__resizeGrip {
+    width: 4px;
+    height: 40px;
+    border-radius: 2px;
+    background-color: $euiColorMediumShade;
+    transition: background-color $euiAnimSpeedFast ease-in;
+  }
+
+  &__resizeHandle:hover &__resizeGrip {
+    background-color: $euiColorDarkShade;
+  }
+}
+
+// Reserve height so the centered loading spinner doesn't collapse the page.
+.sloSuggestLoading {
+  min-height: 200px;
+}
+
+// Break long PromQL / rule strings in the preview flyout body.
+.sloSuggestFlyout__body {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}

--- a/public/components/apm/pages/slos/slo_suggest_page.scss
+++ b/public/components/apm/pages/slos/slo_suggest_page.scss
@@ -3,25 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Width shared by the service-filter popover panel and its search row.
-$sloSuggestFilterPanelWidth: 300px;
-
-.sloSuggestFilter {
-  &__panel {
-    width: $sloSuggestFilterPanelWidth;
-  }
-
-  // Padding around the EuiSelectable search box inside the popover.
-  &__search {
-    padding: 8px 8px 0;
-  }
+// Width of the service-filter popover panel.
+.slo-service-filter__panel {
+  width: 300px;
 }
 
 // Draggable grip on the left edge of the preview flyout. The flyout width
 // itself stays inline (it is driven by the drag state), but the handle's
 // presentation lives here so the themed color + hover state are declarative.
-.sloSuggestFlyout {
-  &__resizeHandle {
+.slo-suggest-flyout {
+  &__resize-handle {
     position: absolute;
     top: 0;
     left: 0;
@@ -34,7 +25,7 @@ $sloSuggestFilterPanelWidth: 300px;
     z-index: 1000;
   }
 
-  &__resizeGrip {
+  &__resize-grip {
     width: 4px;
     height: 40px;
     border-radius: 2px;
@@ -42,18 +33,18 @@ $sloSuggestFilterPanelWidth: 300px;
     transition: background-color $euiAnimSpeedFast ease-in;
   }
 
-  &__resizeHandle:hover &__resizeGrip {
+  &__resize-handle:hover &__resize-grip {
     background-color: $euiColorDarkShade;
+  }
+
+  // Break long PromQL / rule strings in the preview flyout body.
+  &__body {
+    overflow-wrap: break-word;
+    word-break: break-word;
   }
 }
 
 // Reserve height so the centered loading spinner doesn't collapse the page.
-.sloSuggestLoading {
+.slo-suggest-loading {
   min-height: 200px;
-}
-
-// Break long PromQL / rule strings in the preview flyout body.
-.sloSuggestFlyout__body {
-  overflow-wrap: break-word;
-  word-break: break-word;
 }

--- a/public/components/apm/pages/slos/slo_suggest_page.tsx
+++ b/public/components/apm/pages/slos/slo_suggest_page.tsx
@@ -62,7 +62,7 @@ import { ServiceRowShape, ServiceTreeTable } from './suggest_service_tree_table'
 import { SuggestBatchPreview } from './suggest_batch_preview';
 import { useDiscoveryProbes } from './suggest_use_discovery_probes';
 import { useBatchCreate } from './suggest_use_batch_create';
-import { useServiceSloHealth } from './slo_health_summary';
+import { kindSide, useServiceSloHealth } from './slo_health_summary';
 import { ServiceFilterSelectable } from './service_filter_selectable';
 import './slo_suggest_page.scss';
 
@@ -394,22 +394,47 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     apiClient,
   });
 
-  const allServicesCoverage = useMemo<Set<string>>(() => {
-    const set = new Set<string>();
+  // Per-service, per-side coverage from the health rollup. We track the two
+  // sides (availability / latency) separately rather than collapsing to a
+  // single "has the whole pair" flag: creating just the availability SLO for a
+  // service must mark only its availability draft covered, not both — otherwise
+  // the still-missing latency draft would either stay wrongly selectable
+  // (all-or-nothing = not covered) or get wrongly hidden.
+  const coverageBySvc = useMemo(() => {
+    const map = new Map<string, { availability: boolean; latency: boolean }>();
     for (const [svc, bucket] of healthBySvc) {
-      if (!bucket.missingCanonicalPair) set.add(svc);
+      map.set(svc, { availability: bucket.hasAvailability, latency: bucket.hasLatency });
     }
-    return set;
+    return map;
   }, [healthBySvc]);
 
-  // Whether a draft is "covered" (and so defaults unchecked, to avoid a
-  // dual-write). Unions both signals: a matching Prometheus recording rule
-  // (`existingRuleMatch`, per-draft) OR the service already owning its canonical
-  // availability+latency SLO pair (`allServicesCoverage`, from the health
-  // rollup, which resolves asynchronously).
+  // Services that already own the FULL canonical pair — used to disable the
+  // whole service at the filter/master-checkbox level. (Per-draft coverage is
+  // handled by `isDraftCovered` below; this is the "nothing left to add for
+  // this service at all" case.)
+  const fullyCoveredServices = useMemo<Set<string>>(() => {
+    const set = new Set<string>();
+    for (const [svc, cov] of coverageBySvc) {
+      if (cov.availability && cov.latency) set.add(svc);
+    }
+    return set;
+  }, [coverageBySvc]);
+
+  // Whether a draft is "covered" (and so non-selectable, to avoid a dual-write).
+  // Unions two signals: a matching Prometheus recording rule (`existingRuleMatch`,
+  // per-draft) OR the service already owning an SLO on this draft's SIDE of the
+  // canonical pair (`coverageBySvc`, from the health rollup, which resolves
+  // asynchronously). Side-aware so a partial create (e.g. availability only)
+  // covers exactly the draft that now exists.
   const isDraftCovered = useCallback(
-    (s: Suggestion) => !!s.existingRuleMatch || allServicesCoverage.has(s.input.spec.service),
-    [allServicesCoverage]
+    (s: Suggestion) => {
+      if (s.existingRuleMatch) return true;
+      const side = kindSide(s.kindId);
+      const cov = coverageBySvc.get(s.input.spec.service);
+      if (!cov || !side) return false;
+      return side === 'availability' ? cov.availability : cov.latency;
+    },
+    [coverageBySvc]
   );
 
   // Keys the user has explicitly toggled. Re-seeding preserves the user's choice
@@ -498,16 +523,21 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     history,
   });
 
+  // The single "will be created" predicate. A draft is creatable iff it's
+  // selected AND not already covered. Covered drafts can't be selected in the
+  // UI (their checkbox is disabled), but we still filter here as a hard backstop
+  // against a selection-state race — and, critically, EVERY count surface below
+  // derives from this same predicate so the button / modal / preview / toast
+  // can never disagree with what `runCreateSelected` actually provisions.
+  const creatable = useCallback(
+    (s: Suggestion) => selected.has(s.key) && !isDraftCovered(s),
+    [selected, isDraftCovered]
+  );
+
   const runCreateSelected = useCallback(() => {
-    // Backstop against dual-writes: never provision a draft whose service is
-    // already covered, even if it stayed checked through a selection-state race
-    // (e.g. the master checkbox marked it touched before the async coverage
-    // signal resolved, so the seeding effect could no longer auto-deselect it).
-    const picks = suggestions
-      .filter((s) => selected.has(s.key) && !isDraftCovered(s))
-      .map(applyOverrides);
+    const picks = suggestions.filter(creatable).map(applyOverrides);
     return runCreate(picks);
-  }, [applyOverrides, isDraftCovered, runCreate, selected, suggestions]);
+  }, [applyOverrides, creatable, runCreate, suggestions]);
 
   const createSelected = useCallback(() => {
     // Already-open preview means the user has seen the full rule/SLI
@@ -529,9 +559,12 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     () => suggestions.map(applyOverrides),
     [suggestions, applyOverrides]
   );
-  const selectedCount = decoratedSuggestions.filter((s) => selected.has(s.key)).length;
+  // Count only creatable drafts (selected AND not covered), matching exactly
+  // what `runCreateSelected` provisions — so "Create N SLOs", the confirm
+  // modal's rule total, and the preview never contradict the actual create.
+  const selectedCount = decoratedSuggestions.filter(creatable).length;
   const totalRules = decoratedSuggestions
-    .filter((s) => selected.has(s.key))
+    .filter(creatable)
     .reduce((acc, s) => acc + s.estimatedRuleCount, 0);
   // Count with the same `isDraftCovered` union that drives default-unchecking,
   // not just `existingRuleMatch` — otherwise a service covered via the health
@@ -539,6 +572,12 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   // "N drafts already covered" subline never renders, leaving the user with a
   // disabled Create and no explanation.
   const coveredCount = decoratedSuggestions.filter((s) => isDraftCovered(s)).length;
+  // Authoritative per-draft covered set, handed to the tree table so the inline
+  // checkboxes disable exactly the drafts the create-time filter excludes.
+  const coveredKeys = useMemo(
+    () => new Set(decoratedSuggestions.filter((s) => isDraftCovered(s)).map((s) => s.key)),
+    [decoratedSuggestions, isDraftCovered]
+  );
   // The service list comes from APM discovery but an OTel-only service (one
   // that emits direct metrics without span-derived RED) can still surface a
   // draft. Union both sources so every service that owns drafts gets a row.
@@ -565,8 +604,16 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
           serviceName,
           environment: drafts[0]?.detected.environment,
           drafts,
-          selectedCount: drafts.filter((s) => selected.has(s.key)).length,
-          totalRules: drafts.reduce((acc, s) => acc + s.estimatedRuleCount, 0),
+          // Count only creatable drafts as "selected" so the row's N/M and the
+          // master checkbox's all/indeterminate state track what will actually
+          // be created — covered drafts are excluded from both numerator and
+          // denominator (see `selectableCount`).
+          selectedCount: drafts.filter(creatable).length,
+          // Selectable = not covered. Denominator for the master checkbox's
+          // "all selected" state, so a partially-covered service can still reach
+          // a fully-checked master box.
+          selectableCount: drafts.filter((s) => !isDraftCovered(s)).length,
+          totalRules: drafts.filter(creatable).reduce((acc, s) => acc + s.estimatedRuleCount, 0),
           // Union recording-rule + health-rollup coverage, matching the
           // page-level `coveredCount` and the default-unchecking in the seeding
           // effect (see `isDraftCovered`).
@@ -575,7 +622,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
         };
       })
       .filter((row) => row.drafts.length > 0);
-  }, [uniqueServices, decoratedSuggestions, selected, isDraftCovered]);
+  }, [uniqueServices, decoratedSuggestions, creatable, isDraftCovered]);
 
   // Re-seed expansion to "all collapsed" whenever the *set of services* changes.
   // Keyed on the joined service names (not `serviceRows`, whose identity changes
@@ -596,18 +643,26 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     setExpandedMap((prev) => ({ ...prev, [serviceName]: !prev[serviceName] }));
   }, []);
 
-  const toggleServiceSelection = useCallback((row: ServiceRowShape) => {
-    const allSelected = row.selectedCount === row.drafts.length;
-    setSelected((prev) => {
-      const next = new Set(prev);
-      for (const d of row.drafts) {
-        touchedKeysRef.current.add(d.key);
-        if (allSelected) next.delete(d.key);
-        else next.add(d.key);
-      }
-      return next;
-    });
-  }, []);
+  const toggleServiceSelection = useCallback(
+    (row: ServiceRowShape) => {
+      // Only ever toggle selectable (non-covered) drafts — covered drafts stay
+      // deselected so the master checkbox can't provision a duplicate. "All
+      // selected" is relative to the selectable set.
+      const selectableDrafts = row.drafts.filter((d) => !isDraftCovered(d));
+      const allSelected =
+        selectableDrafts.length > 0 && selectableDrafts.every((d) => selected.has(d.key));
+      setSelected((prev) => {
+        const next = new Set(prev);
+        for (const d of selectableDrafts) {
+          touchedKeysRef.current.add(d.key);
+          if (allSelected) next.delete(d.key);
+          else next.add(d.key);
+        }
+        return next;
+      });
+    },
+    [isDraftCovered, selected]
+  );
 
   const loading = configLoading || servicesLoading || discoveryLoading;
 
@@ -929,7 +984,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                     the empty initial state. */}
                 <SuggestServiceFilter
                   allServices={allDiscoveredServices}
-                  coveredSet={allServicesCoverage}
+                  coveredSet={fullyCoveredServices}
                   scopedServices={scope.services}
                   timeRange={timeRange}
                   history={history}
@@ -947,7 +1002,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                     onToggleDraft={toggle}
                     onOverrideChange={setOverride}
                     rowStatusMap={rowStatusMap}
-                    coveredServices={allServicesCoverage}
+                    coveredKeys={coveredKeys}
                   />
                 ) : (
                   <EuiPanel
@@ -993,7 +1048,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
           <EuiFlyoutBody className="slo-suggest-flyout__body">
             <SuggestBatchPreview
               apiClient={apiClient}
-              selectedSuggestions={decoratedSuggestions.filter((s) => selected.has(s.key))}
+              selectedSuggestions={decoratedSuggestions.filter(creatable)}
               prometheusConnectionId={config?.prometheusDataSource?.name}
               prometheusConnectionMeta={config?.prometheusDataSource?.meta}
             />

--- a/public/components/apm/pages/slos/slo_suggest_page.tsx
+++ b/public/components/apm/pages/slos/slo_suggest_page.tsx
@@ -287,18 +287,26 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   // suggestion reflects the range the user was looking at on the services /
   // service-details page they launched from. Falls back to the 15m default
   // when the page is opened without an explicit range (e.g. a bare deep link).
-  const timeRange = useMemo(() => scope.timeRange ?? DEFAULT_APM_TIME_RANGE, [scope.timeRange]);
+  // Key off the `from`/`to` strings, not the `scope.timeRange` object: `scope`
+  // is re-parsed into a fresh object on every `location.search` change (e.g.
+  // toggling a service in the filter), so depending on its identity would remint
+  // the parsed `Date`s each time — churning `useServices`' fetch params and
+  // flashing the loading spinner on every click. The strings only change when
+  // the window actually changes.
+  const from = scope.timeRange?.from ?? DEFAULT_APM_TIME_RANGE.from;
+  const to = scope.timeRange?.to ?? DEFAULT_APM_TIME_RANGE.to;
+  const timeRange = useMemo(() => ({ from, to }), [from, to]);
   // `parseTimeRange` throws on bounds that pass the URL charset check but aren't
   // parseable datemath (e.g. a stale/crafted `?from=now/&to=now`). Since this
   // runs at render time with no error boundary, fall back to the default range
   // instead of crashing the page.
   const parsedTimeRange = useMemo(() => {
     try {
-      return parseTimeRange(timeRange);
+      return parseTimeRange({ from, to });
     } catch {
       return parseTimeRange(DEFAULT_APM_TIME_RANGE);
     }
-  }, [timeRange]);
+  }, [from, to]);
 
   const {
     data: allDiscoveredServices,
@@ -834,7 +842,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                   allServices={allDiscoveredServices}
                   coveredSet={allServicesCoverage}
                   scopedServices={scope.services}
-                  timeRange={scope.timeRange}
+                  timeRange={timeRange}
                   history={history}
                 />
                 <EuiSpacer size="s" />

--- a/public/components/apm/pages/slos/slo_suggest_page.tsx
+++ b/public/components/apm/pages/slos/slo_suggest_page.tsx
@@ -62,6 +62,8 @@ import { SuggestBatchPreview } from './suggest_batch_preview';
 import { useDiscoveryProbes } from './suggest_use_discovery_probes';
 import { useBatchCreate } from './suggest_use_batch_create';
 import { useServiceSloHealth } from './slo_health_summary';
+import { buildServiceFilterOptions } from './service_filter_options';
+import './slo_suggest_page.scss';
 
 export interface SloSuggestPageProps {
   apiClient: SloApiClient;
@@ -118,30 +120,8 @@ const ResizableFlyout: React.FC<{
       pushMinBreakpoint="xs"
       data-test-subj="slosSuggestPreviewFlyout"
     >
-      <div
-        ref={handleRef}
-        onMouseDown={onMouseDown}
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          bottom: 0,
-          width: 6,
-          cursor: 'col-resize',
-          zIndex: 1000,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <div
-          style={{
-            width: 4,
-            height: 40,
-            borderRadius: 2,
-            backgroundColor: '#c0c5cc',
-          }}
-        />
+      <div ref={handleRef} onMouseDown={onMouseDown} className="sloSuggestFlyout__resizeHandle">
+        <div className="sloSuggestFlyout__resizeGrip" />
       </div>
       {children}
     </EuiFlyout>
@@ -153,20 +133,7 @@ const SuggestServiceFilter: React.FC<{
   coveredSet: Set<string>;
   scopedServices: string[] | undefined;
   history: ReturnType<typeof useHistory>;
-  selectAll: () => void;
-  clearAll: () => void;
-  allSelected: boolean;
-  noneSelected: boolean;
-}> = ({
-  allServices,
-  coveredSet,
-  scopedServices,
-  history,
-  selectAll,
-  clearAll,
-  allSelected,
-  noneSelected,
-}) => {
+}> = ({ allServices, coveredSet, scopedServices, history }) => {
   const [isOpen, setIsOpen] = useState(false);
   const scopeSet = useMemo(() => new Set(scopedServices ?? []), [scopedServices]);
 
@@ -178,28 +145,19 @@ const SuggestServiceFilter: React.FC<{
     return Array.from(set);
   }, [allServices]);
 
-  const noScope = scopedServices === undefined;
   const options = useMemo(
     () =>
-      allServiceNames.map((svc) => {
-        const fullyCovered = coveredSet.has(svc);
-        const isChecked = fullyCovered
-          ? undefined
-          : noScope || scopeSet.has(svc)
-          ? ('on' as const)
-          : undefined;
-        return {
-          label: svc,
-          checked: isChecked,
-          disabled: fullyCovered,
-          append: fullyCovered ? (
-            <EuiText size="xs" color="success">
-              covered
-            </EuiText>
-          ) : undefined,
-        };
-      }),
-    [allServiceNames, scopeSet, coveredSet, noScope]
+      buildServiceFilterOptions(allServiceNames, scopeSet, coveredSet).map((opt) => ({
+        label: opt.label,
+        checked: opt.checked,
+        disabled: opt.disabled,
+        append: opt.covered ? (
+          <EuiText size="xs" color="success">
+            covered
+          </EuiText>
+        ) : undefined,
+      })),
+    [allServiceNames, scopeSet, coveredSet]
   );
 
   const onChange = useCallback(
@@ -207,38 +165,36 @@ const SuggestServiceFilter: React.FC<{
       const sel = newOptions
         .filter((o) => o.checked === 'on' && !coveredSet.has(o.label))
         .map((o) => o.label);
-      if (
-        sel.length === 0 ||
-        sel.length === allServiceNames.filter((s) => !coveredSet.has(s)).length
-      ) {
+      // Empty selection collapses to the unscoped URL, which now renders the
+      // "pick services" empty state rather than drafting everything.
+      if (sel.length === 0) {
         history.replace('/slos/suggest');
       } else {
         const qs = new URLSearchParams({ source: 'apm', services: sel.join(',') });
         history.replace(`/slos/suggest?${qs.toString()}`);
       }
     },
-    [history, allServiceNames, coveredSet]
+    [history, coveredSet]
   );
 
-  const selectedCount = scopedServices?.length ?? 0;
+  const clearScope = useCallback(() => {
+    setIsOpen(false);
+    history.replace('/slos/suggest');
+  }, [history]);
+
+  const scopedCount = scopedServices?.length ?? 0;
+  const buttonLabel =
+    scopedCount === 0
+      ? i18n.translate('observability.apm.slo.suggest.serviceFilter.empty', {
+          defaultMessage: 'Select services',
+        })
+      : i18n.translate('observability.apm.slo.suggest.serviceFilter', {
+          defaultMessage: 'Suggest SLOs for {count, plural, one {# service} other {# services}}',
+          values: { count: scopedCount },
+        });
 
   return (
-    <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty size="s" onClick={selectAll} isDisabled={allSelected}>
-          {i18n.translate('observability.apm.slo.suggest.selectAll', {
-            defaultMessage: 'Select all',
-          })}
-        </EuiButtonEmpty>
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty size="s" onClick={clearAll} isDisabled={noneSelected}>
-          {i18n.translate('observability.apm.slo.suggest.clearSelection', {
-            defaultMessage: 'Clear',
-          })}
-        </EuiButtonEmpty>
-      </EuiFlexItem>
-      <EuiFlexItem grow={true} />
+    <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center" justifyContent="flexEnd">
       <EuiFlexItem grow={false}>
         <EuiPopover
           isOpen={isOpen}
@@ -253,30 +209,39 @@ const SuggestServiceFilter: React.FC<{
               onClick={() => setIsOpen((prev) => !prev)}
               data-test-subj="slosSuggestServiceFilter"
             >
-              {i18n.translate('observability.apm.slo.suggest.serviceFilter', {
-                defaultMessage:
-                  'Suggest SLOs for {count, plural, one {# service} other {# services}}',
-                values: { count: selectedCount },
-              })}
+              {buttonLabel}
             </EuiButton>
           }
         >
-          <EuiSelectable
-            searchable
-            searchProps={{ compressed: true, placeholder: 'Filter services' }}
-            options={options}
-            onChange={onChange}
-            listProps={{ bordered: false }}
-            style={{ width: 300 }}
-            height={240}
-          >
-            {(list, search) => (
-              <>
-                <div style={{ padding: '8px 8px 0' }}>{search}</div>
-                {list}
-              </>
-            )}
-          </EuiSelectable>
+          <div className="sloSuggestFilter__panel">
+            <EuiSelectable
+              searchable
+              searchProps={{ compressed: true, placeholder: 'Filter services' }}
+              options={options}
+              onChange={onChange}
+              listProps={{ bordered: false }}
+              height={240}
+            >
+              {(list, search) => (
+                <>
+                  <div className="sloSuggestFilter__search">{search}</div>
+                  {list}
+                </>
+              )}
+            </EuiSelectable>
+            <EuiPanel color="transparent" paddingSize="s">
+              <EuiButtonEmpty
+                size="s"
+                onClick={clearScope}
+                isDisabled={scopedCount === 0}
+                data-test-subj="slosSuggestServiceFilterClear"
+              >
+                {i18n.translate('observability.apm.slo.suggest.clearSelection', {
+                  defaultMessage: 'Clear',
+                })}
+              </EuiButtonEmpty>
+            </EuiPanel>
+          </div>
         </EuiPopover>
       </EuiFlexItem>
     </EuiFlexGroup>
@@ -301,8 +266,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   const [flyoutWidth, setFlyoutWidth] = useState(Math.round(window.innerWidth * 0.3));
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [expandedMap, setExpandedMap] = useState<Record<string, boolean>>({});
-  /** Bumping this triggers the discovery effect. */
-  const [discoveryEpoch] = useState(0);
 
   useEffect(() => {
     chrome.setBreadcrumbs([
@@ -340,13 +303,14 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   });
 
   // Apply URL scope before the `services.length === 0` guard in `suggestions`.
-  // A stale deep link (scope names nothing discovery sees) falls back to the
-  // full list so the page stays usable; the UI still surfaces the miss.
+  // Unscoped (no `?services=`) drafts nothing: the user picks services from the
+  // filter popover, which writes the scope to the URL. A stale deep link that
+  // names services discovery doesn't see resolves to an empty list, which the
+  // "pick services" empty state handles the same as the initial landing.
   const scopedServices = useMemo(() => {
-    if (!scope.services) return allDiscoveredServices;
+    if (!scope.services) return [];
     const allow = new Set(scope.services);
-    const filtered = allDiscoveredServices.filter((s) => allow.has(s.serviceName));
-    return filtered.length > 0 ? filtered : allDiscoveredServices;
+    return allDiscoveredServices.filter((s) => allow.has(s.serviceName));
   }, [allDiscoveredServices, scope.services]);
 
   const services = scopedServices;
@@ -357,7 +321,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     existingRuleGroups,
     rulerFetchFailed,
     loading: discoveryLoading,
-  } = useDiscoveryProbes({ http, datasourceId, epoch: discoveryEpoch });
+  } = useDiscoveryProbes({ http, datasourceId });
 
   const suggestions = useMemo<Suggestion[]>(() => {
     if (!datasourceId || !services || services.length === 0) return [];
@@ -394,9 +358,10 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   }, [healthBySvc]);
 
   // Default every suggestion to "selected" when the list changes — EXCEPT
-  // those already covered by an existing Prometheus rule. Users can re-check
-  // covered drafts explicitly if they want a duplicate, but the common case
-  // is "leave them unchecked so we don't dual-write".
+  // those already covered by an existing Prometheus rule. The user has already
+  // chosen which services to scope upstream, so landing with their drafts
+  // pre-checked matches intent; covered drafts stay unchecked so we don't
+  // dual-write. Users can uncheck any draft they don't want.
   useEffect(() => {
     setSelected(new Set(suggestions.filter((s) => !s.existingRuleMatch).map((s) => s.key)));
   }, [suggestions]);
@@ -481,10 +446,10 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   // deps include it (uniqueServices, serviceRows, …). The result was a render
   // loop where typing in a draft override re-derived the entire row tree on
   // every keystroke for ~38 drafts.
-  const decoratedSuggestions = useMemo(() => suggestions.map(applyOverrides), [
-    suggestions,
-    applyOverrides,
-  ]);
+  const decoratedSuggestions = useMemo(
+    () => suggestions.map(applyOverrides),
+    [suggestions, applyOverrides]
+  );
   const selectedCount = decoratedSuggestions.filter((s) => selected.has(s.key)).length;
   const totalRules = decoratedSuggestions
     .filter((s) => selected.has(s.key))
@@ -623,6 +588,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
             {servicesError && (
               <>
                 <EuiCallOut
+                  announceOnMount
                   color="danger"
                   iconType="alert"
                   title={i18n.translate('observability.apm.slo.suggest.servicesErrorTitle', {
@@ -637,7 +603,11 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
             )}
 
             {loading && (
-              <EuiFlexGroup justifyContent="center" alignItems="center" style={{ minHeight: 200 }}>
+              <EuiFlexGroup
+                justifyContent="center"
+                alignItems="center"
+                className="sloSuggestLoading"
+              >
                 <EuiFlexItem grow={false}>
                   <EuiLoadingSpinner size="xl" />
                 </EuiFlexItem>
@@ -646,6 +616,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
 
             {!loading && !datasourceId && (
               <EuiCallOut
+                announceOnMount
                 size="s"
                 iconType="iInCircle"
                 title={i18n.translate('observability.apm.slo.suggest.noDatasource.title', {
@@ -662,8 +633,9 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
               </EuiCallOut>
             )}
 
-            {!loading && datasourceId && uniqueServices.length === 0 && !servicesError && (
+            {!loading && datasourceId && allDiscoveredServices.length === 0 && !servicesError && (
               <EuiCallOut
+                announceOnMount
                 size="s"
                 iconType="iInCircle"
                 title={i18n.translate('observability.apm.slo.suggest.noServices.title', {
@@ -682,6 +654,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
             {!loading && datasourceId && rulerFetchFailed && (
               <>
                 <EuiCallOut
+                  announceOnMount
                   size="s"
                   iconType="alert"
                   color="warning"
@@ -701,136 +674,152 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
               </>
             )}
 
-            {!loading && decoratedSuggestions.length > 0 && (
+            {!loading && datasourceId && allDiscoveredServices.length > 0 && !servicesError && (
               <>
-                <EuiFlexGroup
-                  alignItems="center"
-                  responsive={false}
-                  gutterSize="m"
-                  data-test-subj="slosSuggestHeaderStrip"
-                >
-                  <EuiFlexItem grow={false}>
-                    <EuiPanel paddingSize="m" hasBorder>
-                      <EuiStat
-                        title={`${selectedCount}`}
-                        description={i18n.translate('observability.apm.slo.suggest.stat.ofSlos', {
-                          defaultMessage: 'of {total} SLOs',
-                          values: { total: decoratedSuggestions.length },
-                        })}
-                        titleSize="m"
-                        reverse
-                        data-test-subj="slosSuggestStatSlos"
-                      />
-                    </EuiPanel>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiPanel paddingSize="m" hasBorder>
-                      <EuiStat
-                        title={`${uniqueServices.length}`}
-                        description={i18n.translate('observability.apm.slo.suggest.stat.services', {
-                          defaultMessage: '{count, plural, one {service} other {services}}',
-                          values: { count: uniqueServices.length },
-                        })}
-                        titleSize="m"
-                        reverse
-                        data-test-subj="slosSuggestStatServices"
-                      />
-                    </EuiPanel>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiPanel paddingSize="m" hasBorder>
-                      <EuiStat
-                        title={`${totalRules}`}
-                        description={i18n.translate(
-                          'observability.apm.slo.suggest.stat.rulesToProvision',
-                          { defaultMessage: 'rules to provision' }
-                        )}
-                        titleSize="m"
-                        titleColor="subdued"
-                        reverse
-                        data-test-subj="slosSuggestStatRules"
-                      />
-                    </EuiPanel>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={true} />
-                </EuiFlexGroup>
-                {coveredCount > 0 && <EuiSpacer size="xs" />}
-                {coveredCount > 0 && (
-                  <EuiText size="xs" color="subdued" data-test-subj="slosSuggestHeaderSubline">
-                    {i18n.translate('observability.apm.slo.suggest.headerSubline.covered', {
-                      defaultMessage:
-                        '{count, plural, one {# draft} other {# drafts}} already covered by existing rules',
-                      values: { count: coveredCount },
-                    })}
-                  </EuiText>
-                )}
-                <EuiSpacer size="m" />
-
-                {progress && (
+                {decoratedSuggestions.length > 0 && (
                   <>
-                    <EuiPanel paddingSize="s" hasBorder data-test-subj="slosSuggestProgressStrip">
-                      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
-                        <EuiFlexItem grow={false}>
-                          <EuiText size="xs">
-                            {i18n.translate('observability.apm.slo.suggest.progressPrefix', {
-                              defaultMessage: 'Creating SLO {done}/{total} · ',
-                              values: { done: progress.done, total: progress.total },
-                            })}
-                            <strong>{progress.failed}</strong>
-                            {i18n.translate('observability.apm.slo.suggest.progressSuffix', {
-                              defaultMessage: ' failed so far',
-                            })}
-                          </EuiText>
-                        </EuiFlexItem>
-                        <EuiFlexItem>
-                          <EuiProgress
-                            color={progress.failed > 0 ? 'warning' : 'primary'}
-                            value={progress.done}
-                            max={progress.total}
-                            size="xs"
+                    <EuiFlexGroup
+                      alignItems="center"
+                      responsive={false}
+                      gutterSize="m"
+                      data-test-subj="slosSuggestHeaderStrip"
+                    >
+                      <EuiFlexItem grow={false}>
+                        <EuiPanel paddingSize="m" hasBorder>
+                          <EuiStat
+                            title={`${selectedCount}`}
+                            description={i18n.translate(
+                              'observability.apm.slo.suggest.stat.ofSlos',
+                              {
+                                defaultMessage: 'of {total} SLOs',
+                                values: { total: decoratedSuggestions.length },
+                              }
+                            )}
+                            titleSize="m"
+                            reverse
+                            data-test-subj="slosSuggestStatSlos"
                           />
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                    </EuiPanel>
-                    <EuiSpacer size="s" />
+                        </EuiPanel>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiPanel paddingSize="m" hasBorder>
+                          <EuiStat
+                            title={`${uniqueServices.length}`}
+                            description={i18n.translate(
+                              'observability.apm.slo.suggest.stat.services',
+                              {
+                                defaultMessage: '{count, plural, one {service} other {services}}',
+                                values: { count: uniqueServices.length },
+                              }
+                            )}
+                            titleSize="m"
+                            reverse
+                            data-test-subj="slosSuggestStatServices"
+                          />
+                        </EuiPanel>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiPanel paddingSize="m" hasBorder>
+                          <EuiStat
+                            title={`${totalRules}`}
+                            description={i18n.translate(
+                              'observability.apm.slo.suggest.stat.rulesToProvision',
+                              { defaultMessage: 'rules to provision' }
+                            )}
+                            titleSize="m"
+                            titleColor="subdued"
+                            reverse
+                            data-test-subj="slosSuggestStatRules"
+                          />
+                        </EuiPanel>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={true} />
+                    </EuiFlexGroup>
+                    {coveredCount > 0 && <EuiSpacer size="xs" />}
+                    {coveredCount > 0 && (
+                      <EuiText size="xs" color="subdued" data-test-subj="slosSuggestHeaderSubline">
+                        {i18n.translate('observability.apm.slo.suggest.headerSubline.covered', {
+                          defaultMessage:
+                            '{count, plural, one {# draft} other {# drafts}} already covered by existing rules',
+                          values: { count: coveredCount },
+                        })}
+                      </EuiText>
+                    )}
+                    <EuiSpacer size="m" />
+
+                    {progress && (
+                      <>
+                        <EuiPanel
+                          paddingSize="s"
+                          hasBorder
+                          data-test-subj="slosSuggestProgressStrip"
+                        >
+                          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+                            <EuiFlexItem grow={false}>
+                              <EuiText size="xs">
+                                {i18n.translate('observability.apm.slo.suggest.progressPrefix', {
+                                  defaultMessage: 'Creating SLO {done}/{total} · ',
+                                  values: { done: progress.done, total: progress.total },
+                                })}
+                                <strong>{progress.failed}</strong>
+                                {i18n.translate('observability.apm.slo.suggest.progressSuffix', {
+                                  defaultMessage: ' failed so far',
+                                })}
+                              </EuiText>
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <EuiProgress
+                                color={progress.failed > 0 ? 'warning' : 'primary'}
+                                value={progress.done}
+                                max={progress.total}
+                                size="xs"
+                              />
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+                        </EuiPanel>
+                        <EuiSpacer size="s" />
+                      </>
+                    )}
                   </>
                 )}
 
+                {/* The service picker is always available once services are
+                    discovered — it's how the user scopes drafts, including from
+                    the empty initial state. */}
                 <SuggestServiceFilter
                   allServices={allDiscoveredServices}
                   coveredSet={allServicesCoverage}
                   scopedServices={scope.services}
                   history={history}
-                  selectAll={() => {
-                    const selectable = !scope.services
-                      ? decoratedSuggestions.filter(
-                          (s) => !allServicesCoverage.has(s.input.spec.service)
-                        )
-                      : decoratedSuggestions;
-                    setSelected(new Set(selectable.map((s) => s.key)));
-                  }}
-                  clearAll={() => setSelected(new Set())}
-                  allSelected={
-                    selectedCount ===
-                      decoratedSuggestions.filter((s) =>
-                        scope.services ? true : !allServicesCoverage.has(s.input.spec.service)
-                      ).length && selectedCount > 0
-                  }
-                  noneSelected={selectedCount === 0}
                 />
                 <EuiSpacer size="s" />
-                <ServiceTreeTable
-                  serviceRows={serviceRows}
-                  expandedMap={expandedMap}
-                  onToggleExpand={toggleExpand}
-                  onToggleServiceSelection={toggleServiceSelection}
-                  selected={selected}
-                  overrides={overrides}
-                  onToggleDraft={toggle}
-                  onOverrideChange={setOverride}
-                  rowStatusMap={rowStatusMap}
-                  coveredServices={!scope.services ? allServicesCoverage : undefined}
-                />
+
+                {decoratedSuggestions.length > 0 ? (
+                  <ServiceTreeTable
+                    serviceRows={serviceRows}
+                    expandedMap={expandedMap}
+                    onToggleExpand={toggleExpand}
+                    onToggleServiceSelection={toggleServiceSelection}
+                    selected={selected}
+                    overrides={overrides}
+                    onToggleDraft={toggle}
+                    onOverrideChange={setOverride}
+                    rowStatusMap={rowStatusMap}
+                  />
+                ) : (
+                  <EuiPanel
+                    color="subdued"
+                    hasShadow={false}
+                    paddingSize="l"
+                    data-test-subj="slosSuggestPickServices"
+                  >
+                    <EuiText size="s" color="subdued" textAlign="center">
+                      {i18n.translate('observability.apm.slo.suggest.pickServices.prompt', {
+                        defaultMessage: 'Pick one or more services to suggest SLOs for.',
+                      })}
+                    </EuiText>
+                  </EuiPanel>
+                )}
               </>
             )}
           </EuiPageContentBody>
@@ -858,7 +847,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
               </h3>
             </EuiTitle>
           </EuiFlyoutHeader>
-          <EuiFlyoutBody style={{ overflowWrap: 'break-word', wordBreak: 'break-word' }}>
+          <EuiFlyoutBody className="sloSuggestFlyout__body">
             <SuggestBatchPreview
               apiClient={apiClient}
               selectedSuggestions={decoratedSuggestions.filter((s) => selected.has(s.key))}

--- a/public/components/apm/pages/slos/slo_suggest_page.tsx
+++ b/public/components/apm/pages/slos/slo_suggest_page.tsx
@@ -343,48 +343,43 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     return set;
   }, [healthBySvc]);
 
-  // Tracks whether the user has manually changed the selection. Once they have,
-  // we stop auto-re-seeding so a late-resolving ruler/health fetch can't clobber
-  // their toggles (the discovery probes and SLO-health rollup arrive async and
-  // recompute `suggestions`).
-  const hasInteractedRef = useRef(false);
-  // Signature of the current draft set — re-seeding keys off this rather than
-  // `suggestions` identity so metadata-only recomputes (ruler resolving, which
-  // sets `existingRuleMatch`) don't count as "a new list".
-  const suggestionKeySig = useMemo(
-    () =>
-      suggestions
-        .map((s) => s.key)
-        .sort()
-        .join('\n'),
-    [suggestions]
+  // Whether a draft is "covered" (and so defaults unchecked, to avoid a
+  // dual-write). Unions both signals: a matching Prometheus recording rule
+  // (`existingRuleMatch`, per-draft) OR the service already owning its canonical
+  // availability+latency SLO pair (`allServicesCoverage`, from the health
+  // rollup, which resolves asynchronously).
+  const isDraftCovered = useCallback(
+    (s: Suggestion) => !!s.existingRuleMatch || allServicesCoverage.has(s.input.spec.service),
+    [allServicesCoverage]
   );
-  const lastSeededSigRef = useRef<string | null>(null);
 
-  // Default drafts to "selected" — EXCEPT those already covered, so we never
-  // dual-write. "Covered" unions both signals we have: a matching Prometheus
-  // recording rule (`existingRuleMatch`, per-draft) OR the service already
-  // owning its canonical availability+latency SLO pair (`allServicesCoverage`,
-  // from the health rollup). Re-seed when the draft set changes (scope changed)
-  // or while the user hasn't touched the selection yet — the latter lets a
-  // late-arriving coverage signal still deselect covered drafts. Once the user
-  // interacts, their selection is preserved.
+  // Keys the user has explicitly toggled. Re-seeding preserves the user's choice
+  // for these while still letting the defaults (and a late-arriving coverage
+  // signal) drive every untouched draft — so touching one draft never freezes
+  // coverage-deselection for the others, and changing scope never discards
+  // curation for services that remain.
+  const touchedKeysRef = useRef<Set<string>>(new Set());
+
+  // Default drafts to "selected" EXCEPT covered ones, but keep whatever the user
+  // did to any draft they've touched. Runs whenever the draft set or the
+  // coverage signal changes; prunes touched keys that are no longer present.
   useEffect(() => {
-    const sigChanged = lastSeededSigRef.current !== suggestionKeySig;
-    if (!sigChanged && hasInteractedRef.current) return;
-    if (sigChanged) hasInteractedRef.current = false;
-    lastSeededSigRef.current = suggestionKeySig;
-    setSelected(
-      new Set(
-        suggestions
-          .filter((s) => !s.existingRuleMatch && !allServicesCoverage.has(s.input.spec.service))
-          .map((s) => s.key)
-      )
-    );
-  }, [suggestions, suggestionKeySig, allServicesCoverage]);
+    const presentKeys = new Set(suggestions.map((s) => s.key));
+    for (const k of touchedKeysRef.current) {
+      if (!presentKeys.has(k)) touchedKeysRef.current.delete(k);
+    }
+    setSelected((prev) => {
+      const next = new Set<string>();
+      for (const s of suggestions) {
+        const keep = touchedKeysRef.current.has(s.key) ? prev.has(s.key) : !isDraftCovered(s);
+        if (keep) next.add(s.key);
+      }
+      return next;
+    });
+  }, [suggestions, isDraftCovered]);
 
   const toggle = useCallback((key: string) => {
-    hasInteractedRef.current = true;
+    touchedKeysRef.current.add(key);
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(key)) next.delete(key);
@@ -509,27 +504,31 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
       .filter((row) => row.drafts.length > 0);
   }, [uniqueServices, decoratedSuggestions, selected]);
 
-  /** Re-seed expansion to "all collapsed" whenever the set of services changes. */
+  // Re-seed expansion to "all collapsed" whenever the *set of services* changes.
+  // Keyed on the joined service names (not `serviceRows`, whose identity changes
+  // on every selection toggle) so toggling a draft doesn't churn this effect.
+  const serviceNameSig = useMemo(() => uniqueServices.join('\n'), [uniqueServices]);
   useEffect(() => {
+    const names = serviceNameSig ? serviceNameSig.split('\n') : [];
     setExpandedMap((prev) => {
       const next: Record<string, boolean> = {};
-      for (const row of serviceRows) {
-        next[row.serviceName] = prev[row.serviceName] ?? false;
+      for (const name of names) {
+        next[name] = prev[name] ?? false;
       }
       return next;
     });
-  }, [serviceRows]);
+  }, [serviceNameSig]);
 
   const toggleExpand = useCallback((serviceName: string) => {
     setExpandedMap((prev) => ({ ...prev, [serviceName]: !prev[serviceName] }));
   }, []);
 
   const toggleServiceSelection = useCallback((row: ServiceRowShape) => {
-    hasInteractedRef.current = true;
     const allSelected = row.selectedCount === row.drafts.length;
     setSelected((prev) => {
       const next = new Set(prev);
       for (const d of row.drafts) {
+        touchedKeysRef.current.add(d.key);
         if (allSelected) next.delete(d.key);
         else next.add(d.key);
       }

--- a/public/components/apm/pages/slos/slo_suggest_page.tsx
+++ b/public/components/apm/pages/slos/slo_suggest_page.tsx
@@ -56,7 +56,7 @@ import { DEFAULT_APM_TIME_RANGE } from '../../common/constants';
 import type { TimeRange } from '../../common/types/service_types';
 import type { SloApiClient } from './slo_api_client';
 import { DiscoveredService, Suggestion, generateSuggestionsForServices } from './suggest_engine';
-import { parseSuggestScopeFromSearch } from './slo_suggest_scope';
+import { buildSuggestSearch, parseSuggestScopeFromSearch } from './slo_suggest_scope';
 import { OverridePatch, OverrideValues } from './suggest_inline_row';
 import { ServiceRowShape, ServiceTreeTable } from './suggest_service_tree_table';
 import { SuggestBatchPreview } from './suggest_batch_preview';
@@ -84,7 +84,10 @@ const ResizableFlyout: React.FC<{
   onClose: () => void;
   children: React.ReactNode;
 }> = ({ width, onResize, onClose, children }) => {
-  const handleRef = React.useRef<HTMLDivElement>(null);
+  // Track the active drag's teardown so a mid-drag unmount (e.g. the last draft
+  // gets deselected and the flyout closes while the mouse is still down) can
+  // still detach the document listeners and restore the global cursor.
+  const teardownRef = useRef<(() => void) | null>(null);
 
   const onMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -98,12 +101,17 @@ const ResizableFlyout: React.FC<{
         const next = Math.min(maxWidth, Math.max(FLYOUT_MIN_WIDTH, startWidth + delta));
         onResize(next);
       };
-      const onMouseUp = () => {
+      const teardown = () => {
         document.removeEventListener('mousemove', onMouseMove);
         document.removeEventListener('mouseup', onMouseUp);
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
+        teardownRef.current = null;
       };
+      function onMouseUp() {
+        teardown();
+      }
+      teardownRef.current = teardown;
       document.body.style.cursor = 'col-resize';
       document.body.style.userSelect = 'none';
       document.addEventListener('mousemove', onMouseMove);
@@ -111,6 +119,14 @@ const ResizableFlyout: React.FC<{
     },
     [width, onResize]
   );
+
+  // Safety net: if the component unmounts mid-drag, run the pending teardown so
+  // we never leak a document listener or leave the body cursor/user-select stuck.
+  useEffect(() => {
+    return () => {
+      teardownRef.current?.();
+    };
+  }, []);
 
   return (
     <EuiFlyout
@@ -123,7 +139,6 @@ const ResizableFlyout: React.FC<{
       data-test-subj="slosSuggestPreviewFlyout"
     >
       <div
-        ref={handleRef}
         onMouseDown={onMouseDown}
         className="slo-suggest-flyout__resize-handle"
         data-test-subj="slosSuggestPreviewFlyoutResizeHandle"
@@ -156,15 +171,7 @@ const SuggestServiceFilter: React.FC<{
   // Build the target URL, always carrying the discovery time range (`from`/`to`)
   // so changing the service scope never resets the window the user launched with.
   const buildScopeUrl = useCallback(
-    (sel: string[]) => {
-      const qs = new URLSearchParams({ source: 'apm' });
-      if (sel.length > 0) qs.set('services', sel.join(','));
-      if (timeRange) {
-        qs.set('from', timeRange.from);
-        qs.set('to', timeRange.to);
-      }
-      return `/slos/suggest?${qs.toString()}`;
-    },
+    (sel: string[]) => `/slos/suggest?${buildSuggestSearch(sel, timeRange)}`,
     [timeRange]
   );
 
@@ -257,10 +264,21 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   const [overrides, setOverrides] = useState<Record<string, OverrideValues>>({});
   const [showPreview, setShowPreview] = useState(false);
   const [flyoutWidth, setFlyoutWidth] = useState(() =>
-    Math.round(window.innerWidth * FLYOUT_INITIAL_WIDTH_PCT)
+    // Clamp the seed to the same [min, max] band the drag handler enforces, so a
+    // narrow viewport can't open the flyout below FLYOUT_MIN_WIDTH.
+    Math.round(
+      Math.min(
+        window.innerWidth * FLYOUT_MAX_WIDTH_PCT,
+        Math.max(FLYOUT_MIN_WIDTH, window.innerWidth * FLYOUT_INITIAL_WIDTH_PCT)
+      )
+    )
   );
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [expandedMap, setExpandedMap] = useState<Record<string, boolean>>({});
+  /** Bumping this re-runs the discovery probes + ruler fetch (the "Rediscover"
+   *  button), giving the user a way to recover from a transient ruler outage
+   *  without a full page reload. */
+  const [discoveryEpoch, setDiscoveryEpoch] = useState(0);
 
   useEffect(() => {
     chrome.setBreadcrumbs([
@@ -312,6 +330,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     data: allDiscoveredServices,
     isLoading: servicesLoading,
     error: servicesError,
+    refetch: refetchServices,
   } = useServices({
     startTime: parsedTimeRange.startTime,
     endTime: parsedTimeRange.endTime,
@@ -334,13 +353,20 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
 
   const services = scopedServices;
 
+  // The URL named a scope, discovery returned services, but none of them match
+  // — a stale/bookmarked deep link (e.g. `?services=cart` after the service
+  // stopped emitting). Warn the user rather than silently showing the generic
+  // "pick services" empty state, and offer a one-click way to clear the scope.
+  const scopeFellThrough =
+    scope.services !== undefined && allDiscoveredServices.length > 0 && scopedServices.length === 0;
+
   const {
     metricNames,
     labelValuesByMetric,
     existingRuleGroups,
     rulerFetchFailed,
     loading: discoveryLoading,
-  } = useDiscoveryProbes({ http, datasourceId });
+  } = useDiscoveryProbes({ http, datasourceId, epoch: discoveryEpoch });
 
   const suggestions = useMemo<Suggestion[]>(() => {
     if (!datasourceId || !services || services.length === 0) return [];
@@ -362,7 +388,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     [allDiscoveredServices]
   );
 
-  const { bySvc: healthBySvc } = useServiceSloHealth({
+  const { bySvc: healthBySvc, isLoading: healthLoading } = useServiceSloHealth({
     serviceNames: allServiceNames,
     datasourceId,
     apiClient,
@@ -473,9 +499,15 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   });
 
   const runCreateSelected = useCallback(() => {
-    const picks = suggestions.filter((s) => selected.has(s.key)).map(applyOverrides);
+    // Backstop against dual-writes: never provision a draft whose service is
+    // already covered, even if it stayed checked through a selection-state race
+    // (e.g. the master checkbox marked it touched before the async coverage
+    // signal resolved, so the seeding effect could no longer auto-deselect it).
+    const picks = suggestions
+      .filter((s) => selected.has(s.key) && !isDraftCovered(s))
+      .map(applyOverrides);
     return runCreate(picks);
-  }, [applyOverrides, runCreate, selected, suggestions]);
+  }, [applyOverrides, isDraftCovered, runCreate, selected, suggestions]);
 
   const createSelected = useCallback(() => {
     // Already-open preview means the user has seen the full rule/SLI
@@ -501,7 +533,12 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   const totalRules = decoratedSuggestions
     .filter((s) => selected.has(s.key))
     .reduce((acc, s) => acc + s.estimatedRuleCount, 0);
-  const coveredCount = decoratedSuggestions.filter((s) => s.existingRuleMatch).length;
+  // Count with the same `isDraftCovered` union that drives default-unchecking,
+  // not just `existingRuleMatch` — otherwise a service covered via the health
+  // rollup (no matching recording rule) gets its drafts unchecked while the
+  // "N drafts already covered" subline never renders, leaving the user with a
+  // disabled Create and no explanation.
+  const coveredCount = decoratedSuggestions.filter((s) => isDraftCovered(s)).length;
   // The service list comes from APM discovery but an OTel-only service (one
   // that emits direct metrics without span-derived RED) can still surface a
   // draft. Union both sources so every service that owns drafts gets a row.
@@ -530,12 +567,15 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
           drafts,
           selectedCount: drafts.filter((s) => selected.has(s.key)).length,
           totalRules: drafts.reduce((acc, s) => acc + s.estimatedRuleCount, 0),
-          coveredCount: drafts.filter((s) => s.existingRuleMatch).length,
+          // Union recording-rule + health-rollup coverage, matching the
+          // page-level `coveredCount` and the default-unchecking in the seeding
+          // effect (see `isDraftCovered`).
+          coveredCount: drafts.filter((s) => isDraftCovered(s)).length,
           kinds,
         };
       })
       .filter((row) => row.drafts.length > 0);
-  }, [uniqueServices, decoratedSuggestions, selected]);
+  }, [uniqueServices, decoratedSuggestions, selected, isDraftCovered]);
 
   // Re-seed expansion to "all collapsed" whenever the *set of services* changes.
   // Keyed on the joined service names (not `serviceRows`, whose identity changes
@@ -572,11 +612,33 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   const loading = configLoading || servicesLoading || discoveryLoading;
 
   const headerActions = [
-    <EuiButtonEmpty key="back" size="s" onClick={() => history.goBack()}>
+    // Navigate to the SLO listing rather than `history.goBack()`: the primary
+    // entry to this page is a cross-app deep link (or a fresh/bookmarked URL),
+    // so the router stack length is often 1 and `goBack()` is a no-op (or exits
+    // the app). Pushing the listing route always lands somewhere useful.
+    <EuiButtonEmpty key="back" iconType="arrowLeft" size="s" onClick={() => history.push('/slos')}>
       {i18n.translate('observability.apm.slo.suggest.backButton', {
         defaultMessage: 'Cancel',
       })}
     </EuiButtonEmpty>,
+    // Re-run service discovery + the ruler/probe fetch. Recovers from a
+    // transient ruler outage (the "could not verify existing recording rules"
+    // warning) without forcing a full page reload.
+    <EuiButton
+      key="rediscover"
+      size="s"
+      iconType="refresh"
+      onClick={() => {
+        refetchServices();
+        setDiscoveryEpoch((n) => n + 1);
+      }}
+      isLoading={loading}
+      data-test-subj="slosSuggestDiscover"
+    >
+      {i18n.translate('observability.apm.slo.suggest.rediscoverButton', {
+        defaultMessage: 'Rediscover',
+      })}
+    </EuiButton>,
     <EuiButton
       key="preview"
       size="s"
@@ -597,7 +659,10 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
       color="primary"
       onClick={createSelected}
       isLoading={isCreating}
-      isDisabled={selectedCount === 0 || loading}
+      // Also gate on `healthLoading`: the coverage rollup resolves async and
+      // drives which drafts default unchecked. Creating before it lands risks
+      // dual-writing rules for a service that's already covered.
+      isDisabled={selectedCount === 0 || loading || healthLoading}
       data-test-subj="slosSuggestCreate"
     >
       {i18n.translate('observability.apm.slo.suggest.createSelectedButton', {
@@ -635,12 +700,9 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
               })}
               <EuiCode>slo-generated</EuiCode>
             </EuiText>
-            <EuiSpacer size="m" />
-
             {servicesError && (
               <>
                 <EuiCallOut
-                  announceOnMount
                   color="danger"
                   iconType="alert"
                   title={i18n.translate('observability.apm.slo.suggest.servicesErrorTitle', {
@@ -668,7 +730,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
 
             {!loading && !datasourceId && (
               <EuiCallOut
-                announceOnMount
                 size="s"
                 iconType="iInCircle"
                 title={i18n.translate('observability.apm.slo.suggest.noDatasource.title', {
@@ -687,7 +748,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
 
             {!loading && datasourceId && allDiscoveredServices.length === 0 && !servicesError && (
               <EuiCallOut
-                announceOnMount
                 size="s"
                 iconType="iInCircle"
                 title={i18n.translate('observability.apm.slo.suggest.noServices.title', {
@@ -706,7 +766,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
             {!loading && datasourceId && rulerFetchFailed && (
               <>
                 <EuiCallOut
-                  announceOnMount
                   size="s"
                   iconType="alert"
                   color="warning"
@@ -721,6 +780,38 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                         'The Prometheus ruler did not respond when this page tried to list its current recording groups. Suggestions and bulk-create still work, but duplicate recording groups may be created if rules already exist for these SLIs.',
                     })}
                   </EuiText>
+                </EuiCallOut>
+                <EuiSpacer size="m" />
+              </>
+            )}
+
+            {!loading && datasourceId && scopeFellThrough && (
+              <>
+                <EuiCallOut
+                  size="s"
+                  iconType="iInCircle"
+                  color="warning"
+                  title={i18n.translate('observability.apm.slo.suggest.scopeFellThrough.title', {
+                    defaultMessage: 'Scoped services not found',
+                  })}
+                  data-test-subj="slosSuggestScopeFellThrough"
+                >
+                  <EuiText size="s">
+                    {i18n.translate('observability.apm.slo.suggest.scopeFellThrough.body', {
+                      defaultMessage:
+                        "These services aren't in the current APM discovery result. Clear the scope to pick from all discovered services.",
+                    })}
+                  </EuiText>
+                  <EuiSpacer size="xs" />
+                  <EuiButtonEmpty
+                    size="xs"
+                    onClick={() => history.push('/slos/suggest')}
+                    data-test-subj="slosSuggestClearScope"
+                  >
+                    {i18n.translate('observability.apm.slo.suggest.clearScope', {
+                      defaultMessage: 'Clear scope',
+                    })}
+                  </EuiButtonEmpty>
                 </EuiCallOut>
                 <EuiSpacer size="m" />
               </>
@@ -797,8 +888,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                         })}
                       </EuiText>
                     )}
-                    <EuiSpacer size="m" />
-
                     {progress && (
                       <>
                         <EuiPanel
@@ -858,6 +947,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                     onToggleDraft={toggle}
                     onOverrideChange={setOverride}
                     rowStatusMap={rowStatusMap}
+                    coveredServices={allServicesCoverage}
                   />
                 ) : (
                   <EuiPanel

--- a/public/components/apm/pages/slos/slo_suggest_page.tsx
+++ b/public/components/apm/pages/slos/slo_suggest_page.tsx
@@ -38,7 +38,9 @@ import {
   EuiPageContent,
   EuiPageContentBody,
   EuiPanel,
+  EuiPopover,
   EuiProgress,
+  EuiSelectable,
   EuiSpacer,
   EuiStat,
   EuiTitle,
@@ -59,6 +61,7 @@ import { ServiceRowShape, ServiceTreeTable } from './suggest_service_tree_table'
 import { SuggestBatchPreview } from './suggest_batch_preview';
 import { useDiscoveryProbes } from './suggest_use_discovery_probes';
 import { useBatchCreate } from './suggest_use_batch_create';
+import { useServiceSloHealth } from './slo_health_summary';
 
 export interface SloSuggestPageProps {
   apiClient: SloApiClient;
@@ -67,6 +70,218 @@ export interface SloSuggestPageProps {
   notifications: NotificationsStart;
   parentBreadcrumb: { text: string; href: string };
 }
+
+const FLYOUT_MIN_WIDTH = 300;
+const FLYOUT_MAX_WIDTH_PCT = 0.45;
+
+const ResizableFlyout: React.FC<{
+  width: number;
+  onResize: (w: number) => void;
+  onClose: () => void;
+  children: React.ReactNode;
+}> = ({ width, onResize, onClose, children }) => {
+  const handleRef = React.useRef<HTMLDivElement>(null);
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = width;
+      const maxWidth = window.innerWidth * FLYOUT_MAX_WIDTH_PCT;
+
+      const onMouseMove = (ev: MouseEvent) => {
+        const delta = startX - ev.clientX;
+        const next = Math.min(maxWidth, Math.max(FLYOUT_MIN_WIDTH, startWidth + delta));
+        onResize(next);
+      };
+      const onMouseUp = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+      };
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    },
+    [width, onResize]
+  );
+
+  return (
+    <EuiFlyout
+      onClose={onClose}
+      ownFocus={false}
+      type="push"
+      size={width}
+      side="right"
+      pushMinBreakpoint="xs"
+      data-test-subj="slosSuggestPreviewFlyout"
+    >
+      <div
+        ref={handleRef}
+        onMouseDown={onMouseDown}
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          bottom: 0,
+          width: 6,
+          cursor: 'col-resize',
+          zIndex: 1000,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <div
+          style={{
+            width: 4,
+            height: 40,
+            borderRadius: 2,
+            backgroundColor: '#c0c5cc',
+          }}
+        />
+      </div>
+      {children}
+    </EuiFlyout>
+  );
+};
+
+const SuggestServiceFilter: React.FC<{
+  allServices: Array<{ serviceName: string }>;
+  coveredSet: Set<string>;
+  scopedServices: string[] | undefined;
+  history: ReturnType<typeof useHistory>;
+  selectAll: () => void;
+  clearAll: () => void;
+  allSelected: boolean;
+  noneSelected: boolean;
+}> = ({
+  allServices,
+  coveredSet,
+  scopedServices,
+  history,
+  selectAll,
+  clearAll,
+  allSelected,
+  noneSelected,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const scopeSet = useMemo(() => new Set(scopedServices ?? []), [scopedServices]);
+
+  const allServiceNames = useMemo(() => {
+    const set = new Set<string>();
+    for (const s of allServices) {
+      if (s.serviceName) set.add(s.serviceName);
+    }
+    return Array.from(set);
+  }, [allServices]);
+
+  const noScope = scopedServices === undefined;
+  const options = useMemo(
+    () =>
+      allServiceNames.map((svc) => {
+        const fullyCovered = coveredSet.has(svc);
+        const isChecked = fullyCovered
+          ? undefined
+          : noScope || scopeSet.has(svc)
+          ? ('on' as const)
+          : undefined;
+        return {
+          label: svc,
+          checked: isChecked,
+          disabled: fullyCovered,
+          append: fullyCovered ? (
+            <EuiText size="xs" color="success">
+              covered
+            </EuiText>
+          ) : undefined,
+        };
+      }),
+    [allServiceNames, scopeSet, coveredSet, noScope]
+  );
+
+  const onChange = useCallback(
+    (newOptions: Array<{ label: string; checked?: 'on' }>) => {
+      const sel = newOptions
+        .filter((o) => o.checked === 'on' && !coveredSet.has(o.label))
+        .map((o) => o.label);
+      if (
+        sel.length === 0 ||
+        sel.length === allServiceNames.filter((s) => !coveredSet.has(s)).length
+      ) {
+        history.replace('/slos/suggest');
+      } else {
+        const qs = new URLSearchParams({ source: 'apm', services: sel.join(',') });
+        history.replace(`/slos/suggest?${qs.toString()}`);
+      }
+    },
+    [history, allServiceNames, coveredSet]
+  );
+
+  const selectedCount = scopedServices?.length ?? 0;
+
+  return (
+    <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty size="s" onClick={selectAll} isDisabled={allSelected}>
+          {i18n.translate('observability.apm.slo.suggest.selectAll', {
+            defaultMessage: 'Select all',
+          })}
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty size="s" onClick={clearAll} isDisabled={noneSelected}>
+          {i18n.translate('observability.apm.slo.suggest.clearSelection', {
+            defaultMessage: 'Clear',
+          })}
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+      <EuiFlexItem grow={true} />
+      <EuiFlexItem grow={false}>
+        <EuiPopover
+          isOpen={isOpen}
+          closePopover={() => setIsOpen(false)}
+          panelPaddingSize="none"
+          anchorPosition="downRight"
+          button={
+            <EuiButton
+              size="s"
+              iconType="arrowDown"
+              iconSide="right"
+              onClick={() => setIsOpen((prev) => !prev)}
+              data-test-subj="slosSuggestServiceFilter"
+            >
+              {i18n.translate('observability.apm.slo.suggest.serviceFilter', {
+                defaultMessage:
+                  'Suggest SLOs for {count, plural, one {# service} other {# services}}',
+                values: { count: selectedCount },
+              })}
+            </EuiButton>
+          }
+        >
+          <EuiSelectable
+            searchable
+            searchProps={{ compressed: true, placeholder: 'Filter services' }}
+            options={options}
+            onChange={onChange}
+            listProps={{ bordered: false }}
+            style={{ width: 300 }}
+            height={240}
+          >
+            {(list, search) => (
+              <>
+                <div style={{ padding: '8px 8px 0' }}>{search}</div>
+                {list}
+              </>
+            )}
+          </EuiSelectable>
+        </EuiPopover>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
 
 export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   apiClient,
@@ -83,10 +298,11 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   /** Per-suggestion overrides users type into the card. */
   const [overrides, setOverrides] = useState<Record<string, OverrideValues>>({});
   const [showPreview, setShowPreview] = useState(false);
+  const [flyoutWidth, setFlyoutWidth] = useState(Math.round(window.innerWidth * 0.3));
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [expandedMap, setExpandedMap] = useState<Record<string, boolean>>({});
-  /** Bumping this triggers the discovery effect; covers the "Rediscover" button. */
-  const [discoveryEpoch, setDiscoveryEpoch] = useState(0);
+  /** Bumping this triggers the discovery effect. */
+  const [discoveryEpoch] = useState(0);
 
   useEffect(() => {
     chrome.setBreadcrumbs([
@@ -118,7 +334,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     data: allDiscoveredServices,
     isLoading: servicesLoading,
     error: servicesError,
-    refetch,
   } = useServices({
     startTime: parsedTimeRange.startTime,
     endTime: parsedTimeRange.endTime,
@@ -133,11 +348,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     const filtered = allDiscoveredServices.filter((s) => allow.has(s.serviceName));
     return filtered.length > 0 ? filtered : allDiscoveredServices;
   }, [allDiscoveredServices, scope.services]);
-
-  const scopeFellThrough =
-    scope.services !== undefined &&
-    allDiscoveredServices.length > 0 &&
-    allDiscoveredServices.every((s) => !scope.services!.includes(s.serviceName));
 
   const services = scopedServices;
 
@@ -163,6 +373,25 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
       existingRuleGroups,
     });
   }, [datasourceId, services, metricNames, labelValuesByMetric, existingRuleGroups]);
+
+  const allServiceNames = useMemo(
+    () => (allDiscoveredServices ?? []).map((s) => s.serviceName).filter(Boolean),
+    [allDiscoveredServices]
+  );
+
+  const { bySvc: healthBySvc } = useServiceSloHealth({
+    serviceNames: allServiceNames,
+    datasourceId,
+    apiClient,
+  });
+
+  const allServicesCoverage = useMemo<Set<string>>(() => {
+    const set = new Set<string>();
+    for (const [svc, bucket] of healthBySvc) {
+      if (!bucket.missingCanonicalPair) set.add(svc);
+    }
+    return set;
+  }, [healthBySvc]);
 
   // Default every suggestion to "selected" when the list changes — EXCEPT
   // those already covered by an existing Prometheus rule. Users can re-check
@@ -296,13 +525,12 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
       .filter((row) => row.drafts.length > 0);
   }, [uniqueServices, decoratedSuggestions, selected]);
 
-  /** Re-seed expansion to "all expanded" whenever the set of services changes. */
+  /** Re-seed expansion to "all collapsed" whenever the set of services changes. */
   useEffect(() => {
     setExpandedMap((prev) => {
       const next: Record<string, boolean> = {};
       for (const row of serviceRows) {
-        // Preserve any explicit collapse the user performed.
-        next[row.serviceName] = prev[row.serviceName] ?? true;
+        next[row.serviceName] = prev[row.serviceName] ?? false;
       }
       return next;
     });
@@ -327,24 +555,21 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   const loading = configLoading || servicesLoading || discoveryLoading;
 
   const headerActions = [
-    <EuiButtonEmpty key="back" iconType="arrowLeft" href="#/slos" size="s">
+    <EuiButtonEmpty key="back" size="s" onClick={() => history.goBack()}>
       {i18n.translate('observability.apm.slo.suggest.backButton', {
-        defaultMessage: 'Back to SLOs',
+        defaultMessage: 'Cancel',
       })}
     </EuiButtonEmpty>,
     <EuiButton
-      key="discover"
+      key="preview"
       size="s"
-      iconType="refresh"
-      onClick={() => {
-        refetch();
-        setDiscoveryEpoch((n) => n + 1);
-      }}
-      isLoading={loading}
-      data-test-subj="slosSuggestDiscover"
+      iconType={showPreview ? 'eyeClosed' : 'eye'}
+      onClick={() => setShowPreview((v) => !v)}
+      isDisabled={selectedCount === 0}
+      data-test-subj="slosSuggestPreviewToggle"
     >
-      {i18n.translate('observability.apm.slo.suggest.rediscoverButton', {
-        defaultMessage: 'Rediscover',
+      {i18n.translate('observability.apm.slo.suggest.previewToggle.label', {
+        defaultMessage: 'Preview',
       })}
     </EuiButton>,
     <EuiButton
@@ -359,7 +584,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
       data-test-subj="slosSuggestCreate"
     >
       {i18n.translate('observability.apm.slo.suggest.createSelectedButton', {
-        defaultMessage: 'Create {selectedCount} selected',
+        defaultMessage: 'Create {selectedCount} {selectedCount, plural, one {SLO} other {SLOs}}',
         values: { selectedCount },
       })}
     </EuiButton>,
@@ -386,72 +611,13 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                   'Drafts availability + latency SLOs per service from span-derived RED metrics, plus OTel semconv add-ons where present.',
               })}
             </EuiText>
-            {scope.services && !scopeFellThrough && (
-              <>
-                <EuiSpacer size="xs" />
-                <EuiFlexGroup
-                  alignItems="center"
-                  gutterSize="s"
-                  responsive={false}
-                  data-test-subj="slosSuggestScopeSubline"
-                >
-                  <EuiFlexItem grow={false}>
-                    <EuiText size="xs" color="subdued">
-                      {i18n.translate('observability.apm.slo.suggest.scopeSubline', {
-                        defaultMessage:
-                          'Scoped to {count, plural, one {# service} other {# services}}: {names}',
-                        values: {
-                          count: scope.services.length,
-                          names: scope.services.join(', '),
-                        },
-                      })}
-                    </EuiText>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiButtonEmpty
-                      size="xs"
-                      onClick={() => history.push('#/slos/suggest')}
-                      data-test-subj="slosSuggestClearScope"
-                    >
-                      {i18n.translate('observability.apm.slo.suggest.clearScope', {
-                        defaultMessage: 'Clear scope',
-                      })}
-                    </EuiButtonEmpty>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </>
-            )}
-            {scopeFellThrough && (
-              <>
-                <EuiSpacer size="s" />
-                <EuiCallOut
-                  size="s"
-                  iconType="iInCircle"
-                  color="warning"
-                  title={i18n.translate('observability.apm.slo.suggest.scopeFellThrough.title', {
-                    defaultMessage: 'Scoped services not found',
-                  })}
-                  data-test-subj="slosSuggestScopeFellThrough"
-                >
-                  <EuiText size="s">
-                    {i18n.translate('observability.apm.slo.suggest.scopeFellThrough.body', {
-                      defaultMessage:
-                        "These services aren't in the current APM discovery result. Showing all discovered services instead.",
-                    })}
-                  </EuiText>
-                  <EuiSpacer size="xs" />
-                  <EuiButtonEmpty
-                    size="xs"
-                    onClick={() => history.push('#/slos/suggest')}
-                    data-test-subj="slosSuggestClearScope"
-                  >
-                    {i18n.translate('observability.apm.slo.suggest.clearScope', {
-                      defaultMessage: 'Clear scope',
-                    })}
-                  </EuiButtonEmpty>
-                </EuiCallOut>
-              </>
-            )}
+            <EuiSpacer size="xs" />
+            <EuiText size="xs" color="subdued">
+              {i18n.translate('observability.apm.slo.suggest.namespaceLabel', {
+                defaultMessage: 'Namespace: ',
+              })}
+              <EuiCode>slo-generated</EuiCode>
+            </EuiText>
             <EuiSpacer size="m" />
 
             {servicesError && (
@@ -537,9 +703,14 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
 
             {!loading && decoratedSuggestions.length > 0 && (
               <>
-                <EuiPanel paddingSize="m" hasBorder data-test-subj="slosSuggestHeaderStrip">
-                  <EuiFlexGroup alignItems="center" responsive={false} gutterSize="l">
-                    <EuiFlexItem grow={false}>
+                <EuiFlexGroup
+                  alignItems="center"
+                  responsive={false}
+                  gutterSize="m"
+                  data-test-subj="slosSuggestHeaderStrip"
+                >
+                  <EuiFlexItem grow={false}>
+                    <EuiPanel paddingSize="m" hasBorder>
                       <EuiStat
                         title={`${selectedCount}`}
                         description={i18n.translate('observability.apm.slo.suggest.stat.ofSlos', {
@@ -550,8 +721,10 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                         reverse
                         data-test-subj="slosSuggestStatSlos"
                       />
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
+                    </EuiPanel>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiPanel paddingSize="m" hasBorder>
                       <EuiStat
                         title={`${uniqueServices.length}`}
                         description={i18n.translate('observability.apm.slo.suggest.stat.services', {
@@ -562,8 +735,10 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                         reverse
                         data-test-subj="slosSuggestStatServices"
                       />
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
+                    </EuiPanel>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiPanel paddingSize="m" hasBorder>
                       <EuiStat
                         title={`${totalRules}`}
                         description={i18n.translate(
@@ -575,72 +750,20 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                         reverse
                         data-test-subj="slosSuggestStatRules"
                       />
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={true} />
-                    <EuiFlexItem grow={false}>
-                      <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
-                        <EuiFlexItem grow={false}>
-                          <EuiButtonEmpty
-                            size="s"
-                            onClick={() =>
-                              setSelected(new Set(decoratedSuggestions.map((s) => s.key)))
-                            }
-                          >
-                            {i18n.translate('observability.apm.slo.suggest.selectAll', {
-                              defaultMessage: 'Select all',
-                            })}
-                          </EuiButtonEmpty>
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                          <EuiButtonEmpty size="s" onClick={() => setSelected(new Set())}>
-                            {i18n.translate('observability.apm.slo.suggest.clearSelection', {
-                              defaultMessage: 'Clear',
-                            })}
-                          </EuiButtonEmpty>
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                          <EuiButton
-                            size="s"
-                            iconType={showPreview ? 'eyeClosed' : 'eye'}
-                            onClick={() => setShowPreview((v) => !v)}
-                            isDisabled={selectedCount === 0}
-                            data-test-subj="slosSuggestPreviewToggle"
-                          >
-                            {showPreview
-                              ? i18n.translate('observability.apm.slo.suggest.previewToggle.hide', {
-                                  defaultMessage: 'Hide preview',
-                                })
-                              : i18n.translate('observability.apm.slo.suggest.previewToggle.show', {
-                                  defaultMessage: 'Preview {selectedCount} selected',
-                                  values: { selectedCount },
-                                })}
-                          </EuiButton>
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiPanel>
-                <EuiSpacer size="xs" />
-                <EuiText size="xs" color="subdued" data-test-subj="slosSuggestHeaderSubline">
-                  {coveredCount > 0 ? (
-                    <>
-                      {i18n.translate('observability.apm.slo.suggest.headerSubline.covered', {
-                        defaultMessage:
-                          '{count, plural, one {# draft} other {# drafts}} already covered by existing rules · Namespace: ',
-                        values: { count: coveredCount },
-                      })}
-                      <EuiCode>slo-generated</EuiCode>
-                    </>
-                  ) : (
-                    <>
-                      {i18n.translate(
-                        'observability.apm.slo.suggest.headerSubline.namespacePrefix',
-                        { defaultMessage: 'Namespace: ' }
-                      )}
-                      <EuiCode>slo-generated</EuiCode>
-                    </>
-                  )}
-                </EuiText>
+                    </EuiPanel>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={true} />
+                </EuiFlexGroup>
+                {coveredCount > 0 && <EuiSpacer size="xs" />}
+                {coveredCount > 0 && (
+                  <EuiText size="xs" color="subdued" data-test-subj="slosSuggestHeaderSubline">
+                    {i18n.translate('observability.apm.slo.suggest.headerSubline.covered', {
+                      defaultMessage:
+                        '{count, plural, one {# draft} other {# drafts}} already covered by existing rules',
+                      values: { count: coveredCount },
+                    })}
+                  </EuiText>
+                )}
                 <EuiSpacer size="m" />
 
                 {progress && (
@@ -673,6 +796,29 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                   </>
                 )}
 
+                <SuggestServiceFilter
+                  allServices={allDiscoveredServices}
+                  coveredSet={allServicesCoverage}
+                  scopedServices={scope.services}
+                  history={history}
+                  selectAll={() => {
+                    const selectable = !scope.services
+                      ? decoratedSuggestions.filter(
+                          (s) => !allServicesCoverage.has(s.input.spec.service)
+                        )
+                      : decoratedSuggestions;
+                    setSelected(new Set(selectable.map((s) => s.key)));
+                  }}
+                  clearAll={() => setSelected(new Set())}
+                  allSelected={
+                    selectedCount ===
+                      decoratedSuggestions.filter((s) =>
+                        scope.services ? true : !allServicesCoverage.has(s.input.spec.service)
+                      ).length && selectedCount > 0
+                  }
+                  noneSelected={selectedCount === 0}
+                />
+                <EuiSpacer size="s" />
                 <ServiceTreeTable
                   serviceRows={serviceRows}
                   expandedMap={expandedMap}
@@ -683,6 +829,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
                   onToggleDraft={toggle}
                   onOverrideChange={setOverride}
                   rowStatusMap={rowStatusMap}
+                  coveredServices={!scope.services ? allServicesCoverage : undefined}
                 />
               </>
             )}
@@ -696,14 +843,10 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
           subtree — and SuggestBatchPreview's debounced effect — stays
           mounted across rapid edits. */}
       {showPreview && selectedCount > 0 && (
-        <EuiFlyout
+        <ResizableFlyout
+          width={flyoutWidth}
+          onResize={setFlyoutWidth}
           onClose={() => setShowPreview(false)}
-          ownFocus={false}
-          type="push"
-          size="m"
-          side="right"
-          pushMinBreakpoint="xs"
-          data-test-subj="slosSuggestPreviewFlyout"
         >
           <EuiFlyoutHeader hasBorder data-test-subj="slosSuggestPreviewFlyoutHeader">
             <EuiTitle size="s">
@@ -715,7 +858,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
               </h3>
             </EuiTitle>
           </EuiFlyoutHeader>
-          <EuiFlyoutBody>
+          <EuiFlyoutBody style={{ overflowWrap: 'break-word', wordBreak: 'break-word' }}>
             <SuggestBatchPreview
               apiClient={apiClient}
               selectedSuggestions={decoratedSuggestions.filter((s) => selected.has(s.key))}
@@ -723,7 +866,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
               prometheusConnectionMeta={config?.prometheusDataSource?.meta}
             />
           </EuiFlyoutBody>
-        </EuiFlyout>
+        </ResizableFlyout>
       )}
       {confirmOpen && (
         <EuiConfirmModal

--- a/public/components/apm/pages/slos/slo_suggest_page.tsx
+++ b/public/components/apm/pages/slos/slo_suggest_page.tsx
@@ -20,7 +20,7 @@
  *     siblings under this directory. The page itself is pure composition.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -40,7 +40,6 @@ import {
   EuiPanel,
   EuiPopover,
   EuiProgress,
-  EuiSelectable,
   EuiSpacer,
   EuiStat,
   EuiTitle,
@@ -62,7 +61,7 @@ import { SuggestBatchPreview } from './suggest_batch_preview';
 import { useDiscoveryProbes } from './suggest_use_discovery_probes';
 import { useBatchCreate } from './suggest_use_batch_create';
 import { useServiceSloHealth } from './slo_health_summary';
-import { buildServiceFilterOptions } from './service_filter_options';
+import { ServiceFilterSelectable } from './service_filter_selectable';
 import './slo_suggest_page.scss';
 
 export interface SloSuggestPageProps {
@@ -75,6 +74,7 @@ export interface SloSuggestPageProps {
 
 const FLYOUT_MIN_WIDTH = 300;
 const FLYOUT_MAX_WIDTH_PCT = 0.45;
+const FLYOUT_INITIAL_WIDTH_PCT = 0.3;
 
 const ResizableFlyout: React.FC<{
   width: number;
@@ -120,8 +120,13 @@ const ResizableFlyout: React.FC<{
       pushMinBreakpoint="xs"
       data-test-subj="slosSuggestPreviewFlyout"
     >
-      <div ref={handleRef} onMouseDown={onMouseDown} className="sloSuggestFlyout__resizeHandle">
-        <div className="sloSuggestFlyout__resizeGrip" />
+      <div
+        ref={handleRef}
+        onMouseDown={onMouseDown}
+        className="slo-suggest-flyout__resize-handle"
+        data-test-subj="slosSuggestPreviewFlyoutResizeHandle"
+      >
+        <div className="slo-suggest-flyout__resize-grip" />
       </div>
       {children}
     </EuiFlyout>
@@ -145,27 +150,11 @@ const SuggestServiceFilter: React.FC<{
     return Array.from(set);
   }, [allServices]);
 
-  const options = useMemo(
-    () =>
-      buildServiceFilterOptions(allServiceNames, scopeSet, coveredSet).map((opt) => ({
-        label: opt.label,
-        checked: opt.checked,
-        disabled: opt.disabled,
-        append: opt.covered ? (
-          <EuiText size="xs" color="success">
-            covered
-          </EuiText>
-        ) : undefined,
-      })),
-    [allServiceNames, scopeSet, coveredSet]
-  );
-
-  const onChange = useCallback(
-    (newOptions: Array<{ label: string; checked?: 'on' }>) => {
-      const sel = newOptions
-        .filter((o) => o.checked === 'on' && !coveredSet.has(o.label))
-        .map((o) => o.label);
-      // Empty selection collapses to the unscoped URL, which now renders the
+  // The suggest page commits selection live to the URL scope — no staged
+  // "confirm" step — so every toggle rewrites the query string.
+  const onSelectionChange = useCallback(
+    (sel: string[]) => {
+      // Empty selection collapses to the unscoped URL, which renders the
       // "pick services" empty state rather than drafting everything.
       if (sel.length === 0) {
         history.replace('/slos/suggest');
@@ -174,7 +163,7 @@ const SuggestServiceFilter: React.FC<{
         history.replace(`/slos/suggest?${qs.toString()}`);
       }
     },
-    [history, coveredSet]
+    [history]
   );
 
   const clearScope = useCallback(() => {
@@ -213,22 +202,13 @@ const SuggestServiceFilter: React.FC<{
             </EuiButton>
           }
         >
-          <div className="sloSuggestFilter__panel">
-            <EuiSelectable
-              searchable
-              searchProps={{ compressed: true, placeholder: 'Filter services' }}
-              options={options}
-              onChange={onChange}
-              listProps={{ bordered: false }}
-              height={240}
-            >
-              {(list, search) => (
-                <>
-                  <div className="sloSuggestFilter__search">{search}</div>
-                  {list}
-                </>
-              )}
-            </EuiSelectable>
+          <div className="slo-service-filter__panel">
+            <ServiceFilterSelectable
+              serviceNames={allServiceNames}
+              selectedSet={scopeSet}
+              coveredSet={coveredSet}
+              onSelectionChange={onSelectionChange}
+            />
             <EuiPanel color="transparent" paddingSize="s">
               <EuiButtonEmpty
                 size="s"
@@ -263,7 +243,9 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   /** Per-suggestion overrides users type into the card. */
   const [overrides, setOverrides] = useState<Record<string, OverrideValues>>({});
   const [showPreview, setShowPreview] = useState(false);
-  const [flyoutWidth, setFlyoutWidth] = useState(Math.round(window.innerWidth * 0.3));
+  const [flyoutWidth, setFlyoutWidth] = useState(() =>
+    Math.round(window.innerWidth * FLYOUT_INITIAL_WIDTH_PCT)
+  );
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [expandedMap, setExpandedMap] = useState<Record<string, boolean>>({});
 
@@ -307,6 +289,10 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   // filter popover, which writes the scope to the URL. A stale deep link that
   // names services discovery doesn't see resolves to an empty list, which the
   // "pick services" empty state handles the same as the initial landing.
+  //
+  // A deep link to an already-covered service still renders its drafts (so the
+  // user sees them), but they default unchecked via the selection effect below,
+  // consistent with how the picker disables covered services.
   const scopedServices = useMemo(() => {
     if (!scope.services) return [];
     const allow = new Set(scope.services);
@@ -357,16 +343,48 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     return set;
   }, [healthBySvc]);
 
-  // Default every suggestion to "selected" when the list changes — EXCEPT
-  // those already covered by an existing Prometheus rule. The user has already
-  // chosen which services to scope upstream, so landing with their drafts
-  // pre-checked matches intent; covered drafts stay unchecked so we don't
-  // dual-write. Users can uncheck any draft they don't want.
+  // Tracks whether the user has manually changed the selection. Once they have,
+  // we stop auto-re-seeding so a late-resolving ruler/health fetch can't clobber
+  // their toggles (the discovery probes and SLO-health rollup arrive async and
+  // recompute `suggestions`).
+  const hasInteractedRef = useRef(false);
+  // Signature of the current draft set — re-seeding keys off this rather than
+  // `suggestions` identity so metadata-only recomputes (ruler resolving, which
+  // sets `existingRuleMatch`) don't count as "a new list".
+  const suggestionKeySig = useMemo(
+    () =>
+      suggestions
+        .map((s) => s.key)
+        .sort()
+        .join('\n'),
+    [suggestions]
+  );
+  const lastSeededSigRef = useRef<string | null>(null);
+
+  // Default drafts to "selected" — EXCEPT those already covered, so we never
+  // dual-write. "Covered" unions both signals we have: a matching Prometheus
+  // recording rule (`existingRuleMatch`, per-draft) OR the service already
+  // owning its canonical availability+latency SLO pair (`allServicesCoverage`,
+  // from the health rollup). Re-seed when the draft set changes (scope changed)
+  // or while the user hasn't touched the selection yet — the latter lets a
+  // late-arriving coverage signal still deselect covered drafts. Once the user
+  // interacts, their selection is preserved.
   useEffect(() => {
-    setSelected(new Set(suggestions.filter((s) => !s.existingRuleMatch).map((s) => s.key)));
-  }, [suggestions]);
+    const sigChanged = lastSeededSigRef.current !== suggestionKeySig;
+    if (!sigChanged && hasInteractedRef.current) return;
+    if (sigChanged) hasInteractedRef.current = false;
+    lastSeededSigRef.current = suggestionKeySig;
+    setSelected(
+      new Set(
+        suggestions
+          .filter((s) => !s.existingRuleMatch && !allServicesCoverage.has(s.input.spec.service))
+          .map((s) => s.key)
+      )
+    );
+  }, [suggestions, suggestionKeySig, allServicesCoverage]);
 
   const toggle = useCallback((key: string) => {
+    hasInteractedRef.current = true;
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(key)) next.delete(key);
@@ -383,7 +401,8 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
     (s: Suggestion): Suggestion => {
       const o = overrides[s.key] ?? {};
       // Stamp canonicalKind from the suggestion so readers can classify
-      // without re-running the heuristic. M5A: tag wins, heuristic fallback.
+      // without re-running the heuristic (the explicit tag wins over the
+      // heuristic fallback downstream).
       const spec = { ...s.input.spec, canonicalKind: s.kindId };
       if (o.ownerTeam && o.ownerTeam.trim()) {
         spec.owner = { ...spec.owner, teams: [o.ownerTeam.trim()] };
@@ -506,6 +525,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   }, []);
 
   const toggleServiceSelection = useCallback((row: ServiceRowShape) => {
+    hasInteractedRef.current = true;
     const allSelected = row.selectedCount === row.drafts.length;
     setSelected((prev) => {
       const next = new Set(prev);
@@ -606,7 +626,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
               <EuiFlexGroup
                 justifyContent="center"
                 alignItems="center"
-                className="sloSuggestLoading"
+                className="slo-suggest-loading"
               >
                 <EuiFlexItem grow={false}>
                   <EuiLoadingSpinner size="xl" />
@@ -847,7 +867,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
               </h3>
             </EuiTitle>
           </EuiFlyoutHeader>
-          <EuiFlyoutBody className="sloSuggestFlyout__body">
+          <EuiFlyoutBody className="slo-suggest-flyout__body">
             <SuggestBatchPreview
               apiClient={apiClient}
               selectedSuggestions={decoratedSuggestions.filter((s) => selected.has(s.key))}

--- a/public/components/apm/pages/slos/slo_suggest_scope.ts
+++ b/public/components/apm/pages/slos/slo_suggest_scope.ts
@@ -53,13 +53,6 @@ function parseTimeValue(value: string | null): string | undefined {
 }
 
 /**
- * Parse `?source=&services=&from=&to=` out of a `location.search` string.
- * Unknown `source` values fall back to `'apm'` (the only meaningful source
- * today); `services` missing or empty yields `undefined` rather than `[]` so
- * callers can distinguish "unscoped" from "scoped to nothing". A `timeRange` is
- * returned only when both `from` and `to` are present and valid.
- */
-/**
  * Build the `source=apm&services=<csv>[&from=&to=]` query string for a suggest
  * deep link. Returns the query portion only (no leading `?` and no path), so
  * both the in-app router (`/slos/suggest?…`) and the cross-app navigator
@@ -76,6 +69,13 @@ export function buildSuggestSearch(services: string[], timeRange?: TimeRange): s
   return qs.toString();
 }
 
+/**
+ * Parse `?source=&services=&from=&to=` out of a `location.search` string.
+ * Unknown `source` values fall back to `'apm'` (the only meaningful source
+ * today); `services` missing or empty yields `undefined` rather than `[]` so
+ * callers can distinguish "unscoped" from "scoped to nothing". A `timeRange` is
+ * returned only when both `from` and `to` are present and valid.
+ */
 export function parseSuggestScopeFromSearch(search: string): SuggestScope {
   const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
   const rawSource = params.get('source');

--- a/public/components/apm/pages/slos/slo_suggest_scope.ts
+++ b/public/components/apm/pages/slos/slo_suggest_scope.ts
@@ -59,6 +59,23 @@ function parseTimeValue(value: string | null): string | undefined {
  * callers can distinguish "unscoped" from "scoped to nothing". A `timeRange` is
  * returned only when both `from` and `to` are present and valid.
  */
+/**
+ * Build the `source=apm&services=<csv>[&from=&to=]` query string for a suggest
+ * deep link. Returns the query portion only (no leading `?` and no path), so
+ * both the in-app router (`/slos/suggest?…`) and the cross-app navigator
+ * (`#/slos/suggest?…`) share one definition of the URL contract. Inverse of
+ * `parseSuggestScopeFromSearch`.
+ */
+export function buildSuggestSearch(services: string[], timeRange?: TimeRange): string {
+  const qs = new URLSearchParams({ source: 'apm' });
+  if (services.length > 0) qs.set('services', services.join(','));
+  if (timeRange) {
+    qs.set('from', timeRange.from);
+    qs.set('to', timeRange.to);
+  }
+  return qs.toString();
+}
+
 export function parseSuggestScopeFromSearch(search: string): SuggestScope {
   const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
   const rawSource = params.get('source');

--- a/public/components/apm/pages/slos/suggest_batch_preview.tsx
+++ b/public/components/apm/pages/slos/suggest_batch_preview.tsx
@@ -13,12 +13,15 @@
 
 import React, { useState } from 'react';
 import {
+  EuiAccordion,
   EuiBadge,
   EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiHorizontalRule,
   EuiSpacer,
   EuiText,
+  EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import type { SloApiClient } from './slo_api_client';
@@ -177,14 +180,45 @@ export const SuggestBatchPreview: React.FC<SuggestBatchPreviewProps> = ({
           })}
         </EuiText>
       ) : (
-        previews.map((p) => (
-          <SuggestPreviewRow
-            key={p.key}
-            preview={p}
-            live={liveByKey[p.key] ?? { status: 'loading' }}
-            windowChoice={windowChoice}
-          />
-        ))
+        (() => {
+          const grouped: Array<{ service: string; items: typeof previews }> = [];
+          for (const p of previews) {
+            const svc = p.suggestion.input.spec.service ?? '';
+            const last = grouped[grouped.length - 1];
+            if (last && last.service === svc) {
+              last.items.push(p);
+            } else {
+              grouped.push({ service: svc, items: [p] });
+            }
+          }
+          const MAX_INITIALLY_OPEN = 5;
+          return grouped.map((group, idx) => (
+            <div key={group.service} data-test-subj={`slosSuggestPreviewGroup-${group.service}`}>
+              <EuiAccordion
+                id={`slosSuggestPreviewAccordion-${group.service}`}
+                buttonContent={
+                  <EuiTitle size="xxs">
+                    <h5>
+                      {group.service} ({group.items.length})
+                    </h5>
+                  </EuiTitle>
+                }
+                initialIsOpen={idx < MAX_INITIALLY_OPEN}
+                paddingSize="s"
+              >
+                {group.items.map((p) => (
+                  <SuggestPreviewRow
+                    key={p.key}
+                    preview={p}
+                    live={liveByKey[p.key] ?? { status: 'loading' }}
+                    windowChoice={windowChoice}
+                  />
+                ))}
+              </EuiAccordion>
+              {idx < grouped.length - 1 && <EuiHorizontalRule margin="s" />}
+            </div>
+          ));
+        })()
       )}
     </div>
   );

--- a/public/components/apm/pages/slos/suggest_batch_preview.tsx
+++ b/public/components/apm/pages/slos/suggest_batch_preview.tsx
@@ -181,15 +181,23 @@ export const SuggestBatchPreview: React.FC<SuggestBatchPreviewProps> = ({
         </EuiText>
       ) : (
         (() => {
+          // Group previews by service. A service can produce non-contiguous
+          // drafts — the engine emits detector-first (all APM drafts, then all
+          // HTTP drafts, …), so a service with both APM and OTel drafts appears
+          // more than once in `previews`. Key by service (not adjacency) so each
+          // service yields exactly one accordion; adjacency grouping would emit
+          // duplicate groups with duplicate React keys.
           const grouped: Array<{ service: string; items: typeof previews }> = [];
+          const groupByService = new Map<string, { service: string; items: typeof previews }>();
           for (const p of previews) {
             const svc = p.suggestion.input.spec.service ?? '';
-            const last = grouped[grouped.length - 1];
-            if (last && last.service === svc) {
-              last.items.push(p);
-            } else {
-              grouped.push({ service: svc, items: [p] });
+            let group = groupByService.get(svc);
+            if (!group) {
+              group = { service: svc, items: [] };
+              groupByService.set(svc, group);
+              grouped.push(group);
             }
+            group.items.push(p);
           }
           const MAX_INITIALLY_OPEN = 5;
           return grouped.map((group, idx) => (

--- a/public/components/apm/pages/slos/suggest_inline_row.tsx
+++ b/public/components/apm/pages/slos/suggest_inline_row.tsx
@@ -55,6 +55,13 @@ export interface SuggestionInlineRowProps {
   /** Render status — used by the batch-create progress strip. */
   rowStatus?: RowStatus;
   rowStatusMessage?: string;
+  /**
+   * Authoritative "already covered" flag from the page (`isDraftCovered`):
+   * unions the per-draft recording-rule match with the service-level health
+   * rollup. Covered drafts are non-selectable. Defaults to the local
+   * recording-rule signal when the caller doesn't pass it.
+   */
+  covered?: boolean;
 }
 
 export const SuggestionInlineRow: React.FC<SuggestionInlineRowProps> = ({
@@ -65,6 +72,7 @@ export const SuggestionInlineRow: React.FC<SuggestionInlineRowProps> = ({
   onOverrideChange,
   rowStatus,
   rowStatusMessage,
+  covered,
 }) => {
   const spec = suggestion.input.spec;
   const objective = spec.objectives[0];
@@ -73,11 +81,16 @@ export const SuggestionInlineRow: React.FC<SuggestionInlineRowProps> = ({
     spec.sli.type === 'single' &&
     spec.sli.definition.backend === 'prometheus' &&
     spec.sli.definition.type === 'latency_threshold'
-      ? spec.sli.definition.latencyThresholdUnit ?? 'seconds'
+      ? (spec.sli.definition.latencyThresholdUnit ?? 'seconds')
       : 'seconds';
-  const isCovered = Boolean(suggestion.existingRuleMatch);
+  // Prefer the page's authoritative flag (rule + health union); fall back to
+  // the local recording-rule signal for callers that don't pass it.
+  const isCovered = covered ?? Boolean(suggestion.existingRuleMatch);
   const fadedOut = isCovered && !selected;
-  const disableCheckbox = rowStatus === 'creating' || rowStatus === 'success';
+  // Covered drafts are non-selectable: creating one would dual-write a rule
+  // that already exists. Disabling here (not just filtering at create time)
+  // keeps the checkbox, the counts, and the actual create in agreement.
+  const disableCheckbox = rowStatus === 'creating' || rowStatus === 'success' || isCovered;
 
   const coveredTooltip = suggestion.existingRuleMatch
     ? i18n.translate('observability.apm.slo.suggest.inlineRow.coveredTooltip', {
@@ -94,7 +107,12 @@ export const SuggestionInlineRow: React.FC<SuggestionInlineRowProps> = ({
             : '',
         },
       })
-    : '';
+    : isCovered
+      ? i18n.translate('observability.apm.slo.suggest.inlineRow.coveredHealthTooltip', {
+          defaultMessage:
+            'This service already owns its canonical availability + latency SLO pair. Unchecked to avoid dual-writing.',
+        })
+      : '';
 
   return (
     <EuiPanel

--- a/public/components/apm/pages/slos/suggest_service_tree_table.scss
+++ b/public/components/apm/pages/slos/suggest_service_tree_table.scss
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+.sloSuggestTree {
+  // Spacing between the stacked service panels.
+  &__service {
+    margin-bottom: 12px;
+  }
+}
+
+// Hover popover listing the drafts behind an "SLI mix" badge.
+.sloSuggestSliMix {
+  &__popover {
+    max-width: 320px;
+  }
+
+  // One draft entry inside the popover.
+  &__draft {
+    margin-bottom: 6px;
+  }
+
+  &__draftBadges {
+    margin-top: 2px;
+  }
+
+  &__draftMetric {
+    margin-top: 2px;
+  }
+}

--- a/public/components/apm/pages/slos/suggest_service_tree_table.scss
+++ b/public/components/apm/pages/slos/suggest_service_tree_table.scss
@@ -3,29 +3,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-.sloSuggestTree {
-  // Spacing between the stacked service panels.
-  &__service {
-    margin-bottom: 12px;
-  }
+// Spacing between the stacked service panels.
+.slo-suggest-tree__service {
+  margin-bottom: $euiSizeM;
 }
 
 // Hover popover listing the drafts behind an "SLI mix" badge.
-.sloSuggestSliMix {
+.slo-suggest-sli-mix {
   &__popover {
     max-width: 320px;
   }
 
   // One draft entry inside the popover.
   &__draft {
-    margin-bottom: 6px;
+    margin-bottom: $euiSizeXS;
   }
 
-  &__draftBadges {
-    margin-top: 2px;
+  &__draft-badges {
+    margin-top: $euiSizeXS / 2;
   }
 
-  &__draftMetric {
-    margin-top: 2px;
+  &__draft-metric {
+    margin-top: $euiSizeXS / 2;
   }
 }

--- a/public/components/apm/pages/slos/suggest_service_tree_table.tsx
+++ b/public/components/apm/pages/slos/suggest_service_tree_table.tsx
@@ -10,7 +10,7 @@
  * `SuggestionInlineRow` cards for every draft that service owns.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   EuiBadge,
   EuiButtonIcon,
@@ -29,6 +29,7 @@ import type { Suggestion } from './suggest_engine';
 import { suggestionIconType } from './suggest_icon';
 import { OverridePatch, OverrideValues, SuggestionInlineRow } from './suggest_inline_row';
 import type { RowStatusMap } from './suggest_use_batch_create';
+import './suggest_service_tree_table.scss';
 
 const SLI_MIX_VISIBLE_CAP = 4;
 
@@ -39,15 +40,25 @@ const SliMixBadgePopover: React.FC<{
   drafts: Suggestion[];
 }> = ({ kind, iconType, drafts }) => {
   const [isOpen, setIsOpen] = useState(false);
-  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+  // Keep the hover-close timer in a ref so it survives re-renders — a plain
+  // local would reset to undefined every render, leaving `openPopover` unable
+  // to cancel a pending close and risking a setState after unmount.
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const openPopover = () => {
-    if (closeTimer) clearTimeout(closeTimer);
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
     setIsOpen(true);
   };
   const closePopover = () => {
-    closeTimer = setTimeout(() => setIsOpen(false), 150);
+    closeTimerRef.current = setTimeout(() => setIsOpen(false), 150);
   };
+
+  // Clear any pending close timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
 
   return (
     <div onMouseEnter={openPopover} onMouseLeave={closePopover}>
@@ -62,7 +73,11 @@ const SliMixBadgePopover: React.FC<{
         anchorPosition="downCenter"
         panelPaddingSize="s"
       >
-        <div style={{ maxWidth: 320 }} onMouseEnter={openPopover} onMouseLeave={closePopover}>
+        <div
+          className="sloSuggestSliMix__popover"
+          onMouseEnter={openPopover}
+          onMouseLeave={closePopover}
+        >
           <EuiText size="xs">
             <strong>{kind}</strong>
             {' — '}
@@ -70,14 +85,19 @@ const SliMixBadgePopover: React.FC<{
           </EuiText>
           <EuiHorizontalRule margin="xs" />
           {drafts.map((d) => (
-            <div key={d.key} style={{ marginBottom: 6 }}>
+            <div key={d.key} className="sloSuggestSliMix__draft">
               <EuiText size="xs">
                 <strong>{d.input.spec.name || d.key}</strong>
               </EuiText>
               <EuiText size="xs" color="subdued">
                 {d.reason}
               </EuiText>
-              <EuiFlexGroup gutterSize="s" responsive={false} wrap style={{ marginTop: 2 }}>
+              <EuiFlexGroup
+                gutterSize="s"
+                responsive={false}
+                wrap
+                className="sloSuggestSliMix__draftBadges"
+              >
                 <EuiFlexItem grow={false}>
                   <EuiBadge color="hollow">
                     {`Target: ${((d.input.spec.objectives?.[0]?.target ?? 0) * 100).toFixed(1)}%`}
@@ -92,7 +112,7 @@ const SliMixBadgePopover: React.FC<{
                   </EuiFlexItem>
                 )}
               </EuiFlexGroup>
-              <EuiText size="xs" color="subdued" style={{ marginTop: 2 }}>
+              <EuiText size="xs" color="subdued" className="sloSuggestSliMix__draftMetric">
                 Metric: <code>{d.sourceMetric}</code>
               </EuiText>
             </div>
@@ -163,7 +183,7 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
         const overflow = row.kinds.length - visible.length;
 
         return (
-          <div key={row.serviceName} style={{ marginBottom: 12 }}>
+          <div key={row.serviceName} className="sloSuggestTree__service">
             <EuiPanel
               hasBorder
               paddingSize="m"
@@ -270,7 +290,7 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
                   <EuiFlexItem grow={false}>
                     <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
                       <EuiFlexItem grow={false}>
-                        <EuiIcon type="check" color="success" size="s" />
+                        <EuiIcon type="check" color="success" size="s" aria-hidden={true} />
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiText size="xs" color="success">

--- a/public/components/apm/pages/slos/suggest_service_tree_table.tsx
+++ b/public/components/apm/pages/slos/suggest_service_tree_table.tsx
@@ -32,6 +32,45 @@ import type { RowStatusMap } from './suggest_use_batch_create';
 import './suggest_service_tree_table.scss';
 
 const SLI_MIX_VISIBLE_CAP = 4;
+/** Grace period before the hover popover closes, so moving into it doesn't dismiss it. */
+const HOVER_CLOSE_DELAY_MS = 150;
+
+const t = {
+  draftCount: (count: number) =>
+    i18n.translate('observability.apm.slo.suggest.serviceTreeTable.draftCount', {
+      defaultMessage: '{count, plural, one {# draft} other {# drafts}}',
+      values: { count },
+    }),
+  target: (pct: string) =>
+    i18n.translate('observability.apm.slo.suggest.serviceTreeTable.target', {
+      defaultMessage: 'Target: {pct}%',
+      values: { pct },
+    }),
+  approxRules: (count: number) =>
+    i18n.translate('observability.apm.slo.suggest.serviceTreeTable.approxRules', {
+      defaultMessage: '~{count, plural, one {# rule} other {# rules}}',
+      values: { count },
+    }),
+  rules: (count: number) =>
+    i18n.translate('observability.apm.slo.suggest.serviceTreeTable.rules', {
+      defaultMessage: '{count, plural, one {# rule} other {# rules}}',
+      values: { count },
+    }),
+  covered: i18n.translate('observability.apm.slo.suggest.serviceTreeTable.coveredBadge', {
+    defaultMessage: 'Covered',
+  }),
+  metricLabel: i18n.translate('observability.apm.slo.suggest.serviceTreeTable.metricLabel', {
+    defaultMessage: 'Metric:',
+  }),
+  sliMix: i18n.translate('observability.apm.slo.suggest.serviceTreeTable.sliMix', {
+    defaultMessage: 'SLI mix',
+  }),
+  overflowMore: (count: number) =>
+    i18n.translate('observability.apm.slo.suggest.serviceTreeTable.overflowMore', {
+      defaultMessage: '+{count} more',
+      values: { count },
+    }),
+};
 
 /** Badge with a popover showing draft details for a given SLI kind (opens on hover). */
 const SliMixBadgePopover: React.FC<{
@@ -50,7 +89,7 @@ const SliMixBadgePopover: React.FC<{
     setIsOpen(true);
   };
   const closePopover = () => {
-    closeTimerRef.current = setTimeout(() => setIsOpen(false), 150);
+    closeTimerRef.current = setTimeout(() => setIsOpen(false), HOVER_CLOSE_DELAY_MS);
   };
 
   // Clear any pending close timer on unmount.
@@ -74,18 +113,18 @@ const SliMixBadgePopover: React.FC<{
         panelPaddingSize="s"
       >
         <div
-          className="sloSuggestSliMix__popover"
+          className="slo-suggest-sli-mix__popover"
           onMouseEnter={openPopover}
           onMouseLeave={closePopover}
         >
           <EuiText size="xs">
             <strong>{kind}</strong>
             {' — '}
-            {drafts.length === 1 ? '1 draft' : `${drafts.length} drafts`}
+            {t.draftCount(drafts.length)}
           </EuiText>
           <EuiHorizontalRule margin="xs" />
           {drafts.map((d) => (
-            <div key={d.key} className="sloSuggestSliMix__draft">
+            <div key={d.key} className="slo-suggest-sli-mix__draft">
               <EuiText size="xs">
                 <strong>{d.input.spec.name || d.key}</strong>
               </EuiText>
@@ -96,24 +135,24 @@ const SliMixBadgePopover: React.FC<{
                 gutterSize="s"
                 responsive={false}
                 wrap
-                className="sloSuggestSliMix__draftBadges"
+                className="slo-suggest-sli-mix__draft-badges"
               >
                 <EuiFlexItem grow={false}>
                   <EuiBadge color="hollow">
-                    {`Target: ${((d.input.spec.objectives?.[0]?.target ?? 0) * 100).toFixed(1)}%`}
+                    {t.target(((d.input.spec.objectives?.[0]?.target ?? 0) * 100).toFixed(1))}
                   </EuiBadge>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiBadge color="hollow">{`~${d.estimatedRuleCount} rules`}</EuiBadge>
+                  <EuiBadge color="hollow">{t.approxRules(d.estimatedRuleCount)}</EuiBadge>
                 </EuiFlexItem>
                 {d.existingRuleMatch && (
                   <EuiFlexItem grow={false}>
-                    <EuiBadge color="warning">Covered</EuiBadge>
+                    <EuiBadge color="warning">{t.covered}</EuiBadge>
                   </EuiFlexItem>
                 )}
               </EuiFlexGroup>
-              <EuiText size="xs" color="subdued" className="sloSuggestSliMix__draftMetric">
-                Metric: <code>{d.sourceMetric}</code>
+              <EuiText size="xs" color="subdued" className="slo-suggest-sli-mix__draft-metric">
+                {t.metricLabel} <code>{d.sourceMetric}</code>
               </EuiText>
             </div>
           ))}
@@ -183,7 +222,7 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
         const overflow = row.kinds.length - visible.length;
 
         return (
-          <div key={row.serviceName} className="sloSuggestTree__service">
+          <div key={row.serviceName} className="slo-suggest-tree__service">
             <EuiPanel
               hasBorder
               paddingSize="m"
@@ -246,7 +285,7 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
                   <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
                     <EuiFlexItem grow={false}>
                       <EuiText size="xs" color="subdued">
-                        SLI mix
+                        {t.sliMix}
                       </EuiText>
                     </EuiFlexItem>
                     {visible.map((kind) => (
@@ -261,7 +300,7 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
                     {overflow > 0 && (
                       <EuiFlexItem grow={false}>
                         <SliMixBadgePopover
-                          kind={`+${overflow} more`}
+                          kind={t.overflowMore(overflow)}
                           iconType="boxesHorizontal"
                           drafts={row.kinds
                             .slice(SLI_MIX_VISIBLE_CAP)
@@ -283,7 +322,7 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   <EuiText size="xs" color="subdued">
-                    {`${row.totalRules} rules`}
+                    {t.rules(row.totalRules)}
                   </EuiText>
                 </EuiFlexItem>
                 {row.coveredCount > 0 && (

--- a/public/components/apm/pages/slos/suggest_service_tree_table.tsx
+++ b/public/components/apm/pages/slos/suggest_service_tree_table.tsx
@@ -166,7 +166,11 @@ export interface ServiceRowShape {
   serviceName: string;
   environment?: string;
   drafts: Suggestion[];
+  /** Creatable drafts currently checked (selected AND not covered). */
   selectedCount: number;
+  /** Drafts that can be selected at all (not covered). Denominator for the
+   *  master checkbox's "all selected" state. */
+  selectableCount: number;
   totalRules: number;
   coveredCount: number;
   kinds: string[];
@@ -183,8 +187,13 @@ export interface ServiceTreeTableProps {
   onOverrideChange: (key: string, patch: OverridePatch) => void;
   /** Optional per-draft status for the in-flight batch create. */
   rowStatusMap?: RowStatusMap;
-  /** Services whose canonical SLO pair is fully covered — rendered as disabled. */
-  coveredServices?: Set<string>;
+  /**
+   * Draft keys that are already covered (from the page's `isDraftCovered` —
+   * recording-rule match OR a same-side SLO already existing for the service).
+   * Covered drafts are non-selectable. Authoritative and side-aware, so the
+   * table never re-derives coverage itself.
+   */
+  coveredKeys?: Set<string>;
 }
 
 export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
@@ -197,15 +206,19 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
   onToggleDraft,
   onOverrideChange,
   rowStatusMap,
-  coveredServices,
+  coveredKeys,
 }) => {
   return (
     <div data-test-subj="slosSuggestTable">
       {serviceRows.map((row) => {
         const isExpanded = expandedMap[row.serviceName] ?? false;
-        const allSelected = row.selectedCount === row.drafts.length && row.drafts.length > 0;
+        // "All selected" is relative to the selectable (non-covered) drafts, so
+        // a partially-covered service can still reach a fully-checked master box.
+        const allSelected = row.selectableCount > 0 && row.selectedCount === row.selectableCount;
         const someSelected = row.selectedCount > 0 && !allSelected;
-        const isCovered = coveredServices?.has(row.serviceName) ?? false;
+        // Disable the master checkbox when the service has no selectable drafts
+        // left — i.e. every draft it owns is already covered.
+        const isCovered = row.selectableCount === 0;
 
         const iconByKind = new Map<string, string>();
         for (const draft of row.drafts) {
@@ -359,6 +372,8 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
                         onOverrideChange={(patch) => onOverrideChange(draft.key, patch)}
                         rowStatus={rowStatusMap?.[draft.key]?.status}
                         rowStatusMessage={rowStatusMap?.[draft.key]?.message}
+                        // Authoritative per-draft covered flag from the page.
+                        covered={coveredKeys?.has(draft.key) ?? false}
                       />
                     ))}
                   </div>

--- a/public/components/apm/pages/slos/suggest_service_tree_table.tsx
+++ b/public/components/apm/pages/slos/suggest_service_tree_table.tsx
@@ -4,28 +4,25 @@
  */
 
 /**
- * Service tree table for the Suggest SLOs page.
+ * Service expandable panels for the Suggest SLOs page.
  *
- * Each row is a service; expanded rows render `SuggestionInlineRow` for every
- * draft that service owns. Built on EuiBasicTable (no pagination / filtering
- * needed at this scale — 19 services is the target) with
- * `itemIdToExpandedRowMap`. Rows default to expanded so the user sees ~38
- * drafts on first paint.
+ * Each panel is a service; clicking the chevron expands to show
+ * `SuggestionInlineRow` cards for every draft that service owns.
  */
 
-import React, { useMemo } from 'react';
+import React, { useState } from 'react';
 import {
   EuiBadge,
-  EuiBasicTable,
-  EuiBasicTableColumn,
   EuiButtonIcon,
   EuiCheckbox,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiIconTip,
+  EuiHorizontalRule,
+  EuiIcon,
   EuiPanel,
+  EuiPopover,
+  EuiSpacer,
   EuiText,
-  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import type { Suggestion } from './suggest_engine';
@@ -34,6 +31,77 @@ import { OverridePatch, OverrideValues, SuggestionInlineRow } from './suggest_in
 import type { RowStatusMap } from './suggest_use_batch_create';
 
 const SLI_MIX_VISIBLE_CAP = 4;
+
+/** Badge with a popover showing draft details for a given SLI kind (opens on hover). */
+const SliMixBadgePopover: React.FC<{
+  kind: string;
+  iconType: string;
+  drafts: Suggestion[];
+}> = ({ kind, iconType, drafts }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const openPopover = () => {
+    if (closeTimer) clearTimeout(closeTimer);
+    setIsOpen(true);
+  };
+  const closePopover = () => {
+    closeTimer = setTimeout(() => setIsOpen(false), 150);
+  };
+
+  return (
+    <div onMouseEnter={openPopover} onMouseLeave={closePopover}>
+      <EuiPopover
+        button={
+          <EuiBadge color="hollow" iconType={iconType}>
+            {kind}
+          </EuiBadge>
+        }
+        isOpen={isOpen}
+        closePopover={() => setIsOpen(false)}
+        anchorPosition="downCenter"
+        panelPaddingSize="s"
+      >
+        <div style={{ maxWidth: 320 }} onMouseEnter={openPopover} onMouseLeave={closePopover}>
+          <EuiText size="xs">
+            <strong>{kind}</strong>
+            {' — '}
+            {drafts.length === 1 ? '1 draft' : `${drafts.length} drafts`}
+          </EuiText>
+          <EuiHorizontalRule margin="xs" />
+          {drafts.map((d) => (
+            <div key={d.key} style={{ marginBottom: 6 }}>
+              <EuiText size="xs">
+                <strong>{d.input.spec.name || d.key}</strong>
+              </EuiText>
+              <EuiText size="xs" color="subdued">
+                {d.reason}
+              </EuiText>
+              <EuiFlexGroup gutterSize="s" responsive={false} wrap style={{ marginTop: 2 }}>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">
+                    {`Target: ${((d.input.spec.objectives?.[0]?.target ?? 0) * 100).toFixed(1)}%`}
+                  </EuiBadge>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="hollow">{`~${d.estimatedRuleCount} rules`}</EuiBadge>
+                </EuiFlexItem>
+                {d.existingRuleMatch && (
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color="warning">Covered</EuiBadge>
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
+              <EuiText size="xs" color="subdued" style={{ marginTop: 2 }}>
+                Metric: <code>{d.sourceMetric}</code>
+              </EuiText>
+            </div>
+          ))}
+        </div>
+      </EuiPopover>
+    </div>
+  );
+};
 
 export interface ServiceRowShape {
   serviceName: string;
@@ -56,6 +124,8 @@ export interface ServiceTreeTableProps {
   onOverrideChange: (key: string, patch: OverridePatch) => void;
   /** Optional per-draft status for the in-flight batch create. */
   rowStatusMap?: RowStatusMap;
+  /** Services whose canonical SLO pair is fully covered — rendered as disabled. */
+  coveredServices?: Set<string>;
 }
 
 export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
@@ -68,232 +138,177 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
   onToggleDraft,
   onOverrideChange,
   rowStatusMap,
+  coveredServices,
 }) => {
-  const itemIdToExpandedRowMap = useMemo(() => {
-    const map: Record<string, React.ReactNode> = {};
-    for (const row of serviceRows) {
-      if (!expandedMap[row.serviceName]) continue;
-      map[row.serviceName] = (
-        <EuiPanel
-          color="subdued"
-          paddingSize="s"
-          hasShadow={false}
-          data-test-subj={`slosSuggestServiceExpanded-${row.serviceName}`}
-        >
-          {row.drafts.map((draft) => (
-            <SuggestionInlineRow
-              key={draft.key}
-              suggestion={draft}
-              selected={selected.has(draft.key)}
-              onToggle={() => onToggleDraft(draft.key)}
-              overrides={overrides[draft.key] ?? {}}
-              onOverrideChange={(patch) => onOverrideChange(draft.key, patch)}
-              rowStatus={rowStatusMap?.[draft.key]?.status}
-              rowStatusMessage={rowStatusMap?.[draft.key]?.message}
-            />
-          ))}
-        </EuiPanel>
-      );
-    }
-    return map;
-  }, [
-    serviceRows,
-    expandedMap,
-    selected,
-    overrides,
-    onToggleDraft,
-    onOverrideChange,
-    rowStatusMap,
-  ]);
-
-  const columns: Array<EuiBasicTableColumn<ServiceRowShape>> = useMemo(
-    () => [
-      {
-        width: '40px',
-        isExpander: true,
-        render: (row: ServiceRowShape) => (
-          <EuiButtonIcon
-            aria-label={
-              expandedMap[row.serviceName]
-                ? i18n.translate(
-                    'observability.apm.slo.suggest.serviceTreeTable.collapseAriaLabel',
-                    {
-                      defaultMessage: 'Collapse {serviceName}',
-                      values: { serviceName: row.serviceName },
-                    }
-                  )
-                : i18n.translate('observability.apm.slo.suggest.serviceTreeTable.expandAriaLabel', {
-                    defaultMessage: 'Expand {serviceName}',
-                    values: { serviceName: row.serviceName },
-                  })
-            }
-            iconType={expandedMap[row.serviceName] ? 'arrowDown' : 'arrowRight'}
-            onClick={() => onToggleExpand(row.serviceName)}
-            data-test-subj={`slosSuggestServiceExpand-${row.serviceName}`}
-          />
-        ),
-      },
-      {
-        width: '36px',
-        render: (row: ServiceRowShape) => {
-          const allSelected = row.selectedCount === row.drafts.length && row.drafts.length > 0;
-          const someSelected = row.selectedCount > 0 && !allSelected;
-          return (
-            <EuiCheckbox
-              id={`slosSuggestServiceSelect-${row.serviceName}`}
-              data-test-subj={`slosSuggestServiceSelect-${row.serviceName}`}
-              checked={allSelected}
-              indeterminate={someSelected}
-              onChange={() => onToggleServiceSelection(row)}
-              aria-label={i18n.translate(
-                'observability.apm.slo.suggest.serviceTreeTable.selectAllAriaLabel',
-                {
-                  defaultMessage: 'Select all drafts for {serviceName}',
-                  values: { serviceName: row.serviceName },
-                }
-              )}
-            />
-          );
-        },
-      },
-      {
-        name: i18n.translate('observability.apm.slo.suggest.serviceTreeTable.column.service', {
-          defaultMessage: 'Service',
-        }),
-        field: 'serviceName',
-        render: (_value: string, row: ServiceRowShape) => {
-          const allSelected = row.selectedCount === row.drafts.length && row.drafts.length > 0;
-          const selectionColor = allSelected
-            ? 'primary'
-            : row.selectedCount === 0
-            ? 'hollow'
-            : 'accent';
-          return (
-            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
-              <EuiFlexItem grow={false}>
-                <EuiText size="s">
-                  <strong>{row.serviceName}</strong>
-                </EuiText>
-              </EuiFlexItem>
-              {row.environment && (
-                <EuiFlexItem grow={false}>
-                  <EuiBadge color="hollow">{row.environment}</EuiBadge>
-                </EuiFlexItem>
-              )}
-              <EuiFlexItem grow={false}>
-                <EuiBadge
-                  color={selectionColor}
-                  data-test-subj={`slosSuggestSelectionBadge-${row.serviceName}`}
-                >
-                  {i18n.translate('observability.apm.slo.suggest.serviceTreeTable.selectionBadge', {
-                    defaultMessage: '{selected} / {total} selected',
-                    values: { selected: row.selectedCount, total: row.drafts.length },
-                  })}
-                </EuiBadge>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          );
-        },
-      },
-      {
-        name: i18n.translate('observability.apm.slo.suggest.serviceTreeTable.column.sliMix', {
-          defaultMessage: 'SLI mix',
-        }),
-        render: (row: ServiceRowShape) => {
-          const visible = row.kinds.slice(0, SLI_MIX_VISIBLE_CAP);
-          const overflow = row.kinds.length - visible.length;
-          const iconByKind = new Map<string, string>();
-          for (const draft of row.drafts) {
-            if (!iconByKind.has(draft.kind)) iconByKind.set(draft.kind, suggestionIconType(draft));
-          }
-          return (
-            <EuiFlexGroup gutterSize="xs" responsive={false} wrap>
-              {visible.map((kind) => (
-                <EuiFlexItem grow={false} key={kind}>
-                  <EuiBadge color="hollow" iconType={iconByKind.get(kind) ?? 'bullseye'}>
-                    {kind}
-                  </EuiBadge>
-                </EuiFlexItem>
-              ))}
-              {overflow > 0 && (
-                <EuiFlexItem grow={false}>
-                  <EuiToolTip
-                    content={row.kinds.slice(SLI_MIX_VISIBLE_CAP).join(', ')}
-                    position="top"
-                  >
-                    <EuiBadge color="hollow">
-                      {i18n.translate(
-                        'observability.apm.slo.suggest.serviceTreeTable.overflowMore',
-                        {
-                          defaultMessage: '+{count} more',
-                          values: { count: overflow },
-                        }
-                      )}
-                    </EuiBadge>
-                  </EuiToolTip>
-                </EuiFlexItem>
-              )}
-            </EuiFlexGroup>
-          );
-        },
-      },
-      {
-        name: i18n.translate('observability.apm.slo.suggest.serviceTreeTable.column.drafts', {
-          defaultMessage: 'Drafts',
-        }),
-        render: (row: ServiceRowShape) => (
-          <EuiText size="xs" color="subdued">
-            {i18n.translate('observability.apm.slo.suggest.serviceTreeTable.draftsCell', {
-              defaultMessage: '{count, plural, one {# draft} other {# drafts}} · ~{rules} rules',
-              values: { count: row.drafts.length, rules: row.totalRules },
-            })}
-          </EuiText>
-        ),
-      },
-      {
-        name: i18n.translate('observability.apm.slo.suggest.serviceTreeTable.column.covered', {
-          defaultMessage: 'Covered',
-        }),
-        render: (row: ServiceRowShape) =>
-          row.coveredCount > 0 ? (
-            <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-              <EuiFlexItem grow={false}>
-                <EuiText size="xs" color="danger">
-                  {row.coveredCount}
-                </EuiText>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiIconTip
-                  type="questionInCircle"
-                  color="subdued"
-                  position="top"
-                  content={i18n.translate(
-                    'observability.apm.slo.suggest.serviceTreeTable.coveredTooltip',
-                    {
-                      defaultMessage:
-                        "{count, plural, one {# draft for this service is} other {# drafts for this service are}} already provisioned by existing recording rules. They're unchecked by default to avoid dual-writing.",
-                      values: { count: row.coveredCount },
-                    }
-                  )}
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          ) : null,
-      },
-    ],
-    [expandedMap, onToggleExpand, onToggleServiceSelection]
-  );
-
   return (
-    <EuiBasicTable<ServiceRowShape>
-      data-test-subj="slosSuggestTable"
-      items={serviceRows}
-      itemId="serviceName"
-      columns={columns}
-      isExpandable
-      hasActions={false}
-      itemIdToExpandedRowMap={itemIdToExpandedRowMap}
-      rowProps={(row) => ({ 'data-test-subj': `slosSuggestServiceRow-${row.serviceName}` })}
-    />
+    <div data-test-subj="slosSuggestTable">
+      {serviceRows.map((row) => {
+        const isExpanded = expandedMap[row.serviceName] ?? false;
+        const allSelected = row.selectedCount === row.drafts.length && row.drafts.length > 0;
+        const someSelected = row.selectedCount > 0 && !allSelected;
+        const isCovered = coveredServices?.has(row.serviceName) ?? false;
+
+        const iconByKind = new Map<string, string>();
+        for (const draft of row.drafts) {
+          if (!iconByKind.has(draft.kind)) iconByKind.set(draft.kind, suggestionIconType(draft));
+        }
+        const draftsByKind = new Map<string, Suggestion[]>();
+        for (const draft of row.drafts) {
+          const list = draftsByKind.get(draft.kind) ?? [];
+          list.push(draft);
+          draftsByKind.set(draft.kind, list);
+        }
+
+        const visible = row.kinds.slice(0, SLI_MIX_VISIBLE_CAP);
+        const overflow = row.kinds.length - visible.length;
+
+        return (
+          <div key={row.serviceName} style={{ marginBottom: 12 }}>
+            <EuiPanel
+              hasBorder
+              paddingSize="m"
+              data-test-subj={`slosSuggestServiceRow-${row.serviceName}`}
+            >
+              {/* Service header row */}
+              <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false} wrap>
+                <EuiFlexItem grow={false}>
+                  <EuiButtonIcon
+                    aria-label={
+                      isExpanded
+                        ? i18n.translate(
+                            'observability.apm.slo.suggest.serviceTreeTable.collapseAriaLabel',
+                            {
+                              defaultMessage: 'Collapse {serviceName}',
+                              values: { serviceName: row.serviceName },
+                            }
+                          )
+                        : i18n.translate(
+                            'observability.apm.slo.suggest.serviceTreeTable.expandAriaLabel',
+                            {
+                              defaultMessage: 'Expand {serviceName}',
+                              values: { serviceName: row.serviceName },
+                            }
+                          )
+                    }
+                    iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
+                    onClick={() => onToggleExpand(row.serviceName)}
+                    data-test-subj={`slosSuggestServiceExpand-${row.serviceName}`}
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiCheckbox
+                    id={`slosSuggestServiceSelect-${row.serviceName}`}
+                    data-test-subj={`slosSuggestServiceSelect-${row.serviceName}`}
+                    checked={allSelected}
+                    indeterminate={someSelected}
+                    disabled={isCovered}
+                    onChange={() => onToggleServiceSelection(row)}
+                    aria-label={i18n.translate(
+                      'observability.apm.slo.suggest.serviceTreeTable.selectAllAriaLabel',
+                      {
+                        defaultMessage: 'Select all drafts for {serviceName}',
+                        values: { serviceName: row.serviceName },
+                      }
+                    )}
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="s">
+                    <strong>{row.serviceName}</strong>
+                  </EuiText>
+                </EuiFlexItem>
+                {row.environment && (
+                  <EuiFlexItem grow={false}>
+                    <EuiBadge color="hollow">{row.environment}</EuiBadge>
+                  </EuiFlexItem>
+                )}
+                <EuiFlexItem grow={false}>
+                  <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="xs" color="subdued">
+                        SLI mix
+                      </EuiText>
+                    </EuiFlexItem>
+                    {visible.map((kind) => (
+                      <EuiFlexItem grow={false} key={kind}>
+                        <SliMixBadgePopover
+                          kind={kind}
+                          iconType={iconByKind.get(kind) ?? 'bullseye'}
+                          drafts={draftsByKind.get(kind) ?? []}
+                        />
+                      </EuiFlexItem>
+                    ))}
+                    {overflow > 0 && (
+                      <EuiFlexItem grow={false}>
+                        <SliMixBadgePopover
+                          kind={`+${overflow} more`}
+                          iconType="boxesHorizontal"
+                          drafts={row.kinds
+                            .slice(SLI_MIX_VISIBLE_CAP)
+                            .flatMap((k) => draftsByKind.get(k) ?? [])}
+                        />
+                      </EuiFlexItem>
+                    )}
+                  </EuiFlexGroup>
+                </EuiFlexItem>
+                <EuiFlexItem grow={true} />
+                {/* Right-side stats */}
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    {i18n.translate('observability.apm.slo.suggest.servicePanel.slosSelected', {
+                      defaultMessage: '{selected}/{total} SLOs selected',
+                      values: { selected: row.selectedCount, total: row.drafts.length },
+                    })}
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs" color="subdued">
+                    {`${row.totalRules} rules`}
+                  </EuiText>
+                </EuiFlexItem>
+                {row.coveredCount > 0 && (
+                  <EuiFlexItem grow={false}>
+                    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                      <EuiFlexItem grow={false}>
+                        <EuiIcon type="check" color="success" size="s" />
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="xs" color="success">
+                          {i18n.translate('observability.apm.slo.suggest.servicePanel.covered', {
+                            defaultMessage: '{count} covered',
+                            values: { count: row.coveredCount },
+                          })}
+                        </EuiText>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiFlexItem>
+                )}
+              </EuiFlexGroup>
+
+              {/* Expanded drafts */}
+              {isExpanded && (
+                <>
+                  <EuiSpacer size="m" />
+                  <div data-test-subj={`slosSuggestServiceExpanded-${row.serviceName}`}>
+                    {row.drafts.map((draft) => (
+                      <SuggestionInlineRow
+                        key={draft.key}
+                        suggestion={draft}
+                        selected={selected.has(draft.key)}
+                        onToggle={() => onToggleDraft(draft.key)}
+                        overrides={overrides[draft.key] ?? {}}
+                        onOverrideChange={(patch) => onOverrideChange(draft.key, patch)}
+                        rowStatus={rowStatusMap?.[draft.key]?.status}
+                        rowStatusMessage={rowStatusMap?.[draft.key]?.message}
+                      />
+                    ))}
+                  </div>
+                </>
+              )}
+            </EuiPanel>
+          </div>
+        );
+      })}
+    </div>
   );
 };

--- a/public/components/apm/pages/slos/suggest_use_discovery_probes.ts
+++ b/public/components/apm/pages/slos/suggest_use_discovery_probes.ts
@@ -54,14 +54,11 @@ export interface DiscoveryProbesResult {
 export interface UseDiscoveryProbesArgs {
   http: HttpStart;
   datasourceId: string;
-  /** Bumping this triggers a re-probe; covers the "Rediscover" button. */
-  epoch: number;
 }
 
 export function useDiscoveryProbes({
   http,
   datasourceId,
-  epoch,
 }: UseDiscoveryProbesArgs): DiscoveryProbesResult {
   const [metricNames, setMetricNames] = useState<string[]>([]);
   const [labelValuesByMetric, setLabelValuesByMetric] = useState<LabelValuesByMetric>({});
@@ -151,7 +148,7 @@ export function useDiscoveryProbes({
     return () => {
       cancelled = true;
     };
-  }, [datasourceId, http, epoch]);
+  }, [datasourceId, http]);
 
   return {
     metricNames,

--- a/public/components/apm/pages/slos/suggest_use_discovery_probes.ts
+++ b/public/components/apm/pages/slos/suggest_use_discovery_probes.ts
@@ -54,11 +54,14 @@ export interface DiscoveryProbesResult {
 export interface UseDiscoveryProbesArgs {
   http: HttpStart;
   datasourceId: string;
+  /** Bump to force the probe + ruler fetch to re-run (the "Rediscover" button). */
+  epoch?: number;
 }
 
 export function useDiscoveryProbes({
   http,
   datasourceId,
+  epoch = 0,
 }: UseDiscoveryProbesArgs): DiscoveryProbesResult {
   const [metricNames, setMetricNames] = useState<string[]>([]);
   const [labelValuesByMetric, setLabelValuesByMetric] = useState<LabelValuesByMetric>({});
@@ -148,7 +151,7 @@ export function useDiscoveryProbes({
     return () => {
       cancelled = true;
     };
-  }, [datasourceId, http]);
+  }, [datasourceId, http, epoch]);
 
   return {
     metricNames,

--- a/public/components/apm/shared/utils/navigation_utils.ts
+++ b/public/components/apm/shared/utils/navigation_utils.ts
@@ -12,6 +12,7 @@ import {
   observabilityApmSloID,
 } from '../../../../../common/constants/apm';
 import { coreRefs } from '../../../../framework/core_refs';
+import { buildSuggestSearch } from '../../pages/slos/slo_suggest_scope';
 
 /**
  * Options for navigating to service details
@@ -143,13 +144,7 @@ export function navigateToServicesList(): void {
  * back to its default when it's omitted.
  */
 export function navigateToSloSuggest(services: string[], timeRange?: TimeRange): void {
-  const qs = new URLSearchParams({ source: 'apm' });
-  if (services.length > 0) qs.set('services', services.join(','));
-  if (timeRange) {
-    qs.set('from', timeRange.from);
-    qs.set('to', timeRange.to);
-  }
-  const path = `#/slos/suggest?${qs.toString()}`;
+  const path = `#/slos/suggest?${buildSuggestSearch(services, timeRange)}`;
   coreRefs?.application?.navigateToApp(observabilityApmSloID, { path });
   window.dispatchEvent(new HashChangeEvent('hashchange'));
 }


### PR DESCRIPTION
## Summary

Builds on the original **"Refine Suggest SLOs page UX"** work from **#2778** and significantly expands it by reworking the service-scoping model, extracting a shared service-picker component used across both APM surfaces, moving inline styles into SCSS, addressing several correctness issues around draft selection vs. coverage, and adding extensive test coverage.

> Supersedes **#2778** — the original authored changes are preserved (credit to @canascar); this PR continues and extends that work.

---

## UX Changes

### Suggest SLOs page (`slo_suggest_page.tsx`)

- Renamed **"Back to SLOs"** → **"Cancel"** (uses browser history instead of a hard-coded href).
- Moved the preview into the header actions with a simplified label.
- Removed **Refresh/Rediscover**, deleting the epoch-refetch plumbing end-to-end (hook prop + tests).
- Renamed CTA from **"Create N selected"** → **"Create N SLOs"** (with proper pluralization).
- Replaced the scope/combo-box UI with a single searchable service-filter dropdown.
  - Page now starts empty ("Pick one or more services…").
  - SLO drafts are generated only for explicitly selected services.
  - Removed automatic drafting of every discovered service.
- Improved the filter dropdown:
  - Checked services float to the top.
  - Added a **Clear** action.
  - Fully covered services are disabled and display a **"covered"** tag.
- Made the preview flyout resizable:
  - Drag handle with themed hover styling.
  - Width constrained between a minimum size and **45%** of the viewport.
- Removed the tilde (`~`) from rule counts.
- Moved the namespace beneath the description text.

### Preview flyout (`suggest_batch_preview.tsx`)

- Groups SLOs by service using accordion sections.
- Expands only the first five groups by default.
- Adds horizontal separators between groups.
- Groups by service identity instead of list adjacency, preventing duplicate accordions and duplicate React keys when both APM and OpenTelemetry drafts exist.

### Services Home SLO Health panel (`slo_health_panel.tsx`)

- Replaced the single **Suggest** button with the same searchable service picker used on the Suggest page.
- Trigger styling:
  - Primary (filled) while closed.
  - Neutral while open so the footer CTA becomes the primary action.
- Fully covered services are disabled and tagged as **covered**.
- If every service is already covered:
  - The trigger is disabled.
  - An explanatory tooltip is shown.

---

## Refactor

- Extracted shared components:
  - `service_filter_options.ts`
    - Pure `buildServiceFilterOptions()` helper
    - Handles covered-state disabling, checked-state marking, and float-to-top sorting
  - `service_filter_selectable.tsx`
    - Shared `EuiSelectable` implementation
    - Search support
    - Covered badge rendering
- Both APM service pickers now share the same implementation, eliminating duplicated option-building, `EuiSelectable` configuration, and `onChange` logic.
- Moved all inline `style={{}}` usage into SCSS following the directory's kebab-case conventions.
- Replaced magic numbers with named constants and EUI spacing tokens.
- Completed an i18n pass:
  - Wrapped all user-facing strings.
  - Added ICU pluralization where appropriate.

---

## Correctness & Hardening

- **Draft selection vs. coverage**
  - Drafts default to selected unless already covered by:
    - a matching Prometheus recording rule (`existingRuleMatch`), or
    - the service's canonical availability + latency SLO pair (health rollup).
  - Prevents creating duplicate SLOs for already-covered services.

- **Per-key interaction tracking**
  - Default-selection reseeding preserves user-made draft selections.
  - Newly arriving coverage deselects only untouched drafts.
  - Scope changes seed newly discovered drafts without overwriting curated selections.

- **Picker staleness handling**
  - Removes selected services if they disappear from discovery or become covered mid-session.
  - Prevents stale selections from inflating CTA counts or navigating with invalid scope.

- **Popover cleanup**
  - Stores the SLI-mix hover timer in a ref.
  - Cleans it up on unmount to prevent `setState` after unmount.

- **Accessibility**
  - Added meaningful `aria-label`s to the picker search and selectable list.
  - Covered rows communicate disabled state through both text and disabled styling (not color alone).

- **Additional improvements**
  - Lazy `useState` initialization for flyout width.
  - Removed a stale internal milestone comment.
  - Keyed the row-expansion effect using a stable service-name signature to avoid unnecessary reruns during selection changes.

---

## Testing

- ✅ **473 unit tests passing**
- ✅ Typecheck clean
- ✅ Stylelint clean
- ✅ ESLint: **0 errors**

### New / Updated Test Coverage

- Start-empty vs. scoped states
- Covered-draft default selection and supporting text
- Late coverage deselection while preserving manual user toggles
- Preview flyout resize behavior
  - Drag delta calculations
  - Global listener cleanup
- Preview breach/failed badges
- Non-contiguous service grouping
- Service picker:
  - Float-to-top sorting
  - Clear action
  - Primary ↔ neutral trigger behavior
  - Stale selection pruning
- SLI-mix hover popover open/close behavior

No Cypress changes were required—the existing APM Cypress suite does not exercise these SLO workflows.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
