### PR TITLE
[APM] Timerange session storage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,6 +54,14 @@ module.exports = [
       ],
       '@typescript-eslint/no-explicit-any': 'warn',
       'no-console': 0,
+      // The shared `eui` config targets a newer upstream EUI than the
+      // `@opensearch-project/oui@1.22.1` this repo aliases `@elastic/eui` to.
+      // These two rules autofix in props (`announceOnMount` on EuiCallOut,
+      // `disableScreenReaderOutput` on EuiToolTip) that don't exist in OUI
+      // 1.22.1's type defs, so `--fix` (incl. the lint-staged pre-commit hook)
+      // injects code that fails `yarn typecheck`. Disable until OUI catches up.
+      '@elastic/eui/callout-announce-on-mount': 'off',
+      '@elastic/eui/sr-output-disabled-tooltip': 'off',
       '@osd/eslint/no-restricted-paths': [
         'error',
         {

--- a/public/components/apm/common/constants.ts
+++ b/public/components/apm/common/constants.ts
@@ -34,6 +34,23 @@ export const EXPLORE_APP_ID = 'explore';
 export const LEGACY_BANNER_DISMISSED_KEY = 'apm.legacyBannerDismissed';
 
 /**
+ * sessionStorage key for the shared APM time range. All APM pages (services,
+ * service details, application map, SLO detail) read and write this key so the
+ * selected time range persists across reloads/navigation and is shared between
+ * pages instead of resetting to the default. Uses sessionStorage to match the
+ * Trace Analytics convention (see trace_analytics/home.tsx).
+ */
+export const APM_TIME_RANGE_STORAGE_KEY = 'apm.timeRange';
+
+/**
+ * Default APM time range used when nothing has been persisted yet.
+ */
+export const DEFAULT_APM_TIME_RANGE = {
+  from: 'now-15m',
+  to: 'now',
+} as const;
+
+/**
  * Constants for APM components
  */
 export const APM_CONSTANTS = {

--- a/public/components/apm/pages/application_map/application_map_page.tsx
+++ b/public/components/apm/pages/application_map/application_map_page.tsx
@@ -30,6 +30,7 @@ import { useServiceMapMetrics } from '../../shared/hooks/use_service_map_metrics
 import { useSelectedEdgeMetrics } from '../../shared/hooks/use_selected_edge_metrics';
 import { useGroupMetrics } from '../../shared/hooks/use_group_metrics';
 import { parseTimeRange } from '../../shared/utils/time_utils';
+import { usePersistentTimeRange } from '../../shared/hooks/use_persistent_time_range';
 import { openServiceDetailsInNewTab } from '../../shared/utils/navigation_utils';
 import {
   ServiceMapSidebar,
@@ -126,8 +127,10 @@ export const ApplicationMapPage: React.FC<ApplicationMapPageProps> = ({
   // Modal state
   const [isSettingsModalVisible, setIsSettingsModalVisible] = useState(false);
 
-  // Time range state
-  const [timeRange, setTimeRange] = useState<TimeRange>(
+  // Shared, persisted time range (sessionStorage) so the map keeps the user's
+  // selection instead of resetting to the default. A `from`/`to` deep link (see
+  // the URL-param effect below) still overrides this on mount.
+  const [timeRange, setTimeRange] = usePersistentTimeRange(
     APPLICATION_MAP_CONSTANTS.DEFAULT_TIME_RANGE
   );
 
@@ -135,9 +138,8 @@ export const ApplicationMapPage: React.FC<ApplicationMapPageProps> = ({
   const [filters, setFilters] = useState<ApplicationMapFilters>(DEFAULT_FILTERS);
 
   // Navigation state for hierarchical view
-  const [navigationState, setNavigationState] = useState<MapNavigationState>(
-    DEFAULT_NAVIGATION_STATE
-  );
+  const [navigationState, setNavigationState] =
+    useState<MapNavigationState>(DEFAULT_NAVIGATION_STATE);
 
   // Selected node state for details panel
   const [selectedNode, setSelectedNode] = useState<SelectedNodeState | null>(null);
@@ -203,7 +205,9 @@ export const ApplicationMapPage: React.FC<ApplicationMapPageProps> = ({
     if (fromParam && toParam) {
       setTimeRange({ from: fromParam, to: toParam });
     }
-  }, []); // Empty deps - run only on mount
+    // `setTimeRange` is stable (useCallback); listed to satisfy exhaustive-deps
+    // without changing the mount-only intent.
+  }, [setTimeRange]); // Run only on mount
 
   // Show toast when config fetch error occurs
   useEffect(() => {
@@ -282,7 +286,11 @@ export const ApplicationMapPage: React.FC<ApplicationMapPageProps> = ({
   }, [nodes]);
 
   // Fetch RED metrics for all services
-  const { metricsMap, isLoading: metricsLoading, refetch: refetchMetrics } = useServiceMapMetrics({
+  const {
+    metricsMap,
+    isLoading: metricsLoading,
+    refetch: refetchMetrics,
+  } = useServiceMapMetrics({
     services: servicesList,
     startTime: parsedTimeRange.startTime,
     endTime: parsedTimeRange.endTime,
@@ -334,9 +342,12 @@ export const ApplicationMapPage: React.FC<ApplicationMapPageProps> = ({
   const isLoading = mapLoading || metricsLoading;
 
   // Handle time range change
-  const handleTimeChange = useCallback((newTimeRange: TimeRange) => {
-    setTimeRange(newTimeRange);
-  }, []);
+  const handleTimeChange = useCallback(
+    (newTimeRange: TimeRange) => {
+      setTimeRange(newTimeRange);
+    },
+    [setTimeRange]
+  );
 
   // Handle refresh
   const handleRefresh = useCallback(() => {
@@ -630,7 +641,12 @@ export const ApplicationMapPage: React.FC<ApplicationMapPageProps> = ({
           <HeaderControlledComponentsWrapper components={[settingsButton]} />
           <EuiPageContent>
             <EuiPageContentBody>
-              <EuiCallOut title={i18nTexts.error.title} color="danger" iconType="alert">
+              <EuiCallOut
+                announceOnMount
+                title={i18nTexts.error.title}
+                color="danger"
+                iconType="alert"
+              >
                 <p>{mapError.message}</p>
               </EuiCallOut>
             </EuiPageContentBody>

--- a/public/components/apm/pages/application_map/application_map_page.tsx
+++ b/public/components/apm/pages/application_map/application_map_page.tsx
@@ -641,12 +641,7 @@ export const ApplicationMapPage: React.FC<ApplicationMapPageProps> = ({
           <HeaderControlledComponentsWrapper components={[settingsButton]} />
           <EuiPageContent>
             <EuiPageContentBody>
-              <EuiCallOut
-                announceOnMount
-                title={i18nTexts.error.title}
-                color="danger"
-                iconType="alert"
-              >
+              <EuiCallOut title={i18nTexts.error.title} color="danger" iconType="alert">
                 <p>{mapError.message}</p>
               </EuiCallOut>
             </EuiPageContentBody>

--- a/public/components/apm/pages/service_details/service_slo_tab.tsx
+++ b/public/components/apm/pages/service_details/service_slo_tab.tsx
@@ -396,7 +396,6 @@ export const ServiceSloTab: React.FC<ServiceSloTabProps> = ({
     return (
       <EuiPanel hasBorder paddingSize="m" data-test-subj="serviceSloTab">
         <EuiCallOut
-          announceOnMount
           color="warning"
           iconType="lock"
           title={t.forbiddenTitle}
@@ -416,7 +415,6 @@ export const ServiceSloTab: React.FC<ServiceSloTabProps> = ({
     return (
       <EuiPanel hasBorder paddingSize="m" data-test-subj="serviceSloTab">
         <EuiCallOut
-          announceOnMount
           color="danger"
           iconType="alert"
           title={t.errorTitle}
@@ -505,7 +503,6 @@ export const ServiceSloTab: React.FC<ServiceSloTabProps> = ({
         <>
           <EuiSpacer size="m" />
           <EuiCallOut
-            announceOnMount
             color="warning"
             iconType="alert"
             size="s"

--- a/public/components/apm/pages/service_details/service_slo_tab.tsx
+++ b/public/components/apm/pages/service_details/service_slo_tab.tsx
@@ -289,14 +289,15 @@ export const ServiceSloTab: React.FC<ServiceSloTabProps> = ({
   isLoading,
   error: accessError,
   refetch,
+  timeRange,
 }) => {
   const showSkeleton = useDelayedLoading(isLoading);
   const total = bucket?.total ?? 0;
   const isFirstLoad = isLoading && total === 0 && !accessError;
 
   const onSuggest = useCallback(() => {
-    navigateToSloSuggest([serviceName]);
-  }, [serviceName]);
+    navigateToSloSuggest([serviceName], timeRange);
+  }, [serviceName, timeRange]);
 
   const onCreateManually = useCallback(() => {
     coreRefs?.application?.navigateToApp(observabilityApmSloID, { path: '#/slos/create' });
@@ -395,6 +396,7 @@ export const ServiceSloTab: React.FC<ServiceSloTabProps> = ({
     return (
       <EuiPanel hasBorder paddingSize="m" data-test-subj="serviceSloTab">
         <EuiCallOut
+          announceOnMount
           color="warning"
           iconType="lock"
           title={t.forbiddenTitle}
@@ -414,6 +416,7 @@ export const ServiceSloTab: React.FC<ServiceSloTabProps> = ({
     return (
       <EuiPanel hasBorder paddingSize="m" data-test-subj="serviceSloTab">
         <EuiCallOut
+          announceOnMount
           color="danger"
           iconType="alert"
           title={t.errorTitle}
@@ -502,6 +505,7 @@ export const ServiceSloTab: React.FC<ServiceSloTabProps> = ({
         <>
           <EuiSpacer size="m" />
           <EuiCallOut
+            announceOnMount
             color="warning"
             iconType="alert"
             size="s"

--- a/public/components/apm/pages/services_home/services_home.tsx
+++ b/public/components/apm/pages/services_home/services_home.tsx
@@ -56,6 +56,7 @@ import { TopServicesByFaultRate } from '../../shared/components/fault_widgets/to
 import { TopDependenciesByFaultRate } from '../../shared/components/fault_widgets/top_dependencies_by_fault_rate';
 import { TimeRange, ServiceTableItem } from '../../common/types/service_types';
 import { parseTimeRange } from '../../shared/utils/time_utils';
+import { usePersistentTimeRange } from '../../shared/hooks/use_persistent_time_range';
 import { parseEnvironmentType } from '../../query_services/query_requests/response_processor';
 import {
   navigateToServiceMap,
@@ -188,6 +189,7 @@ const ServicesTablePanelUI: React.FC<ServicesTablePanelProps> = ({
         error={sloError}
         onRetry={sloRefetch}
         prometheusConnectionId={sloDatasourceId}
+        timeRange={timeRange}
       />
     )}
 
@@ -281,10 +283,9 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
   parentBreadcrumb: _parentBreadcrumb,
   onServiceClick,
 }) => {
-  const [timeRange, setTimeRange] = useState<TimeRange>({
-    from: 'now-15m',
-    to: 'now',
-  });
+  // Shared, persisted time range (sessionStorage) so the picker keeps the
+  // user's selection instead of resetting on every navigation/reload.
+  const [timeRange, setTimeRange] = usePersistentTimeRange();
 
   // Flyout state
   const [flyoutState, setFlyoutState] = useState<FlyoutState | null>(null);
@@ -343,7 +344,13 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
 
   const parsedTimeRange = useMemo(() => parseTimeRange(timeRange), [timeRange]);
 
-  const { data: services, isLoading, error, availableGroupByAttributes, refetch } = useServices({
+  const {
+    data: services,
+    isLoading,
+    error,
+    availableGroupByAttributes,
+    refetch,
+  } = useServices({
     startTime: parsedTimeRange.startTime,
     endTime: parsedTimeRange.endTime,
     refreshTrigger,
@@ -367,7 +374,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
   // circuits on empty serviceNames / datasourceId, so `.list` never runs.
   const sloApiClientStub = useMemo(
     () =>
-      (({
+      ({
         list: () =>
           Promise.resolve({
             results: [],
@@ -377,7 +384,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
             nextCursor: null,
             prevCursor: null,
           }),
-      } as unknown) as SloApiClient),
+      }) as unknown as SloApiClient,
     []
   );
 
@@ -422,9 +429,12 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
     [sloHealth.bySvc, sloHealth.isLoading, sloHealthError]
   );
 
-  const handleTimeChange = useCallback((newTimeRange: TimeRange) => {
-    setTimeRange(newTimeRange);
-  }, []);
+  const handleTimeChange = useCallback(
+    (newTimeRange: TimeRange) => {
+      setTimeRange(newTimeRange);
+    },
+    [setTimeRange]
+  );
 
   // Filtered attribute values based on search queries
   const filteredAttributeValues = useMemo(() => {
@@ -564,7 +574,11 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
 
   // Fetch RED (Request rate, Error rate, Duration) metrics for ALL services
   // Fetched separately and before filtering to avoid re-fetching on filter changes
-  const { metricsMap, isLoading: metricsLoading, refetch: refetchMetrics } = useServicesRedMetrics({
+  const {
+    metricsMap,
+    isLoading: metricsLoading,
+    refetch: refetchMetrics,
+  } = useServicesRedMetrics({
     services: (services || []).map((s) => ({
       serviceName: s.serviceName,
       environment: s.environment,
@@ -860,7 +874,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
             justifyContent="center"
           >
             <EuiFlexItem grow={false}>
-              <EuiToolTip content={i18nTexts.actions.viewSpans}>
+              <EuiToolTip content={i18nTexts.actions.viewSpans} disableScreenReaderOutput>
                 <EuiButtonIcon
                   iconType="apmTrace"
                   aria-label={i18nTexts.actions.viewSpans}
@@ -877,7 +891,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
               </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiToolTip content={i18nTexts.actions.viewLogs}>
+              <EuiToolTip content={i18nTexts.actions.viewLogs} disableScreenReaderOutput>
                 <EuiButtonIcon
                   iconType="discoverApp"
                   autoFocus={false}
@@ -895,7 +909,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
               </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiToolTip content={i18nTexts.actions.viewServiceMap}>
+              <EuiToolTip content={i18nTexts.actions.viewServiceMap} disableScreenReaderOutput>
                 <EuiButtonIcon
                   iconType="navAiFlow"
                   aria-label={i18nTexts.actions.viewServiceMap}
@@ -916,7 +930,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
             <EuiFlexItem grow={false}>{`Latency (${latencyPercentile.toUpperCase()})`}</EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiToolTip content={i18nTexts.tableTooltips.latency}>
-                <EuiIcon type="questionInCircle" size="s" color="subdued" />
+                <EuiIcon type="questionInCircle" size="s" color="subdued" aria-hidden={true} />
               </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -968,7 +982,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
             <EuiFlexItem grow={false}>{i18nTexts.table.throughput}</EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiToolTip content={i18nTexts.tableTooltips.throughput}>
-                <EuiIcon type="questionInCircle" size="s" color="subdued" />
+                <EuiIcon type="questionInCircle" size="s" color="subdued" aria-hidden={true} />
               </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -1017,7 +1031,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
             <EuiFlexItem grow={false}>{i18nTexts.table.failureRatio}</EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiToolTip content={i18nTexts.tableTooltips.failureRatio}>
-                <EuiIcon type="questionInCircle" size="s" color="subdued" />
+                <EuiIcon type="questionInCircle" size="s" color="subdued" aria-hidden={true} />
               </EuiToolTip>
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -1084,7 +1098,12 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
                   <EuiFlexItem grow={false}>{SLO_HEALTH_COLUMN_HEADER}</EuiFlexItem>
                   <EuiFlexItem grow={false}>
                     <EuiToolTip content={SLO_HEALTH_COLUMN_HEADER_TIP}>
-                      <EuiIcon type="questionInCircle" size="s" color="subdued" />
+                      <EuiIcon
+                        type="questionInCircle"
+                        size="s"
+                        color="subdued"
+                        aria-hidden={true}
+                      />
                     </EuiToolTip>
                   </EuiFlexItem>
                 </EuiFlexGroup>
@@ -1102,6 +1121,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
                     bucket={accessed.bucket}
                     isLoading={accessed.isLoading}
                     error={accessed.error}
+                    timeRange={timeRange}
                   />
                 );
               },
@@ -1126,7 +1146,12 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
         <EuiPageBody>
           <EuiPageContent>
             <EuiPageContentBody>
-              <EuiCallOut title={i18nTexts.error.title} color="danger" iconType="alert">
+              <EuiCallOut
+                announceOnMount
+                title={i18nTexts.error.title}
+                color="danger"
+                iconType="alert"
+              >
                 <p>{error.message}</p>
               </EuiCallOut>
             </EuiPageContentBody>

--- a/public/components/apm/pages/services_home/services_home.tsx
+++ b/public/components/apm/pages/services_home/services_home.tsx
@@ -874,7 +874,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
             justifyContent="center"
           >
             <EuiFlexItem grow={false}>
-              <EuiToolTip content={i18nTexts.actions.viewSpans} disableScreenReaderOutput>
+              <EuiToolTip content={i18nTexts.actions.viewSpans}>
                 <EuiButtonIcon
                   iconType="apmTrace"
                   aria-label={i18nTexts.actions.viewSpans}
@@ -891,7 +891,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
               </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiToolTip content={i18nTexts.actions.viewLogs} disableScreenReaderOutput>
+              <EuiToolTip content={i18nTexts.actions.viewLogs}>
                 <EuiButtonIcon
                   iconType="discoverApp"
                   autoFocus={false}
@@ -909,7 +909,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
               </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiToolTip content={i18nTexts.actions.viewServiceMap} disableScreenReaderOutput>
+              <EuiToolTip content={i18nTexts.actions.viewServiceMap}>
                 <EuiButtonIcon
                   iconType="navAiFlow"
                   aria-label={i18nTexts.actions.viewServiceMap}
@@ -1146,12 +1146,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
         <EuiPageBody>
           <EuiPageContent>
             <EuiPageContentBody>
-              <EuiCallOut
-                announceOnMount
-                title={i18nTexts.error.title}
-                color="danger"
-                iconType="alert"
-              >
+              <EuiCallOut title={i18nTexts.error.title} color="danger" iconType="alert">
                 <p>{error.message}</p>
               </EuiCallOut>
             </EuiPageContentBody>

--- a/public/components/apm/pages/services_home/slo_health_panel.tsx
+++ b/public/components/apm/pages/services_home/slo_health_panel.tsx
@@ -188,7 +188,6 @@ export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
       <>
         <EuiPanel hasBorder paddingSize="m" data-test-subj="sloHealthPanel">
           <EuiCallOut
-            announceOnMount
             size="s"
             color="warning"
             iconType="lock"

--- a/public/components/apm/pages/services_home/slo_health_panel.tsx
+++ b/public/components/apm/pages/services_home/slo_health_panel.tsx
@@ -31,6 +31,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { navigateToSloListing, navigateToSloSuggest } from '../../shared/utils/navigation_utils';
+import type { TimeRange } from '../../common/types/service_types';
 import type { SloHealthAccessError, SloHealthBucket } from '../slos/slo_health_summary';
 import { ChipRow } from '../slos/slo_health_chip_row';
 import { SloBudgetSparkline } from './slo_budget_sparkline';
@@ -50,6 +51,11 @@ export interface SloHealthPanelProps {
    * in rather than re-derived so the panel stays framework-agnostic.
    */
   prometheusConnectionId?: string;
+  /**
+   * Current time range from the services page, forwarded to the Suggest SLOs
+   * page so discovery reuses the window the user is viewing.
+   */
+  timeRange?: TimeRange;
 }
 
 export interface SloHealthCellProps {
@@ -57,6 +63,8 @@ export interface SloHealthCellProps {
   bucket: SloHealthBucket | undefined;
   isLoading: boolean;
   error: SloHealthAccessError | undefined;
+  /** Current time range, forwarded to Suggest SLOs (see SloHealthPanelProps). */
+  timeRange?: TimeRange;
 }
 
 // ============================================================================
@@ -151,6 +159,7 @@ export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
   error,
   onRetry,
   prometheusConnectionId,
+  timeRange,
 }) => {
   const showSkeleton = useDelayedLoading(isLoading);
 
@@ -167,8 +176,8 @@ export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
   }, [allServices, bySvc]);
 
   const onClickSuggest = useCallback(() => {
-    navigateToSloSuggest(missingPairServices);
-  }, [missingPairServices]);
+    navigateToSloSuggest(missingPairServices, timeRange);
+  }, [missingPairServices, timeRange]);
 
   const onClickViewAll = useCallback(() => {
     navigateToSloListing(allServices);
@@ -179,6 +188,7 @@ export const SloHealthPanel: React.FC<SloHealthPanelProps> = ({
       <>
         <EuiPanel hasBorder paddingSize="m" data-test-subj="sloHealthPanel">
           <EuiCallOut
+            announceOnMount
             size="s"
             color="warning"
             iconType="lock"
@@ -396,6 +406,7 @@ const SloHealthCellUI: React.FC<SloHealthCellProps> = ({
   bucket,
   isLoading,
   error,
+  timeRange,
 }) => {
   if (error?.kind === 'forbidden') {
     return (
@@ -404,6 +415,7 @@ const SloHealthCellUI: React.FC<SloHealthCellProps> = ({
           type="lock"
           color="subdued"
           data-test-subj={`sloHealthCellForbidden-${serviceName}`}
+          aria-hidden={true}
         />
       </EuiToolTip>
     );
@@ -411,7 +423,12 @@ const SloHealthCellUI: React.FC<SloHealthCellProps> = ({
   if (error) {
     return (
       <EuiToolTip content={t.cellLoadError}>
-        <EuiIcon type="alert" color="danger" data-test-subj={`sloHealthCellError-${serviceName}`} />
+        <EuiIcon
+          type="alert"
+          color="danger"
+          data-test-subj={`sloHealthCellError-${serviceName}`}
+          aria-hidden={true}
+        />
       </EuiToolTip>
     );
   }
@@ -433,7 +450,7 @@ const SloHealthCellUI: React.FC<SloHealthCellProps> = ({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiLink
-            onClick={() => navigateToSloSuggest([serviceName])}
+            onClick={() => navigateToSloSuggest([serviceName], timeRange)}
             data-test-subj={`sloHealthCellSuggest-${serviceName}`}
           >
             <EuiText size="xs">{t.suggestRow}</EuiText>
@@ -477,6 +494,7 @@ const SloHealthCellUI: React.FC<SloHealthCellProps> = ({
               type="alert"
               color="warning"
               data-test-subj={`sloHealthMissingPairIcon-${serviceName}`}
+              aria-hidden={true}
             />
           </EuiToolTip>
         </EuiFlexItem>

--- a/public/components/apm/pages/slos/__tests__/slo_suggest_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_suggest_page.test.tsx
@@ -42,21 +42,21 @@ import type {
 function makeHttp(): HttpStart {
   // The discovery effect fires probes + ruler fetch; resolve them all to
   // empty so the page renders without loading-spinner getting stuck.
-  return ({
+  return {
     get: jest.fn().mockImplementation((url: string) => {
       if (url.includes('/metadata/label-values/')) return Promise.resolve({ values: [] });
       if (url.includes('/rules')) return Promise.resolve({ data: { groups: [] } });
       return Promise.resolve({});
     }),
-  } as unknown) as HttpStart;
+  } as unknown as HttpStart;
 }
 
 function makeChrome(): ChromeStart {
-  return ({ setBreadcrumbs: jest.fn() } as unknown) as ChromeStart;
+  return { setBreadcrumbs: jest.fn() } as unknown as ChromeStart;
 }
 
 function makeNotifications(): NotificationsStart {
-  return ({
+  return {
     toasts: {
       addSuccess: jest.fn(),
       addDanger: jest.fn(),
@@ -64,19 +64,20 @@ function makeNotifications(): NotificationsStart {
       addInfo: jest.fn(),
       addError: jest.fn(),
     },
-  } as unknown) as NotificationsStart;
+  } as unknown as NotificationsStart;
 }
 
 function makeApiClient(): SloApiClient {
-  return ({
+  return {
     create: jest.fn().mockResolvedValue(undefined),
     preview: jest.fn().mockResolvedValue({ groupName: 'g', interval: 30, rules: [], yaml: '' }),
-  } as unknown) as SloApiClient;
+  } as unknown as SloApiClient;
 }
 
 function renderPage(
   opts: {
     rulerFails?: boolean;
+    initialEntry?: string;
   } = {}
 ) {
   mockUseApmConfig.mockReturnValue({
@@ -93,20 +94,20 @@ function renderPage(
     refetch: jest.fn(),
   });
   const http = opts.rulerFails
-    ? (({
+    ? ({
         get: jest.fn().mockImplementation((url: string) => {
           if (url.includes('/rules')) return Promise.reject(new Error('ruler down'));
           if (url.includes('/metadata/label-values/')) return Promise.resolve({ values: [] });
           return Promise.resolve({});
         }),
-      } as unknown) as HttpStart)
+      } as unknown as HttpStart)
     : makeHttp();
   // Suppress per-probe / ruler failure console.warn / .error so they don't
   // pollute the test report.
   jest.spyOn(console, 'warn').mockImplementation(() => {});
   const apiClient = makeApiClient();
   const result = render(
-    <MemoryRouter initialEntries={['/slos/suggest']}>
+    <MemoryRouter initialEntries={[opts.initialEntry ?? '/slos/suggest']}>
       <SloSuggestPage
         apiClient={apiClient}
         http={http}
@@ -124,6 +125,14 @@ describe('SloSuggestPage', () => {
     mockUseApmConfig.mockReset();
     mockUseServices.mockReset();
     jest.restoreAllMocks();
+  });
+
+  it('renders without crashing when the URL carries an unparseable time range', async () => {
+    // `now/` passes the scope charset check but dateMath.parse() returns
+    // undefined, so parseTimeRange would throw. The page must fall back to the
+    // default range and still render rather than crashing at render time.
+    renderPage({ initialEntry: '/slos/suggest?from=now%2F&to=now' });
+    expect(await screen.findByTestId('slosSuggestPage')).toBeInTheDocument();
   });
 
   it('mounts with mocked services and renders the page chrome', async () => {

--- a/public/components/apm/pages/slos/__tests__/slo_suggest_scope.test.ts
+++ b/public/components/apm/pages/slos/__tests__/slo_suggest_scope.test.ts
@@ -93,6 +93,19 @@ describe('parseSuggestScopeFromSearch', () => {
       });
     });
 
+    it('parses slash-rounded datemath from EuiSuperDatePicker quick ranges', () => {
+      // `now/d`, `now/w`, `now-1d/d` etc. contain a slash — the char class must
+      // allow it or the carried-over range is silently dropped.
+      expect(parseSuggestScopeFromSearch('?from=now%2Fd&to=now%2Fd').timeRange).toEqual({
+        from: 'now/d',
+        to: 'now/d',
+      });
+      expect(parseSuggestScopeFromSearch('?from=now-1d%2Fd&to=now').timeRange).toEqual({
+        from: 'now-1d/d',
+        to: 'now',
+      });
+    });
+
     it('returns undefined when only one bound is present', () => {
       expect(parseSuggestScopeFromSearch('?from=now-1h').timeRange).toBeUndefined();
       expect(parseSuggestScopeFromSearch('?to=now').timeRange).toBeUndefined();

--- a/public/components/apm/pages/slos/__tests__/slo_suggest_scope.test.ts
+++ b/public/components/apm/pages/slos/__tests__/slo_suggest_scope.test.ts
@@ -7,14 +7,23 @@ import { parseSuggestScopeFromSearch } from '../slo_suggest_scope';
 
 describe('parseSuggestScopeFromSearch', () => {
   it('returns default source and no services for an empty search', () => {
-    expect(parseSuggestScopeFromSearch('')).toEqual({ source: 'apm', services: undefined });
-    expect(parseSuggestScopeFromSearch('?')).toEqual({ source: 'apm', services: undefined });
+    expect(parseSuggestScopeFromSearch('')).toEqual({
+      source: 'apm',
+      services: undefined,
+      timeRange: undefined,
+    });
+    expect(parseSuggestScopeFromSearch('?')).toEqual({
+      source: 'apm',
+      services: undefined,
+      timeRange: undefined,
+    });
   });
 
   it('accepts the `apm` source', () => {
     expect(parseSuggestScopeFromSearch('?source=apm')).toEqual({
       source: 'apm',
       services: undefined,
+      timeRange: undefined,
     });
   });
 
@@ -26,6 +35,7 @@ describe('parseSuggestScopeFromSearch', () => {
     expect(parseSuggestScopeFromSearch('?services=foo,bar,baz')).toEqual({
       source: 'apm',
       services: ['foo', 'bar', 'baz'],
+      timeRange: undefined,
     });
   });
 
@@ -33,6 +43,7 @@ describe('parseSuggestScopeFromSearch', () => {
     expect(parseSuggestScopeFromSearch('?services=foo,%20bar%20,,baz')).toEqual({
       source: 'apm',
       services: ['foo', 'bar', 'baz'],
+      timeRange: undefined,
     });
   });
 
@@ -40,10 +51,12 @@ describe('parseSuggestScopeFromSearch', () => {
     expect(parseSuggestScopeFromSearch('?services=')).toEqual({
       source: 'apm',
       services: undefined,
+      timeRange: undefined,
     });
     expect(parseSuggestScopeFromSearch('?services=,,,')).toEqual({
       source: 'apm',
       services: undefined,
+      timeRange: undefined,
     });
   });
 
@@ -51,6 +64,7 @@ describe('parseSuggestScopeFromSearch', () => {
     expect(parseSuggestScopeFromSearch('?source=apm&services=checkout,cart')).toEqual({
       source: 'apm',
       services: ['checkout', 'cart'],
+      timeRange: undefined,
     });
   });
 
@@ -58,6 +72,47 @@ describe('parseSuggestScopeFromSearch', () => {
     expect(parseSuggestScopeFromSearch('?services=my%20svc,other%2Fpath')).toEqual({
       source: 'apm',
       services: ['my svc', 'other/path'],
+      timeRange: undefined,
+    });
+  });
+
+  describe('timeRange', () => {
+    it('parses relative from/to into a timeRange', () => {
+      expect(parseSuggestScopeFromSearch('?from=now-1h&to=now').timeRange).toEqual({
+        from: 'now-1h',
+        to: 'now',
+      });
+    });
+
+    it('parses absolute ISO from/to into a timeRange', () => {
+      expect(
+        parseSuggestScopeFromSearch('?from=2024-01-01T00:00:00Z&to=2024-01-02T00:00:00Z').timeRange
+      ).toEqual({
+        from: '2024-01-01T00:00:00Z',
+        to: '2024-01-02T00:00:00Z',
+      });
+    });
+
+    it('returns undefined when only one bound is present', () => {
+      expect(parseSuggestScopeFromSearch('?from=now-1h').timeRange).toBeUndefined();
+      expect(parseSuggestScopeFromSearch('?to=now').timeRange).toBeUndefined();
+    });
+
+    it('returns undefined when a bound contains disallowed characters', () => {
+      expect(parseSuggestScopeFromSearch('?from=now-1h&to=<script>').timeRange).toBeUndefined();
+    });
+
+    it('returns undefined when a bound exceeds the length limit', () => {
+      const longValue = 'n'.repeat(300);
+      expect(parseSuggestScopeFromSearch(`?from=now-1h&to=${longValue}`).timeRange).toBeUndefined();
+    });
+
+    it('parses services and timeRange together', () => {
+      expect(parseSuggestScopeFromSearch('?services=checkout&from=now-24h&to=now')).toEqual({
+        source: 'apm',
+        services: ['checkout'],
+        timeRange: { from: 'now-24h', to: 'now' },
+      });
     });
   });
 });

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -39,6 +39,7 @@ import { ChromeStart, NotificationsStart } from '../../../../../../../src/core/p
 import { HeaderControlledComponentsWrapper } from '../../../../plugin_helpers/plugin_headerControl';
 import { TimeRangePicker } from '../../shared/components/time_filter';
 import { TimeRange } from '../../common/types/service_types';
+import { usePersistentTimeRange } from '../../shared/hooks/use_persistent_time_range';
 import { SloVisualizations } from './slo_visualizations';
 import { SloMetadataPanel } from './slo_metadata_panel';
 import { SloAlertsPanel } from './slo_alerts_panel';
@@ -156,8 +157,8 @@ const DetailHeader: React.FC<DetailHeaderProps> = ({
     attainmentDelta === null
       ? euiThemeVars.euiTextSubduedColor
       : attainmentDelta >= 0
-      ? euiThemeVars.euiColorSuccessText
-      : euiThemeVars.euiColorDangerText;
+        ? euiThemeVars.euiColorSuccessText
+        : euiThemeVars.euiColorDangerText;
   const deltaSign = attainmentDelta !== null && attainmentDelta >= 0 ? '+' : '';
 
   return (
@@ -191,7 +192,12 @@ const DetailHeader: React.FC<DetailHeaderProps> = ({
             {sliLeafType && (
               <EuiFlexItem grow={false}>
                 <EuiText size="s" color="subdued">
-                  <EuiIcon type={templateIconFor(iconSummaryFromDoc(doc))} size="s" /> {sliLeafType}
+                  <EuiIcon
+                    type={templateIconFor(iconSummaryFromDoc(doc))}
+                    size="s"
+                    aria-hidden={true}
+                  />{' '}
+                  {sliLeafType}
                 </EuiText>
               </EuiFlexItem>
             )}
@@ -282,7 +288,7 @@ const DetailHeader: React.FC<DetailHeaderProps> = ({
         buttonContent={
           <EuiText size="s">
             <strong>
-              <EuiIcon type="iInCircle" size="s" />{' '}
+              <EuiIcon type="iInCircle" size="s" aria-hidden={true} />{' '}
               {i18n.translate('observability.apm.slo.detail.summaryAccordion.label', {
                 defaultMessage: 'Summary & SLI details',
               })}
@@ -392,14 +398,14 @@ function buildObjectiveRow(
   const sli = doc.spec.sli.type === 'single' ? doc.spec.sli : null;
   const latencyUnit =
     sli?.definition.backend === 'prometheus' && sli.definition.type === 'latency_threshold'
-      ? sli.definition.latencyThresholdUnit ?? 'seconds'
+      ? (sli.definition.latencyThresholdUnit ?? 'seconds')
       : 'seconds';
   const threshold =
     obj.latencyThreshold !== undefined
       ? `≤ ${obj.latencyThreshold}${latencyUnit === 'milliseconds' ? 'ms' : 's'}`
       : obj.thresholdBound
-      ? `${obj.thresholdBound.operator} ${obj.thresholdBound.value}`
-      : '—';
+        ? `${obj.thresholdBound.operator} ${obj.thresholdBound.value}`
+        : '—';
 
   // SloAlarmConfig is SLO-wide, not per-objective — so every row shows the
   // same boolean. That's the closest signal we have in the persisted spec
@@ -448,7 +454,10 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [timeRange, setTimeRange] = useState<TimeRange>({ from: 'now-1h', to: 'now' });
+  // Shared, persisted time range (sessionStorage) so the SLO detail picker
+  // stays in sync with the rest of APM. Falls back to a 1h window — a more
+  // useful default for burn-rate charts — when nothing is stored yet.
+  const [timeRange, setTimeRange] = usePersistentTimeRange({ from: 'now-1h', to: 'now' });
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const advancedRef = useRef<HTMLDivElement | null>(null);
@@ -694,8 +703,8 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
     ruleHealthState === 'ruler_unreachable'
       ? ruleHealthState
       : doc.liveStatus.state === 'rules_missing'
-      ? 'rules_missing'
-      : null;
+        ? 'rules_missing'
+        : null;
 
   // Recording-rule names from the persisted provisioning record. Dedup
   // shape: SLOs carry `recordingFingerprints` (objective name → fingerprint).
@@ -895,6 +904,7 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
             {derivedCalloutState === 'rules_missing' || derivedCalloutState === 'rules_partial' ? (
               <>
                 <EuiCallOut
+                  announceOnMount
                   color="danger"
                   iconType="alert"
                   title={i18n.translate('observability.apm.slo.detail.rulesMissingCallout.title', {
@@ -952,6 +962,7 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
             ) : derivedCalloutState === 'ruler_unreachable' ? (
               <>
                 <EuiCallOut
+                  announceOnMount
                   color="warning"
                   iconType="alert"
                   title={i18n.translate(
@@ -1032,7 +1043,7 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
                   buttonContent={
                     <EuiText size="s">
                       <strong>
-                        <EuiIcon type="advancedSettingsApp" size="s" />{' '}
+                        <EuiIcon type="advancedSettingsApp" size="s" aria-hidden={true} />{' '}
                         {i18n.translate('observability.apm.slo.detail.advancedAccordion.label', {
                           defaultMessage: 'Advanced details',
                         })}
@@ -1138,7 +1149,7 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
                         buttonContent={
                           <EuiText size="s">
                             <strong>
-                              <EuiIcon type="indexRuntime" size="s" />{' '}
+                              <EuiIcon type="indexRuntime" size="s" aria-hidden={true} />{' '}
                               {i18n.translate(
                                 'observability.apm.slo.detail.recordingRulesAccordion.label',
                                 { defaultMessage: 'Recording rules' }

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -904,7 +904,6 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
             {derivedCalloutState === 'rules_missing' || derivedCalloutState === 'rules_partial' ? (
               <>
                 <EuiCallOut
-                  announceOnMount
                   color="danger"
                   iconType="alert"
                   title={i18n.translate('observability.apm.slo.detail.rulesMissingCallout.title', {
@@ -962,7 +961,6 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
             ) : derivedCalloutState === 'ruler_unreachable' ? (
               <>
                 <EuiCallOut
-                  announceOnMount
                   color="warning"
                   iconType="alert"
                   title={i18n.translate(

--- a/public/components/apm/pages/slos/slo_suggest_page.tsx
+++ b/public/components/apm/pages/slos/slo_suggest_page.tsx
@@ -51,6 +51,7 @@ import { HeaderControlledComponentsWrapper } from '../../../../plugin_helpers/pl
 import { useApmConfig } from '../../config/apm_config_context';
 import { useServices } from '../../shared/hooks/use_services';
 import { parseTimeRange } from '../../shared/utils/time_utils';
+import { DEFAULT_APM_TIME_RANGE } from '../../common/constants';
 import type { SloApiClient } from './slo_api_client';
 import { DiscoveredService, Suggestion, generateSuggestionsForServices } from './suggest_engine';
 import { parseSuggestScopeFromSearch } from './slo_suggest_scope';
@@ -109,9 +110,11 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   // APM config rather than picking here.
   const datasourceId = config?.prometheusDataSource?.name ?? '';
 
-  // Same time range as Services Home's default (15m) — discovery is only about
-  // "does this service emit traces right now?", not historical enumeration.
-  const timeRange = useMemo(() => ({ from: 'now-15m', to: 'now' }), []);
+  // Discovery window comes from the caller via the URL (`from`/`to`) so the
+  // suggestion reflects the range the user was looking at on the services /
+  // service-details page they launched from. Falls back to the 15m default
+  // when the page is opened without an explicit range (e.g. a bare deep link).
+  const timeRange = useMemo(() => scope.timeRange ?? DEFAULT_APM_TIME_RANGE, [scope.timeRange]);
   const parsedTimeRange = useMemo(() => parseTimeRange(timeRange), [timeRange]);
 
   const {
@@ -252,10 +255,10 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   // deps include it (uniqueServices, serviceRows, …). The result was a render
   // loop where typing in a draft override re-derived the entire row tree on
   // every keystroke for ~38 drafts.
-  const decoratedSuggestions = useMemo(() => suggestions.map(applyOverrides), [
-    suggestions,
-    applyOverrides,
-  ]);
+  const decoratedSuggestions = useMemo(
+    () => suggestions.map(applyOverrides),
+    [suggestions, applyOverrides]
+  );
   const selectedCount = decoratedSuggestions.filter((s) => selected.has(s.key)).length;
   const totalRules = decoratedSuggestions
     .filter((s) => selected.has(s.key))
@@ -425,6 +428,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
               <>
                 <EuiSpacer size="s" />
                 <EuiCallOut
+                  announceOnMount
                   size="s"
                   iconType="iInCircle"
                   color="warning"
@@ -457,6 +461,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
             {servicesError && (
               <>
                 <EuiCallOut
+                  announceOnMount
                   color="danger"
                   iconType="alert"
                   title={i18n.translate('observability.apm.slo.suggest.servicesErrorTitle', {
@@ -480,6 +485,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
 
             {!loading && !datasourceId && (
               <EuiCallOut
+                announceOnMount
                 size="s"
                 iconType="iInCircle"
                 title={i18n.translate('observability.apm.slo.suggest.noDatasource.title', {
@@ -498,6 +504,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
 
             {!loading && datasourceId && uniqueServices.length === 0 && !servicesError && (
               <EuiCallOut
+                announceOnMount
                 size="s"
                 iconType="iInCircle"
                 title={i18n.translate('observability.apm.slo.suggest.noServices.title', {
@@ -516,6 +523,7 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
             {!loading && datasourceId && rulerFetchFailed && (
               <>
                 <EuiCallOut
+                  announceOnMount
                   size="s"
                   iconType="alert"
                   color="warning"

--- a/public/components/apm/pages/slos/slo_suggest_page.tsx
+++ b/public/components/apm/pages/slos/slo_suggest_page.tsx
@@ -115,7 +115,17 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
   // service-details page they launched from. Falls back to the 15m default
   // when the page is opened without an explicit range (e.g. a bare deep link).
   const timeRange = useMemo(() => scope.timeRange ?? DEFAULT_APM_TIME_RANGE, [scope.timeRange]);
-  const parsedTimeRange = useMemo(() => parseTimeRange(timeRange), [timeRange]);
+  // `parseTimeRange` throws on bounds that pass the URL charset check but aren't
+  // parseable datemath (e.g. a stale/crafted `?from=now/&to=now`). Since this
+  // runs at render time with no error boundary, fall back to the default range
+  // instead of crashing the page.
+  const parsedTimeRange = useMemo(() => {
+    try {
+      return parseTimeRange(timeRange);
+    } catch {
+      return parseTimeRange(DEFAULT_APM_TIME_RANGE);
+    }
+  }, [timeRange]);
 
   const {
     data: allDiscoveredServices,
@@ -428,7 +438,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
               <>
                 <EuiSpacer size="s" />
                 <EuiCallOut
-                  announceOnMount
                   size="s"
                   iconType="iInCircle"
                   color="warning"
@@ -461,7 +470,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
             {servicesError && (
               <>
                 <EuiCallOut
-                  announceOnMount
                   color="danger"
                   iconType="alert"
                   title={i18n.translate('observability.apm.slo.suggest.servicesErrorTitle', {
@@ -485,7 +493,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
 
             {!loading && !datasourceId && (
               <EuiCallOut
-                announceOnMount
                 size="s"
                 iconType="iInCircle"
                 title={i18n.translate('observability.apm.slo.suggest.noDatasource.title', {
@@ -504,7 +511,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
 
             {!loading && datasourceId && uniqueServices.length === 0 && !servicesError && (
               <EuiCallOut
-                announceOnMount
                 size="s"
                 iconType="iInCircle"
                 title={i18n.translate('observability.apm.slo.suggest.noServices.title', {
@@ -523,7 +529,6 @@ export const SloSuggestPage: React.FC<SloSuggestPageProps> = ({
             {!loading && datasourceId && rulerFetchFailed && (
               <>
                 <EuiCallOut
-                  announceOnMount
                   size="s"
                   iconType="alert"
                   color="warning"

--- a/public/components/apm/pages/slos/slo_suggest_scope.ts
+++ b/public/components/apm/pages/slos/slo_suggest_scope.ts
@@ -3,11 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { TimeRange } from '../../common/types/service_types';
+
 /**
  * URL-param parsing for the "Suggest SLOs" page. The page accepts
- *   #/slos/suggest[?source=apm][&services=<csv>]
+ *   #/slos/suggest[?source=apm][&services=<csv>][&from=<time>&to=<time>]
  * when entered from APM surfaces so it can scope the service list to the
- * caller's intent (e.g. "suggest missing SLOs for foo,bar").
+ * caller's intent (e.g. "suggest missing SLOs for foo,bar") and reuse the
+ * time range the user was viewing when they launched suggestion.
  *
  * `source` is currently validated only for `'apm'`; the field exists so
  * future CTAs can add new sources without a URL-shape change.
@@ -19,6 +22,12 @@ export interface SuggestScope {
   source: SuggestSource;
   /** `undefined` = unscoped (show everything `useServices()` returns). */
   services: string[] | undefined;
+  /**
+   * Time range carried over from the launching page. `undefined` when the page
+   * is opened without an explicit (and valid) range, so callers can fall back
+   * to a default.
+   */
+  timeRange: TimeRange | undefined;
 }
 
 const KNOWN_SOURCES: SuggestSource[] = ['apm'];
@@ -27,24 +36,40 @@ function isKnownSource(value: string): value is SuggestSource {
   return (KNOWN_SOURCES as string[]).includes(value);
 }
 
+/** Allowed characters for a relative/absolute time value (e.g. `now-15m`, ISO). */
+const TIME_VALUE_REGEX = /^[a-zA-Z0-9_\-:+.TZ ]+$/;
+
+/** Validate a single `from`/`to` value; returns `undefined` when unusable. */
+function parseTimeValue(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 256 || !TIME_VALUE_REGEX.test(trimmed)) return undefined;
+  return trimmed;
+}
+
 /**
- * Parse `?source=&services=` out of a `location.search` string. Unknown
- * `source` values fall back to `'apm'` (the only meaningful source today);
- * `services` missing or empty yields `undefined` rather than `[]` so callers
- * can distinguish "unscoped" from "scoped to nothing".
+ * Parse `?source=&services=&from=&to=` out of a `location.search` string.
+ * Unknown `source` values fall back to `'apm'` (the only meaningful source
+ * today); `services` missing or empty yields `undefined` rather than `[]` so
+ * callers can distinguish "unscoped" from "scoped to nothing". A `timeRange` is
+ * returned only when both `from` and `to` are present and valid.
  */
 export function parseSuggestScopeFromSearch(search: string): SuggestScope {
   const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
   const rawSource = params.get('source');
   const source: SuggestSource = rawSource && isKnownSource(rawSource) ? rawSource : 'apm';
 
+  const from = parseTimeValue(params.get('from'));
+  const to = parseTimeValue(params.get('to'));
+  const timeRange = from && to ? { from, to } : undefined;
+
   const rawServices = params.get('services');
-  if (!rawServices) return { source, services: undefined };
+  if (!rawServices) return { source, services: undefined, timeRange };
 
   const services = rawServices
     .split(',')
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 
-  return { source, services: services.length > 0 ? services : undefined };
+  return { source, services: services.length > 0 ? services : undefined, timeRange };
 }

--- a/public/components/apm/pages/slos/slo_suggest_scope.ts
+++ b/public/components/apm/pages/slos/slo_suggest_scope.ts
@@ -36,8 +36,13 @@ function isKnownSource(value: string): value is SuggestSource {
   return (KNOWN_SOURCES as string[]).includes(value);
 }
 
-/** Allowed characters for a relative/absolute time value (e.g. `now-15m`, ISO). */
-const TIME_VALUE_REGEX = /^[a-zA-Z0-9_\-:+.TZ ]+$/;
+/**
+ * Allowed characters for a relative/absolute time value. Covers relative
+ * datemath (`now-15m`), slash-rounded datemath from EuiSuperDatePicker quick
+ * ranges (`now/d`, `now/w`, `now-1d/d`), and absolute ISO timestamps
+ * (`2024-01-01T00:00:00Z`).
+ */
+const TIME_VALUE_REGEX = /^[a-zA-Z0-9_\-:+./TZ ]+$/;
 
 /** Validate a single `from`/`to` value; returns `undefined` when unusable. */
 function parseTimeValue(value: string | null): string | undefined {

--- a/public/components/apm/services.tsx
+++ b/public/components/apm/services.tsx
@@ -27,7 +27,7 @@ import { navigateToServiceDetails } from './shared/utils/navigation_utils';
 import { TimeRangePicker } from './shared/components/time_filter';
 import { LanguageIcon } from './shared/components/language_icon';
 import { LegacyBanner } from './shared/components/legacy_banner';
-import { TimeRange } from './common/types/service_types';
+import { usePersistentTimeRange } from './shared/hooks/use_persistent_time_range';
 import './shared/styles/apm_common.scss';
 
 export interface ApmServicesProps {
@@ -45,10 +45,9 @@ export const Services = (props: ApmServicesProps) => {
 
   // Service details page state - lifted from ServiceDetails for header rendering
   const [isServiceDetailsRoute, setIsServiceDetailsRoute] = useState(false);
-  const [serviceDetailsTimeRange, setServiceDetailsTimeRange] = useState<TimeRange>({
-    from: 'now-15m',
-    to: 'now',
-  });
+  // Shared, persisted time range so navigating between services / service
+  // details doesn't reset the picker back to the default range.
+  const [serviceDetailsTimeRange, setServiceDetailsTimeRange] = usePersistentTimeRange();
   const [serviceDetailsRefreshTrigger, setServiceDetailsRefreshTrigger] = useState(0);
   const [currentServiceLanguage, setCurrentServiceLanguage] = useState<string | undefined>();
 
@@ -111,7 +110,7 @@ export const Services = (props: ApmServicesProps) => {
         onClick={() => setIsSettingsModalVisible(true)}
       />,
     ],
-    [serviceDetailsTimeRange, handleServiceDetailsRefresh]
+    [serviceDetailsTimeRange, setServiceDetailsTimeRange, handleServiceDetailsRefresh]
   );
 
   // Show loading spinner while checking config

--- a/public/components/apm/shared/hooks/__tests__/use_persistent_time_range.test.ts
+++ b/public/components/apm/shared/hooks/__tests__/use_persistent_time_range.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { usePersistentTimeRange } from '../use_persistent_time_range';
+import { APM_TIME_RANGE_STORAGE_KEY, DEFAULT_APM_TIME_RANGE } from '../../../common/constants';
+
+describe('usePersistentTimeRange', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it('returns the default time range when nothing is stored', () => {
+    const { result } = renderHook(() => usePersistentTimeRange());
+    expect(result.current[0]).toEqual(DEFAULT_APM_TIME_RANGE);
+  });
+
+  it('returns a custom default when provided and nothing is stored', () => {
+    const custom = { from: 'now-1h', to: 'now' };
+    const { result } = renderHook(() => usePersistentTimeRange(custom));
+    expect(result.current[0]).toEqual(custom);
+  });
+
+  it('hydrates the initial value from sessionStorage', () => {
+    const stored = { from: 'now-24h', to: 'now' };
+    sessionStorage.setItem(APM_TIME_RANGE_STORAGE_KEY, JSON.stringify(stored));
+
+    const { result } = renderHook(() => usePersistentTimeRange());
+    expect(result.current[0]).toEqual(stored);
+  });
+
+  it('persists updates to sessionStorage', () => {
+    const { result } = renderHook(() => usePersistentTimeRange());
+
+    act(() => {
+      result.current[1]({ from: 'now-7d', to: 'now' });
+    });
+
+    expect(result.current[0]).toEqual({ from: 'now-7d', to: 'now' });
+    expect(JSON.parse(sessionStorage.getItem(APM_TIME_RANGE_STORAGE_KEY)!)).toEqual({
+      from: 'now-7d',
+      to: 'now',
+    });
+  });
+
+  it('syncs the value across two hook instances in the same tab', () => {
+    const first = renderHook(() => usePersistentTimeRange());
+    const second = renderHook(() => usePersistentTimeRange());
+
+    act(() => {
+      first.result.current[1]({ from: 'now-30m', to: 'now' });
+    });
+
+    // The second instance should observe the change via the custom event.
+    expect(second.result.current[0]).toEqual({ from: 'now-30m', to: 'now' });
+  });
+
+  it('falls back to the default when stored JSON is malformed', () => {
+    sessionStorage.setItem(APM_TIME_RANGE_STORAGE_KEY, '{not valid json');
+
+    const { result } = renderHook(() => usePersistentTimeRange());
+    expect(result.current[0]).toEqual(DEFAULT_APM_TIME_RANGE);
+  });
+
+  it('falls back to the default when stored value has the wrong shape', () => {
+    sessionStorage.setItem(APM_TIME_RANGE_STORAGE_KEY, JSON.stringify({ from: 123, to: null }));
+
+    const { result } = renderHook(() => usePersistentTimeRange());
+    expect(result.current[0]).toEqual(DEFAULT_APM_TIME_RANGE);
+  });
+
+  it('falls back to the default when stored value is missing fields', () => {
+    sessionStorage.setItem(APM_TIME_RANGE_STORAGE_KEY, JSON.stringify({ from: 'now-1h' }));
+
+    const { result } = renderHook(() => usePersistentTimeRange());
+    expect(result.current[0]).toEqual(DEFAULT_APM_TIME_RANGE);
+  });
+
+  it('still updates in-memory state when sessionStorage writes throw', () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => usePersistentTimeRange());
+
+    act(() => {
+      result.current[1]({ from: 'now-90m', to: 'now' });
+    });
+
+    expect(result.current[0]).toEqual({ from: 'now-90m', to: 'now' });
+    setItemSpy.mockRestore();
+  });
+
+  it('falls back to the default when sessionStorage reads throw', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('access denied');
+    });
+
+    const { result } = renderHook(() => usePersistentTimeRange());
+    expect(result.current[0]).toEqual(DEFAULT_APM_TIME_RANGE);
+  });
+
+  it('unsubscribes from the sync event on unmount', () => {
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => usePersistentTimeRange());
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('apm.timeRangeChange', expect.any(Function));
+    removeSpy.mockRestore();
+  });
+});

--- a/public/components/apm/shared/hooks/__tests__/use_persistent_time_range.test.ts
+++ b/public/components/apm/shared/hooks/__tests__/use_persistent_time_range.test.ts
@@ -79,6 +79,51 @@ describe('usePersistentTimeRange', () => {
     expect(result.current[0]).toEqual(DEFAULT_APM_TIME_RANGE);
   });
 
+  // A crafted/stale deep link can write a non-empty but unparseable datemath
+  // bound (`now-`, `now+`, `now.`, `nowZ`) through the shared key. These pass a
+  // naive string check but make dateMath.parse return undefined, so downstream
+  // parseTimeRange would throw. The hook must reject them everywhere.
+  it.each(['now-', 'now+', 'now.', 'nowZ'])(
+    'falls back to the default when a stored bound (%s) is unparseable datemath',
+    (badBound) => {
+      sessionStorage.setItem(
+        APM_TIME_RANGE_STORAGE_KEY,
+        JSON.stringify({ from: badBound, to: 'now' })
+      );
+
+      const { result } = renderHook(() => usePersistentTimeRange());
+      expect(result.current[0]).toEqual(DEFAULT_APM_TIME_RANGE);
+    }
+  );
+
+  it('ignores a setTimeRange call with an unparseable bound (keeps prior range, persists nothing)', () => {
+    const { result } = renderHook(() => usePersistentTimeRange());
+
+    act(() => {
+      result.current[1]({ from: 'now-2h', to: 'now' });
+    });
+    expect(result.current[0]).toEqual({ from: 'now-2h', to: 'now' });
+
+    // Poison write is rejected — state and storage keep the last valid range.
+    act(() => {
+      result.current[1]({ from: 'now-', to: 'now' });
+    });
+    expect(result.current[0]).toEqual({ from: 'now-2h', to: 'now' });
+    expect(JSON.parse(sessionStorage.getItem(APM_TIME_RANGE_STORAGE_KEY)!)).toEqual({
+      from: 'now-2h',
+      to: 'now',
+    });
+  });
+
+  it('accepts slash-rounded datemath bounds (now/d)', () => {
+    const { result } = renderHook(() => usePersistentTimeRange());
+
+    act(() => {
+      result.current[1]({ from: 'now/d', to: 'now/d' });
+    });
+    expect(result.current[0]).toEqual({ from: 'now/d', to: 'now/d' });
+  });
+
   it('still updates in-memory state when sessionStorage writes throw', () => {
     const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new Error('QuotaExceededError');

--- a/public/components/apm/shared/hooks/use_persistent_time_range.ts
+++ b/public/components/apm/shared/hooks/use_persistent_time_range.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { TimeRange } from '../../common/types/service_types';
+import { APM_TIME_RANGE_STORAGE_KEY, DEFAULT_APM_TIME_RANGE } from '../../common/constants';
+
+/**
+ * Custom event dispatched when the persisted time range changes within the tab.
+ * sessionStorage is per-tab and does not emit `storage` events to the tab that
+ * wrote it, so we emit this to keep every APM picker mounted in the current tab
+ * in sync (e.g. a header picker and an in-page picker on the same route).
+ */
+const APM_TIME_RANGE_EVENT = 'apm.timeRangeChange';
+
+/**
+ * Narrow an unknown value to a valid TimeRange. Guards against corrupt or
+ * legacy sessionStorage payloads so a bad value can never crash the picker.
+ */
+const isValidTimeRange = (value: unknown): value is TimeRange =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as TimeRange).from === 'string' &&
+  typeof (value as TimeRange).to === 'string' &&
+  (value as TimeRange).from.length > 0 &&
+  (value as TimeRange).to.length > 0;
+
+/**
+ * Read the persisted time range from sessionStorage, falling back to `fallback`
+ * when nothing is stored or the stored value is invalid/unreadable.
+ */
+const readStoredTimeRange = (fallback: TimeRange): TimeRange => {
+  try {
+    const raw = sessionStorage.getItem(APM_TIME_RANGE_STORAGE_KEY);
+    if (!raw) {
+      return fallback;
+    }
+    const parsed = JSON.parse(raw);
+    return isValidTimeRange(parsed) ? parsed : fallback;
+  } catch {
+    // Malformed JSON or sessionStorage access denied (e.g. privacy mode)
+    return fallback;
+  }
+};
+
+/**
+ * Hook for a time range that persists to sessionStorage and is shared across all
+ * APM pages. Instead of every page resetting to the default range on mount,
+ * they all read and write a single shared key, so the user's selected range
+ * survives reloads/navigation and follows them between pages within the tab.
+ *
+ * Uses sessionStorage to match the Trace Analytics convention
+ * (trace_analytics/home.tsx). Changes are synced live to every consumer mounted
+ * in the current tab via a custom event.
+ *
+ * @param defaultTimeRange - Range to use when nothing has been persisted yet.
+ * @returns A `[timeRange, setTimeRange]` tuple mirroring `useState`.
+ */
+export const usePersistentTimeRange = (
+  defaultTimeRange: TimeRange = DEFAULT_APM_TIME_RANGE
+): [TimeRange, (timeRange: TimeRange) => void] => {
+  const [timeRange, setTimeRangeState] = useState<TimeRange>(() =>
+    readStoredTimeRange(defaultTimeRange)
+  );
+
+  const setTimeRange = useCallback((newTimeRange: TimeRange) => {
+    setTimeRangeState(newTimeRange);
+    try {
+      sessionStorage.setItem(APM_TIME_RANGE_STORAGE_KEY, JSON.stringify(newTimeRange));
+    } catch {
+      // Ignore write failures (private mode / quota) — in-memory state still updates
+    }
+    // Notify other hook instances mounted in this same tab.
+    try {
+      window.dispatchEvent(
+        new CustomEvent<TimeRange>(APM_TIME_RANGE_EVENT, { detail: newTimeRange })
+      );
+    } catch {
+      // CustomEvent unsupported — cross-page sync degrades gracefully
+    }
+  }, []);
+
+  // Subscribe to changes from other APM pages mounted in this tab.
+  useEffect(() => {
+    const handleCustomEvent = (event: Event) => {
+      const detail = (event as CustomEvent<TimeRange>).detail;
+      if (isValidTimeRange(detail)) {
+        setTimeRangeState(detail);
+      }
+    };
+
+    window.addEventListener(APM_TIME_RANGE_EVENT, handleCustomEvent);
+    return () => {
+      window.removeEventListener(APM_TIME_RANGE_EVENT, handleCustomEvent);
+    };
+  }, []);
+
+  return [timeRange, setTimeRange];
+};

--- a/public/components/apm/shared/hooks/use_persistent_time_range.ts
+++ b/public/components/apm/shared/hooks/use_persistent_time_range.ts
@@ -4,6 +4,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
+import dateMath from '@elastic/datemath';
 import { TimeRange } from '../../common/types/service_types';
 import { APM_TIME_RANGE_STORAGE_KEY, DEFAULT_APM_TIME_RANGE } from '../../common/constants';
 
@@ -16,8 +17,25 @@ import { APM_TIME_RANGE_STORAGE_KEY, DEFAULT_APM_TIME_RANGE } from '../../common
 const APM_TIME_RANGE_EVENT = 'apm.timeRangeChange';
 
 /**
+ * True when `bound` is datemath `parseTimeRange`/downstream `dateMath.parse`
+ * can actually resolve. Values like `now-`, `now+`, `now.`, `nowZ` are
+ * non-empty strings that still resolve to `undefined`, which would make
+ * `parseTimeRange` throw at render time on the pages that consume this range.
+ */
+const isParseableBound = (bound: string): boolean => {
+  try {
+    return dateMath.parse(bound) !== undefined;
+  } catch {
+    return false;
+  }
+};
+
+/**
  * Narrow an unknown value to a valid TimeRange. Guards against corrupt or
- * legacy sessionStorage payloads so a bad value can never crash the picker.
+ * legacy sessionStorage payloads — and, critically, rejects non-empty but
+ * unparseable datemath bounds so a poison value (e.g. from a crafted/stale
+ * deep link) can neither be persisted nor rehydrated into the shared key,
+ * which would otherwise crash every APM page reading it.
  */
 const isValidTimeRange = (value: unknown): value is TimeRange =>
   typeof value === 'object' &&
@@ -25,7 +43,9 @@ const isValidTimeRange = (value: unknown): value is TimeRange =>
   typeof (value as TimeRange).from === 'string' &&
   typeof (value as TimeRange).to === 'string' &&
   (value as TimeRange).from.length > 0 &&
-  (value as TimeRange).to.length > 0;
+  (value as TimeRange).to.length > 0 &&
+  isParseableBound((value as TimeRange).from) &&
+  isParseableBound((value as TimeRange).to);
 
 /**
  * Read the persisted time range from sessionStorage, falling back to `fallback`
@@ -66,6 +86,13 @@ export const usePersistentTimeRange = (
   );
 
   const setTimeRange = useCallback((newTimeRange: TimeRange) => {
+    // Reject unparseable ranges (e.g. a crafted/stale deep link's `from=now-`
+    // written through by a page's mount effect) so poison never reaches
+    // in-memory state or the shared key, where it would crash consumers that
+    // call `parseTimeRange` unguarded. Keeps the current valid range instead.
+    if (!isValidTimeRange(newTimeRange)) {
+      return;
+    }
     setTimeRangeState(newTimeRange);
     try {
       sessionStorage.setItem(APM_TIME_RANGE_STORAGE_KEY, JSON.stringify(newTimeRange));

--- a/public/components/apm/shared/utils/__tests__/navigation_utils.test.ts
+++ b/public/components/apm/shared/utils/__tests__/navigation_utils.test.ts
@@ -9,6 +9,7 @@ import {
   navigateToSpanDetails,
   navigateToExploreLogs,
   navigateToDatasetCorrelations,
+  navigateToSloSuggest,
 } from '../navigation_utils';
 import { coreRefs } from '../../../../../framework/core_refs';
 
@@ -367,6 +368,60 @@ describe('navigation_utils', () => {
       navigateToDatasetCorrelations('test-dataset');
 
       expect(window.location.href).toContain('tab:correlatedDatasets');
+    });
+  });
+
+  describe('navigateToSloSuggest', () => {
+    const navigateToAppMock = jest.fn();
+    let dispatchSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      (coreRefs as any).application = { navigateToApp: navigateToAppMock };
+      dispatchSpy = jest.spyOn(window, 'dispatchEvent').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+      dispatchSpy.mockRestore();
+      delete (coreRefs as any).application;
+    });
+
+    const getPath = () => navigateToAppMock.mock.calls[0][1].path as string;
+
+    it('builds a path with source=apm and the services csv', () => {
+      navigateToSloSuggest(['checkout', 'cart']);
+
+      expect(navigateToAppMock).toHaveBeenCalledTimes(1);
+      const path = getPath();
+      expect(path).toContain('source=apm');
+      expect(path).toContain('services=checkout%2Ccart');
+    });
+
+    it('omits the services param when the list is empty', () => {
+      navigateToSloSuggest([]);
+
+      expect(getPath()).not.toContain('services=');
+    });
+
+    it('includes from/to when a time range is provided', () => {
+      navigateToSloSuggest(['checkout'], { from: 'now-24h', to: 'now' });
+
+      const path = getPath();
+      expect(path).toContain('from=now-24h');
+      expect(path).toContain('to=now');
+    });
+
+    it('omits from/to when no time range is provided', () => {
+      navigateToSloSuggest(['checkout']);
+
+      const path = getPath();
+      expect(path).not.toContain('from=');
+      expect(path).not.toContain('to=');
+    });
+
+    it('dispatches a hashchange event so the HashRouter picks up the path', () => {
+      navigateToSloSuggest(['checkout'], { from: 'now-1h', to: 'now' });
+
+      expect(dispatchSpy).toHaveBeenCalledWith(expect.any(HashChangeEvent));
     });
   });
 });

--- a/public/components/apm/shared/utils/navigation_utils.ts
+++ b/public/components/apm/shared/utils/navigation_utils.ts
@@ -134,12 +134,21 @@ export function navigateToServicesList(): void {
 
 /**
  * Navigates to the SLO suggest page scoped to the given services.
- * `#/slos/suggest?source=apm&services=<csv>` inside the apm-slo app — we
- * cross a HashRouter boundary, so go through `application.navigateToApp`.
+ * `#/slos/suggest?source=apm&services=<csv>[&from=<time>&to=<time>]` inside the
+ * apm-slo app — we cross a HashRouter boundary, so go through
+ * `application.navigateToApp`.
+ *
+ * The optional `timeRange` carries the range the user was viewing on the
+ * launching page so discovery reflects the same window; the suggest page falls
+ * back to its default when it's omitted.
  */
-export function navigateToSloSuggest(services: string[]): void {
+export function navigateToSloSuggest(services: string[], timeRange?: TimeRange): void {
   const qs = new URLSearchParams({ source: 'apm' });
   if (services.length > 0) qs.set('services', services.join(','));
+  if (timeRange) {
+    qs.set('from', timeRange.from);
+    qs.set('to', timeRange.to);
+  }
   const path = `#/slos/suggest?${qs.toString()}`;
   coreRefs?.application?.navigateToApp(observabilityApmSloID, { path });
   window.dispatchEvent(new HashChangeEvent('hashchange'));


### PR DESCRIPTION
## Description

Every APM page previously initialized its time-range picker with a hardcoded default (`now-15m`, or `now-1h` for SLO detail) using local `useState`. As a result:

- The picker reset to its default on every navigation and page reload.
- Each page maintained its own independent time range.
- A time range selected on the Services page was lost when navigating to the Application Map, Service Details, or SLO pages.

This PR introduces a single shared, persisted time range so the user's selection survives reloads and remains consistent across the APM experience.

---

## Approach

### Shared persistence via `sessionStorage`

A new `usePersistentTimeRange` hook stores the selected time range under a shared `sessionStorage` key (`apm.timeRange`).

Instead of maintaining isolated local state, every page with a time picker now reads from and writes to this shared value, keeping the selected range synchronized across APM pages within the same browser tab.

### Why `sessionStorage` instead of `localStorage`?

This matches the existing convention used by Trace Analytics (`trace_analytics/home.tsx`), which already persists its time range in `sessionStorage`, keeping behavior consistent across the Observability plugin.

Trade-off:

- ✅ Persists across navigation and page reloads within the same tab.
- ❌ Resets when the browser tab is closed.

### Live in-tab synchronization

`sessionStorage` does not emit `storage` events to the tab that performs the write.

To keep multiple mounted time pickers synchronized (for example, a header picker and an in-page picker), the hook dispatches a same-tab `CustomEvent` whenever the value changes.

### Defensive reads and writes

The hook:

- Validates the stored payload before using it.
- Falls back to the default when data is malformed or missing.
- Gracefully handles storage exceptions (private browsing, quota limits, etc.) without crashing the picker.

### SLO Suggestions use the redirect URL

The **Suggest SLOs** page intentionally does **not** contain its own time picker.

Instead, the launching page passes its current time range through the navigation URL (`from` / `to`).

The Suggest page:

- Uses the supplied range when present.
- Falls back to the default 15-minute window when opened directly (for example, via a deep link).

This ensures suggestions reflect the exact time window the user was viewing when selecting **Suggest SLOs**.

---

## Pages Covered

| Page | Behavior After This PR |
|------|-------------------------|
| **Services** (`#/services`) | Shared persisted time picker |
| **Service Details** (`#/service-details/...`) | Shared persisted picker (URL `from`/`to` still overrides) |
| **Application Map** (`#/application-map`) | Shared persisted picker (URL `from`/`to` still overrides) |
| **SLO Listing** (`#/slos`) | No time picker (unchanged) |
| **SLO Detail** (`#/slos/:id`) | Shared persisted picker (falls back to `now-1h` when nothing is stored) |
| **Suggest SLOs** (`#/slos/suggest`) | Receives time range through the redirect URL; falls back to `now-15m` |

---

## Changes

### New

- `shared/hooks/use_persistent_time_range.ts`
  - Shared hook returning `[timeRange, setTimeRange]`, mirroring `useState`.
- `common/constants.ts`
  - Added:
    - `APM_TIME_RANGE_STORAGE_KEY`
    - `DEFAULT_APM_TIME_RANGE`

### Integrated shared persistence

Replaced local picker state with `usePersistentTimeRange` in:

- `services.tsx`
- `pages/services_home/services_home.tsx`
- `pages/application_map/application_map_page.tsx`
- `pages/slos/slo_detail_page.tsx`

### SLO Suggestions redirect

Updated navigation to preserve the current time range:

- `shared/utils/navigation_utils.ts`
  - `navigateToSloSuggest(services, timeRange?)` now includes `from` / `to` query parameters.
- `pages/slos/slo_suggest_scope.ts`
  - Parses and validates `from` / `to` using the existing URL time validation.
- `pages/slos/slo_suggest_page.tsx`
  - Uses `scope.timeRange ?? DEFAULT_APM_TIME_RANGE`.
- Forwarded the current time range from:
  - `pages/service_details/service_slo_tab.tsx`
  - `pages/services_home/slo_health_panel.tsx`
    - Panel CTA
    - Per-row Suggest SLO links

---

## Testing

### New

- `use_persistent_time_range.test.ts` (**11 tests**)
  - Default values
  - Custom defaults
  - Hydration from storage
  - Persistence
  - Cross-instance synchronization
  - Malformed data fallback
  - Missing-field fallback
  - Storage read/write exception handling
  - Unmount cleanup

### Extended

**`slo_suggest_scope.test.ts`**

Added coverage for:

- Relative time ranges
- Absolute ISO timestamps
- Single-bound values
- Invalid characters
- Maximum length validation
- Combined services + time range parsing

Updated existing assertions for the new `timeRange` field.

**`navigation_utils.test.ts`**

Added coverage for:

- Service CSV encoding
- Empty service list omission
- `from` / `to` inclusion and omission
- `hashchange` dispatch

### Validation

- ✅ **1,175 APM tests passing (89 suites)**
- ✅ Typecheck clean
- ✅ Lint clean on all modified files

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
