### PR TITLE
remove js-yaml and use the deps from core

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "antlr4ts": "^0.5.0-alpha.4",
     "echarts": "^6.0.0",
     "isomorphic-dompurify": "~2.29.0",
-    "js-yaml": "^4.2.0",
     "json5": "^2.2.3",
     "mime": "^3.0.0",
     "performance-now": "^2.1.0",
@@ -45,7 +44,6 @@
   },
   "devDependencies": {
     "@cypress/skip-test": "^2.6.1",
-    "@types/js-yaml": "^4.0.5",
     "@types/mime": "^3.0.1",
     "@types/react-plotly.js": "^2.6.3",
     "@types/sanitize-filename": "^1.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,11 +254,6 @@
   dependencies:
     "@types/unist" "^2"
 
-"@types/js-yaml@^4.0.5":
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
-  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
-
 "@types/mime@^3.0.1":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.4.tgz#2198ac274de6017b44d941e00261d5bc6a0e0a45"
@@ -1367,7 +1362,7 @@ jest-dom@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.1.0, js-yaml@^4.2.0:
+js-yaml@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
   integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==


### PR DESCRIPTION
### Description
core already has js-yaml, declaring it here would require us to keep package.json version same as core, it's unnecessary

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
