### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/public/components/apm/shared/utils/__tests__/navigation_utils.test.ts
+++ b/public/components/apm/shared/utils/__tests__/navigation_utils.test.ts
@@ -26,20 +26,18 @@ jest.mock('../../../../../framework/core_refs', () => ({
 
 describe('navigation_utils', () => {
   let windowOpenSpy: jest.SpyInstance;
-  const originalLocation = window.location;
 
   beforeEach(() => {
     jest.clearAllMocks();
     windowOpenSpy = jest.spyOn(window, 'open').mockImplementation();
 
-    // Mock window.location.href
-    delete (window as any).location;
-    window.location = { href: '' } as Location;
+    // window.location is mocked globally by jest-location-mock; reset it to the
+    // default test origin before each test so href assertions start clean.
+    window.location.assign('http://localhost:5601/');
   });
 
   afterEach(() => {
     windowOpenSpy.mockRestore();
-    window.location = originalLocation;
   });
 
   describe('navigateToServiceMap', () => {

--- a/public/components/apm/shared/utils/navigation_utils.ts
+++ b/public/components/apm/shared/utils/navigation_utils.ts
@@ -365,5 +365,5 @@ export function navigateToDatasetCorrelations(datasetId: string): void {
   const fullUrl = coreRefs.http?.basePath.prepend(`/app/${path}`) || `/app/${path}`;
 
   // Navigate in same tab
-  window.location.href = fullUrl;
+  window.location.assign(fullUrl);
 }

--- a/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Create Page can clear query 1`] = `
 <body>
@@ -499,7 +499,7 @@ exports[`Create Page can clear query 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -925,7 +925,7 @@ exports[`Create Page can clear query 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -2031,7 +2031,7 @@ exports[`Create Page clears one trace selected 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -2492,7 +2492,7 @@ exports[`Create Page clears one trace selected 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -3633,7 +3633,7 @@ exports[`Create Page clears service selected 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -4059,7 +4059,7 @@ exports[`Create Page clears service selected 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -5163,7 +5163,7 @@ exports[`Create Page renders empty 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -5587,7 +5587,7 @@ exports[`Create Page renders empty 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -6693,7 +6693,7 @@ exports[`Create Page renders with name and description 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -7119,7 +7119,7 @@ exports[`Create Page renders with name and description 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -8258,7 +8258,7 @@ exports[`Create Page renders with one service selected 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -8684,7 +8684,7 @@ exports[`Create Page renders with one service selected 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -9790,7 +9790,7 @@ exports[`Create Page renders with one trace selected 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -10251,7 +10251,7 @@ exports[`Create Page renders with one trace selected 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -11359,7 +11359,7 @@ exports[`Create Page renders with query 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -11785,7 +11785,7 @@ exports[`Create Page renders with query 1`] = `
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/flyout.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/flyout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Trace Detail Render Flyout component render trace detail 1`] = `
 <body>

--- a/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Log Config component renders empty log config 1`] = `
 <body>

--- a/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Service Config component renders empty service config 1`] = `
 <body>
@@ -159,7 +159,7 @@ exports[`Service Config component renders empty service config 1`] = `
                               value=""
                             />
                             <div
-                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                             />
                           </div>
                         </div>
@@ -587,7 +587,7 @@ exports[`Service Config component renders with one service selected 1`] = `
                               value=""
                             />
                             <div
-                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                             />
                           </div>
                         </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/trace_config.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Trace Config component renders empty trace config 1`] = `
 <body>
@@ -160,7 +160,7 @@ exports[`Trace Config component renders empty trace config 1`] = `
                               value=""
                             />
                             <div
-                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                             />
                           </div>
                         </div>
@@ -851,7 +851,7 @@ exports[`Trace Config component renders with one trace selected 1`] = `
                               value=""
                             />
                             <div
-                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                             />
                           </div>
                         </div>

--- a/public/components/application_analytics/__tests__/__snapshots__/utils.test.tsx.snap
+++ b/public/components/application_analytics/__tests__/__snapshots__/utils.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Utils application analytics helper functions validates and renders getListItem function 1`] = `
 <body>

--- a/public/components/application_analytics/components/app_table.tsx
+++ b/public/components/application_analytics/components/app_table.tsx
@@ -245,7 +245,7 @@ export function AppTable(props: AppTableProps) {
                         {
                           label: createButtonText,
                           run: () => {
-                            window.location.href = '#/create';
+                            window.location.assign('#/create');
                           },
                           iconType: 'plus',
                           iconSide: 'left',

--- a/public/components/common/live_tail/__tests__/__snapshots__/live_tail_button.test.tsx.snap
+++ b/public/components/common/live_tail/__tests__/__snapshots__/live_tail_button.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Live tail button change live tail to 10s interval 1`] = `
 <body>

--- a/public/components/common/search/__tests__/__snapshots__/search.test.tsx.snap
+++ b/public/components/common/search/__tests__/__snapshots__/search.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Explorer Search component renders basic component 1`] = `
 <body>

--- a/public/components/common/search/autocomplete.test.tsx
+++ b/public/components/common/search/autocomplete.test.tsx
@@ -20,12 +20,12 @@ describe('renders autocomplete', function () {
   const tempQuery = '';
   const handleQueryChange = jest.fn();
   const handleQuerySearch = jest.fn();
-  const dslService = ({
+  const dslService = {
     http: jest.fn(),
     fetch: jest.fn(),
     fetchIndices: jest.fn(),
     fetchFields: jest.fn(),
-  } as unknown) as DSLService;
+  } as unknown as DSLService;
   const getSuggestions = jest.fn();
   const onItemSelect = jest.fn();
   const utils = render(
@@ -49,19 +49,19 @@ describe('renders autocomplete', function () {
     act(() => {
       fireEvent.change(searchBar, { target: { value: 'new query' } });
     });
-    expect(handleQueryChange).toBeCalledWith('new query');
+    expect(handleQueryChange).toHaveBeenCalledWith('new query');
   });
 
   it('handles query search on shift enter', () => {
     act(() => {
       fireEvent.keyDown(searchBar, { keyCode: 13, shiftKey: true });
     });
-    expect(handleQuerySearch).toBeCalled();
+    expect(handleQuerySearch).toHaveBeenCalled();
   });
 });
 
 describe('autocomplete logic', function () {
-  const dslService = ({
+  const dslService = {
     http: jest.fn(),
     fetch: jest
       .fn()
@@ -91,7 +91,7 @@ describe('autocomplete logic', function () {
         },
       },
     }),
-  } as unknown) as DSLService;
+  } as unknown as DSLService;
 
   it('suggests source if empty', async () => {
     const input = '';
@@ -104,7 +104,7 @@ describe('autocomplete logic', function () {
       },
     ] as AutocompleteItem[];
     const suggestion = await parseGetSuggestions('', input, dslService);
-    expect(dslService.fetchIndices).toBeCalled();
+    expect(dslService.fetchIndices).toHaveBeenCalled();
     expect(suggestion).toStrictEqual(expected);
   });
 
@@ -194,7 +194,7 @@ describe('autocomplete logic', function () {
       };
     }) as AutocompleteItem[];
     const suggestion = await parseGetSuggestions('', input, dslService);
-    expect(dslService.fetchFields).toBeCalled();
+    expect(dslService.fetchFields).toHaveBeenCalled();
     expect(suggestion).toStrictEqual(expected);
   });
 
@@ -223,7 +223,7 @@ describe('autocomplete logic', function () {
       },
     ] as AutocompleteItem[];
     const suggestion = await parseGetSuggestions('', input, dslService);
-    expect(dslService.fetch).toBeCalled();
+    expect(dslService.fetch).toHaveBeenCalled();
     expect(suggestion).toStrictEqual(expected);
   });
 
@@ -294,7 +294,7 @@ describe('autocomplete logic', function () {
       },
     ] as AutocompleteItem[];
     const suggestion = await parseGetSuggestions('', input, dslService);
-    expect(dslService.fetch).toBeCalled();
+    expect(dslService.fetch).toHaveBeenCalled();
     expect(suggestion).toStrictEqual(expected);
   });
 
@@ -397,7 +397,7 @@ describe('autocomplete logic', function () {
       },
     ] as AutocompleteItem[];
     const suggestion = await parseGetSuggestions('', input, dslService);
-    expect(dslService.fetch).toBeCalled();
+    expect(dslService.fetch).toHaveBeenCalled();
     expect(suggestion).toStrictEqual(expected);
   });
 

--- a/public/components/common/search/search.test.tsx
+++ b/public/components/common/search/search.test.tsx
@@ -72,6 +72,6 @@ describe.skip('Search bar', () => {
 
     const searchBar = utils.getByPlaceholderText('Enter PPL query');
     fireEvent.change(searchBar, { target: { value: 'new query' } });
-    expect(handleQueryChange).toBeCalledWith('new query');
+    expect(handleQueryChange).toHaveBeenCalledWith('new query');
   });
 });

--- a/public/components/custom_panels/__tests__/__snapshots__/custom_panel_table.test.tsx.snap
+++ b/public/components/custom_panels/__tests__/__snapshots__/custom_panel_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Panels Table Component render dashboard table container with panels 1`] = `
 <body>

--- a/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
+++ b/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Panels View Component render panel view container and refresh panel 1`] = `
 <body>

--- a/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view_so.test.tsx.snap
+++ b/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view_so.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Panels View SO Component render panel view container and refresh panel 1`] = `
 <body>

--- a/public/components/custom_panels/__tests__/custom_panel_table.test.tsx
+++ b/public/components/custom_panels/__tests__/custom_panel_table.test.tsx
@@ -91,19 +91,19 @@ describe('Panels Table Component', () => {
   it('create a custom dashboard from empty table view', async () => {
     const utils = renderPanelTable();
 
-    fireEvent.click(utils.getByTestId('customPanels__createNewPanels'));
-    await waitFor(() => {
-      expect(global.window.location.href).toContain('create');
-    });
+    // The create button is an <a href="#/create">. jsdom 26 no longer performs
+    // anchor default navigation on click, so assert the link target directly
+    // instead of the post-click window.location.
+    expect(utils.getByTestId('customPanels__createNewPanels')).toHaveAttribute('href', '#/create');
   });
 
   it('create a custom dashboard from populated table view', async () => {
     const utils = renderPanelTable();
 
-    fireEvent.click(utils.getByTestId('customPanels__createNewPanels'));
-    await waitFor(() => {
-      expect(global.window.location.href).toContain('create');
-    });
+    // The create button is an <a href="#/create">. jsdom 26 no longer performs
+    // anchor default navigation on click, so assert the link target directly
+    // instead of the post-click window.location.
+    expect(utils.getByTestId('customPanels__createNewPanels')).toHaveAttribute('href', '#/create');
   });
 
   it('clone a custom dashboard', async () => {

--- a/public/components/custom_panels/__tests__/custom_panel_view.test.tsx
+++ b/public/components/custom_panels/__tests__/custom_panel_view.test.tsx
@@ -14,11 +14,11 @@ import {
   samplePPLResponse,
   sampleSavedVisualization,
 } from '../../../../test/panels_constants';
-// eslint-disable-next-line jest/no-mocks-import
+
 import httpClientMock from '../../../../test/__mocks__/httpClientMock';
 import PPLService from '../../../../public/services/requests/ppl';
 import DSLService from '../../../../public/services/requests/dsl';
-// eslint-disable-next-line jest/no-mocks-import
+
 import { coreStartMock } from '../../../../test/__mocks__/coreMocks';
 import { HttpResponse } from '../../../../../../src/core/public';
 import { applyMiddleware, createStore } from 'redux';
@@ -67,7 +67,7 @@ describe('Panels View Component', () => {
 
   it('renders panel view container without visualizations', async () => {
     httpClientMock.get = jest.fn(() =>
-      Promise.resolve((sampleEmptyPanel as unknown) as HttpResponse)
+      Promise.resolve(sampleEmptyPanel as unknown as HttpResponse)
     );
     const panelId = 'L8Sx53wBDp0rvEg3yoLb';
     const http = httpClientMock;
@@ -122,12 +122,12 @@ describe('Panels View Component', () => {
     httpClientMock.get = jest.fn(() => {
       if (counter === 0) {
         counter += 1;
-        return Promise.resolve((samplePanel as unknown) as HttpResponse);
-      } else return Promise.resolve((sampleSavedVisualization as unknown) as HttpResponse);
+        return Promise.resolve(samplePanel as unknown as HttpResponse);
+      } else return Promise.resolve(sampleSavedVisualization as unknown as HttpResponse);
     });
 
     httpClientMock.post = jest.fn(() =>
-      Promise.resolve((samplePPLResponse as unknown) as HttpResponse)
+      Promise.resolve(samplePPLResponse as unknown as HttpResponse)
     );
     const panelId = 'L8Sx53wBDp0rvEg3yoLb';
     const http = httpClientMock;
@@ -180,12 +180,12 @@ describe('Panels View Component', () => {
     httpClientMock.get = jest.fn(() => {
       if (counter === 0) {
         counter += 1;
-        return Promise.resolve((samplePanel as unknown) as HttpResponse);
-      } else return Promise.resolve((sampleSavedVisualization as unknown) as HttpResponse);
+        return Promise.resolve(samplePanel as unknown as HttpResponse);
+      } else return Promise.resolve(sampleSavedVisualization as unknown as HttpResponse);
     });
 
     httpClientMock.post = jest.fn(() =>
-      Promise.resolve((samplePPLResponse as unknown) as HttpResponse)
+      Promise.resolve(samplePPLResponse as unknown as HttpResponse)
     );
     const http = httpClientMock;
     const pplService = new PPLService(httpClientMock);
@@ -213,7 +213,7 @@ describe('Panels View Component', () => {
       fireEvent.click(utils.getByTestId('runModalButton'));
     });
     await waitFor(() => {
-      expect(coreRefs.savedObjectsClient.create).toBeCalledTimes(1);
+      expect(coreRefs.savedObjectsClient.create).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/public/components/custom_panels/__tests__/custom_panel_view_so.test.tsx
+++ b/public/components/custom_panels/__tests__/custom_panel_view_so.test.tsx
@@ -15,12 +15,12 @@ import {
   sampleSavedObjectPanel,
   sampleSavedObjectPanelWithVisualization,
 } from '../../../../test/panels_constants';
-// eslint-disable-next-line jest/no-mocks-import
+
 import httpClientMock from '../../../../test/__mocks__/httpClientMock';
 import PPLService from '../../../../public/services/requests/ppl';
 import { HttpResponse } from '../../../../../../src/core/public';
 import DSLService from '../../../../public/services/requests/dsl';
-// eslint-disable-next-line jest/no-mocks-import
+
 import { coreStartMock } from '../../../../test/__mocks__/coreMocks';
 import { applyMiddleware, createStore } from 'redux';
 import { coreRefs } from '../../../framework/core_refs';
@@ -48,10 +48,10 @@ describe('Panels View SO Component', () => {
   http.get = jest.fn(() => {
     if (counter === 0) {
       counter += 1;
-      return Promise.resolve((samplePanel as unknown) as HttpResponse);
-    } else return Promise.resolve((sampleSavedVisualization as unknown) as HttpResponse);
+      return Promise.resolve(samplePanel as unknown as HttpResponse);
+    } else return Promise.resolve(sampleSavedVisualization as unknown as HttpResponse);
   });
-  http.post = jest.fn(() => Promise.resolve((samplePPLResponse as unknown) as HttpResponse));
+  http.post = jest.fn(() => Promise.resolve(samplePPLResponse as unknown as HttpResponse));
   const pplService = new PPLService(http);
   const dslService = new DSLService(http);
   coreRefs.savedObjectsClient.create = jest
@@ -140,7 +140,7 @@ describe('Panels View SO Component', () => {
       fireEvent.click(utils.getByTestId('runModalButton'));
     });
     await waitFor(() => {
-      expect(coreRefs.savedObjectsClient.create).toBeCalledTimes(1);
+      expect(coreRefs.savedObjectsClient.create).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -159,7 +159,7 @@ describe('Panels View SO Component', () => {
       fireEvent.click(utils.getByTestId('popoverModal__deleteButton'));
     });
     await waitFor(() => {
-      expect(coreRefs.http.delete).toBeCalledTimes(1);
+      expect(coreRefs.http.delete).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/public/components/custom_panels/helpers/__tests__/__snapshots__/custom_input_model.test.tsx.snap
+++ b/public/components/custom_panels/helpers/__tests__/__snapshots__/custom_input_model.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Custom Input Model component renders custom input modal with multiple arguments 1`] = `
 <body

--- a/public/components/custom_panels/helpers/__tests__/__snapshots__/modal_container.test.tsx.snap
+++ b/public/components/custom_panels/helpers/__tests__/__snapshots__/modal_container.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Modal Container component renders DeleteModal component 1`] = `
 <body

--- a/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
+++ b/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Utils helper functions renders displayVisualization function 1`] = `
 <div>

--- a/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Empty panel view component renders empty panel view with disabled popover 1`] = `
 <body>

--- a/public/components/custom_panels/panel_modules/panel_grid/__tests__/__snapshots__/panel_grid.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/panel_grid/__tests__/__snapshots__/panel_grid.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Panel Grid Component renders panel grid component with empty visualizations 1`] = `
 <body>

--- a/public/components/custom_panels/panel_modules/visualization_container/__tests__/__snapshots__/visualization_container.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_container/__tests__/__snapshots__/visualization_container.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Visualization Container Component renders add visualization container 1`] = `
 <body>

--- a/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
 <body

--- a/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout_so.test.tsx.snap
+++ b/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout_so.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
 <body

--- a/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/associated_objects_tab.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AssociatedObjectsTab Component renders correctly with associated objects 1`] = `
 <body>

--- a/public/components/datasources/components/__tests__/__snapshots__/connection_details.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/connection_details.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Connection Details test Renders connection details for prometheus datasource 1`] = `
 <body>

--- a/public/components/datasources/components/__tests__/__snapshots__/data_connection.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/data_connection.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Data Connection Page test Renders Prometheus data connection page with data 1`] = `
 <div>

--- a/public/components/datasources/components/__tests__/__snapshots__/inactive_data_connection.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/inactive_data_connection.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Data Connection Inactive Page test Renders inactive data connection callout 1`] = `
 <body>

--- a/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/installed_integrations_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Installed Integrations Table test Renders the empty installed integrations table 1`] = `
 <body>

--- a/public/components/datasources/components/__tests__/__snapshots__/manage_data_connections_description.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/manage_data_connections_description.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Manage Data Connections Description test Renders manage data connections description 1`] = `
 <body>

--- a/public/components/datasources/components/__tests__/__snapshots__/manage_data_connections_table.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/manage_data_connections_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Manage Data Connections Table test Renders manage data connections table with data 1`] = `
 <div>

--- a/public/components/datasources/components/__tests__/__snapshots__/no_access.test.tsx.snap
+++ b/public/components/datasources/components/__tests__/__snapshots__/no_access.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`No access test Renders no access view of data source 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Create acceleration flyout components renders acceleration flyout component with default options 1`] = `
 <body
@@ -223,7 +223,7 @@ exports[`Create acceleration flyout components renders acceleration flyout compo
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>
@@ -348,7 +348,7 @@ exports[`Create acceleration flyout components renders acceleration flyout compo
                                     value=""
                                   />
                                   <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                   />
                                 </div>
                               </div>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration_button.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration_button.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Create acceleration button component renders create acceleration button component with mv state 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration_header.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/create/__tests__/__snapshots__/create_acceleration_header.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Acceleration header renders acceleration flyout header 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/define_index_options.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/define_index_options.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Index options acceleration components renders acceleration index options with covering index options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_advanced_settings.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_advanced_settings.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Advanced Index settings acceleration components renders acceleration index settings with default options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_setting_options.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Index settings acceleration components renders acceleration index settings with default options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_type_selector.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/index_type_selector.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Index type selector components renders type selector with default options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/preview_sql_defintion.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/preview_sql_defintion.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Preview SQL acceleration components renders Preview SQL settings with default covering index options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/source_selector.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/selectors/__tests__/__snapshots__/source_selector.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Source selector components renders source selector with default options 1`] = `
 <body>
@@ -101,7 +101,7 @@ exports[`Source selector components renders source selector with default options
                         value=""
                       />
                       <div
-                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                       />
                     </div>
                   </div>
@@ -226,7 +226,7 @@ exports[`Source selector components renders source selector with default options
                         value=""
                       />
                       <div
-                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                       />
                     </div>
                   </div>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/__tests__/__snapshots__/query_visual_editor.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/__tests__/__snapshots__/query_visual_editor.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Visual builder components renders visual builder with covering index options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/covering_index/__tests__/__snapshots__/covering_index_builder.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/covering_index/__tests__/__snapshots__/covering_index_builder.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Covering index builder components renders covering index builder  with different options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/__tests__/__snapshots__/add_column_popover.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/__tests__/__snapshots__/add_column_popover.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Column popover components in materialized view renders column popover components in materialized view with default options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/__tests__/__snapshots__/column_expression.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/__tests__/__snapshots__/column_expression.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Column expression components in materialized view renders column expression components in materialized view with default options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/__tests__/__snapshots__/group_by_tumble_expression.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/__tests__/__snapshots__/group_by_tumble_expression.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Group by components in materialized view renders group by components in materialized view with default options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/__tests__/__snapshots__/materialized_view_builder.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/materialized_view/__tests__/__snapshots__/materialized_view_builder.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Builder components in materialized view renders builder components in materialized view with default options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/add_fields_modal.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/add_fields_modal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Add fields modal in skipping index renders add fields modal in skipping index with default options 1`] = `
 <body

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/delete_fields_modal.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/delete_fields_modal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Delete fields modal in skipping index renders delete fields modal in skipping index with default options 1`] = `
 <body

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/generate_fields.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/generate_fields.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Generate fields in skipping index Generate fields in skipping index with default options 1`] = `
 <body>

--- a/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/skipping_index_builder.test.tsx.snap
+++ b/public/components/datasources/components/manage/accelerations/create_accelerations_flyout/visual_editors/skipping_index/__tests__/__snapshots__/skipping_index_builder.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Builder components in materialized view renders builder components in materialized view with default options 1`] = `
 <body>

--- a/public/components/event_analytics/__tests__/__snapshots__/no_results.test.tsx.snap
+++ b/public/components/event_analytics/__tests__/__snapshots__/no_results.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`No result component Renders No result component 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/__tests__/__snapshots__/data_grid.test.tsx.snap
+++ b/public/components/event_analytics/explorer/__tests__/__snapshots__/data_grid.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Datagrid component Renders data grid component 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/events_views/__tests__/__snapshots__/doc_viewer.test.tsx.snap
+++ b/public/components/event_analytics/explorer/events_views/__tests__/__snapshots__/doc_viewer.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Datagrid Doc viewer component Renders Doc viewer component 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/events_views/__tests__/__snapshots__/flyout_button.test.tsx.snap
+++ b/public/components/event_analytics/explorer/events_views/__tests__/__snapshots__/flyout_button.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Datagrid Doc viewer row component Renders Doc viewer row component 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/events_views/json_code_block/__tests__/__snapshots__/json_code_block.test.tsx.snap
+++ b/public/components/event_analytics/explorer/events_views/json_code_block/__tests__/__snapshots__/json_code_block.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Doc viewer JSON block component Renders JSON block component 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_header.test.tsx.snap
+++ b/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_header.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Patterns header component Renders header of log patterns 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_table.test.tsx.snap
+++ b/public/components/event_analytics/explorer/log_patterns/__tests__/__snapshots__/patterns_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Pattern table component Renders pattern table 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/query_assist/__tests__/__snapshots__/callouts.test.tsx.snap
+++ b/public/components/event_analytics/explorer/query_assist/__tests__/__snapshots__/callouts.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Callouts spec EmptyQueryCallOut should match snapshot 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/query_assist/__tests__/input.test.tsx
+++ b/public/components/event_analytics/explorer/query_assist/__tests__/input.test.tsx
@@ -73,10 +73,10 @@ describe('<QueryAssistInput /> spec', () => {
       fireEvent.click(component.getByText('Generate and run'));
     });
 
-    expect(httpMock.post).toBeCalledWith(QUERY_ASSIST_API.GENERATE_PPL, {
+    expect(httpMock.post).toHaveBeenCalledWith(QUERY_ASSIST_API.GENERATE_PPL, {
       body: '{"question":"test-input","index":"selected-test-index"}',
     });
-    expect(props.handleQueryChange).toBeCalledWith('source = index');
+    expect(props.handleQueryChange).toHaveBeenCalledWith('source = index');
     expect(props.setCallOut.mock.calls[0][0]).toBeNull();
     expect(props.setCallOut.mock.calls[1][0]).toEqual(
       expect.objectContaining({
@@ -95,7 +95,7 @@ describe('<QueryAssistInput /> spec', () => {
       fireEvent.click(component.getByTestId('query-assist-generate-button'));
     });
 
-    expect(coreRefs.toasts!.addError).toBeCalledWith(
+    expect(coreRefs.toasts!.addError).toHaveBeenCalledWith(
       {
         message: 'Request is throttled. Try again later or contact your administrator',
         statusCode: 429,
@@ -114,11 +114,11 @@ describe('<QueryAssistInput /> spec', () => {
       fireEvent.click(component.getByText('Generate and run'));
     });
 
-    expect(httpMock.post).toBeCalledWith(QUERY_ASSIST_API.GENERATE_PPL, {
+    expect(httpMock.post).toHaveBeenCalledWith(QUERY_ASSIST_API.GENERATE_PPL, {
       body: '{"question":"test-input","index":"selected-test-index"}',
     });
-    expect(httpMock.post).not.toBeCalledWith(QUERY_ASSIST_API.SUMMARIZE, expect.anything());
-    expect(coreRefs.toasts?.addError).toBeCalledWith(
+    expect(httpMock.post).not.toHaveBeenCalledWith(QUERY_ASSIST_API.SUMMARIZE, expect.anything());
+    expect(coreRefs.toasts?.addError).toHaveBeenCalledWith(
       {
         message: 'Request is throttled. Try again later or contact your administrator',
         statusCode: 429,
@@ -140,12 +140,11 @@ describe('<QueryAssistInput /> spec', () => {
       fireEvent.click(component.getByText('Generate and run'));
     });
 
-    expect(httpMock.post).toBeCalledWith(QUERY_ASSIST_API.GENERATE_PPL, {
+    expect(httpMock.post).toHaveBeenCalledWith(QUERY_ASSIST_API.GENERATE_PPL, {
       body: '{"question":"test-input","index":"selected-test-index"}',
     });
-    expect(httpMock.post).toBeCalledWith(QUERY_ASSIST_API.SUMMARIZE, {
-      body:
-        '{"question":"test-input","index":"selected-test-index","isError":true,"query":"","response":"{\\"statusCode\\":429,\\"message\\":\\"Request is throttled. Try again later or contact your administrator\\"}"}',
+    expect(httpMock.post).toHaveBeenCalledWith(QUERY_ASSIST_API.SUMMARIZE, {
+      body: '{"question":"test-input","index":"selected-test-index","isError":true,"query":"","response":"{\\"statusCode\\":429,\\"message\\":\\"Request is throttled. Try again later or contact your administrator\\"}"}',
     });
   });
 
@@ -161,7 +160,7 @@ describe('<QueryAssistInput /> spec', () => {
       fireEvent.click(component.getByText('Generate and run'));
     });
 
-    expect(httpMock.post).toBeCalledWith(QUERY_ASSIST_API.GENERATE_PPL, {
+    expect(httpMock.post).toHaveBeenCalledWith(QUERY_ASSIST_API.GENERATE_PPL, {
       body: '{"question":"test-input","index":"selected-test-index"}',
     });
     expect(props.setCallOut.mock.calls[0][0]).toBeNull();

--- a/public/components/event_analytics/explorer/save_panel/__tests__/__snapshots__/save_panel.test.tsx.snap
+++ b/public/components/event_analytics/explorer/save_panel/__tests__/__snapshots__/save_panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Saved query table component Renders saved query table 1`] = `
 <body>
@@ -59,7 +59,7 @@ exports[`Saved query table component Renders saved query table 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/components/event_analytics/explorer/sidebar/__tests__/__snapshots__/field.test.tsx.snap
+++ b/public/components/event_analytics/explorer/sidebar/__tests__/__snapshots__/field.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Field component Renders a sidebar field 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
+++ b/public/components/event_analytics/explorer/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Siderbar component Renders empty sidebar component 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/timechart/__tests__/__snapshots__/timechart.test.tsx.snap
+++ b/public/components/event_analytics/explorer/timechart/__tests__/__snapshots__/timechart.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Timechart /> spec should match snapshot 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/timechart/__tests__/timechart.test.tsx
+++ b/public/components/event_analytics/explorer/timechart/__tests__/timechart.test.tsx
@@ -51,7 +51,7 @@ describe('<Timechart /> spec', () => {
     fireEvent.change(component.getByTestId('eventAnalytics__EventIntervalSelect'), {
       target: { value: 'w' },
     });
-    expect(props.onChangeInterval).toBeCalledWith('w');
+    expect(props.onChangeInterval).toHaveBeenCalledWith('w');
   });
 
   it('should match snapshot', async () => {

--- a/public/components/event_analytics/explorer/timechart/hits_counter/__tests__/__snapshots__/hits_counter.test.tsx.snap
+++ b/public/components/event_analytics/explorer/timechart/hits_counter/__tests__/__snapshots__/hits_counter.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Hits counter component Renders hits counter 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/timechart/timechart_header/__tests__/__snapshots__/timechart_header.test.tsx.snap
+++ b/public/components/event_analytics/explorer/timechart/timechart_header/__tests__/__snapshots__/timechart_header.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Time chart header component Renders Time chart header component 1`] = `
 <body>

--- a/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/__snapshots__/config_panel.test.tsx.snap
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/__snapshots__/config_panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Config panel component Renders config panel with visualization data 1`] = `
 <body>
@@ -87,7 +87,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -358,7 +358,9 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                               <div
                                 class="euiSpacer euiSpacer--s"
                               />
-                              <div>
+                              <div
+                                style="width: fit-content;"
+                              >
                                 <fieldset
                                   class="euiButtonGroup euiButtonGroup--compressed euiButtonGroup--text"
                                   id="random_html_id"
@@ -438,7 +440,9 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                               <div
                                 class="euiSpacer euiSpacer--s"
                               />
-                              <div>
+                              <div
+                                style="width: fit-content;"
+                              >
                                 <fieldset
                                   class="euiButtonGroup euiButtonGroup--compressed euiButtonGroup--text"
                                   id="random_html_id"
@@ -601,7 +605,9 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                             <div
                               class="euiSpacer euiSpacer--s"
                             />
-                            <div>
+                            <div
+                              style="width: fit-content;"
+                            >
                               <fieldset
                                 class="euiButtonGroup euiButtonGroup--compressed euiButtonGroup--text"
                                 id="random_html_id"
@@ -677,7 +683,9 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                             <div
                               class="euiSpacer euiSpacer--s"
                             />
-                            <div>
+                            <div
+                              style="width: fit-content;"
+                            >
                               <fieldset
                                 class="euiButtonGroup euiButtonGroup--compressed euiButtonGroup--text"
                                 id="random_html_id"
@@ -842,7 +850,9 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                             <div
                               class="euiSpacer euiSpacer--s"
                             />
-                            <div>
+                            <div
+                              style="width: fit-content;"
+                            >
                               <fieldset
                                 class="euiButtonGroup euiButtonGroup--compressed euiButtonGroup--text"
                                 id="random_html_id"
@@ -979,7 +989,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                 >
                                   <button
                                     class="euiRangeTick euiRangeTick--isCustom euiRangeTick--isMin euiRangeTick--hasTickMark"
-                                    style="left: calc(NaN% + 0px); margin-left: -1em;"
+                                    style="left: calc(0px + (% * nan)); margin-left: -1em;"
                                     tabindex="-1"
                                     title="-90°"
                                     type="button"
@@ -988,12 +998,13 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                     <span
                                       aria-hidden="true"
                                       class="euiRangeTick__pseudo"
+                                      style="margin-left: calc(1em + 4px);"
                                     />
                                     -90°
                                   </button>
                                   <button
                                     class="euiRangeTick euiRangeTick--selected euiRangeTick--isCustom"
-                                    style="left: calc(-Infinity% + 8px);"
+                                    style="left: calc(8px + (% * -infinity));"
                                     tabindex="-1"
                                     title="-45°"
                                     type="button"
@@ -1003,7 +1014,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   </button>
                                   <button
                                     class="euiRangeTick euiRangeTick--isCustom"
-                                    style="left: calc(-Infinity% + 8px);"
+                                    style="left: calc(8px + (% * -infinity));"
                                     tabindex="-1"
                                     title="0°"
                                     type="button"
@@ -1013,7 +1024,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   </button>
                                   <button
                                     class="euiRangeTick euiRangeTick--isCustom"
-                                    style="left: calc(-Infinity% + 8px);"
+                                    style="left: calc(8px + (% * -infinity));"
                                     tabindex="-1"
                                     title="45°"
                                     type="button"
@@ -1023,7 +1034,7 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                   </button>
                                   <button
                                     class="euiRangeTick euiRangeTick--isCustom"
-                                    style="left: calc(-Infinity% + 8px);"
+                                    style="left: calc(8px + (% * -infinity));"
                                     tabindex="-1"
                                     title="90°"
                                     type="button"

--- a/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/config_panel.test.tsx
+++ b/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/config_panel.test.tsx
@@ -12,10 +12,12 @@ import {
 } from '../../../../../../../test/event_analytics_constants';
 import { TabContext } from '../../../../hooks';
 import PPLService from '../../../../../../services/requests/ppl';
-// eslint-disable-next-line jest/no-mocks-import
+
 import httpClientMock from '../../../../../../../test/__mocks__/httpClientMock';
 
-jest.mock('!!raw-loader!./default.layout.spec.hjson', () => 'MOCK HJSON STRING');
+// `!!raw-loader!` imports are stubbed globally via the `^!!raw-loader!.*` moduleNameMapper
+// (test/__mocks__/rawLoaderMock.js). An explicit jest.mock() of the mapped specifier fails to
+// resolve under Jest 30, so the mapper alone provides the stub.
 
 describe('Config panel component', () => {
   it('Renders config panel with visualization data', async () => {

--- a/public/components/event_analytics/explorer/visualizations/count_distribution/__tests__/__snapshots__/count_distribution.test.tsx.snap
+++ b/public/components/event_analytics/explorer/visualizations/count_distribution/__tests__/__snapshots__/count_distribution.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Count distribution component Renders count distribution component with data 1`] = `
 <body>

--- a/public/components/event_analytics/home/__tests__/__snapshots__/saved_query_table.test.tsx.snap
+++ b/public/components/event_analytics/home/__tests__/__snapshots__/saved_query_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Saved query table component Renders saved query table 1`] = `
 <body>

--- a/public/components/event_analytics/utils/__tests__/utils.test.tsx
+++ b/public/components/event_analytics/utils/__tests__/utils.test.tsx
@@ -138,6 +138,6 @@ describe('Utils event analytics helper functions', () => {
         "source=opensearch_dashboards_sample_data_logs | where timestamp >= '2023-01-01 00:00:00' and timestamp <= '2023-09-28 23:19:10' | where match(request,'filebeat') | sort + timestamp | head 100 from 0",
     };
     // final query is the only thing being tested here
-    expect(fetchEvents).toBeCalledWith(expectedFinalQuery, 'jdbc', expect.anything());
+    expect(fetchEvents).toHaveBeenCalledWith(expectedFinalQuery, 'jdbc', expect.anything());
   });
 });

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Added Integration View Test Renders added integration view using dummy data 1`] = `
 <body>

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration_flyout.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration_flyout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Add Integration Flyout Test Renders add integration flyout with dummy integration name 1`] = `
 <body

--- a/public/components/integrations/components/__tests__/__snapshots__/added_integration_table.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/added_integration_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Added Integration Table View Test Renders added integration table view using dummy data 1`] = `
 <body>

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_card_view.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Available Integration Card View Test Renders nginx integration card view using dummy data 1`] = `
 <body>

--- a/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/available_integration_table_view.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Available Integration Table View Test Renders nginx integration table view using dummy data 1`] = `
 <body>

--- a/public/components/integrations/components/__tests__/__snapshots__/integration_details.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/integration_details.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Available Integration Table View Test Renders nginx integration table view using dummy data 1`] = `
 <body>

--- a/public/components/integrations/components/__tests__/__snapshots__/integration_fields.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/integration_fields.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Available Integration Table View Test Renders nginx integration table view using dummy data 1`] = `
 <body>

--- a/public/components/integrations/components/__tests__/__snapshots__/integration_header.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/integration_header.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Integration Header Test Renders integration header as expected 1`] = `
 <body>

--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Integration Setup Page Renders integration setup page as expected 1`] = `
 <body
@@ -205,7 +205,7 @@ exports[`Integration Setup Page Renders integration setup page as expected 1`] =
                               value=""
                             />
                             <div
-                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                             />
                           </div>
                         </div>

--- a/public/components/integrations/components/__tests__/__snapshots__/setup_integration_inputs.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/setup_integration_inputs.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Integration Setup Inputs Renders the S3 connector form as expected 1`] = `
 <body>
@@ -199,7 +199,7 @@ exports[`Integration Setup Inputs Renders the S3 connector form as expected 1`] 
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>
@@ -802,7 +802,7 @@ exports[`Integration Setup Inputs Renders the S3 connector form without workflow
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>
@@ -1330,7 +1330,7 @@ exports[`Integration Setup Inputs Renders the connection inputs 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -1525,7 +1525,7 @@ exports[`Integration Setup Inputs Renders the connection inputs with a locked co
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>
@@ -1815,7 +1815,7 @@ exports[`Integration Setup Inputs Renders the index form as expected 1`] = `
                       value=""
                     />
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                     />
                   </div>
                 </div>

--- a/public/components/integrations/components/__tests__/__snapshots__/upload_flyout.test.tsx.snap
+++ b/public/components/integrations/components/__tests__/__snapshots__/upload_flyout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Integration Upload Flyout Renders integration upload flyout as expected 1`] = `
 <body

--- a/public/components/metrics/sidebar/__tests__/__snapshots__/searchbar.test.tsx.snap
+++ b/public/components/metrics/sidebar/__tests__/__snapshots__/searchbar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Search Bar Component Search Side Bar Component with available metrics 1`] = `
 <body>

--- a/public/components/metrics/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
+++ b/public/components/metrics/sidebar/__tests__/__snapshots__/sidebar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Side Bar Component renders Side Bar Component 1`] = `
 <body>
@@ -49,7 +49,7 @@ exports[`Side Bar Component renders Side Bar Component 1`] = `
                     value=""
                   />
                   <div
-                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                   />
                 </div>
               </div>

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Export Metrics Panel Component renders Export Metrics Panel Component 1`] = `
 <body>

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export_panel.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/metrics_export_panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Export Metrics Panel Component renders Export Metrics Panel Component 1`] = `
 <body>
@@ -183,7 +183,7 @@ exports[`Export Metrics Panel Component renders Export Metrics Panel Component 1
                           value=""
                         />
                         <div
-                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                         />
                       </div>
                     </div>

--- a/public/components/metrics/top_menu/__tests__/__snapshots__/top_menu.test.tsx.snap
+++ b/public/components/metrics/top_menu/__tests__/__snapshots__/top_menu.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Metrics Top Menu Component renders Top Menu Component when enabled 1`] = `
 <body>

--- a/public/components/metrics/view/__tests__/__snapshots__/empty_view.test.tsx.snap
+++ b/public/components/metrics/view/__tests__/__snapshots__/empty_view.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Empty View Component renders empty view container without metrics 1`] = `
 <body>

--- a/public/components/metrics/view/__tests__/__snapshots__/metrics_grid.test.tsx.snap
+++ b/public/components/metrics/view/__tests__/__snapshots__/metrics_grid.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Metrics Grid Component renders Metrics Grid Component 1`] = `
 <body>

--- a/public/components/notebooks/components/__tests__/__snapshots__/note_table.test.tsx.snap
+++ b/public/components/notebooks/components/__tests__/__snapshots__/note_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<NoteTable /> spec renders the component 1`] = `
 <body>

--- a/public/components/notebooks/components/__tests__/__snapshots__/notebook.test.tsx.snap
+++ b/public/components/notebooks/components/__tests__/__snapshots__/notebook.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Notebook /> spec Renders the empty component 1`] = `
 <body>

--- a/public/components/notebooks/components/__tests__/note_table.test.tsx
+++ b/public/components/notebooks/components/__tests__/note_table.test.tsx
@@ -69,7 +69,7 @@ describe('<NoteTable /> spec', () => {
     fireEvent.click(utils.getAllByLabelText('Select this row')[0]);
   });
 
-  it('create notebook modal', async () => {
+  it('create notebook button links to the create route', async () => {
     const notebooks = Array.from({ length: 5 }, (v, k) => ({
       path: `path-${k}`,
       id: `id-${k}`,
@@ -77,10 +77,11 @@ describe('<NoteTable /> spec', () => {
       dateModified: 'date-modified',
     }));
     const utils = renderNoteTable({ notebooks });
-    fireEvent.click(utils.getByText('Create notebook'));
-    await waitFor(() => {
-      expect(global.window.location.href).toContain('/create');
-    });
+    // The "Create notebook" button is an <a href="#/create">. jsdom 26 no longer
+    // performs anchor default navigation on click, so assert the link target
+    // directly instead of the post-click window.location.
+    const createButton = utils.getByText('Create notebook').closest('a');
+    expect(createButton).toHaveAttribute('href', '#/create');
   });
 
   it('filters notebooks based on search input', () => {
@@ -104,13 +105,20 @@ describe('<NoteTable /> spec', () => {
     expect(queryByText('path-2')).toBeNull();
   });
 
-  it('displays empty state message and create notebook button', () => {
+  it('displays empty state message and create notebook button', async () => {
+    // The create-notebook modal is opened by the component's mount effect when
+    // the URL hash ends in "create" (previously reached by clicking the
+    // <a href="#/create"> button). jsdom 26 no longer navigates on anchor
+    // clicks, so set the hash explicitly before rendering to open the modal.
+    window.location.assign('#/create');
     const { getAllByText, getAllByTestId } = renderNoteTable({ notebooks: [] });
 
     expect(getAllByText('No notebooks')).toHaveLength(1);
 
     // Create notebook using the modal
-    fireEvent.click(getAllByText('Create notebook')[0]);
+    await waitFor(() => {
+      expect(getAllByTestId('custom-input-modal-input')[0]).toBeInTheDocument();
+    });
     fireEvent.click(getAllByTestId('custom-input-modal-input')[0]);
     fireEvent.input(getAllByTestId('custom-input-modal-input')[0], {
       target: { value: 'test-notebook' },

--- a/public/components/notebooks/components/helpers/__tests__/__snapshots__/modal_containers.test.tsx.snap
+++ b/public/components/notebooks/components/helpers/__tests__/__snapshots__/modal_containers.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`modal_containers spec render delete notebooks modal 1`] = `
 <body

--- a/public/components/notebooks/components/helpers/__tests__/modal_containers.test.tsx
+++ b/public/components/notebooks/components/helpers/__tests__/modal_containers.test.tsx
@@ -87,6 +87,6 @@ describe('modal_containers spec', () => {
       target: { value: 'delete' },
     });
     fireEvent.click(utils.getAllByTestId('delete-notebook-modal-delete-button')[0]);
-    expect(onConfirm).toBeCalled();
+    expect(onConfirm).toHaveBeenCalled();
   });
 });

--- a/public/components/notebooks/components/helpers/__tests__/reporting_context_menu_helper.test.tsx
+++ b/public/components/notebooks/components/helpers/__tests__/reporting_context_menu_helper.test.tsx
@@ -20,7 +20,7 @@ describe('reporting_context_menu_helper tests', () => {
       assign: jest.fn(),
     };
     contextMenuViewReports();
-    expect(window.location.assign).toBeCalledWith('reports-dashboards#/');
+    expect(window.location.assign).toHaveBeenCalledWith('reports-dashboards#/');
     window.location = savedLocation;
   });
 
@@ -34,7 +34,7 @@ describe('reporting_context_menu_helper tests', () => {
       assign: jest.fn(),
     };
     contextMenuCreateReportDefinition('https://mock-base.uri/mock-base-path');
-    expect(window.location.assign).toBeCalledWith(
+    expect(window.location.assign).toHaveBeenCalledWith(
       'reports-dashboards#/create?previous=notebook:mock-base-path?timeFrom=0?timeTo=0'
     );
     window.location = savedLocation;
@@ -65,32 +65,41 @@ describe('reporting_context_menu_helper tests', () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.csv', '__user__', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
+      'Please continue report generation in the new tab.',
+      'success'
+    );
   });
 
   it('generates pdf for global tenant', async () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.pdf', '', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
+      'Please continue report generation in the new tab.',
+      'success'
+    );
   });
 
   it('generates png for custom tenant', async () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(200, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Please continue report generation in the new tab.', 'success');
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
+      'Please continue report generation in the new tab.',
+      'success'
+    );
   });
 
   it('handles 404 error', async () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(404, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith(
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
       'Download error',
       'danger',
       'There was an error generating this report.'
@@ -101,8 +110,8 @@ describe('reporting_context_menu_helper tests', () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(403, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith(
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
       'Error generating report,',
       'danger',
       'Insufficient permissions. Reach out to your OpenSearch Dashboards administrator.'
@@ -113,8 +122,8 @@ describe('reporting_context_menu_helper tests', () => {
     const setToast = jest.fn();
     const toggleReportingLoadingModal = jest.fn();
     await generateReport(503, 'test.png', 'custom_tenant', setToast, toggleReportingLoadingModal);
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith(
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith(
       'Error generating report.',
       'danger',
       'Timed out generating on-demand report from notebook. Try again later.'
@@ -130,7 +139,7 @@ describe('reporting_context_menu_helper tests', () => {
     } catch (error) {
       expect(error.status).toEqual(500);
     }
-    expect(toggleReportingLoadingModal).toBeCalledWith(true);
-    expect(setToast).toBeCalledWith('Tenant error', 'danger', 'Failed to get user tenant.');
+    expect(toggleReportingLoadingModal).toHaveBeenCalledWith(true);
+    expect(setToast).toHaveBeenCalledWith('Tenant error', 'danger', 'Failed to get user tenant.');
   });
 });

--- a/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/custom_input_modal.test.tsx.snap
+++ b/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/custom_input_modal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CustomInputModal /> spec renders the component 1`] = `
 <body

--- a/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/reporting_loading_modal.test.tsx.snap
+++ b/public/components/notebooks/components/helpers/custom_modals/__tests__/__snapshots__/reporting_loading_modal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<GenerateReportLoadingModal /> spec renders the component 1`] = `
 <body

--- a/public/components/notebooks/components/helpers/custom_modals/__tests__/custom_input_modal.test.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/__tests__/custom_input_modal.test.tsx
@@ -59,6 +59,6 @@ describe('<CustomInputModal /> spec', () => {
       target: { value: 'test-name' },
     });
     utils.getByTestId('custom-input-modal-confirm-button').click();
-    expect(runModal).toBeCalledWith('test-name');
+    expect(runModal).toHaveBeenCalledWith('test-name');
   });
 });

--- a/public/components/notebooks/components/helpers/custom_modals/__tests__/reporting_loading_modal.test.tsx
+++ b/public/components/notebooks/components/helpers/custom_modals/__tests__/reporting_loading_modal.test.tsx
@@ -13,6 +13,6 @@ describe('<GenerateReportLoadingModal /> spec', () => {
     const utils = render(<GenerateReportLoadingModal setShowLoading={setShowLoading} />);
     expect(document.body).toMatchSnapshot();
     utils.getByTestId('reporting-loading-modal-close-button').click();
-    expect(setShowLoading).toBeCalledWith(false);
+    expect(setShowLoading).toHaveBeenCalledWith(false);
   });
 });

--- a/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_input.test.tsx.snap
+++ b/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_input.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<para_input /> spec renders the markdown component 1`] = `
 <body>
@@ -133,7 +133,7 @@ exports[`<para_input /> spec renders the visualization component 1`] = `
                               value=""
                             />
                             <div
-                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                             />
                           </div>
                         </div>

--- a/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_output.test.tsx.snap
+++ b/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_output.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ParaOutput /> spec renders dashboards visualization outputs 1`] = `
 <body>

--- a/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_query_grid.test.tsx.snap
+++ b/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/para_query_grid.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<QueryDataGridMemo /> spec renders the component 1`] = `
 <body>

--- a/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/paragraphs.test.tsx.snap
+++ b/public/components/notebooks/components/paragraph_components/__tests__/__snapshots__/paragraphs.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Paragraphs /> spec renders the component 1`] = `
 <body>
@@ -469,7 +469,7 @@ exports[`<Paragraphs /> spec use SavedObject find to fetch visualizations when d
                                       value=""
                                     />
                                     <div
-                                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                                     />
                                   </div>
                                 </div>

--- a/public/components/notebooks/components/paragraph_components/__tests__/para_input.test.tsx
+++ b/public/components/notebooks/components/paragraph_components/__tests__/para_input.test.tsx
@@ -112,7 +112,7 @@ describe('<para_input /> spec', () => {
     );
     const textarea = utils.container.querySelectorAll('textarea#editorArea')[0];
     fireEvent.change(textarea, { target: { value: 'test input' } });
-    expect(setIsOutputStale).toBeCalledWith(true);
+    expect(setIsOutputStale).toHaveBeenCalledWith(true);
   });
 
   it('clicks the visualization component', async () => {

--- a/public/components/overview/components/__tests__/__snapshots__/add_dashboard_callout.test.tsx.snap
+++ b/public/components/overview/components/__tests__/__snapshots__/add_dashboard_callout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Add dashboard callout renders add dashboard callout 1`] = `
 <body>

--- a/public/components/overview/components/__tests__/__snapshots__/add_datasource_callout.test.tsx.snap
+++ b/public/components/overview/components/__tests__/__snapshots__/add_datasource_callout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Add dashboard callout renders add datasource callout 1`] = `
 <body>

--- a/public/components/overview/components/__tests__/__snapshots__/dashboard_controls.test.tsx.snap
+++ b/public/components/overview/components/__tests__/__snapshots__/dashboard_controls.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Dashboard controls - checkDataSource useEffect simplified should render 1`] = `
 <body>

--- a/public/components/overview/components/__tests__/__snapshots__/select_dashboard_flyout.test.tsx.snap
+++ b/public/components/overview/components/__tests__/__snapshots__/select_dashboard_flyout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Select dashboard flyout should render 1`] = `
 <body

--- a/public/components/trace_analytics/components/common/__tests__/__snapshots__/helper_functions.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/__tests__/__snapshots__/helper_functions.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Trace analytics helper functions renders benchmark 1`] = `
 <div>

--- a/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Search bar components renders date picker 1`] = `
 <body>

--- a/public/components/trace_analytics/components/common/__tests__/legacy_route_helpers.test.tsx
+++ b/public/components/trace_analytics/components/common/__tests__/legacy_route_helpers.test.tsx
@@ -15,23 +15,9 @@ import {
 import { coreRefs } from '../../../../../framework/core_refs';
 
 describe('ConvertLegacyTraceAnalyticsUrl', () => {
-  let originalLocation: Location;
-
-  beforeEach(() => {
-    originalLocation = window.location;
-
-    Object.defineProperty(window, 'location', {
-      value: {
-        ...originalLocation,
-        assign: jest.fn(),
-      },
-      writable: true,
-    });
-  });
-
-  afterEach(() => {
-    window.location = originalLocation;
-  });
+  // window.location is mocked globally by jest-location-mock, which exposes
+  // window.location.assign as a Jest spy. clearMocks in jest.config resets it
+  // between tests, so no manual mocking/teardown is needed here.
 
   it('should convert legacy URL correctly', () => {
     const location = {
@@ -129,25 +115,9 @@ describe('ConvertLegacyTraceAnalyticsUrl', () => {
 });
 
 describe('ConvertTraceAnalyticsNewNavUrl', () => {
-  let originalLocation;
-
-  beforeEach(() => {
-    // Save the original window.location object
-    originalLocation = window.location;
-
-    // Mock window.location.assign
-    Object.defineProperty(window, 'location', {
-      value: {
-        assign: jest.fn(),
-      },
-      writable: true,
-    });
-  });
-
-  afterEach(() => {
-    // Restore the original window.location object after each test
-    window.location = originalLocation;
-  });
+  // window.location is mocked globally by jest-location-mock, which exposes
+  // window.location.assign as a Jest spy. clearMocks in jest.config resets it
+  // between tests, so no manual mocking/teardown is needed here.
 
   it('should redirect to the new navigation traces URL if trace ID is present and new nav is enabled', () => {
     const locationMock = {

--- a/public/components/trace_analytics/components/common/__tests__/redirection_helpers.test.tsx
+++ b/public/components/trace_analytics/components/common/__tests__/redirection_helpers.test.tsx
@@ -107,8 +107,7 @@ describe('Redirect Functions', () => {
     };
     const mockAddFilter = jest.fn();
 
-    delete window.location;
-    window.location = { assign: jest.fn(), href: '' };
+    // window.location.assign is a Jest spy provided by jest-location-mock.
 
     redirectToServiceTraces({
       mode: 'data_prepper',

--- a/public/components/trace_analytics/components/common/__tests__/search_bar.test.tsx
+++ b/public/components/trace_analytics/components/common/__tests__/search_bar.test.tsx
@@ -51,7 +51,7 @@ describe('Search bar components', () => {
     fireEvent.change(searchInput, { target: { value: 'queryTest' } });
 
     clock.tick(100);
-    expect(setQuery).toBeCalledWith('queryTest');
+    expect(setQuery).toHaveBeenCalledWith('queryTest');
     clock.restore();
   });
 });

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Filter popover component renders filter popover 1`] = `
 <body>
@@ -68,7 +68,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                           value=""
                         />
                         <div
-                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                         />
                       </div>
                     </div>
@@ -160,7 +160,7 @@ exports[`Filter popover component renders filter popover 1`] = `
                           value=""
                         />
                         <div
-                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; letter-spacing: normal; text-transform: none;"
                         />
                       </div>
                     </div>

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_helpers.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filter_helpers.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Filter helper functions renders range field filter 1`] = `
 <body>

--- a/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/filters/__tests__/__snapshots__/filters.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Filter component renders filters 1`] = `
 <body>

--- a/public/components/trace_analytics/components/common/filters/__tests__/filter_edit_popover.test.tsx
+++ b/public/components/trace_analytics/components/common/filters/__tests__/filter_edit_popover.test.tsx
@@ -35,7 +35,7 @@ describe('Filter popover component', () => {
     const cancelButton = screen.getByTestId('filter-popover-cancel-button');
     fireEvent.click(cancelButton);
 
-    expect(closePopover).toBeCalled();
+    expect(closePopover).toHaveBeenCalled();
 
     const toggleButtons = screen.getAllByTestId('comboBoxToggleListButton');
     fireEvent.click(toggleButtons[0]);

--- a/public/components/trace_analytics/components/common/filters/__tests__/filter_helpers.test.tsx
+++ b/public/components/trace_analytics/components/common/filters/__tests__/filter_helpers.test.tsx
@@ -88,7 +88,7 @@ describe('Filter helper functions', () => {
 
     const input = container.querySelector('input');
     fireEvent.change(input, { target: { value: '100' } });
-    expect(setValue).toBeCalledWith('100');
+    expect(setValue).toHaveBeenCalledWith('100');
   });
 
   it('renders range field filter', async () => {
@@ -102,9 +102,9 @@ describe('Filter helper functions', () => {
 
     const inputs = container.querySelectorAll('input');
     fireEvent.change(inputs[0], { target: { value: '50' } });
-    expect(setValue).toBeCalledWith({ from: '50', to: '100' });
+    expect(setValue).toHaveBeenCalledWith({ from: '50', to: '100' });
 
     fireEvent.change(inputs[1], { target: { value: '200' } });
-    expect(setValue).toBeCalledWith({ from: '0', to: '200' });
+    expect(setValue).toHaveBeenCalledWith({ from: '0', to: '200' });
   });
 });

--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/box_plt.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/box_plt.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Box plot component renders box plot 1`] = `
 <body>

--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/error_rate_plt_.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/error_rate_plt_.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Error rate plot component renders error rate plot 1`] = `
 <body>

--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/latency_trend_plt.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/latency_trend_plt.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Latency trend plot component renders latency plot 1`] = `
 <body>

--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ServiceMap Component renders service map component 1`] = `
 <body>

--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map_scale.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/service_map_scale.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Service map scale component renders service map scale 1`] = `
 <body>

--- a/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/throughput_plt.test.tsx.snap
+++ b/public/components/trace_analytics/components/common/plots/__tests__/__snapshots__/throughput_plt.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Throughput plot component renders throughput plot 1`] = `
 <body>

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Dashboard component renders dashboard 1`] = `
 <body>

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Dashboard table component renders dashboard table 1`] = `
 <body>

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/latency_trend_cell.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/latency_trend_cell.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Latency trend cell component renders latency trend cell 1`] = `
 <body>

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/mode_picker.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/mode_picker.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Mode picker component renders mode picker 1`] = `
 <body>

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_error_rates_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_error_rates_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Error Rates Table component renders empty top error rates table 1`] = `
 <body>

--- a/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_latency_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/top_latency_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Latency Table component renders empty top error rates table 1`] = `
 <body>

--- a/public/components/trace_analytics/components/dashboard/__tests__/dashboard_table.test.tsx
+++ b/public/components/trace_analytics/components/dashboard/__tests__/dashboard_table.test.tsx
@@ -71,14 +71,14 @@ describe('Dashboard table component', () => {
     const percentileButton2 = screen.getByTestId('dashboard-table-percentile-button-2');
     fireEvent.click(percentileButton1);
     fireEvent.click(percentileButton2);
-    expect(addPercentileFilter).toBeCalledTimes(2);
+    expect(addPercentileFilter).toHaveBeenCalledTimes(2);
 
     const traceGroupButton = screen.getByTestId('dashboard-table-trace-group-name-button');
     fireEvent.click(traceGroupButton);
-    expect(addFilter).toBeCalled();
+    expect(addFilter).toHaveBeenCalled();
 
     const tracesButton = screen.getByTestId('dashboard-table-traces-button');
     fireEvent.click(tracesButton);
-    expect(setRedirect).toBeCalledWith(true);
+    expect(setRedirect).toHaveBeenCalledWith(true);
   });
 });

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/service_view.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/service_view.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Service view component renders service view 1`] = `
 <body>

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Services component renders empty services page 1`] = `
 <body>

--- a/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Services table component redirects to the correct URL when the service link is clicked 1`] = `
 <body>

--- a/public/components/trace_analytics/components/services/__tests__/services_table.test.tsx
+++ b/public/components/trace_analytics/components/services/__tests__/services_table.test.tsx
@@ -131,10 +131,7 @@ describe('Services table component', () => {
       },
     ];
 
-    // Mock window.location before rendering
-    const originalLocation = window.location;
-    delete window.location;
-    window.location = { ...originalLocation };
+    // window.location.assign is a Jest spy provided by jest-location-mock.
 
     const { getByTestId } = render(
       <ServicesTable
@@ -167,8 +164,6 @@ describe('Services table component', () => {
     fireEvent.click(serviceLink);
 
     const expectedUrl = generateServiceUrl('checkoutservice', mockDataSourceId, mockMode);
-    expect(window.location.href).toBe(expectedUrl);
-
-    window.location = originalLocation;
+    expect(window.location.assign).toHaveBeenCalledWith(expectedUrl);
   });
 });

--- a/public/components/trace_analytics/components/services/service_view.tsx
+++ b/public/components/trace_analytics/components/services/service_view.tsx
@@ -182,7 +182,7 @@ export function ServiceView(props: ServiceViewProps) {
   }, [props.serviceName, props.setDataSourceMenuSelectable]);
 
   const redirectToServicePage = (service: string) => {
-    window.location.href = generateServiceUrl(service, props.dataSourceMDSId[0].id, mode);
+    window.location.assign(generateServiceUrl(service, props.dataSourceMDSId[0].id, mode));
   };
 
   const onClickConnectedService = (service: string) => {
@@ -419,11 +419,10 @@ export function ServiceView(props: ServiceViewProps) {
     );
   };
 
-  const overview = useMemo(() => renderOverview(), [
-    fields,
-    isServiceOverviewLoading,
-    props.serviceName,
-  ]);
+  const overview = useMemo(
+    () => renderOverview(),
+    [fields, isServiceOverviewLoading, props.serviceName]
+  );
 
   const title = useMemo(
     () =>

--- a/public/components/trace_analytics/components/services/services_table.tsx
+++ b/public/components/trace_analytics/components/services/services_table.tsx
@@ -84,7 +84,7 @@ export function ServicesTable(props: ServicesTableProps) {
     if (page === 'app') {
       setCurrentSelectedService(serviceName);
     } else {
-      window.location.href = generateServiceUrl(serviceName, dataSourceMDSId[0].id, props.mode);
+      window.location.assign(generateServiceUrl(serviceName, dataSourceMDSId[0].id, props.mode));
     }
   };
 
@@ -312,11 +312,10 @@ export function ServicesTable(props: ServicesTableProps) {
     return baseColumns as Array<EuiTableFieldDataColumnType<any>>;
   }, [items, page]);
 
-  const titleBar = useMemo(() => renderTitleBar(items?.length), [
-    items,
-    selectedItems,
-    isServiceTrendEnabled,
-  ]);
+  const titleBar = useMemo(
+    () => renderTitleBar(items?.length),
+    [items, selectedItems, isServiceTrendEnabled]
+  );
 
   return (
     <>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/flyout_list_item.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/flyout_list_item.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<FlyoutListItem /> spec renders the component 1`] = `
 <body>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/service_breakdown_panel.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/service_breakdown_panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Service breakdown panel component renders empty service breakdown panel 1`] = `
 <body>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_flyout.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_flyout.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SpanDetailFlyout /> spec renders the component with data 1`] = `
 <body

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_panel.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SpanDetailPanel component renders correctly with default props 1`] = `
 <body>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/span_detail_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SpanDetailTable Column visibility should hide columns specified in hiddenColumns prop 1`] = `
 <body>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/trace_view.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/trace_view.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Trace view component renders trace view 1`] = `
 <body>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Traces component renders empty traces page 1`] = `
 <body>

--- a/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Traces table component renders empty traces table message 1`] = `
 <body>

--- a/public/components/visualizations/charts/__tests__/__snapshots__/bar.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/bar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Veritcal Bar component Renders veritcal bar component 1`] = `
 <body>

--- a/public/components/visualizations/charts/__tests__/__snapshots__/gauge.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/gauge.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Gauge component Renders gauge component 1`] = `
 <body>

--- a/public/components/visualizations/charts/__tests__/__snapshots__/heatmap.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/heatmap.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Heatmap component Renders heatmap component 1`] = `
 <body>

--- a/public/components/visualizations/charts/__tests__/__snapshots__/histogram.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/histogram.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Histogram component Renders histogram component 1`] = `
 <body>

--- a/public/components/visualizations/charts/__tests__/__snapshots__/horizontal_bar.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/horizontal_bar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Horizontal bar component Renders horizontal bar component 1`] = `
 <body>

--- a/public/components/visualizations/charts/__tests__/__snapshots__/line.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/line.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Line component Renders line component 1`] = `
 <body>

--- a/public/components/visualizations/charts/__tests__/__snapshots__/metrics.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/metrics.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Metrics component Renders Metrics component 1`] = `
 <body>

--- a/public/components/visualizations/charts/__tests__/__snapshots__/pie.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/pie.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Pie component Renders pie component 1`] = `
 <body>

--- a/public/components/visualizations/charts/__tests__/__snapshots__/text.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/text.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Text component Renders text component 1`] = `
 <body>

--- a/public/components/visualizations/charts/__tests__/__snapshots__/treemap.test.tsx.snap
+++ b/public/components/visualizations/charts/__tests__/__snapshots__/treemap.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Treemap component Renders treemap component 1`] = `
 <body>

--- a/public/components/visualizations/plotly/__tests__/__snapshots__/plotly.test.tsx.snap
+++ b/public/components/visualizations/plotly/__tests__/__snapshots__/plotly.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Ploty base component Renders Ploty base component 1`] = `
 <body>

--- a/public/dependencies/components/__snapshots__/data_grid_container.test.tsx.snap
+++ b/public/dependencies/components/__snapshots__/data_grid_container.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<DataGridContainer /> should render empty when rawQuery is not provided 1`] = `<div />`;
 

--- a/public/framework/catalog_cache/cache_intercept.test.ts
+++ b/public/framework/catalog_cache/cache_intercept.test.ts
@@ -51,7 +51,7 @@ describe('Intercept logout handler', () => {
   it('Intercept logout handler should clear the cache session', () => {
     const logoutInterceptFn = catalogRequestIntercept();
     logoutInterceptFn(logoutPath, null);
-    expect(sessionStorage.removeItem).toBeCalledWith(ASYNC_QUERY_DATASOURCE_CACHE);
-    expect(sessionStorage.removeItem).toBeCalledWith(ASYNC_QUERY_ACCELERATIONS_CACHE);
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith(ASYNC_QUERY_DATASOURCE_CACHE);
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith(ASYNC_QUERY_ACCELERATIONS_CACHE);
   });
 });

--- a/public/framework/catalog_cache/cache_manager.test.tsx
+++ b/public/framework/catalog_cache/cache_manager.test.tsx
@@ -249,7 +249,7 @@ describe('CatalogCacheManager', () => {
     it('should throw error if data source not found', () => {
       const dataSourceName = 'nonExistingDataSource';
       const databaseName = 'testDatabase';
-      expect(() => CatalogCacheManager.getDatabase(dataSourceName, databaseName)).toThrowError(
+      expect(() => CatalogCacheManager.getDatabase(dataSourceName, databaseName)).toThrow(
         'DataSource not found exception: ' + dataSourceName
       );
     });
@@ -264,7 +264,7 @@ describe('CatalogCacheManager', () => {
         databases: [],
       };
       CatalogCacheManager.addOrUpdateDataSource(dataSource);
-      expect(() => CatalogCacheManager.getDatabase(dataSourceName, databaseName)).toThrowError(
+      expect(() => CatalogCacheManager.getDatabase(dataSourceName, databaseName)).toThrow(
         'Database not found exception: ' + databaseName
       );
     });
@@ -313,9 +313,9 @@ describe('CatalogCacheManager', () => {
         ],
       };
       CatalogCacheManager.addOrUpdateDataSource(dataSource);
-      expect(() =>
-        CatalogCacheManager.getTable(dataSourceName, databaseName, tableName)
-      ).toThrowError('Table not found exception: ' + tableName);
+      expect(() => CatalogCacheManager.getTable(dataSourceName, databaseName, tableName)).toThrow(
+        'Table not found exception: ' + tableName
+      );
     });
   });
 
@@ -355,7 +355,7 @@ describe('CatalogCacheManager', () => {
         lastUpdated: '2024-03-07T12:00:00Z',
         status: CachedDataSourceStatus.Empty,
       };
-      expect(() => CatalogCacheManager.updateDatabase(dataSourceName, database)).toThrowError(
+      expect(() => CatalogCacheManager.updateDatabase(dataSourceName, database)).toThrow(
         'DataSource not found exception: ' + dataSourceName
       );
     });
@@ -375,7 +375,7 @@ describe('CatalogCacheManager', () => {
         databases: [],
       };
       CatalogCacheManager.addOrUpdateDataSource(dataSource);
-      expect(() => CatalogCacheManager.updateDatabase(dataSourceName, database)).toThrowError(
+      expect(() => CatalogCacheManager.updateDatabase(dataSourceName, database)).toThrow(
         'Database not found exception: ' + database.name
       );
     });

--- a/public/plugin.test.tsx
+++ b/public/plugin.test.tsx
@@ -48,7 +48,7 @@ describe('#setup', () => {
     const observabilityPlugin = new ObservabilityPlugin(initializerContextMock);
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(true);
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       investigationDashboards: {},
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
@@ -60,10 +60,10 @@ describe('#setup', () => {
       dashboard: {
         registerDashboardProvider: jest.fn(),
       },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
-    expect(coreSetup.application.register).toBeCalled();
-    expect(coreSetup.chrome.navGroup.addNavLinksToGroup).toBeCalled();
+    expect(coreSetup.application.register).toHaveBeenCalled();
+    expect(coreSetup.chrome.navGroup.addNavLinksToGroup).toHaveBeenCalled();
 
     const coreStart = coreMock.createStart();
 
@@ -80,9 +80,9 @@ describe('#setup', () => {
           },
         },
       },
-      ({
+      {
         data: dataPluginMock.createStartContract(),
-      } as unknown) as AppPluginStartDependencies
+      } as unknown as AppPluginStartDependencies
     );
 
     expect(updater$.getValue()()).toEqual({
@@ -115,7 +115,7 @@ describe('#setup notebook hiding with investigation plugin', () => {
     const observabilityPlugin = new ObservabilityPlugin(initializerContextMock);
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(false);
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
@@ -123,7 +123,7 @@ describe('#setup notebook hiding with investigation plugin', () => {
       dataSource: {},
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const coreStart = coreMock.createStart();
     const dataStartMock = dataPluginMock.createStartContract();
@@ -142,9 +142,9 @@ describe('#setup notebook hiding with investigation plugin', () => {
           },
         },
       },
-      ({
+      {
         data: dataStartMock,
-      } as unknown) as AppPluginStartDependencies
+      } as unknown as AppPluginStartDependencies
     );
 
     expect(updater$.getValue()()).toEqual({});
@@ -161,7 +161,7 @@ describe('#setup with APM enabled', () => {
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(true); // APM enabled
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
@@ -169,7 +169,7 @@ describe('#setup with APM enabled', () => {
       dataSource: { dataSource: {} }, // MDS enabled
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const registerCalls = (coreSetup.application.register as jest.Mock).mock.calls;
 
@@ -195,7 +195,7 @@ describe('#setup with APM enabled', () => {
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(false); // APM disabled
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
@@ -203,7 +203,7 @@ describe('#setup with APM enabled', () => {
       dataSource: { dataSource: {} },
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const registerCalls = (coreSetup.application.register as jest.Mock).mock.calls;
     const tracesApp = registerCalls.find((call) => call[0].id === 'observability-traces-nav');
@@ -219,7 +219,7 @@ describe('#setup with APM enabled', () => {
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(true); // APM enabled
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
@@ -227,7 +227,7 @@ describe('#setup with APM enabled', () => {
       // dataSource: undefined, // MDS status no longer affects registration
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const registerCalls = (coreSetup.application.register as jest.Mock).mock.calls;
     // Both APM and Trace Analytics apps should be registered
@@ -257,14 +257,14 @@ describe('#setup with APM enabled', () => {
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(true); // APM enabled
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
       uiActions: uiActionsPluginMock.createSetupContract(),
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const coreStart = coreMock.createStart();
     const dataStartMock = dataPluginMock.createStartContract();
@@ -283,9 +283,9 @@ describe('#setup with APM enabled', () => {
           },
         },
       },
-      ({
+      {
         data: dataStartMock,
-      } as unknown) as AppPluginStartDependencies
+      } as unknown as AppPluginStartDependencies
     );
 
     // APM apps should be hidden when discoverTracesEnabled is false
@@ -313,14 +313,14 @@ describe('#setup with APM enabled', () => {
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(true); // APM enabled
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
       uiActions: uiActionsPluginMock.createSetupContract(),
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const coreStart = coreMock.createStart();
     const dataStartMock = dataPluginMock.createStartContract();
@@ -339,9 +339,9 @@ describe('#setup with APM enabled', () => {
           },
         },
       },
-      ({
+      {
         data: dataStartMock,
-      } as unknown) as AppPluginStartDependencies
+      } as unknown as AppPluginStartDependencies
     );
 
     // Trace Analytics apps should be hidden when discoverTracesEnabled is true
@@ -364,14 +364,14 @@ describe('#setup with Alert Manager feature gate', () => {
 
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
       uiActions: uiActionsPluginMock.createSetupContract(),
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const registerCalls = (coreSetup.application.register as jest.Mock).mock.calls;
     const alertingApp = registerCalls.find((call) => call[0].id === 'observability-alerting');
@@ -394,14 +394,14 @@ describe('#setup with Alert Manager feature gate', () => {
 
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
       uiActions: uiActionsPluginMock.createSetupContract(),
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const registerCalls = (coreSetup.application.register as jest.Mock).mock.calls;
     const alertingApp = registerCalls.find((call) => call[0].id === 'observability-alerting');
@@ -427,14 +427,14 @@ describe('#setup with Alert Manager feature gate', () => {
 
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
       uiActions: uiActionsPluginMock.createSetupContract(),
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const coreStart = coreMock.createStart();
     const dataStartMock = dataPluginMock.createStartContract();
@@ -453,7 +453,7 @@ describe('#setup with Alert Manager feature gate', () => {
           },
         },
       },
-      ({ data: dataStartMock } as unknown) as AppPluginStartDependencies
+      { data: dataStartMock } as unknown as AppPluginStartDependencies
     );
 
     expect(alertingUpdater$.getValue()()).toEqual({
@@ -483,14 +483,14 @@ describe('#setup with Alert Manager feature gate', () => {
 
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
       uiActions: uiActionsPluginMock.createSetupContract(),
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const coreStart = coreMock.createStart();
     const dataStartMock = dataPluginMock.createStartContract();
@@ -509,7 +509,7 @@ describe('#setup with Alert Manager feature gate', () => {
           },
         },
       },
-      ({ data: dataStartMock } as unknown) as AppPluginStartDependencies
+      { data: dataStartMock } as unknown as AppPluginStartDependencies
     );
 
     // The default BehaviorSubject value is `() => ({})`. If `start()` did
@@ -545,14 +545,14 @@ describe('#setup with SLO feature gate', () => {
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(true); // APM enabled
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
       uiActions: uiActionsPluginMock.createSetupContract(),
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const coreStart = coreMock.createStart();
     const dataStartMock = dataPluginMock.createStartContract();
@@ -574,7 +574,7 @@ describe('#setup with SLO feature gate', () => {
           },
         },
       },
-      ({ data: dataStartMock } as unknown) as AppPluginStartDependencies
+      { data: dataStartMock } as unknown as AppPluginStartDependencies
     );
 
     expect(latestSloUpdate).toMatchObject({
@@ -607,14 +607,14 @@ describe('#setup with SLO feature gate', () => {
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(true);
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
       uiActions: uiActionsPluginMock.createSetupContract(),
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const coreStart = coreMock.createStart();
     const dataStartMock = dataPluginMock.createStartContract();
@@ -635,7 +635,7 @@ describe('#setup with SLO feature gate', () => {
           },
         },
       },
-      ({ data: dataStartMock } as unknown) as AppPluginStartDependencies
+      { data: dataStartMock } as unknown as AppPluginStartDependencies
     );
 
     expect(latestSloUpdate).toMatchObject({
@@ -668,14 +668,14 @@ describe('#setup with SLO feature gate', () => {
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(true);
 
-    await observabilityPlugin.setup(coreSetup, ({
+    await observabilityPlugin.setup(coreSetup, {
       embeddable: embeddablePluginMock.createSetupContract(),
       visualizations: visualizationsPluginMock.createSetupContract(),
       data: dataPluginMock.createSetupContract(),
       uiActions: uiActionsPluginMock.createSetupContract(),
       contentManagement: contentManagementPluginMocks.createSetupContract(),
       dashboard: { registerDashboardProvider: jest.fn() },
-    } as unknown) as SetupDependencies);
+    } as unknown as SetupDependencies);
 
     const coreStart = coreMock.createStart();
     const dataStartMock = dataPluginMock.createStartContract();
@@ -697,7 +697,7 @@ describe('#setup with SLO feature gate', () => {
           },
         },
       },
-      ({ data: dataStartMock } as unknown) as AppPluginStartDependencies
+      { data: dataStartMock } as unknown as AppPluginStartDependencies
     );
 
     // Neither input emitted a hidden status, so the merged updater's

--- a/server/adaptors/integrations/__test__/builder.test.ts
+++ b/server/adaptors/integrations/__test__/builder.test.ts
@@ -30,19 +30,19 @@ const mockParsedAssets = [
   },
 ];
 
-const mockSavedObjectsClient: SavedObjectsClientContract = ({
+const mockSavedObjectsClient: SavedObjectsClientContract = {
   bulkCreate: jest.fn(),
   create: jest.fn(),
   delete: jest.fn(),
   find: jest.fn(),
   get: jest.fn(),
   update: jest.fn(),
-} as unknown) as SavedObjectsClientContract;
+} as unknown as SavedObjectsClientContract;
 
-const sampleIntegration: IntegrationReader = ({
+const sampleIntegration: IntegrationReader = {
   getAssets: jest.fn().mockResolvedValue(mockParsedAssets),
   getConfig: jest.fn().mockResolvedValue(TEST_INTEGRATION_CONFIG),
-} as unknown) as IntegrationReader;
+} as unknown as IntegrationReader;
 
 describe('IntegrationInstanceBuilder', () => {
   let builder: IntegrationInstanceBuilder;
@@ -227,7 +227,7 @@ describe('IntegrationInstanceBuilder', () => {
         .spyOn(mockUtils, 'deepCheck')
         .mockResolvedValue({ ok: false, error: new Error('Mock error') });
 
-      await expect(builder.build(sampleIntegration, options)).rejects.toThrowError('Mock error');
+      await expect(builder.build(sampleIntegration, options)).rejects.toThrow('Mock error');
     });
 
     it('should reject with an error if getAssets rejects', async () => {
@@ -239,12 +239,12 @@ describe('IntegrationInstanceBuilder', () => {
       const errorMessage = 'Failed to get assets';
       jest
         .spyOn(mockUtils, 'deepCheck')
-        .mockResolvedValue({ ok: true, value: ({} as unknown) as IntegrationConfig });
+        .mockResolvedValue({ ok: true, value: {} as unknown as IntegrationConfig });
       sampleIntegration.getAssets = jest
         .fn()
         .mockResolvedValue({ ok: false, error: new Error(errorMessage) });
 
-      await expect(builder.build(sampleIntegration, options)).rejects.toThrowError(errorMessage);
+      await expect(builder.build(sampleIntegration, options)).rejects.toThrow(errorMessage);
     });
 
     it('should reject with an error if postAssets throws an error', async () => {
@@ -261,14 +261,14 @@ describe('IntegrationInstanceBuilder', () => {
       const errorMessage = 'Failed to post assets';
       jest
         .spyOn(mockUtils, 'deepCheck')
-        .mockResolvedValue({ ok: true, value: ({} as unknown) as IntegrationConfig });
+        .mockResolvedValue({ ok: true, value: {} as unknown as IntegrationConfig });
       sampleIntegration.getAssets = jest.fn().mockResolvedValue({
         ok: true,
         value: [{ type: 'savedObjectBundle', data: remappedAssets }],
       });
       builder.postAssets = jest.fn().mockRejectedValue(new Error(errorMessage));
 
-      await expect(builder.build(sampleIntegration, options)).rejects.toThrowError(errorMessage);
+      await expect(builder.build(sampleIntegration, options)).rejects.toThrow(errorMessage);
     });
   });
 
@@ -361,7 +361,7 @@ describe('IntegrationInstanceBuilder', () => {
       const errorMessage = 'Failed to create assets';
       (mockSavedObjectsClient.bulkCreate as jest.Mock).mockRejectedValue(new Error(errorMessage));
 
-      await expect(builder.postAssets(assets)).rejects.toThrowError(errorMessage);
+      await expect(builder.postAssets(assets)).rejects.toThrow(errorMessage);
     });
   });
 
@@ -399,7 +399,7 @@ describe('IntegrationInstanceBuilder', () => {
       };
 
       const instance = await builder.buildInstance(
-        (integration as unknown) as IntegrationReader,
+        integration as unknown as IntegrationReader,
         refs,
         options
       );
@@ -427,8 +427,8 @@ describe('IntegrationInstanceBuilder', () => {
       };
 
       await expect(
-        builder.buildInstance((integration as unknown) as IntegrationReader, refs, options)
-      ).rejects.toThrowError();
+        builder.buildInstance(integration as unknown as IntegrationReader, refs, options)
+      ).rejects.toThrow();
     });
   });
 });

--- a/server/adaptors/integrations/repository/__test__/integration_reader.test.ts
+++ b/server/adaptors/integrations/repository/__test__/integration_reader.test.ts
@@ -203,7 +203,7 @@ describe('Integration', () => {
 
       expectOkResult(result);
       expect(result.value).toStrictEqual(Buffer.from('logo data', 'ascii'));
-      expect(readFileMock).toBeCalledWith(path.join('sample', 'static', 'logo.png'));
+      expect(readFileMock).toHaveBeenCalledWith(path.join('sample', 'static', 'logo.png'));
     });
 
     it('should return an error if the static file is not found', async () => {
@@ -234,7 +234,7 @@ describe('Integration', () => {
       const result = await integration.getSampleData();
 
       expect(result.value).toStrictEqual({ sampleData: [{ sample: true }] });
-      expect(readFileMock).toBeCalledWith(path.join('sample', 'data', 'sample.json'), {
+      expect(readFileMock).toHaveBeenCalledWith(path.join('sample', 'data', 'sample.json'), {
         encoding: 'utf-8',
       });
     });

--- a/server/plugin.test.ts
+++ b/server/plugin.test.ts
@@ -13,11 +13,11 @@ describe('#setup', () => {
     const observabilityPlugin = new ObservabilityPlugin(intializerContextMock);
     observabilityPlugin.setup(coreSetup, {
       investigationDashboards: {},
-      dataSource: ({
+      dataSource: {
         registerCustomApiSchema: jest.fn(),
-      } as unknown) as ObservabilityPluginSetupDependencies,
+      } as unknown as ObservabilityPluginSetupDependencies,
     });
-    expect(coreSetup.savedObjects.registerType).not.toBeCalledWith(
+    expect(coreSetup.savedObjects.registerType).not.toHaveBeenCalledWith(
       expect.objectContaining({
         type: NOTEBOOK_SAVED_OBJECT,
       })
@@ -51,9 +51,9 @@ describe('#setup capability switcher (dynamic feature flags)', () => {
 
     const plugin = new ObservabilityPlugin(initializerContext);
     await plugin.setup(coreSetup, {
-      dataSource: ({
+      dataSource: {
         registerCustomApiSchema: jest.fn(),
-      } as unknown) as ObservabilityPluginSetupDependencies,
+      } as unknown as ObservabilityPluginSetupDependencies,
     });
 
     // The plugin calls `registerSwitcher` once for the dynamic flag path.

--- a/server/routes/query_assist/utils/__tests__/agents.test.ts
+++ b/server/routes/query_assist/utils/__tests__/agents.test.ts
@@ -61,7 +61,7 @@ describe('Agents helper functions', () => {
 
   it('handles not found errors', async () => {
     mockedTransport.mockRejectedValueOnce(
-      new ResponseError(({
+      new ResponseError({
         body: {
           error: {
             root_cause: [
@@ -76,7 +76,7 @@ describe('Agents helper functions', () => {
           status: 404,
         },
         statusCode: 404,
-      } as unknown) as ApiResponse)
+      } as unknown as ApiResponse)
     );
     await expect(
       getAgentIdByConfig(client, 'test agent')
@@ -110,7 +110,7 @@ describe('Agents helper functions', () => {
       configName: 'new_agent',
       body: { parameters: { param1: 'value1' } },
     });
-    expect(mockedTransport).toBeCalledWith(
+    expect(mockedTransport).toHaveBeenCalledWith(
       expect.objectContaining({ path: '/_plugins/_ml/agents/new-id/_execute' }),
       expect.anything()
     );

--- a/test/__mocks__/rawLoaderMock.js
+++ b/test/__mocks__/rawLoaderMock.js
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Stub for `!!raw-loader!` imports. jest-raw-loader is incompatible with the
+// Jest 28+ transformer API and was removed during the Jest 30 upgrade. No test
+// asserts the real raw file contents (the only consumer mocks the import
+// directly), so a string stub preserves the prior behaviour.
+module.exports = 'raw-loader-stub';

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -41,7 +41,7 @@ module.exports = {
     url: 'http://localhost:5601',
   },
   // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
-  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/upgrading-to-jest29
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -8,7 +8,7 @@ process.env.TZ = 'UTC';
 module.exports = {
   rootDir: '../',
   setupFiles: ['<rootDir>/test/setupTests.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup.jest.ts'],
+  setupFilesAfterEnv: ['jest-location-mock', '<rootDir>/test/setup.jest.ts'],
   roots: ['<rootDir>'],
   testMatch: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
   clearMocks: true,
@@ -25,7 +25,7 @@ module.exports = {
     '\\.(css|less|sass|scss)$': '<rootDir>/test/__mocks__/styleMock.js',
     '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/test/__mocks__/fileMock.js',
     '\\@algolia/autocomplete-theme-classic$': '<rootDir>/test/__mocks__/styleMock.js',
-    '^!!raw-loader!.*': 'jest-raw-loader',
+    '^!!raw-loader!.*': '<rootDir>/test/__mocks__/rawLoaderMock.js',
     // OpenSearch Dashboards path mappings
     '^opensearch-dashboards/public$': '<rootDir>/../../src/core/public',
     '^opensearch-dashboards/public/(.*)$': '<rootDir>/../../src/core/public/$1',
@@ -35,4 +35,15 @@ module.exports = {
     '@hapi/hoek/(?!lib/)(.*)': '<rootDir>/../../node_modules/@hapi/hoek/lib/$1',
   },
   testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    // Set the default URL so window.location.origin is 'http://localhost:5601' rather than
+    // 'http://localhost', avoiding the need for tests to mock window.location.origin.
+    url: 'http://localhost:5601',
+  },
+  // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
+  },
 };

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -4,30 +4,30 @@
  */
 
 import '@testing-library/jest-dom';
-// eslint-disable-next-line jest/no-mocks-import
+
 import './__mocks__/worker.mock';
 import { configure } from '@testing-library/react';
 import { setOSDHttp, setOSDSavedObjectsClient } from '../common/utils';
 import { coreRefs } from '../public/framework/core_refs';
-// eslint-disable-next-line jest/no-mocks-import
+
 import { coreStartMock } from './__mocks__/coreMocks';
 
 configure({ testIdAttribute: 'data-test-subj' });
 
 window.URL.createObjectURL = () => '';
-HTMLCanvasElement.prototype.getContext = () => ('' as unknown) as RenderingContext;
-window.IntersectionObserver = (jest.fn().mockImplementation(() => ({
+HTMLCanvasElement.prototype.getContext = () => '' as unknown as RenderingContext;
+window.IntersectionObserver = jest.fn().mockImplementation(() => ({
   disconnect: () => null,
   observe: () => null,
   takeRecords: () => null,
   unobserve: () => null,
-})) as unknown) as typeof IntersectionObserver;
+})) as unknown as typeof IntersectionObserver;
 
-window.ResizeObserver = (jest.fn().mockImplementation(() => ({
+window.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: () => null,
   observe: () => null,
   unobserve: () => null,
-})) as unknown) as typeof ResizeObserver;
+})) as unknown as typeof ResizeObserver;
 
 jest.mock('@elastic/eui/lib/components/form/form_row/make_id', () => () => 'random-id');
 
@@ -46,9 +46,15 @@ coreRefs.savedObjectsClient = coreStartMock.savedObjects.client;
 coreRefs.toasts = coreStartMock.notifications.toasts;
 coreRefs.chrome = coreStartMock.chrome;
 
+// jest-location-mock uses process.env.HOST as the base URL for its window.location mock.
+// Set it to match testEnvironmentOptions.url so window.location.origin is 'http://localhost:5601'
+// in all jsdom tests, consistent with the rest of the suite.
+process.env.HOST = 'http://localhost:5601';
+
 // Mock window.matchMedia for Monaco editor
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
+  configurable: true,
   value: jest.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
@@ -59,4 +65,18 @@ Object.defineProperty(window, 'matchMedia', {
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
   })),
+});
+
+// jsdom 26 marks window.localStorage and window.sessionStorage as non-configurable.
+// Re-declare them as configurable once here so individual tests can override them
+// with Object.defineProperty without hitting "Cannot redefine property" errors.
+['localStorage', 'sessionStorage'].forEach((key) => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, key);
+  if (descriptor && !descriptor.configurable) {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      writable: true,
+      value: descriptor.value,
+    });
+  }
 });

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -3,5 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { TextEncoder, TextDecoder } from 'util';
+
 require('babel-polyfill');
 require('core-js/stable');
+
+// TextEncoder/TextDecoder polyfill required by react-dom/server (pulled in by
+// server-side tests) and React 18 under the jsdom test environment. jsdom 26
+// no longer provides these globals in every context, so provide them here.
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder as typeof global.TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder as typeof global.TextDecoder;
+}


### PR DESCRIPTION
Closes #2787

### Description

Migrate this plugin's Jest test suite to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary, so it breaks once the core upgrade lands.

**Result:** full suite green — `388 suites / 3312 tests / 267 snapshots passed`, exit 0. Plugin
`tsc --noEmit` clean.

#### Common changes (shared across the plugin-migration campaign)
- **Config (`test/jest.config.js`):** added `jest-location-mock` as the first `setupFilesAfterEnv`
  entry; added `testEnvironmentOptions: { url: 'http://localhost:5601' }`; added the
  `snapshotFormat: { escapeString: true, printBasicPrototype: true }` compatibility shim (Jest 29
  flipped these defaults); replaced the `jest-raw-loader` moduleNameMapper with a local stub
  (`test/__mocks__/rawLoaderMock.js`) since jest-raw-loader is incompatible with the Jest 28+
  transformer API.
- **Setup (`test/setup.jest.ts`):** made the `matchMedia` mock `configurable`; set
  `process.env.HOST = 'http://localhost:5601'`; re-declared non-configurable
  `localStorage`/`sessionStorage` as configurable (jsdom 26).
- **Setup (`test/setupTests.ts`):** added a `TextEncoder`/`TextDecoder` polyfill (server-side tests
  import `react-dom/server`, which needs it under jsdom 26).
- **Matcher codemod:** `toThrowError` → `toThrow` and `toBeCalled*` → `toHaveBeenCalled*` across
  test files (Jest 30 removed the aliases).
- **Snapshots:** bulk-updated the snapshot header URL (`goo.gl/fbAQLP` →
  `jestjs.io/docs/snapshot-testing`) across 134 `.snap` files — Jest 30 refuses to load the old
  header. Regenerated 27 snapshots; verified every non-header diff is jsdom-26 CSS serialization
  only (dropped `font-family: -webkit-small-control`, computed `calc()` values, `width: fit-content`),
  no content regressions.

#### Plugin-specific changes
- **`window.location` (jsdom 26 makes it non-configurable):** changed 4 source sites from
  `window.location.href = X` to `window.location.assign(X)`
  (`apm/shared/utils/navigation_utils.ts`, `application_analytics/components/app_table.tsx`,
  `trace_analytics/components/services/service_view.tsx`, `.../services_table.tsx`). Removed
  `delete window.location` / `Object.defineProperty(window, 'location', …)` blocks from the
  trace-analytics location tests (jest-location-mock provides `.assign` as a spy).
- **Anchor-navigation tests:** `<a href="#/create">` clicks no longer navigate under jsdom 26.
  In `note_table` and `custom_panel_table` tests, assert the anchor's `href` attribute (or set the
  hash before render where a mount effect reads `window.location.hash`) instead of the post-click
  `window.location`.
- **Cross-test location leakage:** fixed a note_table test that depended on a prior test leaving
  `#/create` in the URL (jsdom 16 shared `window.location` across a file; jsdom 26 isolates per test).

No `package.json` change needed — the plugin inherits the parent repo's Jest 30 stack.

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Add: Closes #<this-plugin-issue> -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
