### PR TITLE
[lint] Align EUI/OUI rule overrides with root OSD config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,35 @@ module.exports = [
   ...osdConfig,
   ...eui,
   {
+    // Mirror the root OpenSearch Dashboards `eslint.config.js` "adjust Eui
+    // accessibility rules project-wide" block. The shared `eui` config targets
+    // a newer upstream EUI than the `@opensearch-project/oui@1.22.1` this repo
+    // aliases `@elastic/eui` to (a repo-wide alias set in the root
+    // package.json). Several of these rules are `fixable: 'code'` and autofix
+    // in props/APIs that OUI 1.22.1 does not ship (e.g. `announceOnMount` on
+    // EuiCallOut, `disableScreenReaderOutput` on EuiToolTip), so `--fix` (incl.
+    // the lint-staged pre-commit hook) injects code that fails `yarn
+    // typecheck`. Keep this list in sync with the root config until OUI catches
+    // up to the EUI version the lint plugin expects.
+    rules: {
+      '@elastic/eui/badge-accessibility-rules': 'off',
+      '@elastic/eui/callout-announce-on-mount': 'off',
+      '@elastic/eui/icon-accessibility-rules': 'off',
+      '@elastic/eui/no-css-color': 'off',
+      '@elastic/eui/no-restricted-eui-imports': 'off',
+      '@elastic/eui/no-static-z-index': 'off',
+      '@elastic/eui/no-unnamed-interactive-element': 'off',
+      '@elastic/eui/no-unnamed-radio-group': 'off',
+      '@elastic/eui/prefer-eui-icon-tip': 'off',
+      '@elastic/eui/require-aria-label-for-modals': 'off',
+      '@elastic/eui/require-href-for-link': 'off',
+      '@elastic/eui/require-table-caption': 'off',
+      '@elastic/eui/sr-output-disabled-tooltip': 'off',
+      '@elastic/eui/tooltip-button-icon-wrap': 'off',
+      '@elastic/eui/tooltip-focusable-anchor': 'off',
+    },
+  },
+  {
     // Register Cypress + mocha globals for the .cypress/ integration specs
     // (previously provided by the old kibana eslint config's cypress env).
     files: ['.cypress/**/*.{js,ts}', 'cypress.config.js'],
@@ -54,14 +83,6 @@ module.exports = [
       ],
       '@typescript-eslint/no-explicit-any': 'warn',
       'no-console': 0,
-      // The shared `eui` config targets a newer upstream EUI than the
-      // `@opensearch-project/oui@1.22.1` this repo aliases `@elastic/eui` to.
-      // These two rules autofix in props (`announceOnMount` on EuiCallOut,
-      // `disableScreenReaderOutput` on EuiToolTip) that don't exist in OUI
-      // 1.22.1's type defs, so `--fix` (incl. the lint-staged pre-commit hook)
-      // injects code that fails `yarn typecheck`. Disable until OUI catches up.
-      '@elastic/eui/callout-announce-on-mount': 'off',
-      '@elastic/eui/sr-output-disabled-tooltip': 'off',
       '@osd/eslint/no-restricted-paths': [
         'error',
         {


### PR DESCRIPTION
## Description

Follow-up to the ESLint override added in **#2784**. This PR replaces the two ad hoc EUI rule disables with a dedicated override block that mirrors the root OpenSearch Dashboards `eslint.config.js`, addressing the underlying OUI/EUI compatibility issue more completely and consistently.

## Background

This repository aliases `@elastic/eui` to `@opensearch-project/oui@1.22.1` via the root `package.json`. OUI is OpenSearch's fork of Elastic's EUI and intentionally trails upstream EUI releases. However, the shared `@elastic/eslint-plugin-eui` configuration targets newer upstream EUI APIs.

Several of the plugin's rules are `fixable: "code"` and their autofixers insert props and APIs that do not exist in OUI 1.22.1. For example:

- `callout-announce-on-mount` inserts `announceOnMount` on `EuiCallOut`
- `sr-output-disabled-tooltip` inserts `disableScreenReaderOutput` on `EuiToolTip`

Because this plugin uses a `lint-staged` pre-commit hook that runs `eslint --fix`, every commit silently reintroduced those props, which then failed `yarn typecheck` because OUI's type definitions do not declare them.

PR **#2784** disabled the two rules that were actively causing failures. While that solved the immediate issue, it only addressed **2 of the 15** OUI-incompatible EUI rules, leaving the remaining autofix traps in place.

## Changes

- Added a dedicated **"adjust EUI rules"** override immediately after the `...eui` config spread.
- Disabled the same **15 EUI rules** that the root OpenSearch Dashboards `eslint.config.js` disables:
  - `badge-accessibility`
  - `callout-announce-on-mount`
  - `icon-accessibility`
  - `no-css-color`
  - `no-restricted-eui-imports`
  - `no-static-z-index`
  - `no-unnamed-interactive-element`
  - `no-unnamed-radio-group`
  - `prefer-eui-icon-tip`
  - `require-aria-label-for-modals`
  - `require-href-for-link`
  - `require-table-caption`
  - `sr-output-disabled-tooltip`
  - `tooltip-button-icon-wrap`
  - `tooltip-focusable-anchor`
- Removed the two rule-specific disables from the general rules block, since they are now covered by the new override.
- Documented:
  - the repository-wide OUI alias as the underlying cause, and
  - the root `eslint.config.js` as the source of truth to remain aligned with until OUI catches up to the EUI version expected by the lint plugin.

This follows the canonical OpenSearch Dashboards approach for handling the EUI/OUI version mismatch: using the same override mechanism as the root repository rather than maintaining a growing list of local rule-specific patches.

## Why not just upgrade OUI?

The OUI alias is defined repository-wide in the root `package.json`, and OUI 1.22.1 genuinely does not implement the newer accessibility props introduced by upstream EUI.

Making these autofixes valid would require upgrading OUI across the entire monorepo—a breaking major-version change that is well outside the scope of this plugin.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
