### PR TITLE
[CVE] Bump linkify-it to ^5.0.2 (CVE-2026-59887)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "nanoid": "3.3.8",
     "serialize-javascript": "^7.0.3",
     "@babel/runtime": "^7.26.10",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "linkify-it": "^5.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,12 +1424,12 @@ lilconfig@^3.1.3:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
   integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
 
-linkify-it@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
-  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+linkify-it@^3.0.3, linkify-it@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
   dependencies:
-    uc.micro "^1.0.1"
+    uc.micro "^2.0.0"
 
 lint-staged@^15.2.10:
   version "15.5.2"
@@ -2357,10 +2357,10 @@ typed-styles@^0.0.7:
   resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
   integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
 
-uc.micro@^1.0.1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
-  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+uc.micro@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 unherit@^1.0.4:
   version "1.1.3"


### PR DESCRIPTION
### Description
Resolves the high-severity ReDoS/DoS advisory in `linkify-it` (CVE-2026-59887 / GHSA-v245-v573-v5vm). The `mailto:` validator in `linkify-it < 5.0.2` scans the remaining input at every `mailto:` occurrence via `src_email_name`, causing O(n²) CPU consumption on crafted text. Fixed in `linkify-it@5.0.2`.

`linkify-it` is a transitive dependency and is only pulled in here through:

```
@nteract/outputs → ansi-to-react@^6.0.5 (6.2.6) → linkify-it@^3.0.3
```

Because the patched release (`5.0.2`) is a major bump that breaches the transitive `^3.0.3` range, this adds a `resolutions` override (`"linkify-it": "^5.0.2"`) and regenerates `yarn.lock`. The `^5` constraint keeps us on the 5.x line and deliberately avoids `6.0.0`, which removed the `.pretest()`/`.compile()` APIs.

Only `linkify-it` (3.0.3 → 5.0.2) and its dependency `uc.micro` (1.0.6 → 2.1.0) change in the lockfile.

### Does the major version update break anything?
No. Verified:

- **CJS interop preserved** — `linkify-it@5.0.2` is a dual package (`require` → `build/index.cjs.js`, `import` → `index.mjs`), so `ansi-to-react`'s `require("linkify-it")` still resolves. The CJS build still does `module.exports = LinkifyIt` with the no-`new` factory guard, identical to 3.0.3.
- **API surface used by `ansi-to-react` is intact** — it only calls `linkifyIt({ fuzzyEmail: false }).tlds(["io"], true)` then `.test()` / `.match()`. All of `add`/`set`/`test`/`match`/`matchAtStart`/`tlds` remain in 5.0.2. The breaking API removals (`.pretest()`, `.compile()`, `.onCompile()`, constructor schemas) only landed in `6.0.0`, which we don't upgrade to.
- **No direct usage** — nothing in `dashboards-observability` source imports `linkify-it`; it is purely transitive.

Runtime smoke test against the resolved `5.0.2`, replicating `ansi-to-react`'s exact usage:

```
linkify-it installed version: 5.0.2
test(url): true
match: https://opensearch.org/docs
mailto scan ms: 1   # patched: crafted mailto no longer causes quadratic scan
SMOKE OK
```

### Issues Resolved
Closes https://github.com/opensearch-project/dashboards-observability/issues/2781

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
