### PR TITLE
fix: exclude exponentiation-operator babel transform

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,12 @@ module.exports = function (api) {
   if (api.env('test')) {
     return {
       presets: [
-        require('@babel/preset-env'),
+        // Exclude the exponentiation-operator transform: it rewrites `**` to
+        // Math.pow(), which throws on BigInt operands (e.g. `2n ** 63n` in
+        // @osd/monaco's ppl lint code). Tests run in Node, which supports `**`
+        // natively, so the transform is unnecessary here. Excluding just this
+        // one plugin leaves all other preset-env transforms intact.
+        [require('@babel/preset-env'), { exclude: ['transform-exponentiation-operator'] }],
         require('@babel/preset-react'),
         require('@babel/preset-typescript'),
       ],


### PR DESCRIPTION
### Description

Two Jest suites (`public/plugin.test.tsx` and `public/plugin_helpers/plugin_nav.test.tsx`) fail to run with:

```text
TypeError: Cannot convert a BigInt value to a number
> const LONG_MIN = -(2n ** 63n);
```

**Root cause:** These suites import from `opensearch-dashboards/public`, whose import chain reaches `@osd/monaco`'s PPL lint code (`packages/osd-monaco/src/ppl/lint/explain/explain_quick_fix.ts`), which uses BigInt exponentiation (`2n ** 63n`). This is valid JavaScript.

Our test `babel.config.js` uses `@babel/preset-env` without an explicit target. Under Jest (`NODE_ENV=test`), Browserslist looks for a `[test]` section in the repo `.browserslistrc`, which only defines `[production]` and `[dev]`. With no target found, `@babel/preset-env` falls back to the broadest browser set and enables `@babel/plugin-transform-exponentiation-operator`, which rewrites `**` into `Math.pow()`. `Math.pow()` cannot accept BigInt operands, so the module throws at require time and the entire suite fails to run.

**Fix:** Exclude only the `transform-exponentiation-operator` plugin from `@babel/preset-env` in the test environment. Tests run in Node, which supports `**` natively, so the transform is unnecessary. Excluding only this plugin preserves every other `@babel/preset-env` transform. (An earlier attempt using `targets: { node: 'current' }` was rejected because it also removed `transform-private-methods`, which other source code depends on.)

This is a pre-existing failure on `main` (the `explain_quick_fix.ts` code landed in OpenSearch Dashboards on **2026-07-29**) and is unrelated to any dependency changes.

### Testing

- `yarn test public/plugin.test.tsx public/plugin_helpers/plugin_nav.test.tsx`
  - Both suites pass (21 tests)
- Spot-checked `public/components/common`
  - No regressions

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
