### PR TITLE
fix(trace-analytics): thread dataSourceMDSId on dashboard latencyTrends request

### DIFF
--- a/public/components/trace_analytics/requests/__tests__/helper_funtions.test.tsx
+++ b/public/components/trace_analytics/requests/__tests__/helper_funtions.test.tsx
@@ -5,6 +5,7 @@
 
 import { handleError } from '../helper_functions';
 import { handleDslRequest } from '../request_handler';
+import { handleDashboardRequest } from '../dashboard_request_handler';
 import { coreRefs } from '../../../../../public/framework/core_refs';
 import { CoreStart } from '../../../../../../../src/core/public';
 
@@ -274,6 +275,50 @@ describe('Trace Analytics Error Handling', () => {
 
       expect(toast.title).toBe('Error 504');
       expect(toast.text).toContain('Request timed out');
+    });
+  });
+
+  describe('external data source: dataSourceMDSId must be threaded on every request', () => {
+    // Invariant: when an external data source (MDS) is selected, EVERY trace-analytics
+    // query must carry its dataSourceMDSId. A request dispatched without it falls back to
+    // the local cluster on the server (the `else` branch of trace_analytics_dsl_router).
+    // On a deployment with no local cluster this throws "No Living connections" -> HTTP 400.
+    const MDS_ID = 'test-mds-id';
+
+    // Minimal aggregation payload so the .then() handlers in handleDashboardRequest
+    // don't throw before all requests are dispatched.
+    const emptyAggResponse = {
+      aggregations: {
+        trace_group: { buckets: [] },
+        trace_group_name: { buckets: [] },
+      },
+    };
+
+    beforeEach(() => {
+      mockHttp.post.mockResolvedValue(emptyAggResponse as any);
+    });
+
+    it('handleDashboardRequest sends dataSourceMDSId on ALL dispatched requests', async () => {
+      await handleDashboardRequest(
+        mockHttp,
+        {}, // DSL
+        {}, // timeFilterDSL
+        {}, // latencyTrendDSL
+        [], // items
+        jest.fn(), // setItems
+        'data_prepper',
+        undefined, // setShowTimeoutToast
+        MDS_ID,
+        jest.fn() // setPercentileMap
+      );
+
+      // Every http.post issued by the dashboard flow must carry the MDS id.
+      expect(mockHttp.post).toHaveBeenCalled();
+      const callsMissingMdsId = mockHttp.post.mock.calls.filter(
+        ([, options]) => options?.query?.dataSourceMDSId !== MDS_ID
+      );
+
+      expect(callsMissingMdsId).toHaveLength(0);
     });
   });
 });

--- a/public/components/trace_analytics/requests/dashboard_request_handler.ts
+++ b/public/components/trace_analytics/requests/dashboard_request_handler.ts
@@ -62,8 +62,8 @@ export const handleDashboardRequest = async (
     latencyTrendDSL,
     getLatencyTrendQuery(),
     mode,
-    setShowTimeoutToast,
-    dataSourceMDSId
+    dataSourceMDSId,
+    setShowTimeoutToast
   )
     .then((response) => {
       const map: any = {};


### PR DESCRIPTION
### Description

Follow-up to #2333.

`handleDashboardRequest` builds the Trace Analytics "Trace Groups" dashboard by issuing several `handleDslRequest` calls. Its `latencyTrends` call passed `dataSourceMDSId` and `setShowTimeoutToast` in **transposed order**:

```ts
// handleDslRequest signature:
//   (http, DSL, bodyQuery, mode, dataSourceMDSId?, setShowTimeoutToast?)

// before (bug)
handleDslRequest(http, latencyTrendDSL, getLatencyTrendQuery(), mode,
  setShowTimeoutToast,   // <- lands in the dataSourceMDSId slot
  dataSourceMDSId);      // <- lands in the setShowTimeoutToast slot
```

As a result that request was dispatched with `query.dataSourceMDSId === undefined`. On the server (`trace_analytics_dsl_router`) a missing `dataSourceMDSId` takes the `else` branch and queries the **local cluster** instead of the selected external data source. On deployments that have no local cluster, the legacy client's
connection pool is empty and throws `NoConnections('No Living connections')`, which has no `statusCode` and is returned as **HTTP 400**. Users see `Error 400: No Living connections` (and a follow-on `TypeError: can't access property "aggregations"`, since the failed request resolves to `undefined`) when opening **Trace Groups** against an external data source.

#2333 added `dataSourceMDSId` to the other dashboard trace-group requests but transposed the two arguments at this single call site. This PR restores the correct order.

### Fix

- Swap the arguments back to `(..., mode, dataSourceMDSId, setShowTimeoutToast)` at the `latencyTrends` call in `handleDashboardRequest`.
- Add a regression test asserting that **every** request dispatched by `handleDashboardRequest` carries the selected `dataSourceMDSId` (none may fall back to the local cluster).

Verified before/after on `main`:
- Before: the new test fails — the `latencyTrends` request goes out with `dataSourceMDSId: undefined`.
- After: all tests pass (12/12 in the file).

### Issues Resolved

Fixes the HTTP 400 "No Living connections" on Trace Analytics Trace Groups /
dashboard when using an external data source.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
