### PR TITLE
Add detector and forecaster management to Alerts Manager

### DIFF
--- a/common/types/alerting/unified_types.ts
+++ b/common/types/alerting/unified_types.ts
@@ -170,6 +170,9 @@ export interface Datasource {
   directQueryName?: string;
   /** OSD Multi-Data-Source saved object ID — when set, use context.dataSource.opensearch.getClient(mdsId) */
   mdsId?: string;
+  /** OpenSearch data-source metadata used to gate datasource-specific creation flows. */
+  engineType?: string;
+  version?: string;
   auth?: {
     type: 'basic' | 'apikey' | 'sigv4';
     credentials?: Record<string, string>;
@@ -229,7 +232,12 @@ export interface DatasourceService {
 
 export type UnifiedAlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type UnifiedAlertState =
-  'active' | 'pending' | 'acknowledged' | 'silenced' | 'resolved' | 'error';
+  | 'active'
+  | 'pending'
+  | 'acknowledged'
+  | 'silenced'
+  | 'resolved'
+  | 'error';
 export type UnifiedAlertKind = 'alert' | 'anomaly';
 
 /** Lightweight alert representation for list views and tables. */

--- a/common/types/alerting/unified_types.ts
+++ b/common/types/alerting/unified_types.ts
@@ -172,7 +172,6 @@ export interface Datasource {
   mdsId?: string;
   /** OpenSearch data-source metadata used to gate datasource-specific creation flows. */
   engineType?: string;
-  version?: string;
   auth?: {
     type: 'basic' | 'apikey' | 'sigv4';
     credentials?: Record<string, string>;

--- a/common/types/alerting/unified_types.ts
+++ b/common/types/alerting/unified_types.ts
@@ -232,12 +232,7 @@ export interface DatasourceService {
 
 export type UnifiedAlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type UnifiedAlertState =
-  | 'active'
-  | 'pending'
-  | 'acknowledged'
-  | 'silenced'
-  | 'resolved'
-  | 'error';
+  'active' | 'pending' | 'acknowledged' | 'silenced' | 'resolved' | 'error';
 export type UnifiedAlertKind = 'alert' | 'anomaly';
 
 /** Lightweight alert representation for list views and tables. */

--- a/common/types/alerting/unified_types.ts
+++ b/common/types/alerting/unified_types.ts
@@ -229,12 +229,7 @@ export interface DatasourceService {
 
 export type UnifiedAlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type UnifiedAlertState =
-  | 'active'
-  | 'pending'
-  | 'acknowledged'
-  | 'silenced'
-  | 'resolved'
-  | 'error';
+  'active' | 'pending' | 'acknowledged' | 'silenced' | 'resolved' | 'error';
 export type UnifiedAlertKind = 'alert' | 'anomaly';
 
 /** Lightweight alert representation for list views and tables. */

--- a/common/types/alerting/unified_types.ts
+++ b/common/types/alerting/unified_types.ts
@@ -31,6 +31,11 @@ export interface ADDetector {
   id: string;
   name?: string;
   description?: string;
+  enabled?: boolean;
+  curState?: MonitorStatus;
+  cur_state?: MonitorStatus;
+  taskState?: MonitorStatus;
+  task_state?: MonitorStatus;
   detector_type?: string;
   indices?: string[];
   time_field?: string;
@@ -51,6 +56,11 @@ export interface ADForecaster {
   id: string;
   name?: string;
   description?: string;
+  enabled?: boolean;
+  curState?: MonitorStatus;
+  cur_state?: MonitorStatus;
+  taskState?: MonitorStatus;
+  task_state?: MonitorStatus;
   indices?: string[];
   time_field?: string;
   timeField?: string;
@@ -274,7 +284,29 @@ export type MonitorType =
   | 'anomaly_detector_monitor'
   | 'detector'
   | 'forecaster';
-export type MonitorStatus = 'active' | 'pending' | 'muted' | 'disabled';
+export type MonitorStatus =
+  | 'active'
+  | 'pending'
+  | 'muted'
+  | 'disabled'
+  | 'Running'
+  | 'Stopped'
+  | 'Initializing'
+  | 'Finished'
+  | 'Feature required'
+  | 'Initialization failure'
+  | 'Unexpected failure'
+  | 'Failed'
+  | 'Inactive stopped'
+  | 'Inactive not started'
+  | 'Awaiting data to init'
+  | 'Awaiting data to restart'
+  | 'Initializing test'
+  | 'Initializing forecast'
+  | 'Test complete'
+  | 'Init forecast failure'
+  | 'Forecast failure'
+  | 'Init test failure';
 export type MonitorHealthStatus = 'healthy' | 'failing' | 'no_data';
 export type UnifiedDefinitionType = 'monitor' | 'prometheus_rule' | 'detector' | 'forecaster';
 

--- a/common/utils/shared.ts
+++ b/common/utils/shared.ts
@@ -76,6 +76,11 @@ export const dataSourceFilterFn = (dataSource: SavedObject<DataSourceAttributes>
   );
 };
 
+export const isVersionAtLeast = (version: string, minimumVersion: string): boolean => {
+  const coerced = semver.coerce(version);
+  return coerced ? semver.gte(coerced, minimumVersion) : false;
+};
+
 // Engine types this plugin declines via its manifest's `unsupportedOSDataSourceEngineTypes`.
 // Driven by the manifest declaration so changes flow from one source of truth.
 const UNSUPPORTED_ENGINE_TYPES: readonly string[] =

--- a/common/utils/shared.ts
+++ b/common/utils/shared.ts
@@ -76,11 +76,6 @@ export const dataSourceFilterFn = (dataSource: SavedObject<DataSourceAttributes>
   );
 };
 
-export const isVersionAtLeast = (version: string, minimumVersion: string): boolean => {
-  const coerced = semver.coerce(version);
-  return coerced ? semver.gte(coerced, minimumVersion) : false;
-};
-
 // Engine types this plugin declines via its manifest's `unsupportedOSDataSourceEngineTypes`.
 // Driven by the manifest declaration so changes flow from one source of truth.
 const UNSUPPORTED_ENGINE_TYPES: readonly string[] =

--- a/public/components/alerting/__tests__/alarms_page.test.tsx
+++ b/public/components/alerting/__tests__/alarms_page.test.tsx
@@ -33,6 +33,11 @@ jest.mock('../hooks/use_alerts', () => ({
   useAlerts: (args: unknown) => mockUseAlerts(args),
 }));
 
+const mockUseRulesData = jest.fn();
+jest.mock('../hooks/use_rules_data', () => ({
+  useRulesData: (args: unknown) => mockUseRulesData(args),
+}));
+
 // Capture AlertsDashboard props so we can assert `startTime` / `endTime` /
 // `startMs` / `endMs` / `truncated` / `fallbackHints` are forwarded.
 const mockDashboard = jest.fn();
@@ -66,10 +71,19 @@ jest.mock('../query_services/alerting_opensearch_service', () => ({
 }));
 
 const mockCreateMonitor = jest.fn();
+const mockDeleteMonitor = jest.fn();
+const mockDeleteDetector = jest.fn();
+const mockStopDetector = jest.fn();
+const mockDeleteForecaster = jest.fn();
+const mockStopForecaster = jest.fn();
 jest.mock('../hooks/use_monitor_mutations', () => ({
   useMonitorMutations: () => ({
     createMonitor: mockCreateMonitor,
-    deleteMonitor: jest.fn(),
+    deleteMonitor: mockDeleteMonitor,
+    deleteDetector: mockDeleteDetector,
+    stopDetector: mockStopDetector,
+    deleteForecaster: mockDeleteForecaster,
+    stopForecaster: mockStopForecaster,
     acknowledgeAlert: jest.fn(),
   }),
 }));
@@ -91,13 +105,35 @@ const emptyHookResult = {
   refetch: jest.fn(),
 };
 
+const emptyRulesHookResult = {
+  rules: [],
+  rulesTotal: 0,
+  isLoading: false,
+  error: null,
+  warnings: [],
+  setRules: jest.fn(),
+  setRulesTotal: jest.fn(),
+  refetch: jest.fn(),
+};
+
 beforeEach(() => {
   mockUseAlerts.mockReset();
   mockUseAlerts.mockReturnValue(emptyHookResult);
+  mockUseRulesData.mockReset();
+  mockUseRulesData.mockReturnValue(emptyRulesHookResult);
   mockDashboard.mockClear();
   mockMonitorsTable.mockClear();
   mockGetRuleDetail.mockReset();
   mockCreateMonitor.mockReset();
+  mockDeleteMonitor.mockReset();
+  mockDeleteDetector.mockReset();
+  mockStopDetector.mockReset();
+  mockDeleteForecaster.mockReset();
+  mockStopForecaster.mockReset();
+  mockDeleteDetector.mockResolvedValue({ ok: true });
+  mockStopDetector.mockResolvedValue({ ok: true });
+  mockDeleteForecaster.mockResolvedValue({ ok: true });
+  mockStopForecaster.mockResolvedValue({ ok: true });
   try {
     window.sessionStorage.clear();
   } catch (_e) {
@@ -401,6 +437,56 @@ describe('AlarmsPage', () => {
       'ds-1'
     );
   });
+
+  it.each([
+    {
+      definitionType: 'detector',
+      stop: mockStopDetector,
+      remove: mockDeleteDetector,
+    },
+    {
+      definitionType: 'forecaster',
+      stop: mockStopForecaster,
+      remove: mockDeleteForecaster,
+    },
+  ])(
+    'stops a running $definitionType before deleting it',
+    async ({ definitionType, stop, remove }) => {
+      const resource = {
+        id: `${definitionType}-1`,
+        name: `Running ${definitionType}`,
+        datasourceId: 'ds-1',
+        datasourceType: 'opensearch',
+        definitionType,
+        monitorType: definitionType,
+        status: 'Running',
+        enabled: true,
+      };
+      mockUseRulesData.mockReturnValue({
+        ...emptyRulesHookResult,
+        rules: [resource],
+        rulesTotal: 1,
+      });
+
+      await act(async () => {
+        render(<AlarmsPage {...defaultProps} />);
+      });
+      fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+      const tableProps = mockMonitorsTable.mock.calls[
+        mockMonitorsTable.mock.calls.length - 1
+      ][0] as {
+        onDelete: (ids: string[]) => Promise<void>;
+      };
+
+      await act(async () => {
+        await tableProps.onDelete([resource.id]);
+      });
+
+      expect(stop).toHaveBeenCalledWith(resource.id, resource.datasourceId);
+      expect(remove).toHaveBeenCalledWith(resource.id, resource.datasourceId);
+      expect(stop.mock.invocationCallOrder[0]).toBeLessThan(remove.mock.invocationCallOrder[0]);
+    }
+  );
 
   // ---- URL-reflects-active-tab ---------------------------------------------
   // `handleTabClick` mirrors the active tab into `window.location.hash` so

--- a/public/components/alerting/__tests__/create_ad_rule_payload.test.ts
+++ b/public/components/alerting/__tests__/create_ad_rule_payload.test.ts
@@ -7,9 +7,11 @@ import {
   buildDetectorRules,
   buildRulePayload,
   formFromAdResource,
+  getCreateAdRuleDatasources,
   shouldAutoStartCreatedRule,
   validateForm,
 } from '../create_ad_rule_flyout';
+import type { Datasource } from '../../../../common/types/alerting';
 
 const feature = {
   featureId: 'feature-1',
@@ -112,6 +114,57 @@ const existingDetector = {
 };
 
 describe('AD rule payload serialization', () => {
+  it('only offers standard OpenSearch datasources during creation', () => {
+    const datasources: Datasource[] = [
+      {
+        id: 'aos-1',
+        name: 'AOS',
+        type: 'opensearch',
+        url: '',
+        enabled: true,
+        mdsId: 'aos-1',
+        engineType: 'OpenSearch',
+      },
+      {
+        id: 'aoss-1',
+        name: 'AOSS',
+        type: 'opensearch',
+        url: '',
+        enabled: true,
+        mdsId: 'aoss-1',
+        engineType: 'OpenSearch Serverless',
+      },
+      {
+        id: 'prom-1',
+        name: 'Prometheus',
+        type: 'prometheus',
+        url: '',
+        enabled: true,
+      },
+      {
+        id: 'analytic-1',
+        name: 'Analytic Engine',
+        type: 'opensearch',
+        url: '',
+        enabled: true,
+        mdsId: 'analytic-1',
+        engineType: 'AnalyticEngine',
+      },
+      {
+        id: 'local-cluster',
+        name: 'Local Cluster',
+        type: 'opensearch',
+        url: 'local',
+        enabled: true,
+      },
+    ];
+
+    expect(getCreateAdRuleDatasources(datasources).map(({ id }) => id)).toEqual([
+      'aos-1',
+      'local-cluster',
+    ]);
+  });
+
   it('preserves unmodeled settings while emitting only canonical configuration keys', () => {
     const payload = buildRulePayload('detector', detectorForm, {
       existingResource: existingDetector,

--- a/public/components/alerting/__tests__/create_ad_rule_payload.test.ts
+++ b/public/components/alerting/__tests__/create_ad_rule_payload.test.ts
@@ -7,6 +7,7 @@ import {
   buildDetectorRules,
   buildRulePayload,
   formFromAdResource,
+  shouldAutoStartCreatedRule,
   validateForm,
 } from '../create_ad_rule_flyout';
 
@@ -28,6 +29,11 @@ const detectorForm = {
   filterQuery: '{"term":{"host_name":"new-host"}}',
   customResultIndexEnabled: false,
   resultIndex: '',
+  resultIndexMinAge: '',
+  resultIndexMinSize: '',
+  resultIndexTtl: '',
+  customResultIndexLifecycleEnabled: false,
+  flattenCustomResultIndex: false,
   categoryFieldEnabled: false,
   categoryField: [],
   features: [feature],
@@ -179,5 +185,65 @@ describe('AD rule payload serialization', () => {
     expect(
       validateForm({ ...detectorForm, history: 40, horizon: 181 }, { ruleType: 'forecaster' })
     ).toHaveProperty('horizon');
+  });
+
+  it('serializes forecasting storage settings using the forecasting result index prefix', () => {
+    const payload = buildRulePayload('forecaster', {
+      ...detectorForm,
+      customResultIndexEnabled: true,
+      resultIndex: 'capacity-forecast',
+      resultIndexMinAge: 7,
+      resultIndexMinSize: 1000,
+      resultIndexTtl: 30,
+      customResultIndexLifecycleEnabled: true,
+      flattenCustomResultIndex: true,
+    });
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        resultIndex: 'opensearch-forecast-result-capacity-forecast',
+        resultIndexMinAge: 7,
+        resultIndexMinSize: 1000,
+        resultIndexTtl: 30,
+        flattenCustomResultIndex: true,
+      })
+    );
+  });
+
+  it('omits forecasting storage settings when the default result index is selected', () => {
+    const payload = JSON.parse(
+      JSON.stringify(
+        buildRulePayload('forecaster', {
+          ...detectorForm,
+          customResultIndexEnabled: false,
+          resultIndex: '',
+        })
+      )
+    );
+
+    expect(payload).not.toHaveProperty('resultIndex');
+    expect(payload).not.toHaveProperty('resultIndexMinAge');
+    expect(payload).not.toHaveProperty('resultIndexMinSize');
+    expect(payload).not.toHaveProperty('resultIndexTtl');
+    expect(payload).not.toHaveProperty('flattenCustomResultIndex');
+  });
+
+  it('uses indicator terminology when validating a forecaster', () => {
+    const errors = validateForm(
+      {
+        ...detectorForm,
+        features: [{ ...feature, featureName: '', aggregationOf: '' }],
+      },
+      { ruleType: 'forecaster' }
+    );
+
+    expect(errors['features.0.featureName']).toBe('Indicator name is required.');
+    expect(errors['features.0.aggregationOf']).toBe('Indicator field is required.');
+  });
+
+  it('always auto-starts a newly created forecaster', () => {
+    expect(shouldAutoStartCreatedRule('forecaster', false)).toBe(true);
+    expect(shouldAutoStartCreatedRule('detector', false)).toBe(false);
+    expect(shouldAutoStartCreatedRule('detector', true)).toBe(true);
   });
 });

--- a/public/components/alerting/__tests__/create_ad_rule_payload.test.ts
+++ b/public/components/alerting/__tests__/create_ad_rule_payload.test.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  buildDetectorRules,
+  buildRulePayload,
+  formFromAdResource,
+  validateForm,
+} from '../create_ad_rule_flyout';
+
+const feature = {
+  featureId: 'feature-1',
+  featureName: 'cpu',
+  featureEnabled: true,
+  anomalyDirection: 'below',
+  aggregationBy: 'sum',
+  aggregationOf: 'cpu.value',
+};
+
+const detectorForm = {
+  name: 'detector',
+  description: 'description',
+  datasourceId: 'ds-1',
+  indices: ['metrics-*'],
+  timeField: '@timestamp',
+  filterQuery: '{"term":{"host_name":"new-host"}}',
+  customResultIndexEnabled: false,
+  resultIndex: '',
+  categoryFieldEnabled: false,
+  categoryField: [],
+  features: [feature],
+  shingleSize: 8,
+  interval: 10,
+  frequency: 10,
+  windowDelay: 1,
+  history: 40,
+  horizon: 24,
+  startAfterCreate: true,
+};
+
+const existingDetector = {
+  id: 'detector-1',
+  name: 'detector',
+  seq_no: 4,
+  primary_term: 2,
+  schema_version: 7,
+  recency_emphasis: 128,
+  category_field: ['host_name'],
+  result_index: 'opensearch-ad-plugin-result-old-results',
+  filter_query: { term: { host_name: 'old-host' } },
+  ui_metadata: {
+    visualEditorState: { mode: 'advanced' },
+    filters: [{ field: 'service', operator: 'is', value: 'api' }],
+    features: {
+      cpu: {
+        aggregationBy: 'sum',
+        aggregationOf: 'cpu.value',
+        displayOptions: { precision: 3 },
+      },
+    },
+  },
+  feature_attributes: [
+    {
+      feature_id: 'feature-1',
+      feature_name: 'cpu',
+      feature_enabled: true,
+      aggregation_query: { cpu_feature_query: { sum: { field: 'cpu.value' } } },
+      imputation_method: 'ZERO',
+    },
+  ],
+  rules: [
+    {
+      action: 'IGNORE_ANOMALY',
+      conditions: [
+        {
+          feature_name: 'cpu',
+          threshold_type: 'ACTUAL_OVER_EXPECTED_RATIO',
+          operator: 'LTE',
+          value: 0.2,
+        },
+      ],
+    },
+    {
+      action: 'IGNORE_ANOMALY',
+      conditions: [
+        {
+          feature_name: 'deleted-feature',
+          threshold_type: 'ACTUAL_OVER_EXPECTED_RATIO',
+          operator: 'LTE',
+          value: 0.3,
+        },
+      ],
+    },
+    {
+      action: 'IGNORE_ANOMALY',
+      conditions: [
+        {
+          feature_name: 'cpu',
+          threshold_type: 'ACTUAL_IS_BELOW_EXPECTED',
+        },
+      ],
+    },
+  ],
+};
+
+describe('AD rule payload serialization', () => {
+  it('preserves unmodeled settings while emitting only canonical configuration keys', () => {
+    const payload = buildRulePayload('detector', detectorForm, {
+      existingResource: existingDetector,
+    }) as Record<string, unknown>;
+    const serialized = JSON.parse(JSON.stringify(payload));
+
+    expect(serialized).toEqual(
+      expect.objectContaining({
+        seqNo: 4,
+        primaryTerm: 2,
+        schemaVersion: 7,
+        recencyEmphasis: 128,
+        filterQuery: { term: { host_name: 'new-host' } },
+      })
+    );
+    expect(serialized).not.toHaveProperty('schema_version');
+    expect(serialized).not.toHaveProperty('filter_query');
+    expect(serialized).not.toHaveProperty('categoryField');
+    expect(serialized).not.toHaveProperty('category_field');
+    expect(serialized).not.toHaveProperty('resultIndex');
+    expect(serialized).not.toHaveProperty('result_index');
+    expect(serialized.featureAttributes[0].aggregationQuery).toEqual({
+      cpu_feature_query: { sum: { field: 'cpu.value' } },
+    });
+    expect(serialized.featureAttributes[0].imputationMethod).toBe('ZERO');
+    expect(serialized.uiMetadata).toEqual(
+      expect.objectContaining({
+        visualEditorState: { mode: 'advanced' },
+        filters: [{ field: 'service', operator: 'is', value: 'api' }],
+      })
+    );
+    expect(serialized.uiMetadata.features.cpu.displayOptions).toEqual({ precision: 3 });
+  });
+
+  it('preserves suppression rules, replaces direction rules, and removes deleted-feature rules', () => {
+    const rules = buildDetectorRules([feature], existingDetector);
+
+    expect(rules).toEqual([
+      {
+        action: 'IGNORE_ANOMALY',
+        conditions: [
+          {
+            featureName: 'cpu',
+            thresholdType: 'ACTUAL_OVER_EXPECTED_RATIO',
+            operator: 'LTE',
+            value: 0.2,
+          },
+        ],
+      },
+      {
+        action: 'IGNORE_ANOMALY',
+        conditions: [
+          {
+            featureName: 'cpu',
+            thresholdType: 'ACTUAL_IS_OVER_EXPECTED',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('loads an existing direction rule into the feature form', () => {
+    const form = formFromAdResource('detector', existingDetector, 'ds-1');
+    expect(form.features[0].anomalyDirection).toBe('above');
+  });
+
+  it('validates detector history and forecaster horizon ranges', () => {
+    expect(validateForm({ ...detectorForm, history: 5 }, { ruleType: 'detector' })).toHaveProperty(
+      'history'
+    );
+    expect(
+      validateForm({ ...detectorForm, history: 40, horizon: 181 }, { ruleType: 'forecaster' })
+    ).toHaveProperty('horizon');
+  });
+});

--- a/public/components/alerting/__tests__/detector_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/detector_detail_flyout.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@osd/i18n/react';
 import type { UnifiedRule } from '../../../../common/types/alerting';
 import { DetectorDetailFlyout } from '../detector_detail_flyout';
@@ -88,6 +88,7 @@ describe('DetectorDetailFlyout', () => {
       data: detectorDetail(),
       isLoading: false,
       error: null,
+      refetch: jest.fn(),
     });
 
     render(
@@ -116,6 +117,7 @@ describe('DetectorDetailFlyout', () => {
       data: detectorDetail(),
       isLoading: false,
       error: null,
+      refetch: jest.fn(),
     });
 
     render(
@@ -134,5 +136,31 @@ describe('DetectorDetailFlyout', () => {
 
     expect(onEditSettings).toHaveBeenCalledWith(detectorSummary);
     expect(onEditFeatures).toHaveBeenCalledWith(detectorSummary);
+  });
+
+  it('stops a running detector and refreshes its detail', async () => {
+    const onStop = jest.fn().mockResolvedValue(undefined);
+    const refetch = jest.fn();
+    useRuleDetailMock.mockReturnValue({
+      data: detectorDetail(),
+      isLoading: false,
+      error: null,
+      refetch,
+    });
+
+    render(
+      <I18nProvider>
+        <DetectorDetailFlyout
+          detector={{ ...detectorSummary, status: 'Running' }}
+          onClose={jest.fn()}
+          onStop={onStop}
+        />
+      </I18nProvider>
+    );
+
+    screen.getByTestId('alertManagerDetectorDetailStop').click();
+
+    await waitFor(() => expect(onStop).toHaveBeenCalled());
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/components/alerting/__tests__/detector_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/detector_detail_flyout.test.tsx
@@ -108,4 +108,31 @@ describe('DetectorDetailFlyout', () => {
     expect(screen.getAllByText('10 minutes')).toHaveLength(2);
     expect(useRuleDetailMock).toHaveBeenCalledWith('ds-1', 'det-1', 'detector');
   });
+
+  it('calls edit handlers from detector quick actions', () => {
+    const onEditSettings = jest.fn();
+    const onEditFeatures = jest.fn();
+    useRuleDetailMock.mockReturnValue({
+      data: detectorDetail(),
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <I18nProvider>
+        <DetectorDetailFlyout
+          detector={detectorSummary}
+          onClose={jest.fn()}
+          onEditSettings={onEditSettings}
+          onEditFeatures={onEditFeatures}
+        />
+      </I18nProvider>
+    );
+
+    screen.getByTestId('alertManagerDetectorDetailEditSettings').click();
+    screen.getByTestId('alertManagerDetectorDetailEditFeatures').click();
+
+    expect(onEditSettings).toHaveBeenCalledWith(detectorSummary);
+    expect(onEditFeatures).toHaveBeenCalledWith(detectorSummary);
+  });
 });

--- a/public/components/alerting/__tests__/forecaster_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/forecaster_detail_flyout.test.tsx
@@ -107,4 +107,27 @@ describe('ForecasterDetailFlyout', () => {
     expect(screen.getByText('24')).toBeInTheDocument();
     expect(useRuleDetailMock).toHaveBeenCalledWith('ds-1', 'forecast-1', 'forecaster');
   });
+
+  it('calls edit handler from forecaster quick action', () => {
+    const onEdit = jest.fn();
+    useRuleDetailMock.mockReturnValue({
+      data: forecasterDetail(),
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <I18nProvider>
+        <ForecasterDetailFlyout
+          forecaster={forecasterSummary}
+          onClose={jest.fn()}
+          onEdit={onEdit}
+        />
+      </I18nProvider>
+    );
+
+    screen.getByTestId('alertManagerForecasterDetailEdit').click();
+
+    expect(onEdit).toHaveBeenCalledWith(forecasterSummary);
+  });
 });

--- a/public/components/alerting/__tests__/forecaster_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/forecaster_detail_flyout.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@osd/i18n/react';
 import type { UnifiedRule } from '../../../../common/types/alerting';
 import { ForecasterDetailFlyout } from '../forecaster_detail_flyout';
@@ -88,6 +88,7 @@ describe('ForecasterDetailFlyout', () => {
       data: forecasterDetail(),
       isLoading: false,
       error: null,
+      refetch: jest.fn(),
     });
 
     render(
@@ -114,6 +115,7 @@ describe('ForecasterDetailFlyout', () => {
       data: forecasterDetail(),
       isLoading: false,
       error: null,
+      refetch: jest.fn(),
     });
 
     render(
@@ -129,5 +131,31 @@ describe('ForecasterDetailFlyout', () => {
     screen.getByTestId('alertManagerForecasterDetailEdit').click();
 
     expect(onEdit).toHaveBeenCalledWith(forecasterSummary);
+  });
+
+  it('starts a stopped forecaster and refreshes its detail', async () => {
+    const onStart = jest.fn().mockResolvedValue(undefined);
+    const refetch = jest.fn();
+    useRuleDetailMock.mockReturnValue({
+      data: forecasterDetail(),
+      isLoading: false,
+      error: null,
+      refetch,
+    });
+
+    render(
+      <I18nProvider>
+        <ForecasterDetailFlyout
+          forecaster={{ ...forecasterSummary, enabled: false, status: 'Stopped' }}
+          onClose={jest.fn()}
+          onStart={onStart}
+        />
+      </I18nProvider>
+    );
+
+    screen.getByTestId('alertManagerForecasterDetailStart').click();
+
+    await waitFor(() => expect(onStart).toHaveBeenCalled());
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -192,41 +192,6 @@ describe('MonitorsTable', () => {
     expect(onCreateMonitor).toHaveBeenCalledWith('forecaster');
   });
 
-  it('keeps detector and forecaster create actions independent from logs version gating', () => {
-    const onCreateMonitor = jest.fn();
-    render(
-      <MonitorsTable
-        {...defaultProps}
-        datasources={
-          [
-            {
-              id: 'os-1',
-              name: 'old-os',
-              type: 'opensearch',
-              mdsId: 'old-os-mds',
-              engineType: 'OpenSearch',
-              version: '3.4.0',
-            },
-          ] as unknown as Datasource[]
-        }
-        selectedDsIds={['os-1']}
-        onCreateMonitor={onCreateMonitor}
-      />
-    );
-
-    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
-    expect(screen.getByLabelText('Create logs rule').closest('.euiListGroupItem')).toHaveClass(
-      'euiListGroupItem-isDisabled'
-    );
-
-    fireEvent.click(screen.getByLabelText('Create anomaly detection rule'));
-    expect(onCreateMonitor).toHaveBeenCalledWith('detector');
-
-    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
-    fireEvent.click(screen.getByLabelText('Create forecasting rule'));
-    expect(onCreateMonitor).toHaveBeenCalledWith('forecaster');
-  });
-
   it('disables detector and forecaster creation for an AOSS datasource', () => {
     const onCreateMonitor = jest.fn();
     render(
@@ -255,40 +220,6 @@ describe('MonitorsTable', () => {
     expect(
       screen.getByLabelText('Create forecasting rule').closest('.euiListGroupItem')
     ).toHaveClass('euiListGroupItem-isDisabled');
-  });
-
-  it('enables metrics creation only when a selected datasource is Prometheus', () => {
-    const onCreateMonitor = jest.fn();
-    const { unmount } = render(
-      <MonitorsTable
-        {...defaultProps}
-        datasources={
-          [
-            {
-              id: 'os-1',
-              name: 'OpenSearch',
-              type: 'opensearch',
-              version: '3.8.0',
-            },
-          ] as unknown as Datasource[]
-        }
-        selectedDsIds={['os-1']}
-        onCreateMonitor={onCreateMonitor}
-      />
-    );
-
-    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
-    expect(screen.getByLabelText('Create metrics rule').closest('.euiListGroupItem')).toHaveClass(
-      'euiListGroupItem-isDisabled'
-    );
-
-    unmount();
-    render(
-      <MonitorsTable {...defaultProps} selectedDsIds={['ds-1']} onCreateMonitor={onCreateMonitor} />
-    );
-    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
-    fireEvent.click(screen.getByLabelText('Create metrics rule'));
-    expect(onCreateMonitor).toHaveBeenCalledWith('metrics');
   });
 
   // Regression: deselecting all datasources must wipe both the dependent

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -93,7 +93,9 @@ describe('MonitorsTable', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /sample-http-responses-detector/i }));
+    const detectorLink = screen.getByRole('button', { name: /sample-http-responses-detector/i });
+    expect(detectorLink.closest('tr')).toHaveTextContent('Anomaly Detector');
+    fireEvent.click(detectorLink);
 
     expect(screen.getByTestId('detectorFlyout')).toBeInTheDocument();
   });

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // Stub flyout to avoid pulling in its dependency tree
 jest.mock('../monitor_detail_flyout', () => ({
@@ -52,7 +52,7 @@ const sampleRule = (overrides = {}) => ({
 // display-and-interaction ones the component currently accepts.
 const defaultProps = {
   rules: [sampleRule()],
-  datasources: [{ id: 'ds-1', name: 'prom1', type: 'prometheus' }] as unknown as Datasource[],
+  datasources: ([{ id: 'ds-1', name: 'prom1', type: 'prometheus' }] as unknown) as Datasource[],
   loading: false,
   onDelete: jest.fn(),
   selectedDsIds: ['ds-1'],
@@ -121,7 +121,7 @@ describe('MonitorsTable', () => {
     expect(screen.getByTestId('forecasterFlyout')).toBeInTheDocument();
   });
 
-  it('shows start and stop actions for selected detector and forecaster rows', () => {
+  it('shows start and stop actions for selected detector and forecaster rows', async () => {
     const onStartResources = jest.fn();
     const onStopResources = jest.fn();
     const stoppedDetector = sampleRule({
@@ -156,11 +156,18 @@ describe('MonitorsTable', () => {
 
     fireEvent.click(screen.getByLabelText('Select stopped-detector'));
     fireEvent.click(screen.getByTestId('alertManagerStartSelectedResources'));
-    expect(onStartResources).toHaveBeenCalledWith([expect.objectContaining({ id: 'det-1' })]);
+    await waitFor(() =>
+      expect(onStartResources).toHaveBeenCalledWith([expect.objectContaining({ id: 'det-1' })])
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId('alertManagerStartSelectedResources')).not.toBeInTheDocument()
+    );
 
     fireEvent.click(screen.getByLabelText('Select running-forecaster'));
     fireEvent.click(screen.getByTestId('alertManagerStopSelectedResources'));
-    expect(onStopResources).toHaveBeenCalledWith([expect.objectContaining({ id: 'forecast-1' })]);
+    await waitFor(() =>
+      expect(onStopResources).toHaveBeenCalledWith([expect.objectContaining({ id: 'forecast-1' })])
+    );
   });
 
   it('surfaces detector and forecaster create actions for OpenSearch datasources', () => {
@@ -168,7 +175,9 @@ describe('MonitorsTable', () => {
     render(
       <MonitorsTable
         {...defaultProps}
-        datasources={[{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown as Datasource[]}
+        datasources={
+          ([{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown) as Datasource[]
+        }
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}
       />
@@ -189,7 +198,7 @@ describe('MonitorsTable', () => {
       <MonitorsTable
         {...defaultProps}
         datasources={
-          [
+          ([
             {
               id: 'os-1',
               name: 'old-os',
@@ -197,7 +206,7 @@ describe('MonitorsTable', () => {
               mdsId: 'old-os-mds',
               version: '3.4.0',
             },
-          ] as unknown as Datasource[]
+          ] as unknown) as Datasource[]
         }
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}
@@ -215,6 +224,40 @@ describe('MonitorsTable', () => {
     fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
     fireEvent.click(screen.getByLabelText('Create forecasting rule'));
     expect(onCreateMonitor).toHaveBeenCalledWith('forecaster');
+  });
+
+  it('enables metrics creation only when a selected datasource is Prometheus', () => {
+    const onCreateMonitor = jest.fn();
+    const { unmount } = render(
+      <MonitorsTable
+        {...defaultProps}
+        datasources={
+          ([
+            {
+              id: 'os-1',
+              name: 'OpenSearch',
+              type: 'opensearch',
+              version: '3.8.0',
+            },
+          ] as unknown) as Datasource[]
+        }
+        selectedDsIds={['os-1']}
+        onCreateMonitor={onCreateMonitor}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
+    expect(screen.getByLabelText('Create metrics rule').closest('.euiListGroupItem')).toHaveClass(
+      'euiListGroupItem-isDisabled'
+    );
+
+    unmount();
+    render(
+      <MonitorsTable {...defaultProps} selectedDsIds={['ds-1']} onCreateMonitor={onCreateMonitor} />
+    );
+    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
+    fireEvent.click(screen.getByLabelText('Create metrics rule'));
+    expect(onCreateMonitor).toHaveBeenCalledWith('metrics');
   });
 
   // Regression: deselecting all datasources must wipe both the dependent

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -52,7 +52,7 @@ const sampleRule = (overrides = {}) => ({
 // display-and-interaction ones the component currently accepts.
 const defaultProps = {
   rules: [sampleRule()],
-  datasources: ([{ id: 'ds-1', name: 'prom1', type: 'prometheus' }] as unknown) as Datasource[],
+  datasources: [{ id: 'ds-1', name: 'prom1', type: 'prometheus' }] as unknown as Datasource[],
   loading: false,
   onDelete: jest.fn(),
   selectedDsIds: ['ds-1'],
@@ -168,9 +168,7 @@ describe('MonitorsTable', () => {
     render(
       <MonitorsTable
         {...defaultProps}
-        datasources={
-          ([{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown) as Datasource[]
-        }
+        datasources={[{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown as Datasource[]}
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}
       />
@@ -191,7 +189,7 @@ describe('MonitorsTable', () => {
       <MonitorsTable
         {...defaultProps}
         datasources={
-          ([
+          [
             {
               id: 'os-1',
               name: 'old-os',
@@ -199,7 +197,7 @@ describe('MonitorsTable', () => {
               mdsId: 'old-os-mds',
               version: '3.4.0',
             },
-          ] as unknown) as Datasource[]
+          ] as unknown as Datasource[]
         }
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}
@@ -207,7 +205,9 @@ describe('MonitorsTable', () => {
     );
 
     fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
-    expect(screen.getByLabelText('Create logs rule')).toHaveClass('euiListGroupItem-isDisabled');
+    expect(screen.getByLabelText('Create logs rule').closest('.euiListGroupItem')).toHaveClass(
+      'euiListGroupItem-isDisabled'
+    );
 
     fireEvent.click(screen.getByLabelText('Create anomaly detection rule'));
     expect(onCreateMonitor).toHaveBeenCalledWith('detector');

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -98,7 +98,7 @@ describe('MonitorsTable', () => {
     expect(screen.getByTestId('detectorFlyout')).toBeInTheDocument();
   });
 
-  it('opens the forecaster flyout and keeps forecasters out of bulk monitor selection', () => {
+  it('opens the forecaster flyout and allows forecaster selection', () => {
     render(
       <MonitorsTable
         {...defaultProps}
@@ -115,10 +115,106 @@ describe('MonitorsTable', () => {
       />
     );
 
-    expect(screen.getByLabelText('Select sample-cpu-forecaster')).toBeDisabled();
+    expect(screen.getByLabelText('Select sample-cpu-forecaster')).not.toBeDisabled();
     fireEvent.click(screen.getByRole('button', { name: /sample-cpu-forecaster/i }));
 
     expect(screen.getByTestId('forecasterFlyout')).toBeInTheDocument();
+  });
+
+  it('shows start and stop actions for selected detector and forecaster rows', () => {
+    const onStartResources = jest.fn();
+    const onStopResources = jest.fn();
+    const stoppedDetector = sampleRule({
+      id: 'det-1',
+      name: 'stopped-detector',
+      definitionType: 'detector',
+      monitorType: 'detector',
+      enabled: false,
+      status: 'Stopped' as const,
+      severity: 'info',
+      datasourceType: 'opensearch',
+    });
+    const runningForecaster = sampleRule({
+      id: 'forecast-1',
+      name: 'running-forecaster',
+      definitionType: 'forecaster',
+      monitorType: 'forecaster',
+      enabled: true,
+      status: 'Running' as const,
+      severity: 'info',
+      datasourceType: 'opensearch',
+    });
+
+    render(
+      <MonitorsTable
+        {...defaultProps}
+        rules={[stoppedDetector, runningForecaster]}
+        onStartResources={onStartResources}
+        onStopResources={onStopResources}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Select stopped-detector'));
+    fireEvent.click(screen.getByTestId('alertManagerStartSelectedResources'));
+    expect(onStartResources).toHaveBeenCalledWith([expect.objectContaining({ id: 'det-1' })]);
+
+    fireEvent.click(screen.getByLabelText('Select running-forecaster'));
+    fireEvent.click(screen.getByTestId('alertManagerStopSelectedResources'));
+    expect(onStopResources).toHaveBeenCalledWith([expect.objectContaining({ id: 'forecast-1' })]);
+  });
+
+  it('surfaces detector and forecaster create actions for OpenSearch datasources', () => {
+    const onCreateMonitor = jest.fn();
+    render(
+      <MonitorsTable
+        {...defaultProps}
+        datasources={
+          ([{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown) as Datasource[]
+        }
+        selectedDsIds={['os-1']}
+        onCreateMonitor={onCreateMonitor}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
+    fireEvent.click(screen.getByText('Anomaly detection rule'));
+    expect(onCreateMonitor).toHaveBeenCalledWith('detector');
+
+    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
+    fireEvent.click(screen.getByText('Forecasting rule'));
+    expect(onCreateMonitor).toHaveBeenCalledWith('forecaster');
+  });
+
+  it('keeps detector and forecaster create actions independent from logs version gating', () => {
+    const onCreateMonitor = jest.fn();
+    render(
+      <MonitorsTable
+        {...defaultProps}
+        datasources={
+          ([
+            {
+              id: 'os-1',
+              name: 'old-os',
+              type: 'opensearch',
+              mdsId: 'old-os-mds',
+              version: '3.4.0',
+            },
+          ] as unknown) as Datasource[]
+        }
+        selectedDsIds={['os-1']}
+        onCreateMonitor={onCreateMonitor}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
+    expect(screen.getByLabelText('Create logs rule')).toHaveClass('euiListGroupItem-isDisabled');
+
+    fireEvent.click(screen.getByLabelText('Create anomaly detection rule'));
+    expect(onCreateMonitor).toHaveBeenCalledWith('detector');
+
+    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
+    fireEvent.click(screen.getByLabelText('Create forecasting rule'));
+    expect(onCreateMonitor).toHaveBeenCalledWith('forecaster');
   });
 
   // Regression: deselecting all datasources must wipe both the dependent

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -52,7 +52,7 @@ const sampleRule = (overrides = {}) => ({
 // display-and-interaction ones the component currently accepts.
 const defaultProps = {
   rules: [sampleRule()],
-  datasources: ([{ id: 'ds-1', name: 'prom1', type: 'prometheus' }] as unknown) as Datasource[],
+  datasources: [{ id: 'ds-1', name: 'prom1', type: 'prometheus' }] as unknown as Datasource[],
   loading: false,
   onDelete: jest.fn(),
   selectedDsIds: ['ds-1'],
@@ -175,9 +175,7 @@ describe('MonitorsTable', () => {
     render(
       <MonitorsTable
         {...defaultProps}
-        datasources={
-          ([{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown) as Datasource[]
-        }
+        datasources={[{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown as Datasource[]}
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}
       />
@@ -198,7 +196,7 @@ describe('MonitorsTable', () => {
       <MonitorsTable
         {...defaultProps}
         datasources={
-          ([
+          [
             {
               id: 'os-1',
               name: 'old-os',
@@ -207,7 +205,7 @@ describe('MonitorsTable', () => {
               engineType: 'OpenSearch',
               version: '3.4.0',
             },
-          ] as unknown) as Datasource[]
+          ] as unknown as Datasource[]
         }
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}
@@ -263,14 +261,14 @@ describe('MonitorsTable', () => {
       <MonitorsTable
         {...defaultProps}
         datasources={
-          ([
+          [
             {
               id: 'os-1',
               name: 'OpenSearch',
               type: 'opensearch',
               version: '3.8.0',
             },
-          ] as unknown) as Datasource[]
+          ] as unknown as Datasource[]
         }
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -52,7 +52,7 @@ const sampleRule = (overrides = {}) => ({
 // display-and-interaction ones the component currently accepts.
 const defaultProps = {
   rules: [sampleRule()],
-  datasources: ([{ id: 'ds-1', name: 'prom1', type: 'prometheus' }] as unknown) as Datasource[],
+  datasources: [{ id: 'ds-1', name: 'prom1', type: 'prometheus' }] as unknown as Datasource[],
   loading: false,
   onDelete: jest.fn(),
   selectedDsIds: ['ds-1'],
@@ -175,9 +175,7 @@ describe('MonitorsTable', () => {
     render(
       <MonitorsTable
         {...defaultProps}
-        datasources={
-          ([{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown) as Datasource[]
-        }
+        datasources={[{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown as Datasource[]}
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}
       />
@@ -198,7 +196,7 @@ describe('MonitorsTable', () => {
       <MonitorsTable
         {...defaultProps}
         datasources={
-          ([
+          [
             {
               id: 'os-1',
               name: 'old-os',
@@ -206,7 +204,7 @@ describe('MonitorsTable', () => {
               mdsId: 'old-os-mds',
               version: '3.4.0',
             },
-          ] as unknown) as Datasource[]
+          ] as unknown as Datasource[]
         }
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}
@@ -232,14 +230,14 @@ describe('MonitorsTable', () => {
       <MonitorsTable
         {...defaultProps}
         datasources={
-          ([
+          [
             {
               id: 'os-1',
               name: 'OpenSearch',
               type: 'opensearch',
               version: '3.8.0',
             },
-          ] as unknown) as Datasource[]
+          ] as unknown as Datasource[]
         }
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -52,7 +52,7 @@ const sampleRule = (overrides = {}) => ({
 // display-and-interaction ones the component currently accepts.
 const defaultProps = {
   rules: [sampleRule()],
-  datasources: [{ id: 'ds-1', name: 'prom1', type: 'prometheus' }] as unknown as Datasource[],
+  datasources: ([{ id: 'ds-1', name: 'prom1', type: 'prometheus' }] as unknown) as Datasource[],
   loading: false,
   onDelete: jest.fn(),
   selectedDsIds: ['ds-1'],
@@ -175,7 +175,9 @@ describe('MonitorsTable', () => {
     render(
       <MonitorsTable
         {...defaultProps}
-        datasources={[{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown as Datasource[]}
+        datasources={
+          ([{ id: 'os-1', name: 'local', type: 'opensearch' }] as unknown) as Datasource[]
+        }
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}
       />
@@ -196,15 +198,16 @@ describe('MonitorsTable', () => {
       <MonitorsTable
         {...defaultProps}
         datasources={
-          [
+          ([
             {
               id: 'os-1',
               name: 'old-os',
               type: 'opensearch',
               mdsId: 'old-os-mds',
+              engineType: 'OpenSearch',
               version: '3.4.0',
             },
-          ] as unknown as Datasource[]
+          ] as unknown) as Datasource[]
         }
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}
@@ -224,20 +227,50 @@ describe('MonitorsTable', () => {
     expect(onCreateMonitor).toHaveBeenCalledWith('forecaster');
   });
 
+  it('disables detector and forecaster creation for an AOSS datasource', () => {
+    const onCreateMonitor = jest.fn();
+    render(
+      <MonitorsTable
+        {...defaultProps}
+        datasources={
+          [
+            {
+              id: 'aoss-1',
+              name: 'serverless',
+              type: 'opensearch',
+              mdsId: 'aoss-1',
+              engineType: 'OpenSearch Serverless',
+            },
+          ] as Datasource[]
+        }
+        selectedDsIds={['aoss-1']}
+        onCreateMonitor={onCreateMonitor}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
+    expect(
+      screen.getByLabelText('Create anomaly detection rule').closest('.euiListGroupItem')
+    ).toHaveClass('euiListGroupItem-isDisabled');
+    expect(
+      screen.getByLabelText('Create forecasting rule').closest('.euiListGroupItem')
+    ).toHaveClass('euiListGroupItem-isDisabled');
+  });
+
   it('enables metrics creation only when a selected datasource is Prometheus', () => {
     const onCreateMonitor = jest.fn();
     const { unmount } = render(
       <MonitorsTable
         {...defaultProps}
         datasources={
-          [
+          ([
             {
               id: 'os-1',
               name: 'OpenSearch',
               type: 'opensearch',
               version: '3.8.0',
             },
-          ] as unknown as Datasource[]
+          ] as unknown) as Datasource[]
         }
         selectedDsIds={['os-1']}
         onCreateMonitor={onCreateMonitor}

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -39,6 +39,7 @@ import {
 import { MonitorsTable } from './monitors_table';
 import { CreateMonitor, MonitorFormState } from './create_monitor';
 import type { PrometheusFormState } from './create_monitor/create_monitor_types';
+import { CreateAdRuleFlyout, CreateAdRuleType } from './create_ad_rule_flyout';
 import { EditMonitor } from './create_monitor/edit_monitor';
 import { AlertsDashboard } from './alerts_dashboard';
 import { AlertDetailFlyout } from './alert_detail_flyout';
@@ -60,6 +61,7 @@ import { ALERT_MANAGER_MAX_DATASOURCES_SETTING } from '../../../common/constants
 import { transformPplFormToPayload } from '../../../common/services/alerting/form_transforms';
 import { PPL_MONITOR_NAME_MAX } from '../../../common/services/alerting/validators';
 import { showMonitorCreatedToast } from './toast_helpers';
+import { isDetectorRule, isForecasterRule } from './shared_constants';
 import './alerting.scss';
 import type { OpenSearchFormState } from './create_monitor/create_monitor_types';
 import {
@@ -94,6 +96,14 @@ interface AlarmsPageProps {
 }
 
 type TabId = 'alerts' | 'rules' | 'routing';
+interface AdEditTarget {
+  ruleType: CreateAdRuleType;
+  id: string;
+  datasourceId: string;
+  initialStep?: 'define' | 'model';
+}
+
+type AdResourceLifecycleAction = 'start' | 'stop';
 
 /**
  * Parse a hash-route deep link of the form `#/rules?q=<query>&ds=<dsId>`
@@ -447,12 +457,14 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     },
     [rules, deletedRuleIds]
   );
-  // The popover's "Logs" entry maps to an OpenSearch monitor; "Metrics" toasts
-  // "coming soon" until PR 2 lights up the Prom create flyout. When the user
-  // picks Logs the flyout is forced to the OS variant via this override even
-  // if the parent-page selected datasource happens to be Prometheus.
+  // The popover's "Logs" entry maps to an OpenSearch monitor and "Metrics"
+  // maps to a Prometheus rule. When the user picks Logs the flyout is forced
+  // to the OS variant via this override even if the parent-page selected
+  // datasource happens to be Prometheus.
   const [createBackendType, setCreateBackendType] = useState<MonitorBackendType | null>(null);
+  const [createAdRuleType, setCreateAdRuleType] = useState<CreateAdRuleType | null>(null);
   const [editTarget, setEditTarget] = useState<{ dsId: string; ruleId: string } | null>(null);
+  const [editAdTarget, setEditAdTarget] = useState<AdEditTarget | null>(null);
   const [selectedAlert, setSelectedAlert] = useState<UnifiedAlertSummary | null>(null);
   // Whether the "new alerting experience" intro callout has been dismissed.
   // Persisted in localStorage so it stays hidden across reloads once closed.
@@ -591,6 +603,80 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     }
   };
 
+  const callAdResourceLifecycleMutation = async (
+    rule: UnifiedRuleSummary,
+    action: AdResourceLifecycleAction
+  ) => {
+    if (isDetectorRule(rule)) {
+      if (action === 'stop') return mutations.stopDetector(rule.id, rule.datasourceId);
+      return mutations.startDetector(rule.id, rule.datasourceId);
+    }
+
+    if (isForecasterRule(rule)) {
+      if (action === 'stop') return mutations.stopForecaster(rule.id, rule.datasourceId);
+      return mutations.startForecaster(rule.id, rule.datasourceId);
+    }
+
+    throw new Error('Lifecycle actions are only supported for detectors and forecasters');
+  };
+
+  const getOptimisticLifecycleState = (
+    rule: UnifiedRuleSummary,
+    action: AdResourceLifecycleAction
+  ): Pick<UnifiedRuleSummary, 'enabled' | 'status'> => {
+    if (action === 'stop') return { enabled: false, status: 'Stopped' };
+    return {
+      enabled: true,
+      status: isForecasterRule(rule) ? 'Initializing forecast' : 'Initializing',
+    };
+  };
+
+  const handleAdResourceLifecycle = async (
+    resources: UnifiedRuleSummary[],
+    action: AdResourceLifecycleAction
+  ) => {
+    const succeeded: UnifiedRuleSummary[] = [];
+
+    for (const resource of resources) {
+      if (!isDetectorRule(resource) && !isForecasterRule(resource)) continue;
+      try {
+        await callAdResourceLifecycleMutation(resource, action);
+        succeeded.push(resource);
+      } catch (e: unknown) {
+        addToast(
+          i18n.translate('observability.alerting.alarmsPage.toast.adResourceLifecycleFailed', {
+            defaultMessage: 'Failed to {action} {name}',
+            values: { action, name: resource.name },
+          }),
+          'danger',
+          extractServerErrorMessage(e)
+        );
+      }
+    }
+
+    if (succeeded.length > 0) {
+      setRules((prev) =>
+        prev.map((rule) => {
+          const updated = succeeded.find((resource) => resource.id === rule.id);
+          return updated
+            ? {
+                ...rule,
+                ...getOptimisticLifecycleState(updated, action),
+              }
+            : rule;
+        })
+      );
+      addToast(
+        i18n.translate('observability.alerting.alarmsPage.toast.adResourcesLifecycleUpdated', {
+          defaultMessage:
+            '{count} {count, plural, one {resource} other {resources}} {action, select, start {started} stop {stopped} other {updated}}',
+          values: { count: succeeded.length, action },
+        })
+      );
+      refetchRules();
+    }
+  };
+
   const handleDeleteRules = async (ids: string[]) => {
     const failed: string[] = [];
     for (const id of ids) {
@@ -617,6 +703,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           // only removed once it becomes empty).
           const groupName = rule.group || rule.name;
           await mutations.deletePrometheusRule(rule.datasourceId, groupName, rule.name);
+        } else if (isDetectorRule(rule)) {
+          await mutations.deleteDetector(id, rule.datasourceId);
+        } else if (isForecasterRule(rule)) {
+          await mutations.deleteForecaster(id, rule.datasourceId);
         } else {
           await mutations.deleteMonitor(id, rule.datasourceId);
         }
@@ -635,7 +725,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     if (succeeded.length > 0) {
       addToast(
         i18n.translate('observability.alerting.alarmsPage.toast.monitorsDeleted', {
-          defaultMessage: '{count} alert rule(s) deleted',
+          defaultMessage: '{count} selected resource(s) deleted',
           values: { count: succeeded.length },
         })
       );
@@ -863,6 +953,58 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     }
     return dsId;
   };
+
+  const resolveOpenSearchDatasourceId = useCallback((): string | null => {
+    const selected = selectedDsIds
+      .map((id) => datasources.find((ds) => ds.id === id))
+      .filter((ds): ds is Datasource => !!ds);
+    const openSearchDatasource = selected.find((ds) => ds.type === 'opensearch');
+    if (!openSearchDatasource) {
+      addToast(
+        i18n.translate('observability.alerting.alarmsPage.toast.selectOpenSearchDatasource', {
+          defaultMessage: 'Select an OpenSearch datasource before creating AD resources.',
+        }),
+        'warning'
+      );
+      return null;
+    }
+    return openSearchDatasource.id;
+  }, [addToast, datasources, selectedDsIds]);
+
+  const handleCreateADResource = useCallback(
+    (resourceType: 'detector' | 'forecaster') => {
+      if (resolveOpenSearchDatasourceId() === null) return;
+      setCreateAdRuleType(resourceType);
+    },
+    [resolveOpenSearchDatasourceId]
+  );
+
+  const handleEditDetectorSettings = useCallback((detector: UnifiedRuleSummary) => {
+    setEditAdTarget({
+      ruleType: 'detector',
+      id: detector.id,
+      datasourceId: detector.datasourceId,
+      initialStep: 'define',
+    });
+  }, []);
+
+  const handleEditDetectorFeatures = useCallback((detector: UnifiedRuleSummary) => {
+    setEditAdTarget({
+      ruleType: 'detector',
+      id: detector.id,
+      datasourceId: detector.datasourceId,
+      initialStep: 'model',
+    });
+  }, []);
+
+  const handleEditForecaster = useCallback((forecaster: UnifiedRuleSummary) => {
+    setEditAdTarget({
+      ruleType: 'forecaster',
+      id: forecaster.id,
+      datasourceId: forecaster.datasourceId,
+      initialStep: 'define',
+    });
+  }, []);
 
   // OS create flyout only authors PPL monitors; Prom rules pass raw form state
   // through (PR 2 will add the Prom transform).
@@ -1116,6 +1258,11 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           onDelete={handleDeleteRules}
           onClone={handleCloneRule}
           onEdit={(monitor) => setEditTarget({ dsId: monitor.datasourceId, ruleId: monitor.id })}
+          onEditDetectorSettings={handleEditDetectorSettings}
+          onEditDetectorFeatures={handleEditDetectorFeatures}
+          onEditForecaster={handleEditForecaster}
+          onStartResources={(resources) => handleAdResourceLifecycle(resources, 'start')}
+          onStopResources={(resources) => handleAdResourceLifecycle(resources, 'stop')}
           onToggleEnabled={handleToggleMonitorEnabled}
           onCreateMonitor={(type) => {
             if (type === 'logs') {
@@ -1124,6 +1271,8 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             } else if (type === 'metrics') {
               setCreateBackendType('prometheus');
               setShowCreateMonitor(true);
+            } else if (type === 'detector' || type === 'forecaster') {
+              handleCreateADResource(type);
             }
           }}
           selectedDsIds={selectedDsIds}
@@ -1229,6 +1378,32 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           isNameTaken={isNameTakenForCreate}
           submitError={pplSubmitError ? { pplMessage: pplSubmitError } : undefined}
           onClearPplSubmitError={() => setPplSubmitError(null)}
+        />
+      )}
+      {createAdRuleType && (
+        <CreateAdRuleFlyout
+          ruleType={createAdRuleType}
+          datasources={datasources}
+          selectedDsIds={selectedDsIds}
+          onCancel={() => setCreateAdRuleType(null)}
+          onCreated={() => {
+            setCreateAdRuleType(null);
+            refetchRules();
+          }}
+        />
+      )}
+      {editAdTarget && (
+        <CreateAdRuleFlyout
+          mode="edit"
+          ruleType={editAdTarget.ruleType}
+          editTarget={editAdTarget}
+          datasources={datasources}
+          selectedDsIds={selectedDsIds}
+          onCancel={() => setEditAdTarget(null)}
+          onUpdated={() => {
+            setEditAdTarget(null);
+            refetchRules();
+          }}
         />
       )}
       {editTarget && (

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -61,7 +61,7 @@ import { ALERT_MANAGER_MAX_DATASOURCES_SETTING } from '../../../common/constants
 import { transformPplFormToPayload } from '../../../common/services/alerting/form_transforms';
 import { PPL_MONITOR_NAME_MAX } from '../../../common/services/alerting/validators';
 import { showMonitorCreatedToast } from './toast_helpers';
-import { isDetectorRule, isForecasterRule } from './shared_constants';
+import { isAdResourceRunning, isDetectorRule, isForecasterRule } from './shared_constants';
 import './alerting.scss';
 import type { OpenSearchFormState } from './create_monitor/create_monitor_types';
 import {
@@ -704,8 +704,14 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           const groupName = rule.group || rule.name;
           await mutations.deletePrometheusRule(rule.datasourceId, groupName, rule.name);
         } else if (isDetectorRule(rule)) {
+          if (isAdResourceRunning(rule)) {
+            await mutations.stopDetector(id, rule.datasourceId);
+          }
           await mutations.deleteDetector(id, rule.datasourceId);
         } else if (isForecasterRule(rule)) {
+          if (isAdResourceRunning(rule)) {
+            await mutations.stopForecaster(id, rule.datasourceId);
+          }
           await mutations.deleteForecaster(id, rule.datasourceId);
         } else {
           await mutations.deleteMonitor(id, rule.datasourceId);

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -61,6 +61,7 @@ import { toAdApiDataSourceId, withAdApiDataSource } from './utils/ad_api_paths';
 import { useIndexMappings } from './hooks/use_index_mappings';
 import { useIndices } from './hooks/use_indices';
 import { useRuleDetail } from './hooks/use_rule_detail';
+import { isStandardOpenSearchDatasource } from './shared_constants';
 
 export type CreateAdRuleType = 'detector' | 'forecaster';
 type AdRuleFlyoutMode = 'create' | 'edit';
@@ -349,11 +350,11 @@ const parseFilterQuery = (value: string): Record<string, unknown> => {
   return trimmed ? JSON.parse(trimmed) : { match_all: {} };
 };
 
-const getOpenSearchDatasources = (datasources: Datasource[]): Datasource[] =>
-  datasources.filter((datasource) => datasource.type === 'opensearch');
+export const getCreateAdRuleDatasources = (datasources: Datasource[]): Datasource[] =>
+  datasources.filter(isStandardOpenSearchDatasource);
 
 const getInitialDatasourceId = (datasources: Datasource[], selectedDsIds?: string[]): string => {
-  const openSearchDatasources = getOpenSearchDatasources(datasources);
+  const openSearchDatasources = getCreateAdRuleDatasources(datasources);
   const selected = selectedDsIds
     ?.map((id) => openSearchDatasources.find((datasource) => datasource.id === id))
     .find(Boolean);
@@ -531,9 +532,9 @@ const buildFeatureFormState = (
 };
 
 const getFeatureForms = (resource: Record<string, unknown>): CreateAdFeatureFormState[] => {
-  const features = asArray(getField(resource, 'feature_attributes', 'featureAttributes')).map(
-    (feature) => buildFeatureFormState(resource, feature)
-  );
+  const features = asArray(
+    getField(resource, 'feature_attributes', 'featureAttributes')
+  ).map((feature) => buildFeatureFormState(resource, feature));
   return features.length > 0 ? features : [createInitialFeature()];
 };
 
@@ -1175,18 +1176,18 @@ const errorsForStep = (
       step === 0
         ? ['name', 'datasourceId', 'indices', 'timeField', 'filterQuery', 'resultIndex']
         : step === 1
-          ? [
-              'features',
-              'categoryField',
-              'interval',
-              'frequency',
-              'windowDelay',
-              'history',
-              'shingleSize',
-            ]
-          : step === 2
-            ? []
-            : Object.keys(errors);
+        ? [
+            'features',
+            'categoryField',
+            'interval',
+            'frequency',
+            'windowDelay',
+            'history',
+            'shingleSize',
+          ]
+        : step === 2
+        ? []
+        : Object.keys(errors);
   } else {
     stepFields =
       step === 0
@@ -1200,18 +1201,18 @@ const errorsForStep = (
             'categoryField',
           ]
         : step === 1
-          ? [
-              'interval',
-              'windowDelay',
-              'history',
-              'horizon',
-              'shingleSize',
-              'resultIndex',
-              'resultIndexMinAge',
-              'resultIndexMinSize',
-              'resultIndexTtl',
-            ]
-          : Object.keys(errors);
+        ? [
+            'interval',
+            'windowDelay',
+            'history',
+            'horizon',
+            'shingleSize',
+            'resultIndex',
+            'resultIndexMinAge',
+            'resultIndexMinSize',
+            'resultIndexTtl',
+          ]
+        : Object.keys(errors);
   }
 
   return Object.fromEntries(
@@ -1741,8 +1742,8 @@ const SuggestParametersDialog: React.FC<{
         typeof intervalValue === 'number'
           ? intervalValue
           : typeof frequencyValue === 'number'
-            ? frequencyValue
-            : 10;
+          ? frequencyValue
+          : 10;
 
       const historyValue = payload.history;
       const windowDelayValue = payload.windowDelay?.period?.interval;
@@ -1953,8 +1954,14 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
   onCreated,
   onUpdated,
 }) => {
-  const openSearchDatasources = useMemo(() => getOpenSearchDatasources(datasources), [datasources]);
   const isEdit = mode === 'edit' && !!editTarget;
+  const openSearchDatasources = useMemo(
+    () =>
+      isEdit
+        ? datasources.filter((datasource) => datasource.type === 'opensearch')
+        : getCreateAdRuleDatasources(datasources),
+    [datasources, isEdit]
+  );
   const isDetectorSettingsEdit =
     isEdit && ruleType === 'detector' && editTarget?.initialStep !== 'model';
   const isDetectorModelEdit =
@@ -2009,12 +2016,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           defaultMessage: 'Edit forecasting rule',
         })
     : isDetector
-      ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
-          defaultMessage: 'Create anomaly detection rule',
-        })
-      : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
-          defaultMessage: 'Create forecasting rule',
-        });
+    ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
+        defaultMessage: 'Create anomaly detection rule',
+      })
+    : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
+        defaultMessage: 'Create forecasting rule',
+      });
   const detectorStepTitles = isEdit
     ? [
         isDetectorModelEdit
@@ -2468,12 +2475,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               defaultMessage: 'Forecasting rule updated successfully',
             })
         : isDetector
-          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
-              defaultMessage: 'Anomaly detection rule created successfully',
-            })
-          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
-              defaultMessage: 'Forecasting rule created successfully',
-            });
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
+            defaultMessage: 'Anomaly detection rule created successfully',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
+            defaultMessage: 'Forecasting rule created successfully',
+          });
 
       if (isEdit && isDetector && shouldOfferStartDetectorAfterEdit && editTarget) {
         setStartAfterEditPrompt({
@@ -2521,12 +2528,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 defaultMessage: 'Failed to update forecasting rule',
               })
           : isDetector
-            ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
-                defaultMessage: 'Failed to create anomaly detection rule',
-              })
-            : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
-                defaultMessage: 'Failed to create forecasting rule',
-              }),
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
+              defaultMessage: 'Failed to create anomaly detection rule',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
+              defaultMessage: 'Failed to create forecasting rule',
+            }),
         text: message,
       });
     } finally {
@@ -4136,12 +4143,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           }
         )
       : isAwaitingDataToInit || isAwaitingDataToRestart
-        ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
-            defaultMessage: 'Cancel forecast to edit?',
-          })
-        : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
-            defaultMessage: 'Stop forecast to edit?',
-          });
+      ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
+          defaultMessage: 'Cancel forecast to edit?',
+        })
+      : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
+          defaultMessage: 'Stop forecast to edit?',
+        });
     const forecastModalDescription = (() => {
       if (isInitializingForecast) {
         return i18n.translate(
@@ -4312,14 +4319,14 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     }
                   )
               : isDetector
-                ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
-                    defaultMessage:
-                      'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
-                  })
-                : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
-                    defaultMessage:
-                      'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
-                  })}
+              ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
+                  defaultMessage:
+                    'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
+                })
+              : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
+                  defaultMessage:
+                    'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
+                })}
           </EuiText>
         </EuiFlyoutHeader>
 

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -56,6 +56,7 @@ import {
 import { i18n } from '@osd/i18n';
 import { ADDetector, ADForecaster, Datasource } from '../../../common/types/alerting';
 import { coreRefs } from '../../framework/core_refs';
+import { toAdApiDataSourceId, withAdApiDataSource } from './utils/ad_api_paths';
 import { useIndexMappings } from './hooks/use_index_mappings';
 import { useIndices } from './hooks/use_indices';
 import { useRuleDetail } from './hooks/use_rule_detail';
@@ -139,7 +140,6 @@ interface DetectorSuggestionResponse {
 
 const AD_DETECTOR_API = '/api/anomaly_detectors/detectors';
 const FORECASTER_API = '/api/forecasting/forecasters';
-const LOCAL_OPENSEARCH_DATASOURCE_IDS = new Set(['', 'local', 'local-cluster', 'local_cluster']);
 const OPENSEARCH_SERVERLESS_ENGINE_TYPE = 'OpenSearch Serverless';
 const OPENSEARCH_SERVERLESS_SIGV4_SERVICE = 'aoss';
 const DETECTOR_RUNNING_STATE = 'Running';
@@ -223,16 +223,8 @@ const createInitialForm = (datasourceId: string): CreateAdRuleFormState => ({
   startAfterCreate: true,
 });
 
-const normalizeDataSourceId = (dsId?: string): string =>
-  !dsId || LOCAL_OPENSEARCH_DATASOURCE_IDS.has(dsId) ? '' : dsId;
-
-const withOptionalDatasource = (basePath: string, dsId?: string): string => {
-  const normalized = normalizeDataSourceId(dsId);
-  return normalized ? `${basePath}/${encodeURIComponent(normalized)}` : basePath;
-};
-
-const isServerlessDataSource = async (dsId?: string): Promise<boolean> => {
-  const normalized = normalizeDataSourceId(dsId);
+const isServerlessDataSource = async (dsId: string): Promise<boolean> => {
+  const normalized = toAdApiDataSourceId(dsId);
   if (!normalized || !coreRefs.savedObjectsClient) return false;
 
   try {
@@ -351,35 +343,131 @@ const getInitialDatasourceId = (datasources: Datasource[], selectedDsIds?: strin
   return selected?.id ?? openSearchDatasources[0]?.id ?? '';
 };
 
-const buildFeatureMetadata = (features: CreateAdFeatureFormState[]) =>
-  features.reduce<Record<string, Record<string, string>>>((metadata, feature) => {
-    const featureName = feature.featureName.trim();
-    if (!featureName) return metadata;
-    metadata[featureName] = {
-      featureType: SIMPLE_FEATURE_TYPE,
-      aggregationBy: feature.aggregationBy,
-      aggregationOf: feature.aggregationOf.trim(),
-    };
-    return metadata;
-  }, {});
+const DIRECTION_THRESHOLD_TYPES = new Set(['ACTUAL_IS_BELOW_EXPECTED', 'ACTUAL_IS_OVER_EXPECTED']);
 
-const buildFeatureAttributes = (features: CreateAdFeatureFormState[]) =>
-  features
-    .filter((feature) => feature.featureName.trim())
-    .map((feature) => {
-      const featureName = feature.featureName.trim();
-      return {
-        ...(feature.featureId ? { featureId: feature.featureId } : {}),
-        featureName,
-        featureEnabled: feature.featureEnabled,
-        importance: 1,
-        aggregationQuery: {
-          [toSnakeCase(featureName)]: {
-            [feature.aggregationBy]: { field: feature.aggregationOf.trim() },
-          },
+const toCamelCaseKey = (key: string): string =>
+  key.replace(/_([a-z0-9])/g, (_match, character: string) => character.toUpperCase());
+
+const mapKeysToCamelCase = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(mapKeysToCamelCase);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [
+      toCamelCaseKey(key),
+      mapKeysToCamelCase(nestedValue),
+    ])
+  );
+};
+
+const normalizeFeatureForUpdate = (value: unknown): Record<string, unknown> => {
+  const feature = asRecord(value);
+  const aggregationQuery = getField(feature, 'aggregation_query', 'aggregationQuery');
+  const normalized = mapKeysToCamelCase(
+    Object.fromEntries(
+      Object.entries(feature).filter(
+        ([key]) => key !== 'aggregation_query' && key !== 'aggregationQuery'
+      )
+    )
+  ) as Record<string, unknown>;
+  return {
+    ...normalized,
+    ...(aggregationQuery !== undefined ? { aggregationQuery } : {}),
+  };
+};
+
+const normalizeExistingResourceForUpdate = (
+  resource?: ADDetector | ADForecaster
+): Record<string, unknown> => {
+  const stripped = stripReadOnlyResourceFields(resource);
+  const filterQuery = getField(stripped, 'filter_query', 'filterQuery');
+  const uiMetadata = getField(stripped, 'ui_metadata', 'uiMetadata');
+  const featureAttributes = getField(stripped, 'feature_attributes', 'featureAttributes');
+  const genericFields = Object.fromEntries(
+    Object.entries(stripped).filter(
+      ([key]) =>
+        ![
+          'filter_query',
+          'filterQuery',
+          'ui_metadata',
+          'uiMetadata',
+          'feature_attributes',
+          'featureAttributes',
+        ].includes(key)
+    )
+  );
+
+  return {
+    ...(mapKeysToCamelCase(genericFields) as Record<string, unknown>),
+    ...(filterQuery !== undefined ? { filterQuery } : {}),
+    ...(uiMetadata !== undefined ? { uiMetadata } : {}),
+    ...(featureAttributes !== undefined
+      ? { featureAttributes: asArray(featureAttributes).map(normalizeFeatureForUpdate) }
+      : {}),
+  };
+};
+
+const getRuleConditions = (rule: unknown): unknown[] => asArray(asRecord(rule).conditions);
+
+const getConditionFeatureName = (condition: unknown): string =>
+  stringValue(getField(asRecord(condition), 'feature_name', 'featureName'));
+
+const getConditionThresholdType = (condition: unknown): string =>
+  stringValue(getField(asRecord(condition), 'threshold_type', 'thresholdType'));
+
+const isDirectionRule = (rule: unknown): boolean => {
+  const conditions = getRuleConditions(rule);
+  return (
+    conditions.length === 1 &&
+    DIRECTION_THRESHOLD_TYPES.has(getConditionThresholdType(conditions[0]))
+  );
+};
+
+const inferFeatureDirection = (
+  resource: Record<string, unknown>,
+  featureName: string
+): CreateAdFeatureFormState['anomalyDirection'] => {
+  const directionCondition = asArray(resource.rules)
+    .filter(isDirectionRule)
+    .flatMap(getRuleConditions)
+    .find((condition) => getConditionFeatureName(condition) === featureName);
+  const thresholdType = getConditionThresholdType(directionCondition);
+  if (thresholdType === 'ACTUAL_IS_BELOW_EXPECTED') return 'above';
+  if (thresholdType === 'ACTUAL_IS_OVER_EXPECTED') return 'below';
+  return 'both';
+};
+
+export const buildDetectorRules = (
+  features: CreateAdFeatureFormState[],
+  resource?: ADDetector | ADForecaster
+): unknown[] => {
+  const retainedFeatureNames = new Set(
+    features.map((feature) => feature.featureName.trim()).filter(Boolean)
+  );
+  const preservedRules = asArray(asRecord(resource).rules)
+    .filter((rule) => !isDirectionRule(rule))
+    .filter((rule) => {
+      const referencedFeatures = getRuleConditions(rule)
+        .map(getConditionFeatureName)
+        .filter(Boolean);
+      return referencedFeatures.every((featureName) => retainedFeatureNames.has(featureName));
+    })
+    .map(mapKeysToCamelCase);
+  const directionRules = features
+    .filter((feature) => feature.featureName.trim() && feature.anomalyDirection !== 'both')
+    .map((feature) => ({
+      action: 'IGNORE_ANOMALY',
+      conditions: [
+        {
+          featureName: feature.featureName.trim(),
+          thresholdType:
+            feature.anomalyDirection === 'above'
+              ? 'ACTUAL_IS_BELOW_EXPECTED'
+              : 'ACTUAL_IS_OVER_EXPECTED',
         },
-      };
-    });
+      ],
+    }));
+  return [...preservedRules, ...directionRules];
+};
 
 const getUiMetadataFeatures = (resource: Record<string, unknown>): Record<string, unknown> =>
   asRecord(asRecord(getField(resource, 'ui_metadata', 'uiMetadata')).features);
@@ -419,17 +507,92 @@ const buildFeatureFormState = (
     featureId: stringValue(getField(feature, 'feature_id', 'featureId')) || undefined,
     featureName,
     featureEnabled: booleanValue(getField(feature, 'feature_enabled', 'featureEnabled'), true),
-    anomalyDirection: 'both',
+    anomalyDirection: inferFeatureDirection(resource, featureName),
     aggregationBy: stringValue(metadata.aggregationBy) || queryAggregation.aggregationBy,
     aggregationOf: stringValue(metadata.aggregationOf) || queryAggregation.aggregationOf,
   };
 };
 
 const getFeatureForms = (resource: Record<string, unknown>): CreateAdFeatureFormState[] => {
-  const features = asArray(getField(resource, 'feature_attributes', 'featureAttributes')).map(
-    (feature) => buildFeatureFormState(resource, feature)
-  );
+  const features = asArray(
+    getField(resource, 'feature_attributes', 'featureAttributes')
+  ).map((feature) => buildFeatureFormState(resource, feature));
   return features.length > 0 ? features : [createInitialFeature()];
+};
+
+const buildFeatureMetadata = (
+  features: CreateAdFeatureFormState[],
+  existingResource?: ADDetector | ADForecaster
+) => {
+  const existingFeatures = getUiMetadataFeatures(asRecord(existingResource));
+  return features.reduce<Record<string, Record<string, unknown>>>((metadata, feature) => {
+    const featureName = feature.featureName.trim();
+    if (!featureName) return metadata;
+    metadata[featureName] = {
+      ...asRecord(existingFeatures[featureName]),
+      featureType: SIMPLE_FEATURE_TYPE,
+      aggregationBy: feature.aggregationBy,
+      aggregationOf: feature.aggregationOf.trim(),
+    };
+    return metadata;
+  }, {});
+};
+
+const buildUiMetadata = (
+  features: CreateAdFeatureFormState[],
+  existingResource?: ADDetector | ADForecaster
+) => {
+  const existingUiMetadata = asRecord(
+    getField(asRecord(existingResource), 'ui_metadata', 'uiMetadata')
+  );
+  return {
+    ...existingUiMetadata,
+    features: buildFeatureMetadata(features, existingResource),
+    filters: asArray(existingUiMetadata.filters),
+  };
+};
+
+const buildFeatureAttributes = (
+  features: CreateAdFeatureFormState[],
+  existingResource?: ADDetector | ADForecaster
+) => {
+  const resource = asRecord(existingResource);
+  const existingFeatures = asArray(getField(resource, 'feature_attributes', 'featureAttributes'));
+
+  return features
+    .filter((feature) => feature.featureName.trim())
+    .map((feature) => {
+      const featureName = feature.featureName.trim();
+      const existingFeature = existingFeatures.find((candidate) => {
+        const record = asRecord(candidate);
+        const id = stringValue(getField(record, 'feature_id', 'featureId'));
+        const name = stringValue(getField(record, 'feature_name', 'featureName'));
+        return (feature.featureId && id === feature.featureId) || name === featureName;
+      });
+      const normalizedExistingFeature = normalizeFeatureForUpdate(existingFeature);
+      const previousForm = existingFeature
+        ? buildFeatureFormState(resource, existingFeature)
+        : undefined;
+      const aggregationUnchanged =
+        previousForm?.aggregationBy === feature.aggregationBy &&
+        previousForm?.aggregationOf === feature.aggregationOf;
+      const aggregationQuery = aggregationUnchanged
+        ? normalizedExistingFeature.aggregationQuery
+        : {
+            [toSnakeCase(featureName)]: {
+              [feature.aggregationBy]: { field: feature.aggregationOf.trim() },
+            },
+          };
+
+      return {
+        ...normalizedExistingFeature,
+        ...(feature.featureId ? { featureId: feature.featureId } : {}),
+        featureName,
+        featureEnabled: feature.featureEnabled,
+        importance: normalizedExistingFeature.importance ?? 1,
+        aggregationQuery,
+      };
+    });
 };
 
 const getCategoryFieldFromResource = (resource: Record<string, unknown>): string[] =>
@@ -586,7 +749,7 @@ const stripReadOnlyResourceFields = (
   );
 };
 
-const formFromAdResource = (
+export const formFromAdResource = (
   ruleType: CreateAdRuleType,
   resource: ADDetector | ADForecaster,
   datasourceId: string
@@ -624,7 +787,7 @@ const formFromAdResource = (
   };
 };
 
-const buildRulePayload = (
+export const buildRulePayload = (
   ruleType: CreateAdRuleType,
   form: CreateAdRuleFormState,
   options: {
@@ -634,17 +797,14 @@ const buildRulePayload = (
 ) => {
   const existingResource = asRecord(options.existingResource);
   const commonPayload = {
-    ...stripReadOnlyResourceFields(options.existingResource),
+    ...normalizeExistingResourceForUpdate(options.existingResource),
     ...getConcurrencyFields(existingResource),
     name: form.name.trim(),
     description: form.description.trim(),
     indices: form.indices,
     filterQuery: parseFilterQuery(form.filterQuery),
-    uiMetadata: {
-      features: buildFeatureMetadata(form.features),
-      filters: [],
-    },
-    featureAttributes: buildFeatureAttributes(form.features),
+    uiMetadata: buildUiMetadata(form.features, options.existingResource),
+    featureAttributes: buildFeatureAttributes(form.features, options.existingResource),
     timeField: form.timeField,
     windowDelay: {
       period: { interval: toPositiveInt(form.windowDelay, 0), unit: MINUTES_UNIT },
@@ -660,6 +820,7 @@ const buildRulePayload = (
     const detectorFrequency = parsePositiveInt(form.frequency) ?? detectorInterval;
     return {
       ...commonPayload,
+      resultIndex: undefined,
       ...(shouldIncludeResultIndex && form.resultIndex.trim()
         ? {
             resultIndex: `${CUSTOM_AD_RESULT_INDEX_PREFIX}${form.resultIndex.trim()}`,
@@ -672,7 +833,7 @@ const buildRulePayload = (
         period: { interval: detectorFrequency, unit: MINUTES_UNIT },
       },
       history: Math.max(1, toPositiveInt(form.history, 40)),
-      rules: [],
+      rules: buildDetectorRules(form.features, options.existingResource),
     };
   }
 
@@ -729,9 +890,9 @@ const featureErrorKey = (
   field: 'featureName' | 'aggregationOf' | 'featureLimit'
 ): string => `features.${index}.${field}`;
 
-const validateForm = (
+export const validateForm = (
   form: CreateAdRuleFormState,
-  options: { customResultIndexRequired?: boolean } = {}
+  options: { customResultIndexRequired?: boolean; ruleType: CreateAdRuleType }
 ): Record<string, string> => {
   const errors: Record<string, string> = {};
   if (!form.name.trim()) {
@@ -851,6 +1012,7 @@ const validateForm = (
   const frequencyValue = parsePositiveInt(form.frequency);
   const windowDelayValue = parseNonNegativeInt(form.windowDelay);
   const historyValue = parsePositiveInt(form.history);
+  const horizonValue = parsePositiveInt(form.horizon);
 
   if (intervalValue === undefined) {
     errors.interval = i18n.translate('observability.alerting.createAdRuleFlyout.intervalInvalid', {
@@ -885,9 +1047,17 @@ const validateForm = (
       }
     );
   }
-  if (form.history !== '' && historyValue === undefined) {
+  if (historyValue === undefined || historyValue < 40 || historyValue > 10000) {
     errors.history = i18n.translate('observability.alerting.createAdRuleFlyout.historyInvalid', {
-      defaultMessage: 'History must be a positive integer.',
+      defaultMessage: 'History must be an integer between 40 and 10,000.',
+    });
+  }
+  if (
+    options.ruleType === 'forecaster' &&
+    (horizonValue === undefined || horizonValue < 1 || horizonValue > 180)
+  ) {
+    errors.horizon = i18n.translate('observability.alerting.createAdRuleFlyout.horizonInvalid', {
+      defaultMessage: 'Horizon must be an integer between 1 and 180.',
     });
   }
   if (form.shingleSize < 1 || form.shingleSize > 128) {
@@ -912,18 +1082,18 @@ const errorsForStep = (
       step === 0
         ? ['name', 'datasourceId', 'indices', 'timeField', 'filterQuery', 'resultIndex']
         : step === 1
-          ? [
-              'features',
-              'categoryField',
-              'interval',
-              'frequency',
-              'windowDelay',
-              'history',
-              'shingleSize',
-            ]
-          : step === 2
-            ? []
-            : Object.keys(errors);
+        ? [
+            'features',
+            'categoryField',
+            'interval',
+            'frequency',
+            'windowDelay',
+            'history',
+            'shingleSize',
+          ]
+        : step === 2
+        ? []
+        : Object.keys(errors);
   } else {
     stepFields =
       step === 0
@@ -937,8 +1107,8 @@ const errorsForStep = (
             'categoryField',
           ]
         : step === 1
-          ? ['interval', 'windowDelay', 'history', 'horizon', 'shingleSize']
-          : Object.keys(errors);
+        ? ['interval', 'windowDelay', 'history', 'horizon', 'shingleSize']
+        : Object.keys(errors);
   }
 
   return Object.fromEntries(
@@ -1437,15 +1607,9 @@ const SuggestParametersDialog: React.FC<{
     try {
       const response = await coreRefs.http?.post<
         ApiResponse<DetectorSuggestionResponse> | DetectorSuggestionResponse
-      >(
-        withOptionalDatasource(
-          `${AD_DETECTOR_API}/_suggest/${suggestionParams}`,
-          form.datasourceId
-        ),
-        {
-          body: JSON.stringify(buildDetectorSuggestionPayload(form, intervalForSuggestion)),
-        }
-      );
+      >(withAdApiDataSource(`${AD_DETECTOR_API}/_suggest/${suggestionParams}`, form.datasourceId), {
+        body: JSON.stringify(buildDetectorSuggestionPayload(form, intervalForSuggestion)),
+      });
       const payload =
         response && 'response' in response
           ? (response.response as DetectorSuggestionResponse | undefined)
@@ -1474,8 +1638,8 @@ const SuggestParametersDialog: React.FC<{
         typeof intervalValue === 'number'
           ? intervalValue
           : typeof frequencyValue === 'number'
-            ? frequencyValue
-            : 10;
+          ? frequencyValue
+          : 10;
 
       const historyValue = payload.history;
       const windowDelayValue = payload.windowDelay?.period?.interval;
@@ -1742,12 +1906,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           defaultMessage: 'Edit forecasting rule',
         })
     : isDetector
-      ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
-          defaultMessage: 'Create anomaly detection rule',
-        })
-      : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
-          defaultMessage: 'Create forecasting rule',
-        });
+    ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
+        defaultMessage: 'Create anomaly detection rule',
+      })
+    : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
+        defaultMessage: 'Create forecasting rule',
+      });
   const detectorStepTitles = isEdit
     ? [
         isDetectorModelEdit
@@ -1783,7 +1947,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
         }),
       ];
   const finalStep = stepTitles.length - 1;
-  const allErrors = validateForm(form, { customResultIndexRequired });
+  const allErrors = validateForm(form, { customResultIndexRequired, ruleType });
   const currentValidationStep = isSingleDetectorEdit ? editValidationStep : currentStep;
   const submitBlockingErrors = isEdit
     ? errorsForStep(allErrors, currentValidationStep, ruleType)
@@ -1946,7 +2110,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
       setSubmitError(null);
       try {
         const response = await coreRefs.http?.post<ApiResponse>(
-          withOptionalDatasource(
+          withAdApiDataSource(
             `${AD_DETECTOR_API}/${encodeURIComponent(detectorId)}/start`,
             datasourceId
           )
@@ -2007,7 +2171,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
 
         if (isDetectorRealTimeJobRunning(existingResource)) {
           const response = await coreRefs.http?.post<ApiResponse>(
-            withOptionalDatasource(
+            withAdApiDataSource(
               `${AD_DETECTOR_API}/${encodeURIComponent(editTarget.id)}/stop/false`,
               form.datasourceId
             )
@@ -2017,7 +2181,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
 
         if (isDetectorHistoricalJobRunning(existingResource)) {
           const response = await coreRefs.http?.post<ApiResponse>(
-            withOptionalDatasource(
+            withAdApiDataSource(
               `${AD_DETECTOR_API}/${encodeURIComponent(editTarget.id)}/stop/true`,
               form.datasourceId
             )
@@ -2034,7 +2198,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
         setShouldOfferStartDetectorAfterEdit(stoppedRealTimeDetector);
       } else {
         const response = await coreRefs.http?.post<ApiResponse>(
-          withOptionalDatasource(
+          withAdApiDataSource(
             `${FORECASTER_API}/${encodeURIComponent(editTarget.id)}/stop`,
             form.datasourceId
           )
@@ -2101,7 +2265,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
     }
     setHasSubmitted(true);
     const stepErrors = errorsForStep(
-      validateForm(form, { customResultIndexRequired }),
+      validateForm(form, { customResultIndexRequired, ruleType }),
       currentValidationStep,
       ruleType
     );
@@ -2137,7 +2301,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
       );
       return;
     }
-    const validationErrors = validateForm(form, { customResultIndexRequired });
+    const validationErrors = validateForm(form, { customResultIndexRequired, ruleType });
     const blockingErrors = isEdit
       ? errorsForStep(validationErrors, currentValidationStep, ruleType)
       : validationErrors;
@@ -2148,11 +2312,11 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
       const basePath = isDetector ? AD_DETECTOR_API : FORECASTER_API;
       const requestPath =
         isEdit && editTarget
-          ? withOptionalDatasource(
+          ? withAdApiDataSource(
               `${basePath}/${encodeURIComponent(editTarget.id)}`,
               form.datasourceId
             )
-          : withOptionalDatasource(basePath, form.datasourceId);
+          : withAdApiDataSource(basePath, form.datasourceId);
       const requestBody = JSON.stringify(
         buildRulePayload(ruleType, form, {
           customResultIndexRequired,
@@ -2172,13 +2336,23 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
       }
 
       const createdId = extractCreatedId(response);
+      let autoStartError: string | null = null;
       if (!isEdit && isDetector && createdId && form.startAfterCreate) {
-        await coreRefs.http?.post(
-          withOptionalDatasource(
-            `${basePath}/${encodeURIComponent(createdId)}/start`,
-            form.datasourceId
-          )
-        );
+        try {
+          const startResponse = await coreRefs.http?.post<ApiResponse>(
+            withAdApiDataSource(
+              `${basePath}/${encodeURIComponent(createdId)}/start`,
+              form.datasourceId
+            )
+          );
+          if (!startResponse?.ok) {
+            throw new Error(
+              startResponse?.error || startResponse?.message || 'Start request failed'
+            );
+          }
+        } catch (error) {
+          autoStartError = buildErrorMessage(error);
+        }
       }
 
       const successToastTitle = isEdit
@@ -2190,12 +2364,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               defaultMessage: 'Forecasting rule updated successfully',
             })
         : isDetector
-          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
-              defaultMessage: 'Anomaly detection rule created successfully',
-            })
-          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
-              defaultMessage: 'Forecasting rule created successfully',
-            });
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
+            defaultMessage: 'Anomaly detection rule created successfully',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
+            defaultMessage: 'Forecasting rule created successfully',
+          });
 
       if (isEdit && isDetector && shouldOfferStartDetectorAfterEdit && editTarget) {
         setStartAfterEditPrompt({
@@ -2211,6 +2385,17 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
         onUpdated?.();
       } else {
         onCreated?.();
+        if (autoStartError) {
+          coreRefs.toasts?.addWarning({
+            title: i18n.translate(
+              'observability.alerting.createAdRuleFlyout.detectorCreatedStartFailed',
+              {
+                defaultMessage: 'Rule created but the detector could not be started',
+              }
+            ),
+            text: autoStartError,
+          });
+        }
       }
     } catch (error) {
       const message = buildErrorMessage(error);
@@ -2225,12 +2410,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 defaultMessage: 'Failed to update forecasting rule',
               })
           : isDetector
-            ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
-                defaultMessage: 'Failed to create anomaly detection rule',
-              })
-            : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
-                defaultMessage: 'Failed to create forecasting rule',
-              }),
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
+              defaultMessage: 'Failed to create anomaly detection rule',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
+              defaultMessage: 'Failed to create forecasting rule',
+            }),
         text: message,
       });
     } finally {
@@ -2335,21 +2520,40 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               </span>
             </p>
           }
-          hint={i18n.translate('observability.alerting.createAdRuleFlyout.descriptionHint', {
-            defaultMessage: isDetector
-              ? 'Describe the purpose of the detector.'
-              : 'Describe the purpose of the forecaster.',
-          })}
+          hint={
+            isDetector
+              ? i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.detectorDescriptionHint',
+                  {
+                    defaultMessage: 'Describe the purpose of the detector.',
+                  }
+                )
+              : i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.forecasterDescriptionHint',
+                  {
+                    defaultMessage: 'Describe the purpose of the forecaster.',
+                  }
+                )
+          }
         >
           <EuiTextArea
             value={form.description}
             onChange={(e) => updateForm('description', e.target.value)}
-            placeholder={i18n.translate(
-              'observability.alerting.createAdRuleFlyout.descriptionPlaceholder',
-              {
-                defaultMessage: isDetector ? 'Describe the detector' : 'Describe the forecaster',
-              }
-            )}
+            placeholder={
+              isDetector
+                ? i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.detectorDescriptionPlaceholder',
+                    {
+                      defaultMessage: 'Describe the detector',
+                    }
+                  )
+                : i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.forecasterDescriptionPlaceholder',
+                    {
+                      defaultMessage: 'Describe the forecaster',
+                    }
+                  )
+            }
             rows={3}
             data-test-subj="alertManagerCreateAdRuleDescription"
           />
@@ -3119,7 +3323,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                   value={form.interval}
                   min={1}
                   style={{ width: '100%' }}
-                  onChange={(e) => updateForm('interval', Number(e.target.value))}
+                  onChange={(e) => updateForm('interval', parseNumberInputValue(e.target.value))}
                 />
               </div>
             </EuiFlexItem>
@@ -3155,7 +3359,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                   value={form.windowDelay}
                   min={0}
                   style={{ width: '100%' }}
-                  onChange={(e) => updateForm('windowDelay', Number(e.target.value))}
+                  onChange={(e) => updateForm('windowDelay', parseNumberInputValue(e.target.value))}
                 />
               </div>
             </EuiFlexItem>
@@ -3191,7 +3395,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                   min={1}
                   max={180}
                   style={{ width: '100%' }}
-                  onChange={(e) => updateForm('horizon', Number(e.target.value))}
+                  onChange={(e) => updateForm('horizon', parseNumberInputValue(e.target.value))}
                 />
               </div>
             </EuiFlexItem>
@@ -3230,7 +3434,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                   min={40}
                   max={10000}
                   style={{ width: '100%' }}
-                  onChange={(e) => updateForm('history', Number(e.target.value))}
+                  onChange={(e) => updateForm('history', parseNumberInputValue(e.target.value))}
                 />
               </div>
             </EuiFlexItem>
@@ -3288,7 +3492,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
         .filter((feature) => feature.featureName.trim())
         .map(
           (feature) =>
-            `${feature.featureName.trim()}: ${feature.aggregationBy}(${feature.aggregationOf.trim()})`
+            `${feature.featureName.trim()}: ${
+              feature.aggregationBy
+            }(${feature.aggregationOf.trim()})`
         )
         .join(', ') || '-';
     const descriptionItems = [
@@ -3531,12 +3737,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           }
         )
       : isAwaitingDataToInit || isAwaitingDataToRestart
-        ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
-            defaultMessage: 'Cancel forecast to edit?',
-          })
-        : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
-            defaultMessage: 'Stop forecast to edit?',
-          });
+      ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
+          defaultMessage: 'Cancel forecast to edit?',
+        })
+      : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
+          defaultMessage: 'Stop forecast to edit?',
+        });
     const forecastModalDescription = (() => {
       if (isInitializingForecast) {
         return i18n.translate(
@@ -3671,7 +3877,6 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
       if (isDetectorSettingsEdit) return renderDefineStep();
       if (currentStep === 0) return renderDefineStep();
       if (currentStep === 1) return renderDetectorModelStep();
-      if (isEdit) return renderReviewStep();
       if (currentStep === 2) return renderJobsStep();
       return renderReviewStep();
     }
@@ -3708,14 +3913,14 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     }
                   )
               : isDetector
-                ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
-                    defaultMessage:
-                      'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
-                  })
-                : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
-                    defaultMessage:
-                      'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
-                  })}
+              ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
+                  defaultMessage:
+                    'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
+                })
+              : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
+                  defaultMessage:
+                    'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
+                })}
           </EuiText>
         </EuiFlyoutHeader>
 

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -531,9 +531,9 @@ const buildFeatureFormState = (
 };
 
 const getFeatureForms = (resource: Record<string, unknown>): CreateAdFeatureFormState[] => {
-  const features = asArray(
-    getField(resource, 'feature_attributes', 'featureAttributes')
-  ).map((feature) => buildFeatureFormState(resource, feature));
+  const features = asArray(getField(resource, 'feature_attributes', 'featureAttributes')).map(
+    (feature) => buildFeatureFormState(resource, feature)
+  );
   return features.length > 0 ? features : [createInitialFeature()];
 };
 
@@ -1175,18 +1175,18 @@ const errorsForStep = (
       step === 0
         ? ['name', 'datasourceId', 'indices', 'timeField', 'filterQuery', 'resultIndex']
         : step === 1
-        ? [
-            'features',
-            'categoryField',
-            'interval',
-            'frequency',
-            'windowDelay',
-            'history',
-            'shingleSize',
-          ]
-        : step === 2
-        ? []
-        : Object.keys(errors);
+          ? [
+              'features',
+              'categoryField',
+              'interval',
+              'frequency',
+              'windowDelay',
+              'history',
+              'shingleSize',
+            ]
+          : step === 2
+            ? []
+            : Object.keys(errors);
   } else {
     stepFields =
       step === 0
@@ -1200,18 +1200,18 @@ const errorsForStep = (
             'categoryField',
           ]
         : step === 1
-        ? [
-            'interval',
-            'windowDelay',
-            'history',
-            'horizon',
-            'shingleSize',
-            'resultIndex',
-            'resultIndexMinAge',
-            'resultIndexMinSize',
-            'resultIndexTtl',
-          ]
-        : Object.keys(errors);
+          ? [
+              'interval',
+              'windowDelay',
+              'history',
+              'horizon',
+              'shingleSize',
+              'resultIndex',
+              'resultIndexMinAge',
+              'resultIndexMinSize',
+              'resultIndexTtl',
+            ]
+          : Object.keys(errors);
   }
 
   return Object.fromEntries(
@@ -1741,8 +1741,8 @@ const SuggestParametersDialog: React.FC<{
         typeof intervalValue === 'number'
           ? intervalValue
           : typeof frequencyValue === 'number'
-          ? frequencyValue
-          : 10;
+            ? frequencyValue
+            : 10;
 
       const historyValue = payload.history;
       const windowDelayValue = payload.windowDelay?.period?.interval;
@@ -2009,12 +2009,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           defaultMessage: 'Edit forecasting rule',
         })
     : isDetector
-    ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
-        defaultMessage: 'Create anomaly detection rule',
-      })
-    : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
-        defaultMessage: 'Create forecasting rule',
-      });
+      ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
+          defaultMessage: 'Create anomaly detection rule',
+        })
+      : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
+          defaultMessage: 'Create forecasting rule',
+        });
   const detectorStepTitles = isEdit
     ? [
         isDetectorModelEdit
@@ -2468,12 +2468,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               defaultMessage: 'Forecasting rule updated successfully',
             })
         : isDetector
-        ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
-            defaultMessage: 'Anomaly detection rule created successfully',
-          })
-        : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
-            defaultMessage: 'Forecasting rule created successfully',
-          });
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
+              defaultMessage: 'Anomaly detection rule created successfully',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
+              defaultMessage: 'Forecasting rule created successfully',
+            });
 
       if (isEdit && isDetector && shouldOfferStartDetectorAfterEdit && editTarget) {
         setStartAfterEditPrompt({
@@ -2521,12 +2521,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 defaultMessage: 'Failed to update forecasting rule',
               })
           : isDetector
-          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
-              defaultMessage: 'Failed to create anomaly detection rule',
-            })
-          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
-              defaultMessage: 'Failed to create forecasting rule',
-            }),
+            ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
+                defaultMessage: 'Failed to create anomaly detection rule',
+              })
+            : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
+                defaultMessage: 'Failed to create forecasting rule',
+              }),
         text: message,
       });
     } finally {
@@ -4136,12 +4136,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           }
         )
       : isAwaitingDataToInit || isAwaitingDataToRestart
-      ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
-          defaultMessage: 'Cancel forecast to edit?',
-        })
-      : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
-          defaultMessage: 'Stop forecast to edit?',
-        });
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
+            defaultMessage: 'Cancel forecast to edit?',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
+            defaultMessage: 'Stop forecast to edit?',
+          });
     const forecastModalDescription = (() => {
       if (isInitializingForecast) {
         return i18n.translate(
@@ -4312,14 +4312,14 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     }
                   )
               : isDetector
-              ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
-                  defaultMessage:
-                    'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
-                })
-              : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
-                  defaultMessage:
-                    'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
-                })}
+                ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
+                    defaultMessage:
+                      'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
+                  })
+                : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
+                    defaultMessage:
+                      'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
+                  })}
           </EuiText>
         </EuiFlyoutHeader>
 

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -28,14 +28,12 @@ import {
   EuiSelect,
   EuiTextArea,
   EuiDescriptionList,
-  EuiFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiFlyoutHeader,
-  EuiFormRow,
   EuiHorizontalRule,
   EuiLink,
   EuiLoadingSpinner,
@@ -428,9 +426,9 @@ const buildFeatureFormState = (
 };
 
 const getFeatureForms = (resource: Record<string, unknown>): CreateAdFeatureFormState[] => {
-  const features = asArray(
-    getField(resource, 'feature_attributes', 'featureAttributes')
-  ).map((feature) => buildFeatureFormState(resource, feature));
+  const features = asArray(getField(resource, 'feature_attributes', 'featureAttributes')).map(
+    (feature) => buildFeatureFormState(resource, feature)
+  );
   return features.length > 0 ? features : [createInitialFeature()];
 };
 
@@ -744,7 +742,9 @@ const validateForm = (
   if (!form.datasourceId) {
     errors.datasourceId = i18n.translate(
       'observability.alerting.createAdRuleFlyout.datasourceRequired',
-      { defaultMessage: 'OpenSearch datasource is required.' }
+      {
+        defaultMessage: 'OpenSearch datasource is required.',
+      }
     );
   }
   if (form.indices.length === 0) {
@@ -755,7 +755,9 @@ const validateForm = (
   if (!form.timeField.trim()) {
     errors.timeField = i18n.translate(
       'observability.alerting.createAdRuleFlyout.timeFieldRequired',
-      { defaultMessage: 'Time field is required.' }
+      {
+        defaultMessage: 'Time field is required.',
+      }
     );
   }
   if (
@@ -764,7 +766,9 @@ const validateForm = (
   ) {
     errors.resultIndex = i18n.translate(
       'observability.alerting.createAdRuleFlyout.resultIndexRequired',
-      { defaultMessage: 'Result index name is required.' }
+      {
+        defaultMessage: 'Result index name is required.',
+      }
     );
   }
   if (form.features.length === 0) {
@@ -818,13 +822,17 @@ const validateForm = (
   if (form.categoryFieldEnabled && form.categoryField.length === 0) {
     errors.categoryField = i18n.translate(
       'observability.alerting.createAdRuleFlyout.categoryFieldRequired',
-      { defaultMessage: 'Select at least one categorical field.' }
+      {
+        defaultMessage: 'Select at least one categorical field.',
+      }
     );
   }
   if (form.categoryField.length > 2) {
     errors.categoryField = i18n.translate(
       'observability.alerting.createAdRuleFlyout.categoryFieldMax',
-      { defaultMessage: 'Select no more than two categorical fields.' }
+      {
+        defaultMessage: 'Select no more than two categorical fields.',
+      }
     );
   }
   if (form.filterQuery.trim()) {
@@ -833,7 +841,9 @@ const validateForm = (
     } catch {
       errors.filterQuery = i18n.translate(
         'observability.alerting.createAdRuleFlyout.filterQueryInvalid',
-        { defaultMessage: 'Filter query must be valid JSON.' }
+        {
+          defaultMessage: 'Filter query must be valid JSON.',
+        }
       );
     }
   }
@@ -850,7 +860,9 @@ const validateForm = (
   if (form.frequency !== '' && frequencyValue === undefined) {
     errors.frequency = i18n.translate(
       'observability.alerting.createAdRuleFlyout.frequencyInvalid',
-      { defaultMessage: 'Frequency must be at least 1 minute.' }
+      {
+        defaultMessage: 'Frequency must be at least 1 minute.',
+      }
     );
   }
   if (
@@ -860,13 +872,17 @@ const validateForm = (
   ) {
     errors.frequency = i18n.translate(
       'observability.alerting.createAdRuleFlyout.frequencyMultipleInvalid',
-      { defaultMessage: 'Frequency must be a multiple of interval.' }
+      {
+        defaultMessage: 'Frequency must be a multiple of interval.',
+      }
     );
   }
   if (form.windowDelay !== '' && windowDelayValue === undefined) {
     errors.windowDelay = i18n.translate(
       'observability.alerting.createAdRuleFlyout.windowDelayInvalid',
-      { defaultMessage: 'Window delay must be a non-negative integer.' }
+      {
+        defaultMessage: 'Window delay must be a non-negative integer.',
+      }
     );
   }
   if (form.history !== '' && historyValue === undefined) {
@@ -877,7 +893,9 @@ const validateForm = (
   if (form.shingleSize < 1 || form.shingleSize > 128) {
     errors.shingleSize = i18n.translate(
       'observability.alerting.createAdRuleFlyout.shingleInvalid',
-      { defaultMessage: 'Shingle size must be between 1 and 128.' }
+      {
+        defaultMessage: 'Shingle size must be between 1 and 128.',
+      }
     );
   }
   return errors;
@@ -894,18 +912,18 @@ const errorsForStep = (
       step === 0
         ? ['name', 'datasourceId', 'indices', 'timeField', 'filterQuery', 'resultIndex']
         : step === 1
-        ? [
-            'features',
-            'categoryField',
-            'interval',
-            'frequency',
-            'windowDelay',
-            'history',
-            'shingleSize',
-          ]
-        : step === 2
-        ? []
-        : Object.keys(errors);
+          ? [
+              'features',
+              'categoryField',
+              'interval',
+              'frequency',
+              'windowDelay',
+              'history',
+              'shingleSize',
+            ]
+          : step === 2
+            ? []
+            : Object.keys(errors);
   } else {
     stepFields =
       step === 0
@@ -919,8 +937,8 @@ const errorsForStep = (
             'categoryField',
           ]
         : step === 1
-        ? ['interval', 'windowDelay', 'history', 'horizon', 'shingleSize']
-        : Object.keys(errors);
+          ? ['interval', 'windowDelay', 'history', 'horizon', 'shingleSize']
+          : Object.keys(errors);
   }
 
   return Object.fromEntries(
@@ -1128,7 +1146,9 @@ const AdTimestampSelector: React.FC<{
         onChange={(options) => onChange(options[0]?.label ?? '')}
         placeholder={i18n.translate(
           'observability.alerting.createAdRuleFlyout.timestampFieldPlaceholder',
-          { defaultMessage: 'Find timestamp' }
+          {
+            defaultMessage: 'Find timestamp',
+          }
         )}
         data-test-subj="alertManagerCreateAdRuleTimestamp"
       />
@@ -1184,7 +1204,9 @@ const FeatureFieldSelector: React.FC<{
         }}
         placeholder={i18n.translate(
           'observability.alerting.createAdRuleFlyout.featureFieldPlaceholder',
-          { defaultMessage: 'Select field' }
+          {
+            defaultMessage: 'Select field',
+          }
         )}
         data-test-subj={dataTestSubj ?? 'alertManagerCreateAdRuleFeatureField'}
       />
@@ -1275,11 +1297,15 @@ const CategoryFieldSelector: React.FC<{
               ruleType === 'detector'
                 ? i18n.translate(
                     'observability.alerting.createAdRuleFlyout.enableDetectorCategory',
-                    { defaultMessage: 'Enable categorical fields' }
+                    {
+                      defaultMessage: 'Enable categorical fields',
+                    }
                   )
                 : i18n.translate(
                     'observability.alerting.createAdRuleFlyout.enableForecasterCategory',
-                    { defaultMessage: 'Split time series using categorical fields' }
+                    {
+                      defaultMessage: 'Split time series using categorical fields',
+                    }
                   )
             }
             checked={enabled}
@@ -1317,7 +1343,9 @@ const CategoryFieldSelector: React.FC<{
                     })
                   : i18n.translate(
                       'observability.alerting.createAdRuleFlyout.forecasterCategoryFieldLabel',
-                      { defaultMessage: 'Categorical fields' }
+                      {
+                        defaultMessage: 'Categorical fields',
+                      }
                     )
               }
               helpText={i18n.translate(
@@ -1341,7 +1369,9 @@ const CategoryFieldSelector: React.FC<{
                 }}
                 placeholder={i18n.translate(
                   'observability.alerting.createAdRuleFlyout.categoryFieldPlaceholder',
-                  { defaultMessage: 'Select your categorical fields' }
+                  {
+                    defaultMessage: 'Select your categorical fields',
+                  }
                 )}
                 data-test-subj="alertManagerCreateAdRuleCategoryField"
               />
@@ -1444,8 +1474,8 @@ const SuggestParametersDialog: React.FC<{
         typeof intervalValue === 'number'
           ? intervalValue
           : typeof frequencyValue === 'number'
-          ? frequencyValue
-          : 10;
+            ? frequencyValue
+            : 10;
 
       const historyValue = payload.history;
       const windowDelayValue = payload.windowDelay?.period?.interval;
@@ -1511,11 +1541,15 @@ const SuggestParametersDialog: React.FC<{
               <EuiFormRow
                 label={i18n.translate(
                   'observability.alerting.createAdRuleFlyout.providedIntervalLabel',
-                  { defaultMessage: 'Detection interval' }
+                  {
+                    defaultMessage: 'Detection interval',
+                  }
                 )}
                 helpText={i18n.translate(
                   'observability.alerting.createAdRuleFlyout.providedIntervalHelp',
-                  { defaultMessage: 'A valid interval is from 1 minute to 30 days.' }
+                  {
+                    defaultMessage: 'A valid interval is from 1 minute to 30 days.',
+                  }
                 )}
               >
                 <EuiFieldNumber
@@ -1525,7 +1559,9 @@ const SuggestParametersDialog: React.FC<{
                   onChange={(e) => setProvidedInterval(e.target.value)}
                   append={i18n.translate(
                     'observability.alerting.createAdRuleFlyout.minutesAppend',
-                    { defaultMessage: 'minutes' }
+                    {
+                      defaultMessage: 'minutes',
+                    }
                   )}
                 />
               </EuiFormRow>
@@ -1706,12 +1742,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           defaultMessage: 'Edit forecasting rule',
         })
     : isDetector
-    ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
-        defaultMessage: 'Create anomaly detection rule',
-      })
-    : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
-        defaultMessage: 'Create forecasting rule',
-      });
+      ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
+          defaultMessage: 'Create anomaly detection rule',
+        })
+      : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
+          defaultMessage: 'Create forecasting rule',
+        });
   const detectorStepTitles = isEdit
     ? [
         isDetectorModelEdit
@@ -1930,7 +1966,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
         coreRefs.toasts?.addDanger({
           title: i18n.translate(
             'observability.alerting.createAdRuleFlyout.detectorStartAfterEditFailed',
-            { defaultMessage: 'Failed to start detector' }
+            {
+              defaultMessage: 'Failed to start detector',
+            }
           ),
           text: buildErrorMessage(error),
         });
@@ -2005,13 +2043,17 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           response,
           i18n.translate(
             'observability.alerting.createAdRuleFlyout.forecasterStopForEditFailedMessage',
-            { defaultMessage: 'There was a problem stopping the forecast' }
+            {
+              defaultMessage: 'There was a problem stopping the forecast',
+            }
           )
         );
         coreRefs.toasts?.addSuccess(
           i18n.translate(
             'observability.alerting.createAdRuleFlyout.forecasterStoppedForEditToast',
-            { defaultMessage: 'Successfully stopped the forecast' }
+            {
+              defaultMessage: 'Successfully stopped the forecast',
+            }
           )
         );
         setShouldOfferStartDetectorAfterEdit(false);
@@ -2027,11 +2069,15 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           ruleType === 'detector'
             ? i18n.translate(
                 'observability.alerting.createAdRuleFlyout.detectorStopForEditFailed',
-                { defaultMessage: 'Failed to stop detector' }
+                {
+                  defaultMessage: 'Failed to stop detector',
+                }
               )
             : i18n.translate(
                 'observability.alerting.createAdRuleFlyout.forecasterStopForEditFailed',
-                { defaultMessage: 'Failed to stop forecast' }
+                {
+                  defaultMessage: 'Failed to stop forecast',
+                }
               ),
         text: message,
       });
@@ -2078,11 +2124,15 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
         ruleType === 'detector'
           ? i18n.translate(
               'observability.alerting.createAdRuleFlyout.detectorRunningUpdateBlocked',
-              { defaultMessage: 'Detector cannot be updated while it is running' }
+              {
+                defaultMessage: 'Detector cannot be updated while it is running',
+              }
             )
           : i18n.translate(
               'observability.alerting.createAdRuleFlyout.forecasterActiveUpdateBlocked',
-              { defaultMessage: 'Forecast cannot be updated while it is active' }
+              {
+                defaultMessage: 'Forecast cannot be updated while it is active',
+              }
             )
       );
       return;
@@ -2140,12 +2190,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               defaultMessage: 'Forecasting rule updated successfully',
             })
         : isDetector
-        ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
-            defaultMessage: 'Anomaly detection rule created successfully',
-          })
-        : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
-            defaultMessage: 'Forecasting rule created successfully',
-          });
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
+              defaultMessage: 'Anomaly detection rule created successfully',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
+              defaultMessage: 'Forecasting rule created successfully',
+            });
 
       if (isEdit && isDetector && shouldOfferStartDetectorAfterEdit && editTarget) {
         setStartAfterEditPrompt({
@@ -2175,12 +2225,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 defaultMessage: 'Failed to update forecasting rule',
               })
           : isDetector
-          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
-              defaultMessage: 'Failed to create anomaly detection rule',
-            })
-          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
-              defaultMessage: 'Failed to create forecasting rule',
-            }),
+            ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
+                defaultMessage: 'Failed to create anomaly detection rule',
+              })
+            : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
+                defaultMessage: 'Failed to create forecasting rule',
+              }),
         text: message,
       });
     } finally {
@@ -2264,7 +2314,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
             onChange={(e) => updateForm('name', e.target.value)}
             placeholder={i18n.translate(
               'observability.alerting.createAdRuleFlyout.detectorNamePlaceholder',
-              { defaultMessage: 'Enter detector name' }
+              {
+                defaultMessage: 'Enter detector name',
+              }
             )}
             data-test-subj="alertManagerCreateAdRuleName"
           />
@@ -2294,7 +2346,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
             onChange={(e) => updateForm('description', e.target.value)}
             placeholder={i18n.translate(
               'observability.alerting.createAdRuleFlyout.descriptionPlaceholder',
-              { defaultMessage: isDetector ? 'Describe the detector' : 'Describe the forecaster' }
+              {
+                defaultMessage: isDetector ? 'Describe the detector' : 'Describe the forecaster',
+              }
             )}
             rows={3}
             data-test-subj="alertManagerCreateAdRuleDescription"
@@ -2431,7 +2485,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     id="resultIndexCheckbox"
                     label={i18n.translate(
                       'observability.alerting.createAdRuleFlyout.enableResultIndex',
-                      { defaultMessage: 'Enable custom result index' }
+                      {
+                        defaultMessage: 'Enable custom result index',
+                      }
                     )}
                     checked={form.customResultIndexEnabled}
                     disabled={isEdit}
@@ -2462,7 +2518,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     <EuiFormRow
                       label={i18n.translate(
                         'observability.alerting.createAdRuleFlyout.resultIndexFieldLabel',
-                        { defaultMessage: 'Field' }
+                        {
+                          defaultMessage: 'Field',
+                        }
                       )}
                       helpText={i18n.translate(
                         'observability.alerting.createAdRuleFlyout.resultIndexHelp',
@@ -2477,6 +2535,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                       <EuiFieldText
                         value={form.resultIndex}
                         prepend={CUSTOM_AD_RESULT_INDEX_PREFIX}
+                        isInvalid={!!visibleErrors.resultIndex}
                         placeholder={i18n.translate(
                           'observability.alerting.createAdRuleFlyout.resultIndexPlaceholder',
                           { defaultMessage: 'Enter result index name' }
@@ -2525,7 +2584,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                   <EuiButtonIcon
                     aria-label={i18n.translate(
                       'observability.alerting.createAdRuleFlyout.deleteFeature',
-                      { defaultMessage: 'Delete feature' }
+                      {
+                        defaultMessage: 'Delete feature',
+                      }
                     )}
                     size="s"
                     iconType="trash"
@@ -2555,10 +2616,13 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               >
                 <EuiFieldText
                   value={feature.featureName}
+                  isInvalid={!!featureNameError}
                   onChange={(e) => updateFeature(index, 'featureName', e.target.value)}
                   placeholder={i18n.translate(
                     'observability.alerting.createAdRuleFlyout.featureNamePlaceholder',
-                    { defaultMessage: 'Enter feature name' }
+                    {
+                      defaultMessage: 'Enter feature name',
+                    }
                   )}
                   data-test-subj={`alertManagerCreateAdRuleFeatureName-${index}`}
                 />
@@ -2750,7 +2814,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               id="detectionInterval"
               placeholder={i18n.translate(
                 'observability.alerting.createAdRuleFlyout.intervalPlaceholder',
-                { defaultMessage: 'Interval' }
+                {
+                  defaultMessage: 'Interval',
+                }
               )}
               value={form.interval}
               min={1}
@@ -2789,7 +2855,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               id="frequency"
               placeholder={i18n.translate(
                 'observability.alerting.createAdRuleFlyout.frequencyPlaceholder',
-                { defaultMessage: 'Frequency' }
+                {
+                  defaultMessage: 'Frequency',
+                }
               )}
               value={form.frequency}
               min={1}
@@ -2824,7 +2892,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               id="windowDelay"
               placeholder={i18n.translate(
                 'observability.alerting.createAdRuleFlyout.windowDelayPlaceholder',
-                { defaultMessage: 'Window delay' }
+                {
+                  defaultMessage: 'Window delay',
+                }
               )}
               value={form.windowDelay}
               min={0}
@@ -2859,7 +2929,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               id="history"
               placeholder={i18n.translate(
                 'observability.alerting.createAdRuleFlyout.historyPlaceholder',
-                { defaultMessage: 'History' }
+                {
+                  defaultMessage: 'History',
+                }
               )}
               value={form.history}
               min={40}
@@ -2925,7 +2997,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                   id="shingleSize"
                   placeholder={i18n.translate(
                     'observability.alerting.createAdRuleFlyout.shingleSizePlaceholder',
-                    { defaultMessage: 'Shingle size' }
+                    {
+                      defaultMessage: 'Shingle size',
+                    }
                   )}
                   value={form.shingleSize}
                   min={1}
@@ -3031,7 +3105,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           })}
           helpText={i18n.translate(
             'observability.alerting.createAdRuleFlyout.forecastIntervalHelp',
-            { defaultMessage: 'The interval must be at least one minute.' }
+            {
+              defaultMessage: 'The interval must be at least one minute.',
+            }
           )}
           isInvalid={!!visibleErrors.interval}
           error={visibleErrors.interval}
@@ -3212,9 +3288,7 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
         .filter((feature) => feature.featureName.trim())
         .map(
           (feature) =>
-            `${feature.featureName.trim()}: ${
-              feature.aggregationBy
-            }(${feature.aggregationOf.trim()})`
+            `${feature.featureName.trim()}: ${feature.aggregationBy}(${feature.aggregationOf.trim()})`
         )
         .join(', ') || '-';
     const descriptionItems = [
@@ -3283,7 +3357,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               iconType="alert"
               title={i18n.translate(
                 'observability.alerting.createAdRuleFlyout.reviewValidationTitle',
-                { defaultMessage: 'Some required fields need attention.' }
+                {
+                  defaultMessage: 'Some required fields need attention.',
+                }
               )}
             />
             <EuiSpacer size="m" />
@@ -3323,7 +3399,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                   <h2>
                     {i18n.translate(
                       'observability.alerting.createAdRuleFlyout.stopDetectorToEditTitle',
-                      { defaultMessage: 'Stop detector to proceed?' }
+                      {
+                        defaultMessage: 'Stop detector to proceed?',
+                      }
                     )}
                   </h2>
                 </EuiText>
@@ -3362,7 +3440,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               >
                 {i18n.translate(
                   'observability.alerting.createAdRuleFlyout.stopDetectorProceedButton',
-                  { defaultMessage: 'Stop and proceed to edit' }
+                  {
+                    defaultMessage: 'Stop and proceed to edit',
+                  }
                 )}
               </EuiSmallButton>
             </EuiModalFooter>
@@ -3381,7 +3461,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                   <h2>
                     {i18n.translate(
                       'observability.alerting.createAdRuleFlyout.waitForForecastTestTitle',
-                      { defaultMessage: 'Please wait for test initialization' }
+                      {
+                        defaultMessage: 'Please wait for test initialization',
+                      }
                     )}
                   </h2>
                 </EuiText>
@@ -3394,7 +3476,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 iconType="clock"
                 title={i18n.translate(
                   'observability.alerting.createAdRuleFlyout.forecastTestInProgressTitle',
-                  { defaultMessage: 'Test in progress' }
+                  {
+                    defaultMessage: 'Test in progress',
+                  }
                 )}
               >
                 <p>
@@ -3413,7 +3497,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               <EuiSmallButton fill color="primary" onClick={handleStopForEditModalCancel}>
                 {i18n.translate(
                   'observability.alerting.createAdRuleFlyout.forecastTestUnderstandButton',
-                  { defaultMessage: 'I understand' }
+                  {
+                    defaultMessage: 'I understand',
+                  }
                 )}
               </EuiSmallButton>
             </EuiModalFooter>
@@ -3445,12 +3531,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           }
         )
       : isAwaitingDataToInit || isAwaitingDataToRestart
-      ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
-          defaultMessage: 'Cancel forecast to edit?',
-        })
-      : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
-          defaultMessage: 'Stop forecast to edit?',
-        });
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
+            defaultMessage: 'Cancel forecast to edit?',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
+            defaultMessage: 'Stop forecast to edit?',
+          });
     const forecastModalDescription = (() => {
       if (isInitializingForecast) {
         return i18n.translate(
@@ -3506,7 +3592,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                   iconType="alert"
                   title={i18n.translate(
                     'observability.alerting.createAdRuleFlyout.forecastEditWipeWarningTitle',
-                    { defaultMessage: 'Editing forecast will wipe historical visualizations' }
+                    {
+                      defaultMessage: 'Editing forecast will wipe historical visualizations',
+                    }
                   )}
                 >
                   <p>
@@ -3557,7 +3645,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
         iconType="check"
         title={i18n.translate(
           'observability.alerting.createAdRuleFlyout.detectorUpdatedStartPromptTitle',
-          { defaultMessage: 'Anomaly detection rule updated' }
+          {
+            defaultMessage: 'Anomaly detection rule updated',
+          }
         )}
       >
         <p>
@@ -3618,14 +3708,14 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     }
                   )
               : isDetector
-              ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
-                  defaultMessage:
-                    'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
-                })
-              : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
-                  defaultMessage:
-                    'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
-                })}
+                ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
+                    defaultMessage:
+                      'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
+                  })
+                : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
+                    defaultMessage:
+                      'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
+                  })}
           </EuiText>
         </EuiFlyoutHeader>
 
@@ -3636,7 +3726,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               iconType="alert"
               title={i18n.translate(
                 'observability.alerting.createAdRuleFlyout.noOpenSearchDatasourceTitle',
-                { defaultMessage: 'Select an OpenSearch datasource to create this rule.' }
+                {
+                  defaultMessage: 'Select an OpenSearch datasource to create this rule.',
+                }
               )}
             />
           ) : isEdit && !isEditFormReady && !editDetailError ? (
@@ -3682,7 +3774,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     {startAfterEditPrompt
                       ? i18n.translate(
                           'observability.alerting.createAdRuleFlyout.startDetectorAfterEditTitle',
-                          { defaultMessage: 'Start detector' }
+                          {
+                            defaultMessage: 'Start detector',
+                          }
                         )
                       : stepTitles[currentStep]}
                   </h1>
@@ -3704,7 +3798,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 >
                   {i18n.translate(
                     'observability.alerting.createAdRuleFlyout.closeAfterEditButton',
-                    { defaultMessage: 'Close' }
+                    {
+                      defaultMessage: 'Close',
+                    }
                   )}
                 </EuiButtonEmpty>
               </EuiFlexItem>
@@ -3722,7 +3818,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 >
                   {i18n.translate(
                     'observability.alerting.createAdRuleFlyout.startDetectorAfterEditButton',
-                    { defaultMessage: 'Start detector' }
+                    {
+                      defaultMessage: 'Start detector',
+                    }
                   )}
                 </EuiButton>
               </EuiFlexItem>

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -514,9 +514,9 @@ const buildFeatureFormState = (
 };
 
 const getFeatureForms = (resource: Record<string, unknown>): CreateAdFeatureFormState[] => {
-  const features = asArray(
-    getField(resource, 'feature_attributes', 'featureAttributes')
-  ).map((feature) => buildFeatureFormState(resource, feature));
+  const features = asArray(getField(resource, 'feature_attributes', 'featureAttributes')).map(
+    (feature) => buildFeatureFormState(resource, feature)
+  );
   return features.length > 0 ? features : [createInitialFeature()];
 };
 
@@ -1082,18 +1082,18 @@ const errorsForStep = (
       step === 0
         ? ['name', 'datasourceId', 'indices', 'timeField', 'filterQuery', 'resultIndex']
         : step === 1
-        ? [
-            'features',
-            'categoryField',
-            'interval',
-            'frequency',
-            'windowDelay',
-            'history',
-            'shingleSize',
-          ]
-        : step === 2
-        ? []
-        : Object.keys(errors);
+          ? [
+              'features',
+              'categoryField',
+              'interval',
+              'frequency',
+              'windowDelay',
+              'history',
+              'shingleSize',
+            ]
+          : step === 2
+            ? []
+            : Object.keys(errors);
   } else {
     stepFields =
       step === 0
@@ -1107,8 +1107,8 @@ const errorsForStep = (
             'categoryField',
           ]
         : step === 1
-        ? ['interval', 'windowDelay', 'history', 'horizon', 'shingleSize']
-        : Object.keys(errors);
+          ? ['interval', 'windowDelay', 'history', 'horizon', 'shingleSize']
+          : Object.keys(errors);
   }
 
   return Object.fromEntries(
@@ -1638,8 +1638,8 @@ const SuggestParametersDialog: React.FC<{
         typeof intervalValue === 'number'
           ? intervalValue
           : typeof frequencyValue === 'number'
-          ? frequencyValue
-          : 10;
+            ? frequencyValue
+            : 10;
 
       const historyValue = payload.history;
       const windowDelayValue = payload.windowDelay?.period?.interval;
@@ -1906,12 +1906,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           defaultMessage: 'Edit forecasting rule',
         })
     : isDetector
-    ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
-        defaultMessage: 'Create anomaly detection rule',
-      })
-    : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
-        defaultMessage: 'Create forecasting rule',
-      });
+      ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
+          defaultMessage: 'Create anomaly detection rule',
+        })
+      : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
+          defaultMessage: 'Create forecasting rule',
+        });
   const detectorStepTitles = isEdit
     ? [
         isDetectorModelEdit
@@ -2364,12 +2364,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               defaultMessage: 'Forecasting rule updated successfully',
             })
         : isDetector
-        ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
-            defaultMessage: 'Anomaly detection rule created successfully',
-          })
-        : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
-            defaultMessage: 'Forecasting rule created successfully',
-          });
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
+              defaultMessage: 'Anomaly detection rule created successfully',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
+              defaultMessage: 'Forecasting rule created successfully',
+            });
 
       if (isEdit && isDetector && shouldOfferStartDetectorAfterEdit && editTarget) {
         setStartAfterEditPrompt({
@@ -2410,12 +2410,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 defaultMessage: 'Failed to update forecasting rule',
               })
           : isDetector
-          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
-              defaultMessage: 'Failed to create anomaly detection rule',
-            })
-          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
-              defaultMessage: 'Failed to create forecasting rule',
-            }),
+            ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
+                defaultMessage: 'Failed to create anomaly detection rule',
+              })
+            : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
+                defaultMessage: 'Failed to create forecasting rule',
+              }),
         text: message,
       });
     } finally {
@@ -3737,12 +3737,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           }
         )
       : isAwaitingDataToInit || isAwaitingDataToRestart
-      ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
-          defaultMessage: 'Cancel forecast to edit?',
-        })
-      : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
-          defaultMessage: 'Stop forecast to edit?',
-        });
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
+            defaultMessage: 'Cancel forecast to edit?',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
+            defaultMessage: 'Stop forecast to edit?',
+          });
     const forecastModalDescription = (() => {
       if (isInitializingForecast) {
         return i18n.translate(
@@ -3913,14 +3913,14 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     }
                   )
               : isDetector
-              ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
-                  defaultMessage:
-                    'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
-                })
-              : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
-                  defaultMessage:
-                    'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
-                })}
+                ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
+                    defaultMessage:
+                      'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
+                  })
+                : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
+                    defaultMessage:
+                      'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
+                  })}
           </EuiText>
         </EuiFlyoutHeader>
 

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -532,9 +532,9 @@ const buildFeatureFormState = (
 };
 
 const getFeatureForms = (resource: Record<string, unknown>): CreateAdFeatureFormState[] => {
-  const features = asArray(
-    getField(resource, 'feature_attributes', 'featureAttributes')
-  ).map((feature) => buildFeatureFormState(resource, feature));
+  const features = asArray(getField(resource, 'feature_attributes', 'featureAttributes')).map(
+    (feature) => buildFeatureFormState(resource, feature)
+  );
   return features.length > 0 ? features : [createInitialFeature()];
 };
 
@@ -1176,18 +1176,18 @@ const errorsForStep = (
       step === 0
         ? ['name', 'datasourceId', 'indices', 'timeField', 'filterQuery', 'resultIndex']
         : step === 1
-        ? [
-            'features',
-            'categoryField',
-            'interval',
-            'frequency',
-            'windowDelay',
-            'history',
-            'shingleSize',
-          ]
-        : step === 2
-        ? []
-        : Object.keys(errors);
+          ? [
+              'features',
+              'categoryField',
+              'interval',
+              'frequency',
+              'windowDelay',
+              'history',
+              'shingleSize',
+            ]
+          : step === 2
+            ? []
+            : Object.keys(errors);
   } else {
     stepFields =
       step === 0
@@ -1201,18 +1201,18 @@ const errorsForStep = (
             'categoryField',
           ]
         : step === 1
-        ? [
-            'interval',
-            'windowDelay',
-            'history',
-            'horizon',
-            'shingleSize',
-            'resultIndex',
-            'resultIndexMinAge',
-            'resultIndexMinSize',
-            'resultIndexTtl',
-          ]
-        : Object.keys(errors);
+          ? [
+              'interval',
+              'windowDelay',
+              'history',
+              'horizon',
+              'shingleSize',
+              'resultIndex',
+              'resultIndexMinAge',
+              'resultIndexMinSize',
+              'resultIndexTtl',
+            ]
+          : Object.keys(errors);
   }
 
   return Object.fromEntries(
@@ -1742,8 +1742,8 @@ const SuggestParametersDialog: React.FC<{
         typeof intervalValue === 'number'
           ? intervalValue
           : typeof frequencyValue === 'number'
-          ? frequencyValue
-          : 10;
+            ? frequencyValue
+            : 10;
 
       const historyValue = payload.history;
       const windowDelayValue = payload.windowDelay?.period?.interval;
@@ -2016,12 +2016,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           defaultMessage: 'Edit forecasting rule',
         })
     : isDetector
-    ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
-        defaultMessage: 'Create anomaly detection rule',
-      })
-    : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
-        defaultMessage: 'Create forecasting rule',
-      });
+      ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
+          defaultMessage: 'Create anomaly detection rule',
+        })
+      : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
+          defaultMessage: 'Create forecasting rule',
+        });
   const detectorStepTitles = isEdit
     ? [
         isDetectorModelEdit
@@ -2475,12 +2475,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               defaultMessage: 'Forecasting rule updated successfully',
             })
         : isDetector
-        ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
-            defaultMessage: 'Anomaly detection rule created successfully',
-          })
-        : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
-            defaultMessage: 'Forecasting rule created successfully',
-          });
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
+              defaultMessage: 'Anomaly detection rule created successfully',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
+              defaultMessage: 'Forecasting rule created successfully',
+            });
 
       if (isEdit && isDetector && shouldOfferStartDetectorAfterEdit && editTarget) {
         setStartAfterEditPrompt({
@@ -2528,12 +2528,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 defaultMessage: 'Failed to update forecasting rule',
               })
           : isDetector
-          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
-              defaultMessage: 'Failed to create anomaly detection rule',
-            })
-          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
-              defaultMessage: 'Failed to create forecasting rule',
-            }),
+            ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
+                defaultMessage: 'Failed to create anomaly detection rule',
+              })
+            : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
+                defaultMessage: 'Failed to create forecasting rule',
+              }),
         text: message,
       });
     } finally {
@@ -4143,12 +4143,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           }
         )
       : isAwaitingDataToInit || isAwaitingDataToRestart
-      ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
-          defaultMessage: 'Cancel forecast to edit?',
-        })
-      : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
-          defaultMessage: 'Stop forecast to edit?',
-        });
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
+            defaultMessage: 'Cancel forecast to edit?',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
+            defaultMessage: 'Stop forecast to edit?',
+          });
     const forecastModalDescription = (() => {
       if (isInitializingForecast) {
         return i18n.translate(
@@ -4319,14 +4319,14 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     }
                   )
               : isDetector
-              ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
-                  defaultMessage:
-                    'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
-                })
-              : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
-                  defaultMessage:
-                    'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
-                })}
+                ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
+                    defaultMessage:
+                      'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
+                  })
+                : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
+                    defaultMessage:
+                      'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
+                  })}
           </EuiText>
         </EuiFlyoutHeader>
 

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -1,0 +1,3794 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Alerts Manager-native creation flow for AD-backed resources.
+ *
+ * The AD and Forecasting apps own their full multi-page wizards, but those
+ * pages depend on app-local Redux/context. This flyout mirrors the core
+ * create payload shape in an OUI/EUI workflow so users can create anomaly
+ * detection and forecasting rules without leaving Alerts Manager.
+ */
+import React, { ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  EuiAccordion,
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiCallOut,
+  EuiComboBoxOptionOption,
+  EuiCheckbox,
+  EuiComboBox,
+  EuiFieldNumber,
+  EuiFieldText,
+  EuiFormRow,
+  EuiSelect,
+  EuiTextArea,
+  EuiDescriptionList,
+  EuiFieldNumber,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiFormRow,
+  EuiHorizontalRule,
+  EuiLink,
+  EuiLoadingSpinner,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiOverlayMask,
+  EuiPanel,
+  EuiRadioGroup,
+  EuiSmallButton,
+  EuiSmallButtonEmpty,
+  EuiSpacer,
+  EuiSteps,
+  EuiSwitch,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { ADDetector, ADForecaster, Datasource } from '../../../common/types/alerting';
+import { coreRefs } from '../../framework/core_refs';
+import { useIndexMappings } from './hooks/use_index_mappings';
+import { useIndices } from './hooks/use_indices';
+import { useRuleDetail } from './hooks/use_rule_detail';
+
+export type CreateAdRuleType = 'detector' | 'forecaster';
+type AdRuleFlyoutMode = 'create' | 'edit';
+type EditInitialStep = 'define' | 'model';
+
+interface CreateAdRuleFlyoutEditTarget {
+  id: string;
+  datasourceId: string;
+  initialStep?: EditInitialStep;
+}
+
+export interface CreateAdRuleFlyoutProps {
+  ruleType: CreateAdRuleType;
+  datasources: Datasource[];
+  selectedDsIds?: string[];
+  mode?: AdRuleFlyoutMode;
+  editTarget?: CreateAdRuleFlyoutEditTarget;
+  onCancel: () => void;
+  onCreated?: () => void;
+  onUpdated?: () => void;
+}
+
+type NumericFormValue = number | '';
+type SuggestDialogStep = 'config' | 'loading' | 'error' | 'result';
+type EditLifecycleBlocker = 'detector-running' | 'forecaster-active' | 'forecaster-test';
+
+interface CreateAdFeatureFormState {
+  featureId?: string;
+  featureName: string;
+  featureEnabled: boolean;
+  anomalyDirection: string;
+  aggregationBy: string;
+  aggregationOf: string;
+}
+
+interface CreateAdRuleFormState {
+  name: string;
+  description: string;
+  datasourceId: string;
+  indices: string[];
+  timeField: string;
+  filterQuery: string;
+  customResultIndexEnabled: boolean;
+  resultIndex: string;
+  categoryFieldEnabled: boolean;
+  categoryField: string[];
+  features: CreateAdFeatureFormState[];
+  shingleSize: number;
+  interval: NumericFormValue;
+  frequency: NumericFormValue;
+  windowDelay: NumericFormValue;
+  history: NumericFormValue;
+  horizon: NumericFormValue;
+  startAfterCreate: boolean;
+}
+
+interface ApiResponse<T = { id?: string; detectorId?: string; forecasterId?: string }> {
+  ok?: boolean;
+  response?: T;
+  error?: string;
+  message?: string;
+}
+
+interface DetectorSuggestionPeriod {
+  period?: {
+    interval?: number;
+  };
+}
+
+interface DetectorSuggestionResponse {
+  exception?: string;
+  detectionInterval?: DetectorSuggestionPeriod;
+  interval?: DetectorSuggestionPeriod;
+  frequency?: DetectorSuggestionPeriod;
+  history?: number;
+  windowDelay?: DetectorSuggestionPeriod;
+}
+
+const AD_DETECTOR_API = '/api/anomaly_detectors/detectors';
+const FORECASTER_API = '/api/forecasting/forecasters';
+const LOCAL_OPENSEARCH_DATASOURCE_IDS = new Set(['', 'local', 'local-cluster', 'local_cluster']);
+const OPENSEARCH_SERVERLESS_ENGINE_TYPE = 'OpenSearch Serverless';
+const OPENSEARCH_SERVERLESS_SIGV4_SERVICE = 'aoss';
+const DETECTOR_RUNNING_STATE = 'Running';
+const DETECTOR_INITIALIZING_STATE = 'Initializing';
+const FORECASTER_RUNNING_STATE = 'Running';
+const FORECASTER_INITIALIZING_FORECAST_STATE = 'Initializing forecast';
+const FORECASTER_AWAITING_DATA_TO_INIT_STATE = 'Awaiting data to init';
+const FORECASTER_AWAITING_DATA_TO_RESTART_STATE = 'Awaiting data to restart';
+const FORECASTER_INIT_TEST_STATE = 'Initializing test';
+const FORECASTER_FORECAST_FAILURE_STATE = 'Forecast failure';
+const MINUTES_UNIT = 'Minutes';
+const SIMPLE_FEATURE_TYPE = 'simple_aggs';
+const CUSTOM_FEATURE_TYPE = 'custom_aggs';
+const AD_DOCS_LINK = 'https://opensearch.org/docs/latest/observing-your-data/ad/index/';
+const CUSTOM_AD_RESULT_INDEX_PREFIX = 'opensearch-ad-plugin-result-';
+
+const AGGREGATION_OPTIONS = [
+  { value: 'avg', text: 'average()' },
+  { value: 'value_count', text: 'count()' },
+  { value: 'sum', text: 'sum()' },
+  { value: 'min', text: 'min()' },
+  { value: 'max', text: 'max()' },
+];
+
+const FEATURE_TYPE_OPTIONS = [
+  { value: SIMPLE_FEATURE_TYPE, text: 'Field value' },
+  { value: CUSTOM_FEATURE_TYPE, text: 'Custom expression' },
+];
+
+const FEATURE_DIRECTION_OPTIONS = [
+  { value: 'both', text: 'Deviation in any direction (default)' },
+  { value: 'above', text: 'Rise above expected value' },
+  { value: 'below', text: 'Drop below expected value' },
+];
+
+const NUMBER_TYPES = [
+  'integer',
+  'long',
+  'short',
+  'byte',
+  'double',
+  'float',
+  'half_float',
+  'scaled_float',
+];
+const COUNTABLE_TYPES = [...NUMBER_TYPES, 'keyword', 'text', 'boolean', 'date', 'date_nanos'];
+const CATEGORY_TYPES = ['keyword', 'ip'];
+const MAX_FEATURE_NUM = 5;
+
+const createInitialFeature = (): CreateAdFeatureFormState => ({
+  featureId: undefined,
+  featureName: '',
+  featureEnabled: true,
+  anomalyDirection: 'both',
+  aggregationBy: 'sum',
+  aggregationOf: '',
+});
+
+const resetFeatureFieldSelections = (
+  features: CreateAdFeatureFormState[]
+): CreateAdFeatureFormState[] => features.map((feature) => ({ ...feature, aggregationOf: '' }));
+
+const createInitialForm = (datasourceId: string): CreateAdRuleFormState => ({
+  name: '',
+  description: '',
+  datasourceId,
+  indices: [],
+  timeField: '',
+  filterQuery: '',
+  customResultIndexEnabled: false,
+  resultIndex: '',
+  categoryFieldEnabled: false,
+  categoryField: [],
+  features: [createInitialFeature()],
+  shingleSize: 8,
+  interval: '',
+  frequency: '',
+  windowDelay: '',
+  history: '',
+  horizon: 24,
+  startAfterCreate: true,
+});
+
+const normalizeDataSourceId = (dsId?: string): string =>
+  !dsId || LOCAL_OPENSEARCH_DATASOURCE_IDS.has(dsId) ? '' : dsId;
+
+const withOptionalDatasource = (basePath: string, dsId?: string): string => {
+  const normalized = normalizeDataSourceId(dsId);
+  return normalized ? `${basePath}/${encodeURIComponent(normalized)}` : basePath;
+};
+
+const isServerlessDataSource = async (dsId?: string): Promise<boolean> => {
+  const normalized = normalizeDataSourceId(dsId);
+  if (!normalized || !coreRefs.savedObjectsClient) return false;
+
+  try {
+    const dataSource = await coreRefs.savedObjectsClient.get('data-source', normalized);
+    const attributes = dataSource.attributes as {
+      auth?: {
+        credentials?: {
+          service?: string;
+        };
+      };
+      dataSourceEngineType?: string;
+      endpoint?: string;
+    };
+    return (
+      attributes.dataSourceEngineType === OPENSEARCH_SERVERLESS_ENGINE_TYPE ||
+      attributes.auth?.credentials?.service === OPENSEARCH_SERVERLESS_SIGV4_SERVICE ||
+      attributes.endpoint?.includes('.aoss.amazonaws.com') === true
+    );
+  } catch {
+    return false;
+  }
+};
+
+const toPositiveInt = (value: NumericFormValue, fallback: number): number => {
+  if (value === '') return fallback;
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.floor(value));
+};
+
+const parsePositiveInt = (value: NumericFormValue): number | undefined => {
+  if (value === '') return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  const next = Math.floor(value);
+  return next > 0 ? next : undefined;
+};
+
+const parseNonNegativeInt = (value: NumericFormValue): number | undefined => {
+  if (value === '') return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  const next = Math.floor(value);
+  return next >= 0 ? next : undefined;
+};
+
+const parseNumberInputValue = (value: string): NumericFormValue =>
+  value === '' ? '' : Number(value);
+
+const toSnakeCase = (value: string): string => {
+  const normalized = value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[^A-Za-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+  return normalized || 'feature_1';
+};
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+
+const asArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+const stringValue = (value: unknown, fallback = ''): string =>
+  typeof value === 'string' ? value : fallback;
+
+const numberValue = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+const booleanValue = (value: unknown, fallback: boolean): boolean =>
+  typeof value === 'boolean' ? value : fallback;
+
+const getField = (record: Record<string, unknown>, snakeKey: string, camelKey: string): unknown =>
+  record[snakeKey] !== undefined ? record[snakeKey] : record[camelKey];
+
+const getPeriodInterval = (
+  resource: Record<string, unknown>,
+  snakeKey: string,
+  camelKey: string
+): NumericFormValue => {
+  const period = asRecord(asRecord(getField(resource, snakeKey, camelKey)).period);
+  return numberValue(period.interval) ?? '';
+};
+
+const stripResultIndexPrefix = (value: unknown): string => {
+  const resultIndex = stringValue(value);
+  return resultIndex.startsWith(CUSTOM_AD_RESULT_INDEX_PREFIX)
+    ? resultIndex.slice(CUSTOM_AD_RESULT_INDEX_PREFIX.length)
+    : resultIndex;
+};
+
+const isMatchAllFilter = (filterQuery: Record<string, unknown>): boolean => {
+  const keys = Object.keys(filterQuery);
+  return keys.length === 0 || (keys.length === 1 && !!filterQuery.match_all);
+};
+
+const formatFilterQueryForForm = (value: unknown): string => {
+  const filterQuery = asRecord(value);
+  return isMatchAllFilter(filterQuery) ? '' : JSON.stringify(filterQuery, null, 2);
+};
+
+const formatCategoryField = (form: CreateAdRuleFormState): string[] | undefined =>
+  form.categoryFieldEnabled && form.categoryField.length ? form.categoryField : undefined;
+
+const parseFilterQuery = (value: string): Record<string, unknown> => {
+  const trimmed = value.trim();
+  return trimmed ? JSON.parse(trimmed) : { match_all: {} };
+};
+
+const getOpenSearchDatasources = (datasources: Datasource[]): Datasource[] =>
+  datasources.filter((datasource) => datasource.type === 'opensearch');
+
+const getInitialDatasourceId = (datasources: Datasource[], selectedDsIds?: string[]): string => {
+  const openSearchDatasources = getOpenSearchDatasources(datasources);
+  const selected = selectedDsIds
+    ?.map((id) => openSearchDatasources.find((datasource) => datasource.id === id))
+    .find(Boolean);
+  return selected?.id ?? openSearchDatasources[0]?.id ?? '';
+};
+
+const buildFeatureMetadata = (features: CreateAdFeatureFormState[]) =>
+  features.reduce<Record<string, Record<string, string>>>((metadata, feature) => {
+    const featureName = feature.featureName.trim();
+    if (!featureName) return metadata;
+    metadata[featureName] = {
+      featureType: SIMPLE_FEATURE_TYPE,
+      aggregationBy: feature.aggregationBy,
+      aggregationOf: feature.aggregationOf.trim(),
+    };
+    return metadata;
+  }, {});
+
+const buildFeatureAttributes = (features: CreateAdFeatureFormState[]) =>
+  features
+    .filter((feature) => feature.featureName.trim())
+    .map((feature) => {
+      const featureName = feature.featureName.trim();
+      return {
+        ...(feature.featureId ? { featureId: feature.featureId } : {}),
+        featureName,
+        featureEnabled: feature.featureEnabled,
+        importance: 1,
+        aggregationQuery: {
+          [toSnakeCase(featureName)]: {
+            [feature.aggregationBy]: { field: feature.aggregationOf.trim() },
+          },
+        },
+      };
+    });
+
+const getUiMetadataFeatures = (resource: Record<string, unknown>): Record<string, unknown> =>
+  asRecord(asRecord(getField(resource, 'ui_metadata', 'uiMetadata')).features);
+
+const getFeatureMetadata = (
+  resource: Record<string, unknown>,
+  featureName: string
+): Record<string, unknown> => asRecord(getUiMetadataFeatures(resource)[featureName]);
+
+const getAggregationFromQuery = (
+  feature: Record<string, unknown>
+): Pick<CreateAdFeatureFormState, 'aggregationBy' | 'aggregationOf'> => {
+  const query = asRecord(getField(feature, 'aggregation_query', 'aggregationQuery'));
+  const aggregationName = Object.keys(query)[0];
+  const aggregation = asRecord(query[aggregationName]);
+  const aggregationBy = Object.keys(aggregation)[0];
+  const aggregationDefinition = asRecord(aggregation[aggregationBy]);
+
+  return {
+    aggregationBy: aggregationBy || 'sum',
+    aggregationOf: stringValue(aggregationDefinition.field),
+  };
+};
+
+const buildFeatureFormState = (
+  resource: Record<string, unknown>,
+  rawFeature: unknown
+): CreateAdFeatureFormState => {
+  const feature = asRecord(rawFeature);
+  const featureName =
+    stringValue(getField(feature, 'feature_name', 'featureName')) ||
+    stringValue(getField(feature, 'feature_id', 'featureId'));
+  const metadata = getFeatureMetadata(resource, featureName);
+  const queryAggregation = getAggregationFromQuery(feature);
+
+  return {
+    featureId: stringValue(getField(feature, 'feature_id', 'featureId')) || undefined,
+    featureName,
+    featureEnabled: booleanValue(getField(feature, 'feature_enabled', 'featureEnabled'), true),
+    anomalyDirection: 'both',
+    aggregationBy: stringValue(metadata.aggregationBy) || queryAggregation.aggregationBy,
+    aggregationOf: stringValue(metadata.aggregationOf) || queryAggregation.aggregationOf,
+  };
+};
+
+const getFeatureForms = (resource: Record<string, unknown>): CreateAdFeatureFormState[] => {
+  const features = asArray(
+    getField(resource, 'feature_attributes', 'featureAttributes')
+  ).map((feature) => buildFeatureFormState(resource, feature));
+  return features.length > 0 ? features : [createInitialFeature()];
+};
+
+const getCategoryFieldFromResource = (resource: Record<string, unknown>): string[] =>
+  asArray(getField(resource, 'category_field', 'categoryField'))
+    .map((field) => stringValue(field))
+    .filter(Boolean);
+
+const getConcurrencyFields = (resource: Record<string, unknown>): Record<string, number> => {
+  const seqNo = numberValue(resource.seqNo ?? resource.seq_no);
+  const primaryTerm = numberValue(resource.primaryTerm ?? resource.primary_term);
+  return {
+    ...(seqNo !== undefined ? { seqNo } : {}),
+    ...(primaryTerm !== undefined ? { primaryTerm } : {}),
+  };
+};
+
+const normalizeStateValue = (value: unknown): string => stringValue(value).trim();
+
+const stateMatches = (state: string, values: string[]): boolean =>
+  values.some((value) => state === value || state.toUpperCase() === value);
+
+const getResourceState = (resource?: ADDetector | ADForecaster): string =>
+  normalizeStateValue(getField(asRecord(resource), 'cur_state', 'curState'));
+
+const getTaskState = (resource?: ADDetector | ADForecaster): string =>
+  normalizeStateValue(getField(asRecord(resource), 'task_state', 'taskState'));
+
+const getDetectorJob = (resource?: ADDetector | ADForecaster): Record<string, unknown> =>
+  asRecord(getField(asRecord(resource), 'anomaly_detector_job', 'anomalyDetectorJob'));
+
+const isDetectorRuntimeStateRunning = (resource?: ADDetector | ADForecaster): boolean => {
+  const runningStates = [
+    DETECTOR_RUNNING_STATE,
+    DETECTOR_INITIALIZING_STATE,
+    'RUNNING',
+    'INIT',
+    'CREATED',
+  ];
+  return [getResourceState(resource), getTaskState(resource)].some((state) =>
+    stateMatches(state, runningStates)
+  );
+};
+
+const isDetectorRealTimeJobRunning = (resource?: ADDetector | ADForecaster): boolean => {
+  const jobEnabled = getField(getDetectorJob(resource), 'enabled', 'enabled');
+  if (typeof jobEnabled === 'boolean') return jobEnabled;
+
+  const topLevelEnabled = getField(asRecord(resource), 'enabled', 'enabled');
+  if (typeof topLevelEnabled === 'boolean') return topLevelEnabled;
+
+  return isDetectorRuntimeStateRunning(resource);
+};
+
+const isDetectorHistoricalJobRunning = (resource?: ADDetector | ADForecaster): boolean => {
+  const taskState = getTaskState(resource);
+  return stateMatches(taskState, [
+    DETECTOR_RUNNING_STATE,
+    DETECTOR_INITIALIZING_STATE,
+    'RUNNING',
+    'INIT',
+  ]);
+};
+
+const getDetectorRunningJobsLabel = (resource?: ADDetector | ADForecaster): string => {
+  const realTimeRunning = isDetectorRealTimeJobRunning(resource);
+  const historicalRunning = isDetectorHistoricalJobRunning(resource);
+  if (realTimeRunning && historicalRunning) return 'detector and historical analysis';
+  if (realTimeRunning) return 'detector';
+  if (historicalRunning) return 'historical analysis';
+  return 'detector';
+};
+
+const isForecasterTestInitializing = (resource?: ADDetector | ADForecaster): boolean => {
+  const state = getResourceState(resource);
+  return stateMatches(state, [FORECASTER_INIT_TEST_STATE, 'INIT_TEST']);
+};
+
+const isForecasterActiveForEdit = (resource?: ADDetector | ADForecaster): boolean => {
+  const state = getResourceState(resource);
+  return (
+    booleanValue(getField(asRecord(resource), 'enabled', 'enabled'), false) ||
+    stateMatches(state, [
+      FORECASTER_RUNNING_STATE,
+      FORECASTER_INITIALIZING_FORECAST_STATE,
+      FORECASTER_AWAITING_DATA_TO_INIT_STATE,
+      FORECASTER_AWAITING_DATA_TO_RESTART_STATE,
+      FORECASTER_FORECAST_FAILURE_STATE,
+      'RUNNING',
+      'INITIALIZING_FORECAST',
+      'AWAITING_DATA_TO_INIT',
+      'AWAITING_DATA_TO_RESTART',
+      'FORECAST_FAILURE',
+    ])
+  );
+};
+
+const getEditLifecycleBlocker = (
+  ruleType: CreateAdRuleType,
+  resource: ADDetector | ADForecaster | undefined,
+  hasStoppedForEdit: boolean
+): EditLifecycleBlocker | null => {
+  if (!resource || hasStoppedForEdit) return null;
+  if (ruleType === 'detector') {
+    return isDetectorRealTimeJobRunning(resource) || isDetectorHistoricalJobRunning(resource)
+      ? 'detector-running'
+      : null;
+  }
+  if (isForecasterTestInitializing(resource)) return 'forecaster-test';
+  return isForecasterActiveForEdit(resource) ? 'forecaster-active' : null;
+};
+
+const stripReadOnlyResourceFields = (
+  resource?: ADDetector | ADForecaster
+): Record<string, unknown> => {
+  const readonlyFields = new Set([
+    'id',
+    'primaryTerm',
+    'primary_term',
+    'seqNo',
+    'seq_no',
+    'lastUpdateTime',
+    'last_update_time',
+    'enabled',
+    'enabledTime',
+    'enabled_time',
+    'disabledTime',
+    'disabled_time',
+    'curState',
+    'cur_state',
+    'stateError',
+    'state_error',
+    'initProgress',
+    'init_progress',
+    'anomaly_detector_job',
+    'anomalyDetectorJob',
+    'forecaster_job',
+    'forecasterJob',
+    'realtime_task',
+    'realtimeTask',
+    'run_once_task',
+    'runOnceTask',
+    'task_id',
+    'taskId',
+    'task_state',
+    'taskState',
+    'task_progress',
+    'taskProgress',
+    'task_error',
+    'taskError',
+  ]);
+
+  return Object.fromEntries(
+    Object.entries(asRecord(resource)).filter(([key]) => !readonlyFields.has(key))
+  );
+};
+
+const formFromAdResource = (
+  ruleType: CreateAdRuleType,
+  resource: ADDetector | ADForecaster,
+  datasourceId: string
+): CreateAdRuleFormState => {
+  const rawResource = asRecord(resource);
+  const categoryField = getCategoryFieldFromResource(rawResource);
+  const resultIndex = stripResultIndexPrefix(getField(rawResource, 'result_index', 'resultIndex'));
+  const interval =
+    ruleType === 'detector'
+      ? getPeriodInterval(rawResource, 'detection_interval', 'detectionInterval')
+      : getPeriodInterval(rawResource, 'forecast_interval', 'forecastInterval');
+  const frequency = getPeriodInterval(rawResource, 'frequency', 'frequency');
+
+  return {
+    ...createInitialForm(datasourceId),
+    name: stringValue(rawResource.name),
+    description: stringValue(rawResource.description),
+    datasourceId,
+    indices: asArray(rawResource.indices)
+      .map((index) => stringValue(index))
+      .filter(Boolean),
+    timeField: stringValue(getField(rawResource, 'time_field', 'timeField')),
+    filterQuery: formatFilterQueryForForm(getField(rawResource, 'filter_query', 'filterQuery')),
+    customResultIndexEnabled: !!resultIndex,
+    resultIndex,
+    categoryFieldEnabled: categoryField.length > 0,
+    categoryField,
+    features: getFeatureForms(rawResource),
+    shingleSize: numberValue(getField(rawResource, 'shingle_size', 'shingleSize')) ?? 8,
+    interval,
+    frequency: ruleType === 'detector' && frequency === '' ? interval : frequency,
+    windowDelay: getPeriodInterval(rawResource, 'window_delay', 'windowDelay'),
+    history: numberValue(rawResource.history) ?? '',
+    horizon: numberValue(rawResource.horizon) ?? 24,
+  };
+};
+
+const buildRulePayload = (
+  ruleType: CreateAdRuleType,
+  form: CreateAdRuleFormState,
+  options: {
+    customResultIndexRequired?: boolean;
+    existingResource?: ADDetector | ADForecaster;
+  } = {}
+) => {
+  const existingResource = asRecord(options.existingResource);
+  const commonPayload = {
+    ...stripReadOnlyResourceFields(options.existingResource),
+    ...getConcurrencyFields(existingResource),
+    name: form.name.trim(),
+    description: form.description.trim(),
+    indices: form.indices,
+    filterQuery: parseFilterQuery(form.filterQuery),
+    uiMetadata: {
+      features: buildFeatureMetadata(form.features),
+      filters: [],
+    },
+    featureAttributes: buildFeatureAttributes(form.features),
+    timeField: form.timeField,
+    windowDelay: {
+      period: { interval: toPositiveInt(form.windowDelay, 0), unit: MINUTES_UNIT },
+    },
+    shingleSize: toPositiveInt(form.shingleSize, 8),
+    categoryField: formatCategoryField(form),
+  };
+
+  if (ruleType === 'detector') {
+    const shouldIncludeResultIndex =
+      form.customResultIndexEnabled || options.customResultIndexRequired;
+    const detectorInterval = Math.max(1, toPositiveInt(form.interval, 1));
+    const detectorFrequency = parsePositiveInt(form.frequency) ?? detectorInterval;
+    return {
+      ...commonPayload,
+      ...(shouldIncludeResultIndex && form.resultIndex.trim()
+        ? {
+            resultIndex: `${CUSTOM_AD_RESULT_INDEX_PREFIX}${form.resultIndex.trim()}`,
+          }
+        : {}),
+      detectionInterval: {
+        period: { interval: detectorInterval, unit: MINUTES_UNIT },
+      },
+      frequency: {
+        period: { interval: detectorFrequency, unit: MINUTES_UNIT },
+      },
+      history: Math.max(1, toPositiveInt(form.history, 40)),
+      rules: [],
+    };
+  }
+
+  return {
+    ...commonPayload,
+    forecastInterval: {
+      period: { interval: Math.max(1, toPositiveInt(form.interval, 1)), unit: MINUTES_UNIT },
+    },
+    horizon: Math.max(1, toPositiveInt(form.horizon, 24)),
+    history: Math.max(1, toPositiveInt(form.history, 40)),
+  };
+};
+
+const buildDetectorSuggestionPayload = (form: CreateAdRuleFormState, intervalOverride?: number) => {
+  const categoryField = formatCategoryField(form);
+  return {
+    name: form.name.trim(),
+    description: form.description.trim(),
+    indices: form.indices,
+    filterQuery: parseFilterQuery(form.filterQuery),
+    uiMetadata: {
+      features: buildFeatureMetadata(form.features),
+      filters: [],
+    },
+    featureAttributes: buildFeatureAttributes(form.features),
+    timeField: form.timeField,
+    shingleSize: toPositiveInt(form.shingleSize, 8),
+    ...(categoryField ? { categoryField } : {}),
+    ...(intervalOverride !== undefined
+      ? {
+          detectionInterval: {
+            period: { interval: intervalOverride, unit: MINUTES_UNIT },
+          },
+        }
+      : {}),
+  };
+};
+
+const extractCreatedId = (response: ApiResponse): string | undefined => {
+  const payload = response.response;
+  return payload?.id || payload?.detectorId || payload?.forecasterId;
+};
+
+const buildErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return i18n.translate('observability.alerting.createAdRuleFlyout.unknownError', {
+    defaultMessage: 'Unknown error',
+  });
+};
+
+const featureErrorKey = (
+  index: number,
+  field: 'featureName' | 'aggregationOf' | 'featureLimit'
+): string => `features.${index}.${field}`;
+
+const validateForm = (
+  form: CreateAdRuleFormState,
+  options: { customResultIndexRequired?: boolean } = {}
+): Record<string, string> => {
+  const errors: Record<string, string> = {};
+  if (!form.name.trim()) {
+    errors.name = i18n.translate('observability.alerting.createAdRuleFlyout.nameRequired', {
+      defaultMessage: 'Rule name is required.',
+    });
+  }
+  if (!form.datasourceId) {
+    errors.datasourceId = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.datasourceRequired',
+      { defaultMessage: 'OpenSearch datasource is required.' }
+    );
+  }
+  if (form.indices.length === 0) {
+    errors.indices = i18n.translate('observability.alerting.createAdRuleFlyout.indicesRequired', {
+      defaultMessage: 'Select at least one index, alias, or pattern.',
+    });
+  }
+  if (!form.timeField.trim()) {
+    errors.timeField = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.timeFieldRequired',
+      { defaultMessage: 'Time field is required.' }
+    );
+  }
+  if (
+    (form.customResultIndexEnabled || options.customResultIndexRequired) &&
+    !form.resultIndex.trim()
+  ) {
+    errors.resultIndex = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.resultIndexRequired',
+      { defaultMessage: 'Result index name is required.' }
+    );
+  }
+  if (form.features.length === 0) {
+    errors[featureErrorKey(0, 'featureName')] = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.featureRequired',
+      {
+        defaultMessage: 'Add at least one feature.',
+      }
+    );
+  }
+  if (form.features.length > MAX_FEATURE_NUM) {
+    errors[featureErrorKey(0, 'featureLimit')] = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.featureLimit',
+      {
+        defaultMessage: 'You can add up to 5 features.',
+      }
+    );
+  }
+  const featureNameCounts = form.features.reduce<Record<string, number>>((counts, feature) => {
+    const featureName = feature.featureName.trim().toLowerCase();
+    if (!featureName) return counts;
+    counts[featureName] = (counts[featureName] ?? 0) + 1;
+    return counts;
+  }, {});
+  form.features.forEach((feature, index) => {
+    const featureName = feature.featureName.trim();
+    if (!featureName) {
+      errors[featureErrorKey(index, 'featureName')] = i18n.translate(
+        'observability.alerting.createAdRuleFlyout.featureNameRequired',
+        {
+          defaultMessage: 'Feature name is required.',
+        }
+      );
+    } else if (featureNameCounts[featureName.toLowerCase()] > 1) {
+      errors[featureErrorKey(index, 'featureName')] = i18n.translate(
+        'observability.alerting.createAdRuleFlyout.featureNameDuplicate',
+        {
+          defaultMessage: 'Duplicate feature name.',
+        }
+      );
+    }
+    if (!feature.aggregationOf.trim()) {
+      errors[featureErrorKey(index, 'aggregationOf')] = i18n.translate(
+        'observability.alerting.createAdRuleFlyout.aggregationFieldRequired',
+        {
+          defaultMessage: 'Feature field is required.',
+        }
+      );
+    }
+  });
+  if (form.categoryFieldEnabled && form.categoryField.length === 0) {
+    errors.categoryField = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.categoryFieldRequired',
+      { defaultMessage: 'Select at least one categorical field.' }
+    );
+  }
+  if (form.categoryField.length > 2) {
+    errors.categoryField = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.categoryFieldMax',
+      { defaultMessage: 'Select no more than two categorical fields.' }
+    );
+  }
+  if (form.filterQuery.trim()) {
+    try {
+      JSON.parse(form.filterQuery);
+    } catch {
+      errors.filterQuery = i18n.translate(
+        'observability.alerting.createAdRuleFlyout.filterQueryInvalid',
+        { defaultMessage: 'Filter query must be valid JSON.' }
+      );
+    }
+  }
+  const intervalValue = parsePositiveInt(form.interval);
+  const frequencyValue = parsePositiveInt(form.frequency);
+  const windowDelayValue = parseNonNegativeInt(form.windowDelay);
+  const historyValue = parsePositiveInt(form.history);
+
+  if (intervalValue === undefined) {
+    errors.interval = i18n.translate('observability.alerting.createAdRuleFlyout.intervalInvalid', {
+      defaultMessage: 'Interval must be at least 1 minute.',
+    });
+  }
+  if (form.frequency !== '' && frequencyValue === undefined) {
+    errors.frequency = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.frequencyInvalid',
+      { defaultMessage: 'Frequency must be at least 1 minute.' }
+    );
+  }
+  if (
+    frequencyValue !== undefined &&
+    intervalValue !== undefined &&
+    frequencyValue % intervalValue !== 0
+  ) {
+    errors.frequency = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.frequencyMultipleInvalid',
+      { defaultMessage: 'Frequency must be a multiple of interval.' }
+    );
+  }
+  if (form.windowDelay !== '' && windowDelayValue === undefined) {
+    errors.windowDelay = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.windowDelayInvalid',
+      { defaultMessage: 'Window delay must be a non-negative integer.' }
+    );
+  }
+  if (form.history !== '' && historyValue === undefined) {
+    errors.history = i18n.translate('observability.alerting.createAdRuleFlyout.historyInvalid', {
+      defaultMessage: 'History must be a positive integer.',
+    });
+  }
+  if (form.shingleSize < 1 || form.shingleSize > 128) {
+    errors.shingleSize = i18n.translate(
+      'observability.alerting.createAdRuleFlyout.shingleInvalid',
+      { defaultMessage: 'Shingle size must be between 1 and 128.' }
+    );
+  }
+  return errors;
+};
+
+const errorsForStep = (
+  errors: Record<string, string>,
+  step: number,
+  ruleType: CreateAdRuleType
+): Record<string, string> => {
+  let stepFields: string[];
+  if (ruleType === 'detector') {
+    stepFields =
+      step === 0
+        ? ['name', 'datasourceId', 'indices', 'timeField', 'filterQuery', 'resultIndex']
+        : step === 1
+        ? [
+            'features',
+            'categoryField',
+            'interval',
+            'frequency',
+            'windowDelay',
+            'history',
+            'shingleSize',
+          ]
+        : step === 2
+        ? []
+        : Object.keys(errors);
+  } else {
+    stepFields =
+      step === 0
+        ? [
+            'name',
+            'datasourceId',
+            'indices',
+            'timeField',
+            'filterQuery',
+            'features',
+            'categoryField',
+          ]
+        : step === 1
+        ? ['interval', 'windowDelay', 'history', 'horizon', 'shingleSize']
+        : Object.keys(errors);
+  }
+
+  return Object.fromEntries(
+    Object.entries(errors).filter(
+      ([key]) =>
+        stepFields.includes(key) || (stepFields.includes('features') && key.startsWith('features.'))
+    )
+  );
+};
+
+const AdLearnMore: React.FC = () => (
+  <EuiLink href={AD_DOCS_LINK} target="_blank">
+    {i18n.translate('observability.alerting.createAdRuleFlyout.learnMore', {
+      defaultMessage: 'Learn more',
+    })}
+  </EuiLink>
+);
+
+const AdContentPanel: React.FC<{
+  title: string | ReactNode;
+  subTitle?: ReactNode;
+  children?: ReactNode;
+  hideBody?: boolean;
+}> = ({ title, subTitle, children, hideBody }) => {
+  const hasTitle = typeof title === 'string' ? title !== '' : true;
+
+  return (
+    <EuiPanel style={{ padding: 20 }}>
+      <EuiFlexGroup style={{ padding: 0 }} justifyContent="spaceBetween" alignItems="center">
+        <EuiFlexItem>
+          {typeof title === 'string' ? (
+            <EuiTitle data-test-subj="contentPanelTitle" size="s">
+              <h3>{title}</h3>
+            </EuiTitle>
+          ) : (
+            title
+          )}
+          {subTitle && (
+            <EuiFlexGroup>
+              <EuiFlexItem
+                className="content-panel-subTitle"
+                style={{ lineHeight: 'normal', maxWidth: '75%' }}
+              >
+                {subTitle}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      {hasTitle && !hideBody && (
+        <div>
+          <EuiHorizontalRule margin="s" />
+          <div style={{ padding: '10px 0px' }}>{children}</div>
+        </div>
+      )}
+    </EuiPanel>
+  );
+};
+
+const AdFormattedFormRow: React.FC<{
+  title?: string;
+  formattedTitle?: ReactNode;
+  hint?: string | string[] | ReactNode | ReactNode[];
+  isInvalid?: boolean;
+  error?: ReactNode;
+  fullWidth?: boolean;
+  helpText?: string;
+  rowStyle?: React.CSSProperties;
+  children: ReactElement;
+}> = ({ title, formattedTitle, hint, children, rowStyle, ...formRowProps }) => {
+  const hints = hint
+    ? (Array.isArray(hint) ? hint : [hint]).map((hintItem, index) => (
+        <EuiText key={index} className="sublabel" style={{ maxWidth: 400 }}>
+          {hintItem}
+        </EuiText>
+      ))
+    : null;
+
+  return (
+    <EuiFormRow
+      label={
+        <div style={{ lineHeight: '8px' }}>
+          {formattedTitle || <p>{title}</p>}
+          <br />
+          {hints}
+        </div>
+      }
+      style={rowStyle}
+      {...formRowProps}
+    >
+      {children}
+    </EuiFormRow>
+  );
+};
+
+const AdIndexPicker: React.FC<{
+  dsId: string;
+  selected: string[];
+  onChange: (next: string[]) => void;
+  isInvalid?: boolean;
+  error?: string;
+}> = ({ dsId, selected, onChange, isInvalid, error }) => {
+  const [search, setSearch] = useState('');
+  const { options: discovered, isLoading, error: discoveryError } = useIndices({ dsId, search });
+
+  const selectedOptions: EuiComboBoxOptionOption[] = selected.map((label) => ({ label }));
+  const discoveredOptions: EuiComboBoxOptionOption[] = discovered
+    .filter((option) => !selected.includes(option.label))
+    .map((option) => ({
+      label: option.label,
+      append: option.aliasFor
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.aliasBadge', {
+            defaultMessage: 'alias -> {target}',
+            values: { target: option.aliasFor },
+          })
+        : undefined,
+    }));
+
+  const discoveryErrorMessage = discoveryError
+    ? i18n.translate('observability.alerting.createAdRuleFlyout.indexDiscoveryError', {
+        defaultMessage: 'Could not load indices: {message}',
+        values: { message: discoveryError.message || 'unknown error' },
+      })
+    : undefined;
+
+  return (
+    <AdFormattedFormRow
+      title={i18n.translate('observability.alerting.createAdRuleFlyout.indexLabel', {
+        defaultMessage: 'Index',
+      })}
+      hint={i18n.translate('observability.alerting.createAdRuleFlyout.indexHint', {
+        defaultMessage: 'Choose an index, index pattern or alias as the data source.',
+      })}
+      helpText={i18n.translate('observability.alerting.createAdRuleFlyout.indexHelp', {
+        defaultMessage: 'You can use a wildcard (*) in your index pattern.',
+      })}
+      isInvalid={isInvalid || !!discoveryErrorMessage}
+      error={error || discoveryErrorMessage}
+    >
+      <EuiComboBox
+        async
+        isLoading={isLoading}
+        isClearable={false}
+        isDisabled={!dsId}
+        options={discoveredOptions}
+        selectedOptions={selectedOptions}
+        onSearchChange={setSearch}
+        onCreateOption={(raw) => {
+          const trimmed = raw.trim();
+          if (trimmed && !selected.includes(trimmed)) onChange([...selected, trimmed]);
+        }}
+        onChange={(options) => onChange(options.map((option) => option.label))}
+        placeholder={i18n.translate('observability.alerting.createAdRuleFlyout.indexPlaceholder', {
+          defaultMessage: 'Find indices',
+        })}
+        data-test-subj="alertManagerCreateAdRuleIndex"
+      />
+    </AdFormattedFormRow>
+  );
+};
+
+const AdTimestampSelector: React.FC<{
+  dsId: string;
+  indices: string[];
+  value: string;
+  onChange: (next: string) => void;
+  isInvalid?: boolean;
+  error?: string;
+}> = ({ dsId, indices, value, onChange, isInvalid, error }) => {
+  const { fieldsByType, isLoading } = useIndexMappings({ dsId, indices });
+
+  const timeStampFieldOptions = useMemo(() => {
+    const fields = new Set<string>();
+    (fieldsByType.date ?? []).forEach((field) => fields.add(field));
+    (fieldsByType.date_nanos ?? []).forEach((field) => fields.add(field));
+    return Array.from(fields)
+      .sort()
+      .map((field) => ({ label: field }));
+  }, [fieldsByType]);
+
+  const selectedOptions: EuiComboBoxOptionOption[] = value ? [{ label: value }] : [];
+
+  return (
+    <AdFormattedFormRow
+      title={i18n.translate('observability.alerting.createAdRuleFlyout.timestampFieldLabel', {
+        defaultMessage: 'Timestamp field',
+      })}
+      hint={i18n.translate('observability.alerting.createAdRuleFlyout.timestampFieldHint', {
+        defaultMessage: 'Choose the time field you want to use for time filter.',
+      })}
+      isInvalid={isInvalid}
+      error={error}
+    >
+      <EuiComboBox
+        singleSelection={{ asPlainText: true }}
+        isClearable={false}
+        isDisabled={indices.length === 0}
+        isLoading={isLoading}
+        options={timeStampFieldOptions}
+        selectedOptions={selectedOptions}
+        onCreateOption={(raw) => {
+          const trimmed = raw.trim();
+          if (trimmed) onChange(trimmed);
+        }}
+        onChange={(options) => onChange(options[0]?.label ?? '')}
+        placeholder={i18n.translate(
+          'observability.alerting.createAdRuleFlyout.timestampFieldPlaceholder',
+          { defaultMessage: 'Find timestamp' }
+        )}
+        data-test-subj="alertManagerCreateAdRuleTimestamp"
+      />
+    </AdFormattedFormRow>
+  );
+};
+
+const FeatureFieldSelector: React.FC<{
+  dsId: string;
+  indices: string[];
+  aggregationBy: string;
+  value: string;
+  onChange: (next: string) => void;
+  isInvalid?: boolean;
+  error?: string;
+  dataTestSubj?: string;
+}> = ({ dsId, indices, aggregationBy, value, onChange, isInvalid, error, dataTestSubj }) => {
+  const { fieldsByType, isLoading } = useIndexMappings({ dsId, indices });
+
+  const fieldOptions = useMemo(() => {
+    const allowedTypes = aggregationBy === 'value_count' ? COUNTABLE_TYPES : NUMBER_TYPES;
+    const seen = new Set<string>();
+    allowedTypes.forEach((type) => {
+      (fieldsByType[type] ?? []).forEach((field) => seen.add(field));
+    });
+    return Array.from(seen)
+      .sort()
+      .map((field) => ({ label: field }));
+  }, [aggregationBy, fieldsByType]);
+
+  const selectedOptions: EuiComboBoxOptionOption[] = value ? [{ label: value }] : [];
+
+  return (
+    <EuiFormRow
+      label={i18n.translate('observability.alerting.createAdRuleFlyout.featureFieldLabel', {
+        defaultMessage: 'Field',
+      })}
+      isInvalid={isInvalid}
+      error={error}
+    >
+      <EuiComboBox
+        singleSelection={{ asPlainText: true }}
+        isClearable
+        isDisabled={!dsId || indices.length === 0}
+        isLoading={isLoading}
+        isInvalid={isInvalid}
+        options={fieldOptions}
+        selectedOptions={selectedOptions}
+        onChange={(picked) => onChange(picked[0]?.label ?? '')}
+        onCreateOption={(raw) => {
+          const trimmed = raw.trim();
+          if (trimmed) onChange(trimmed);
+        }}
+        placeholder={i18n.translate(
+          'observability.alerting.createAdRuleFlyout.featureFieldPlaceholder',
+          { defaultMessage: 'Select field' }
+        )}
+        data-test-subj={dataTestSubj ?? 'alertManagerCreateAdRuleFeatureField'}
+      />
+    </EuiFormRow>
+  );
+};
+
+const CategoryFieldSelector: React.FC<{
+  dsId: string;
+  indices: string[];
+  ruleType: CreateAdRuleType;
+  enabled: boolean;
+  selected: string[];
+  onEnabledChange: (next: boolean) => void;
+  onChange: (next: string[]) => void;
+  isInvalid?: boolean;
+  error?: string;
+}> = ({
+  dsId,
+  indices,
+  ruleType,
+  enabled,
+  selected,
+  onEnabledChange,
+  onChange,
+  isInvalid,
+  error,
+}) => {
+  const { fieldsByType, isLoading } = useIndexMappings({ dsId, indices });
+
+  const categoryOptions = useMemo(() => {
+    const seen = new Set<string>();
+    CATEGORY_TYPES.forEach((type) => {
+      (fieldsByType[type] ?? []).forEach((field) => seen.add(field));
+    });
+    return Array.from(seen)
+      .sort()
+      .map((field) => ({ label: field }));
+  }, [fieldsByType]);
+
+  const selectedOptions = selected.map((field) => ({ label: field }));
+  const noCategoryFields = !isLoading && categoryOptions.length === 0;
+
+  return (
+    <AdContentPanel
+      title={
+        <EuiTitle size="s" id="categoryFieldTitle">
+          <h2>
+            {i18n.translate('observability.alerting.createAdRuleFlyout.detectorCategoryTitle', {
+              defaultMessage: 'Categorical fields',
+            })}
+          </h2>
+        </EuiTitle>
+      }
+      subTitle={
+        <EuiText className="content-panel-subTitle" style={{ lineHeight: 'normal' }}>
+          {ruleType === 'detector'
+            ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCategoryHelp', {
+                defaultMessage:
+                  'Split a single time series into multiple time series based on categorical fields. You can select up to 2.',
+              })
+            : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCategoryHelp', {
+                defaultMessage:
+                  'Split time series using categorical fields. You can select up to 2.',
+              })}{' '}
+          <AdLearnMore />
+        </EuiText>
+      }
+    >
+      {noCategoryFields && (
+        <>
+          <EuiCallOut
+            color="warning"
+            iconType="alert"
+            size="s"
+            title={i18n.translate('observability.alerting.createAdRuleFlyout.noCategoryFields', {
+              defaultMessage: 'There are no available category fields for the selected index',
+            })}
+          />
+          <EuiSpacer size="m" />
+        </>
+      )}
+      <EuiFlexGroup direction="column">
+        <EuiFlexItem>
+          <EuiCheckbox
+            id="categoryFieldCheckbox"
+            label={
+              ruleType === 'detector'
+                ? i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.enableDetectorCategory',
+                    { defaultMessage: 'Enable categorical fields' }
+                  )
+                : i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.enableForecasterCategory',
+                    { defaultMessage: 'Split time series using categorical fields' }
+                  )
+            }
+            checked={enabled}
+            disabled={noCategoryFields || !dsId || indices.length === 0}
+            onChange={(e) => {
+              const checked = e.target.checked;
+              onEnabledChange(checked);
+              if (!checked) onChange([]);
+            }}
+          />
+        </EuiFlexItem>
+        {enabled && ruleType === 'detector' && (
+          <EuiFlexItem>
+            <EuiCallOut
+              color="warning"
+              iconType="alert"
+              size="s"
+              title={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.categoryReadonlyWarning',
+                {
+                  defaultMessage:
+                    "You can't change the category fields after you create the detector. Make sure that you only select the fields necessary for your use case.",
+                }
+              )}
+            />
+          </EuiFlexItem>
+        )}
+        {enabled && !noCategoryFields && (
+          <EuiFlexItem>
+            <EuiFormRow
+              label={
+                ruleType === 'detector'
+                  ? i18n.translate('observability.alerting.createAdRuleFlyout.categoryFieldLabel', {
+                      defaultMessage: 'Field',
+                    })
+                  : i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.forecasterCategoryFieldLabel',
+                      { defaultMessage: 'Categorical fields' }
+                    )
+              }
+              helpText={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.categoryFieldHelp',
+                {
+                  defaultMessage:
+                    "You can only apply the categorical fields to the 'ip' and 'keyword' OpenSearch data types.",
+                }
+              )}
+              isInvalid={isInvalid}
+              error={error}
+            >
+              <EuiComboBox
+                isClearable
+                isLoading={isLoading}
+                isInvalid={isInvalid}
+                options={categoryOptions}
+                selectedOptions={selectedOptions}
+                onChange={(options) => {
+                  onChange(options.slice(0, 2).map((option) => option.label));
+                }}
+                placeholder={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.categoryFieldPlaceholder',
+                  { defaultMessage: 'Select your categorical fields' }
+                )}
+                data-test-subj="alertManagerCreateAdRuleCategoryField"
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </AdContentPanel>
+  );
+};
+
+const SuggestParametersDialog: React.FC<{
+  form: CreateAdRuleFormState;
+  onClose: () => void;
+  onUseSuggestedParameters: (values: {
+    interval: number;
+    frequency: number;
+    history: number;
+    windowDelay: number;
+  }) => void;
+}> = ({ form, onClose, onUseSuggestedParameters }) => {
+  const [suggestMode, setSuggestMode] = useState<'all' | 'provided'>('all');
+  const [providedInterval, setProvidedInterval] = useState<string>(
+    String(parsePositiveInt(form.interval) ?? 10)
+  );
+  const [step, setStep] = useState<SuggestDialogStep>('config');
+  const [errorMsg, setErrorMsg] = useState<string | undefined>();
+  const [suggestedInterval, setSuggestedInterval] = useState<number | undefined>();
+  const [suggestedHistory, setSuggestedHistory] = useState<number | undefined>();
+  const [suggestedWindowDelay, setSuggestedWindowDelay] = useState<number | undefined>();
+
+  const radioOptions = [
+    {
+      id: 'all',
+      label: i18n.translate('observability.alerting.createAdRuleFlyout.suggestAllParams', {
+        defaultMessage: 'Suggest detection interval, frequency, history, and window delay',
+      }),
+    },
+    {
+      id: 'provided',
+      label: i18n.translate(
+        'observability.alerting.createAdRuleFlyout.suggestWithProvidedInterval',
+        {
+          defaultMessage: 'Suggest frequency, history, and window delay for the provided interval',
+        }
+      ),
+    },
+  ];
+
+  const onGenerateSuggestions = async () => {
+    setStep('loading');
+    setErrorMsg(undefined);
+    setSuggestedInterval(undefined);
+    setSuggestedHistory(undefined);
+    setSuggestedWindowDelay(undefined);
+
+    const parsedInterval = Number(providedInterval);
+    const intervalForSuggestion =
+      suggestMode === 'all' || Number.isNaN(parsedInterval) ? undefined : parsedInterval;
+    const suggestionParams =
+      suggestMode === 'all' ? 'detection_interval,history,window_delay' : 'history,window_delay';
+
+    try {
+      const response = await coreRefs.http?.post<
+        ApiResponse<DetectorSuggestionResponse> | DetectorSuggestionResponse
+      >(
+        withOptionalDatasource(
+          `${AD_DETECTOR_API}/_suggest/${suggestionParams}`,
+          form.datasourceId
+        ),
+        {
+          body: JSON.stringify(buildDetectorSuggestionPayload(form, intervalForSuggestion)),
+        }
+      );
+      const payload =
+        response && 'response' in response
+          ? (response.response as DetectorSuggestionResponse | undefined)
+          : response;
+
+      if (!payload) {
+        setErrorMsg(
+          i18n.translate('observability.alerting.createAdRuleFlyout.suggestEmptyResponse', {
+            defaultMessage: 'Empty response from suggestDetector.',
+          })
+        );
+        setStep('error');
+        return;
+      }
+
+      if (payload.exception) {
+        setErrorMsg(String(payload.exception));
+        setStep('error');
+        return;
+      }
+
+      const intervalValue =
+        payload.detectionInterval?.period?.interval ?? payload.interval?.period?.interval;
+      const frequencyValue = payload.frequency?.period?.interval;
+      const derivedInterval =
+        typeof intervalValue === 'number'
+          ? intervalValue
+          : typeof frequencyValue === 'number'
+          ? frequencyValue
+          : 10;
+
+      const historyValue = payload.history;
+      const windowDelayValue = payload.windowDelay?.period?.interval;
+
+      setSuggestedInterval(derivedInterval);
+      setSuggestedHistory(typeof historyValue === 'number' ? historyValue : 40);
+      setSuggestedWindowDelay(typeof windowDelayValue === 'number' ? windowDelayValue : 1);
+      setStep('result');
+    } catch (error) {
+      setErrorMsg(buildErrorMessage(error));
+      setStep('error');
+    }
+  };
+
+  const useSuggestedParameters = () => {
+    const intervalToUse = suggestedInterval ?? 10;
+    onUseSuggestedParameters({
+      interval: intervalToUse,
+      frequency: intervalToUse,
+      history: suggestedHistory ?? 40,
+      windowDelay: suggestedWindowDelay ?? 1,
+    });
+    onClose();
+  };
+
+  const isConfig = step === 'config';
+  const isLoading = step === 'loading';
+  const isError = step === 'error';
+  const isResult = step === 'result';
+
+  return (
+    <EuiModal onClose={onClose} initialFocus="[name=radioGroup]">
+      <EuiModalHeader>
+        <EuiModalHeaderTitle data-test-subj="suggestParametersDialogTitle">
+          <h2>
+            {i18n.translate('observability.alerting.createAdRuleFlyout.suggestTitle', {
+              defaultMessage: 'Suggest parameters',
+            })}
+          </h2>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        {isConfig && (
+          <>
+            <EuiText>
+              <p>
+                {i18n.translate('observability.alerting.createAdRuleFlyout.suggestBody', {
+                  defaultMessage:
+                    'Based on your data source and current configuration, OpenSearch can recommend core parameters for your detector.',
+                })}
+              </p>
+            </EuiText>
+            <EuiSpacer size="m" />
+            <EuiRadioGroup
+              name="radioGroup"
+              options={radioOptions}
+              idSelected={suggestMode}
+              onChange={(optionId) => setSuggestMode(optionId as 'all' | 'provided')}
+            />
+            <EuiSpacer size="m" />
+            {suggestMode === 'provided' && (
+              <EuiFormRow
+                label={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.providedIntervalLabel',
+                  { defaultMessage: 'Detection interval' }
+                )}
+                helpText={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.providedIntervalHelp',
+                  { defaultMessage: 'A valid interval is from 1 minute to 30 days.' }
+                )}
+              >
+                <EuiFieldNumber
+                  min={1}
+                  max={43200}
+                  value={providedInterval}
+                  onChange={(e) => setProvidedInterval(e.target.value)}
+                  append={i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.minutesAppend',
+                    { defaultMessage: 'minutes' }
+                  )}
+                />
+              </EuiFormRow>
+            )}
+          </>
+        )}
+
+        {isLoading && (
+          <>
+            <EuiLoadingSpinner size="m" />
+            <EuiText size="s">
+              <p>
+                {i18n.translate('observability.alerting.createAdRuleFlyout.suggestLoading', {
+                  defaultMessage: 'Calculating model parameters...',
+                })}
+              </p>
+              <p>
+                {i18n.translate('observability.alerting.createAdRuleFlyout.suggestLoadingHelp', {
+                  defaultMessage:
+                    'The calculation might take a few minutes. Do not close this window.',
+                })}
+              </p>
+            </EuiText>
+          </>
+        )}
+
+        {isError && (
+          <EuiCallOut
+            title={i18n.translate('observability.alerting.createAdRuleFlyout.suggestError', {
+              defaultMessage: 'Error',
+            })}
+            color="danger"
+            iconType="alert"
+          >
+            <p>{errorMsg}</p>
+          </EuiCallOut>
+        )}
+
+        {isResult && (
+          <EuiText data-test-subj="suggestedParametersResult">
+            <p>
+              {i18n.translate('observability.alerting.createAdRuleFlyout.suggestResultIntro', {
+                defaultMessage: 'Based on your inputs, the suggested parameters are:',
+              })}
+            </p>
+            <div className="eui-textLeft">
+              <span>
+                • Detection interval: {suggestedInterval} minutes
+                <br />
+              </span>
+              <span>
+                • Frequency: {suggestedInterval} minutes
+                <br />
+              </span>
+              <span>
+                • History: {suggestedHistory} intervals
+                {suggestedInterval && suggestedHistory && (
+                  <>
+                    {' '}
+                    ({Math.floor((suggestedHistory * suggestedInterval) / 60)} hours{' '}
+                    {(suggestedHistory * suggestedInterval) % 60} minutes)
+                  </>
+                )}
+                <br />
+              </span>
+              <span>• Window delay: {suggestedWindowDelay} minutes</span>
+            </div>
+          </EuiText>
+        )}
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiSmallButtonEmpty onClick={onClose}>
+          {i18n.translate('observability.alerting.createAdRuleFlyout.suggestCancel', {
+            defaultMessage: 'Cancel',
+          })}
+        </EuiSmallButtonEmpty>
+        {isConfig && (
+          <EuiSmallButton
+            fill
+            iconType="arrowRight"
+            iconSide="right"
+            data-test-subj="generateSuggestionsButton"
+            onClick={onGenerateSuggestions}
+          >
+            {i18n.translate('observability.alerting.createAdRuleFlyout.generateSuggestions', {
+              defaultMessage: 'Generate suggestions',
+            })}
+          </EuiSmallButton>
+        )}
+        {(isLoading || isError || isResult) && (
+          <EuiSmallButton iconType="arrowLeft" onClick={() => setStep('config')}>
+            {i18n.translate('observability.alerting.createAdRuleFlyout.suggestBack', {
+              defaultMessage: 'Back',
+            })}
+          </EuiSmallButton>
+        )}
+        {isResult && (
+          <EuiSmallButton
+            fill
+            color="primary"
+            onClick={useSuggestedParameters}
+            data-test-subj="useSuggestedParametersButton"
+          >
+            {i18n.translate('observability.alerting.createAdRuleFlyout.useSuggestedParameters', {
+              defaultMessage: 'Use suggested parameters',
+            })}
+          </EuiSmallButton>
+        )}
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};
+
+export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
+  ruleType,
+  datasources,
+  selectedDsIds,
+  mode = 'create',
+  editTarget,
+  onCancel,
+  onCreated,
+  onUpdated,
+}) => {
+  const openSearchDatasources = useMemo(() => getOpenSearchDatasources(datasources), [datasources]);
+  const isEdit = mode === 'edit' && !!editTarget;
+  const isDetectorSettingsEdit =
+    isEdit && ruleType === 'detector' && editTarget?.initialStep !== 'model';
+  const isDetectorModelEdit =
+    isEdit && ruleType === 'detector' && editTarget?.initialStep === 'model';
+  const isSingleDetectorEdit = isDetectorSettingsEdit || isDetectorModelEdit;
+  const editValidationStep = isDetectorModelEdit ? 1 : 0;
+  const getInitialStep = useCallback(() => 0, []);
+  const [form, setForm] = useState<CreateAdRuleFormState>(() =>
+    createInitialForm(
+      isEdit && editTarget
+        ? editTarget.datasourceId
+        : getInitialDatasourceId(datasources, selectedDsIds)
+    )
+  );
+  const [currentStep, setCurrentStep] = useState(getInitialStep);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
+  const [showSuggestDialog, setShowSuggestDialog] = useState(false);
+  const [isServerless, setIsServerless] = useState(false);
+  const [hasLoadedEditForm, setHasLoadedEditForm] = useState(false);
+  const [hasStoppedForEdit, setHasStoppedForEdit] = useState(false);
+  const [shouldOfferStartDetectorAfterEdit, setShouldOfferStartDetectorAfterEdit] = useState(false);
+  const [startAfterEditPrompt, setStartAfterEditPrompt] = useState<{
+    detectorId: string;
+    datasourceId: string;
+  } | null>(null);
+  const [showStopForEditModal, setShowStopForEditModal] = useState(false);
+  const [isStoppingForEdit, setIsStoppingForEdit] = useState(false);
+  const [isStartingEditedDetector, setIsStartingEditedDetector] = useState(false);
+  const { data: editDetail, error: editDetailError } = useRuleDetail(
+    editTarget?.datasourceId,
+    editTarget?.id,
+    isEdit ? ruleType : undefined
+  );
+  const existingResource = editDetail?.raw as ADDetector | ADForecaster | undefined;
+
+  const isDetector = ruleType === 'detector';
+  const customResultIndexRequired = isDetector && isServerless;
+  const resultIndexEnabled = form.customResultIndexEnabled || customResultIndexRequired;
+  const isEditFormReady = !isEdit || hasLoadedEditForm;
+  const editLifecycleBlocker = isEdit
+    ? getEditLifecycleBlocker(ruleType, existingResource, hasStoppedForEdit)
+    : null;
+  const title = isEdit
+    ? isDetector
+      ? i18n.translate('observability.alerting.createAdRuleFlyout.editDetectorTitle', {
+          defaultMessage: 'Edit anomaly detection rule',
+        })
+      : i18n.translate('observability.alerting.createAdRuleFlyout.editForecasterTitle', {
+          defaultMessage: 'Edit forecasting rule',
+        })
+    : isDetector
+    ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
+        defaultMessage: 'Create anomaly detection rule',
+      })
+    : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
+        defaultMessage: 'Create forecasting rule',
+      });
+  const detectorStepTitles = isEdit
+    ? [
+        isDetectorModelEdit
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.editModelStep', {
+              defaultMessage: 'Edit model configuration',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.editDetectorSettingsStep', {
+              defaultMessage: 'Edit detector settings',
+            }),
+      ]
+    : [
+        i18n.translate('observability.alerting.createAdRuleFlyout.defineDetectorStep', {
+          defaultMessage: 'Define detector',
+        }),
+        i18n.translate('observability.alerting.createAdRuleFlyout.configureModelStep', {
+          defaultMessage: 'Configure model',
+        }),
+        i18n.translate('observability.alerting.createAdRuleFlyout.detectorJobsStep', {
+          defaultMessage: 'Set up detector jobs',
+        }),
+        i18n.translate('observability.alerting.createAdRuleFlyout.reviewStep', {
+          defaultMessage: 'Review and create',
+        }),
+      ];
+  const stepTitles = isDetector
+    ? detectorStepTitles
+    : [
+        i18n.translate('observability.alerting.createAdRuleFlyout.defineForecasterStep', {
+          defaultMessage: 'Define data source',
+        }),
+        i18n.translate('observability.alerting.createAdRuleFlyout.configureForecastStep', {
+          defaultMessage: 'Add model parameters',
+        }),
+      ];
+  const finalStep = stepTitles.length - 1;
+  const allErrors = validateForm(form, { customResultIndexRequired });
+  const currentValidationStep = isSingleDetectorEdit ? editValidationStep : currentStep;
+  const submitBlockingErrors = isEdit
+    ? errorsForStep(allErrors, currentValidationStep, ruleType)
+    : allErrors;
+  const visibleErrors = hasSubmitted
+    ? errorsForStep(allErrors, currentValidationStep, ruleType)
+    : {};
+
+  useEffect(() => {
+    if (!isEdit || !editTarget) return;
+    setHasLoadedEditForm(false);
+    setForm(createInitialForm(editTarget.datasourceId));
+    setCurrentStep(getInitialStep());
+    setHasSubmitted(false);
+    setSubmitError(null);
+    setHasStoppedForEdit(false);
+    setShouldOfferStartDetectorAfterEdit(false);
+    setStartAfterEditPrompt(null);
+    setShowStopForEditModal(false);
+    setIsStoppingForEdit(false);
+    setIsStartingEditedDetector(false);
+  }, [editTarget, getInitialStep, isEdit]);
+
+  useEffect(() => {
+    if (!isEdit || hasLoadedEditForm || !editTarget || !existingResource) return;
+    setForm(formFromAdResource(ruleType, existingResource, editTarget.datasourceId));
+    setHasLoadedEditForm(true);
+  }, [editTarget, existingResource, hasLoadedEditForm, isEdit, ruleType]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!isDetector) {
+      setIsServerless(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    isServerlessDataSource(form.datasourceId).then((result) => {
+      if (!cancelled) setIsServerless(result);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [form.datasourceId, isDetector]);
+
+  useEffect(() => {
+    if (!customResultIndexRequired) return;
+
+    setForm((prev) =>
+      prev.customResultIndexEnabled ? prev : { ...prev, customResultIndexEnabled: true }
+    );
+  }, [customResultIndexRequired]);
+
+  useEffect(() => {
+    if (isEdit && isEditFormReady && editLifecycleBlocker && !showStopForEditModal) {
+      setShowStopForEditModal(true);
+    }
+  }, [editLifecycleBlocker, isEdit, isEditFormReady, showStopForEditModal]);
+
+  const updateForm = useCallback(
+    <K extends keyof CreateAdRuleFormState>(key: K, value: CreateAdRuleFormState[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+      setSubmitError(null);
+    },
+    []
+  );
+
+  const updateFeature = useCallback(
+    <K extends keyof CreateAdFeatureFormState>(
+      index: number,
+      key: K,
+      value: CreateAdFeatureFormState[K]
+    ) => {
+      setForm((prev) => ({
+        ...prev,
+        features: prev.features.map((feature, featureIndex) =>
+          featureIndex === index ? { ...feature, [key]: value } : feature
+        ),
+      }));
+      setSubmitError(null);
+    },
+    []
+  );
+
+  const addFeature = useCallback(() => {
+    setForm((prev) =>
+      prev.features.length >= MAX_FEATURE_NUM
+        ? prev
+        : { ...prev, features: [...prev.features, createInitialFeature()] }
+    );
+    setSubmitError(null);
+  }, []);
+
+  const removeFeature = useCallback((index: number) => {
+    setForm((prev) => ({
+      ...prev,
+      features:
+        prev.features.length <= 1
+          ? [createInitialFeature()]
+          : prev.features.filter((_, featureIndex) => featureIndex !== index),
+    }));
+    setSubmitError(null);
+  }, []);
+
+  const updateDataSelection = useCallback(
+    (next: Partial<Pick<CreateAdRuleFormState, 'datasourceId' | 'indices'>>) => {
+      setForm((prev) => ({
+        ...prev,
+        ...next,
+        timeField: '',
+        categoryFieldEnabled: false,
+        categoryField: [],
+        features: resetFeatureFieldSelections(prev.features),
+      }));
+      setSubmitError(null);
+    },
+    []
+  );
+
+  const useSuggestedParameters = useCallback(
+    (values: { interval: number; frequency: number; history: number; windowDelay: number }) => {
+      setForm((prev) => ({
+        ...prev,
+        interval: values.interval,
+        frequency: values.frequency,
+        history: values.history,
+        windowDelay: values.windowDelay,
+      }));
+      setSubmitError(null);
+    },
+    []
+  );
+
+  const handleStopForEditModalCancel = useCallback(() => {
+    setShowStopForEditModal(false);
+    onCancel();
+  }, [onCancel]);
+
+  const assertLifecycleActionResponse = useCallback(
+    (response: ApiResponse | undefined, fallbackMessage: string) => {
+      if (!response) throw new Error(fallbackMessage);
+      if (response.ok === false) {
+        throw new Error(response.error || response.message || fallbackMessage);
+      }
+    },
+    []
+  );
+
+  const handleStartEditedDetector = useCallback(
+    async (detectorId: string, datasourceId: string) => {
+      const startErrorMessage = i18n.translate(
+        'observability.alerting.createAdRuleFlyout.detectorStartAfterEditFailedMessage',
+        { defaultMessage: 'There was a problem starting the detector' }
+      );
+
+      setIsStartingEditedDetector(true);
+      setSubmitError(null);
+      try {
+        const response = await coreRefs.http?.post<ApiResponse>(
+          withOptionalDatasource(
+            `${AD_DETECTOR_API}/${encodeURIComponent(detectorId)}/start`,
+            datasourceId
+          )
+        );
+        assertLifecycleActionResponse(response, startErrorMessage);
+        coreRefs.toasts?.addSuccess(
+          i18n.translate(
+            'observability.alerting.createAdRuleFlyout.detectorStartedAfterEditToast',
+            {
+              defaultMessage: 'Detector started successfully',
+            }
+          )
+        );
+        setStartAfterEditPrompt(null);
+        onUpdated?.();
+      } catch (error) {
+        coreRefs.toasts?.addDanger({
+          title: i18n.translate(
+            'observability.alerting.createAdRuleFlyout.detectorStartAfterEditFailed',
+            { defaultMessage: 'Failed to start detector' }
+          ),
+          text: buildErrorMessage(error),
+        });
+      } finally {
+        setIsStartingEditedDetector(false);
+      }
+    },
+    [assertLifecycleActionResponse, onUpdated]
+  );
+
+  const handleCloseAfterEditPrompt = useCallback(() => {
+    setStartAfterEditPrompt(null);
+    if (onUpdated) {
+      onUpdated();
+      return;
+    }
+    onCancel();
+  }, [onCancel, onUpdated]);
+
+  const handleStopAndProceedToEdit = useCallback(async () => {
+    if (!isEdit || !editTarget || !existingResource || !editLifecycleBlocker) return;
+
+    setIsStoppingForEdit(true);
+    setSubmitError(null);
+    try {
+      if (ruleType === 'detector') {
+        const runningJobsLabel = getDetectorRunningJobsLabel(existingResource);
+        const stoppedRealTimeDetector = isDetectorRealTimeJobRunning(existingResource);
+        const stopErrorMessage = i18n.translate(
+          'observability.alerting.createAdRuleFlyout.detectorStopForEditFailedMessage',
+          {
+            defaultMessage: 'There was a problem stopping the {runningJobsLabel}',
+            values: { runningJobsLabel },
+          }
+        );
+
+        if (isDetectorRealTimeJobRunning(existingResource)) {
+          const response = await coreRefs.http?.post<ApiResponse>(
+            withOptionalDatasource(
+              `${AD_DETECTOR_API}/${encodeURIComponent(editTarget.id)}/stop/false`,
+              form.datasourceId
+            )
+          );
+          assertLifecycleActionResponse(response, stopErrorMessage);
+        }
+
+        if (isDetectorHistoricalJobRunning(existingResource)) {
+          const response = await coreRefs.http?.post<ApiResponse>(
+            withOptionalDatasource(
+              `${AD_DETECTOR_API}/${encodeURIComponent(editTarget.id)}/stop/true`,
+              form.datasourceId
+            )
+          );
+          assertLifecycleActionResponse(response, stopErrorMessage);
+        }
+
+        coreRefs.toasts?.addSuccess(
+          i18n.translate('observability.alerting.createAdRuleFlyout.detectorStoppedForEditToast', {
+            defaultMessage: 'Successfully stopped the {runningJobsLabel}',
+            values: { runningJobsLabel },
+          })
+        );
+        setShouldOfferStartDetectorAfterEdit(stoppedRealTimeDetector);
+      } else {
+        const response = await coreRefs.http?.post<ApiResponse>(
+          withOptionalDatasource(
+            `${FORECASTER_API}/${encodeURIComponent(editTarget.id)}/stop`,
+            form.datasourceId
+          )
+        );
+        assertLifecycleActionResponse(
+          response,
+          i18n.translate(
+            'observability.alerting.createAdRuleFlyout.forecasterStopForEditFailedMessage',
+            { defaultMessage: 'There was a problem stopping the forecast' }
+          )
+        );
+        coreRefs.toasts?.addSuccess(
+          i18n.translate(
+            'observability.alerting.createAdRuleFlyout.forecasterStoppedForEditToast',
+            { defaultMessage: 'Successfully stopped the forecast' }
+          )
+        );
+        setShouldOfferStartDetectorAfterEdit(false);
+      }
+
+      setHasStoppedForEdit(true);
+      setShowStopForEditModal(false);
+    } catch (error) {
+      const message = buildErrorMessage(error);
+      setSubmitError(message);
+      coreRefs.toasts?.addDanger({
+        title:
+          ruleType === 'detector'
+            ? i18n.translate(
+                'observability.alerting.createAdRuleFlyout.detectorStopForEditFailed',
+                { defaultMessage: 'Failed to stop detector' }
+              )
+            : i18n.translate(
+                'observability.alerting.createAdRuleFlyout.forecasterStopForEditFailed',
+                { defaultMessage: 'Failed to stop forecast' }
+              ),
+        text: message,
+      });
+    } finally {
+      setIsStoppingForEdit(false);
+    }
+  }, [
+    assertLifecycleActionResponse,
+    editLifecycleBlocker,
+    editTarget,
+    existingResource,
+    form.datasourceId,
+    isEdit,
+    ruleType,
+  ]);
+
+  const handleNext = () => {
+    if (editLifecycleBlocker) {
+      setShowStopForEditModal(true);
+      return;
+    }
+    setHasSubmitted(true);
+    const stepErrors = errorsForStep(
+      validateForm(form, { customResultIndexRequired }),
+      currentValidationStep,
+      ruleType
+    );
+    if (Object.keys(stepErrors).length) return;
+    setHasSubmitted(false);
+    setCurrentStep((step) => Math.min(finalStep, step + 1));
+  };
+
+  const handlePrevious = () => {
+    setHasSubmitted(false);
+    setCurrentStep((step) => Math.max(0, step - 1));
+  };
+
+  const handleSubmit = useCallback(async () => {
+    setHasSubmitted(true);
+    if (isEdit && (!editTarget || !existingResource)) return;
+    if (editLifecycleBlocker) {
+      setShowStopForEditModal(true);
+      coreRefs.toasts?.addDanger(
+        ruleType === 'detector'
+          ? i18n.translate(
+              'observability.alerting.createAdRuleFlyout.detectorRunningUpdateBlocked',
+              { defaultMessage: 'Detector cannot be updated while it is running' }
+            )
+          : i18n.translate(
+              'observability.alerting.createAdRuleFlyout.forecasterActiveUpdateBlocked',
+              { defaultMessage: 'Forecast cannot be updated while it is active' }
+            )
+      );
+      return;
+    }
+    const validationErrors = validateForm(form, { customResultIndexRequired });
+    const blockingErrors = isEdit
+      ? errorsForStep(validationErrors, currentValidationStep, ruleType)
+      : validationErrors;
+    if (Object.keys(blockingErrors).length || isSaving) return;
+    setIsSaving(true);
+    setSubmitError(null);
+    try {
+      const basePath = isDetector ? AD_DETECTOR_API : FORECASTER_API;
+      const requestPath =
+        isEdit && editTarget
+          ? withOptionalDatasource(
+              `${basePath}/${encodeURIComponent(editTarget.id)}`,
+              form.datasourceId
+            )
+          : withOptionalDatasource(basePath, form.datasourceId);
+      const requestBody = JSON.stringify(
+        buildRulePayload(ruleType, form, {
+          customResultIndexRequired,
+          existingResource: isEdit ? existingResource : undefined,
+        })
+      );
+      const response = isEdit
+        ? await coreRefs.http?.put<ApiResponse>(requestPath, { body: requestBody })
+        : await coreRefs.http?.post<ApiResponse>(requestPath, { body: requestBody });
+
+      if (!response?.ok) {
+        throw new Error(
+          response?.error ||
+            response?.message ||
+            (isEdit ? 'Update request failed' : 'Create request failed')
+        );
+      }
+
+      const createdId = extractCreatedId(response);
+      if (!isEdit && isDetector && createdId && form.startAfterCreate) {
+        await coreRefs.http?.post(
+          withOptionalDatasource(
+            `${basePath}/${encodeURIComponent(createdId)}/start`,
+            form.datasourceId
+          )
+        );
+      }
+
+      const successToastTitle = isEdit
+        ? isDetector
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorUpdatedToast', {
+              defaultMessage: 'Anomaly detection rule updated successfully',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterUpdatedToast', {
+              defaultMessage: 'Forecasting rule updated successfully',
+            })
+        : isDetector
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
+            defaultMessage: 'Anomaly detection rule created successfully',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
+            defaultMessage: 'Forecasting rule created successfully',
+          });
+
+      if (isEdit && isDetector && shouldOfferStartDetectorAfterEdit && editTarget) {
+        setStartAfterEditPrompt({
+          detectorId: editTarget.id,
+          datasourceId: form.datasourceId,
+        });
+        coreRefs.toasts?.addSuccess(successToastTitle);
+        return;
+      } else {
+        coreRefs.toasts?.addSuccess(successToastTitle);
+      }
+      if (isEdit) {
+        onUpdated?.();
+      } else {
+        onCreated?.();
+      }
+    } catch (error) {
+      const message = buildErrorMessage(error);
+      setSubmitError(message);
+      coreRefs.toasts?.addDanger({
+        title: isEdit
+          ? isDetector
+            ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorUpdateFailed', {
+                defaultMessage: 'Failed to update anomaly detection rule',
+              })
+            : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterUpdateFailed', {
+                defaultMessage: 'Failed to update forecasting rule',
+              })
+          : isDetector
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
+              defaultMessage: 'Failed to create anomaly detection rule',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
+              defaultMessage: 'Failed to create forecasting rule',
+            }),
+        text: message,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    customResultIndexRequired,
+    currentValidationStep,
+    editLifecycleBlocker,
+    editTarget,
+    existingResource,
+    form,
+    isDetector,
+    isEdit,
+    isSaving,
+    onCreated,
+    onUpdated,
+    ruleType,
+    shouldOfferStartDetectorAfterEdit,
+  ]);
+
+  const datasourceOptions = openSearchDatasources.map((datasource) => ({
+    value: datasource.id,
+    text: datasource.name || datasource.id,
+  }));
+
+  const steps = stepTitles.map((stepTitle, index) => ({
+    title: stepTitle,
+    status: index < currentStep ? 'complete' : index === currentStep ? 'incomplete' : 'disabled',
+    children: index === currentStep ? <span /> : undefined,
+  }));
+  const submitButtonLabel = (() => {
+    if (isSaving) {
+      return isEdit
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.savingButton', {
+            defaultMessage: 'Saving...',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.creatingButton', {
+            defaultMessage: 'Creating...',
+          });
+    }
+
+    return isEdit
+      ? i18n.translate('observability.alerting.createAdRuleFlyout.saveButton', {
+          defaultMessage: 'Save changes',
+        })
+      : i18n.translate('observability.alerting.createAdRuleFlyout.createButton', {
+          defaultMessage: 'Create rule',
+        });
+  })();
+
+  const renderDefineStep = () => (
+    <>
+      <AdContentPanel
+        title={
+          isDetector
+            ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorDetailsTitle', {
+                defaultMessage: 'Detector details',
+              })
+            : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterDetailsTitle', {
+                defaultMessage: 'Forecaster details',
+              })
+        }
+      >
+        <AdFormattedFormRow
+          title={i18n.translate('observability.alerting.createAdRuleFlyout.nameLabel', {
+            defaultMessage: 'Name',
+          })}
+          hint={i18n.translate('observability.alerting.createAdRuleFlyout.nameHint', {
+            defaultMessage: 'Specify a unique and descriptive name that is easy to recognize.',
+          })}
+          helpText={i18n.translate('observability.alerting.createAdRuleFlyout.nameHelpText', {
+            defaultMessage:
+              'Detector name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period).',
+          })}
+          isInvalid={!!visibleErrors.name}
+          error={visibleErrors.name}
+        >
+          <EuiFieldText
+            value={form.name}
+            onChange={(e) => updateForm('name', e.target.value)}
+            placeholder={i18n.translate(
+              'observability.alerting.createAdRuleFlyout.detectorNamePlaceholder',
+              { defaultMessage: 'Enter detector name' }
+            )}
+            data-test-subj="alertManagerCreateAdRuleName"
+          />
+        </AdFormattedFormRow>
+
+        <AdFormattedFormRow
+          formattedTitle={
+            <p>
+              {i18n.translate('observability.alerting.createAdRuleFlyout.descriptionLabel', {
+                defaultMessage: 'Description',
+              })}{' '}
+              <span className="optional">
+                {i18n.translate('observability.alerting.createAdRuleFlyout.optionalLabel', {
+                  defaultMessage: '- optional',
+                })}
+              </span>
+            </p>
+          }
+          hint={i18n.translate('observability.alerting.createAdRuleFlyout.descriptionHint', {
+            defaultMessage: isDetector
+              ? 'Describe the purpose of the detector.'
+              : 'Describe the purpose of the forecaster.',
+          })}
+        >
+          <EuiTextArea
+            value={form.description}
+            onChange={(e) => updateForm('description', e.target.value)}
+            placeholder={i18n.translate(
+              'observability.alerting.createAdRuleFlyout.descriptionPlaceholder',
+              { defaultMessage: isDetector ? 'Describe the detector' : 'Describe the forecaster' }
+            )}
+            rows={3}
+            data-test-subj="alertManagerCreateAdRuleDescription"
+          />
+        </AdFormattedFormRow>
+      </AdContentPanel>
+
+      <EuiSpacer />
+
+      <AdContentPanel
+        title={i18n.translate('observability.alerting.createAdRuleFlyout.selectDataTitle', {
+          defaultMessage: 'Select Data',
+        })}
+      >
+        <AdFormattedFormRow
+          title={i18n.translate('observability.alerting.createAdRuleFlyout.datasourceLabel', {
+            defaultMessage: 'Datasource',
+          })}
+          hint={i18n.translate('observability.alerting.createAdRuleFlyout.datasourceHint', {
+            defaultMessage: 'Select the OpenSearch datasource for this rule.',
+          })}
+          isInvalid={!!visibleErrors.datasourceId}
+          error={visibleErrors.datasourceId}
+        >
+          <EuiSelect
+            options={datasourceOptions}
+            value={form.datasourceId}
+            disabled={isEdit}
+            onChange={(e) => {
+              updateDataSelection({ datasourceId: e.target.value, indices: [] });
+            }}
+            data-test-subj="alertManagerCreateAdRuleDatasource"
+          />
+        </AdFormattedFormRow>
+
+        <AdIndexPicker
+          dsId={form.datasourceId}
+          selected={form.indices}
+          onChange={(next) => {
+            updateDataSelection({ indices: next });
+          }}
+          isInvalid={!!visibleErrors.indices}
+          error={visibleErrors.indices}
+        />
+
+        <AdFormattedFormRow
+          formattedTitle={
+            <p>
+              {i18n.translate('observability.alerting.createAdRuleFlyout.filterQueryLabel', {
+                defaultMessage: 'Filter query',
+              })}{' '}
+              <span className="optional">
+                {i18n.translate('observability.alerting.createAdRuleFlyout.optionalLabel', {
+                  defaultMessage: '- optional',
+                })}
+              </span>
+            </p>
+          }
+          hint={i18n.translate('observability.alerting.createAdRuleFlyout.filterQueryHelp', {
+            defaultMessage: 'Optional OpenSearch query DSL JSON. Leave empty to match all data.',
+          })}
+          isInvalid={!!visibleErrors.filterQuery}
+          error={visibleErrors.filterQuery}
+        >
+          <EuiTextArea
+            value={form.filterQuery}
+            onChange={(e) => updateForm('filterQuery', e.target.value)}
+            placeholder={'{ "match_all": {} }'}
+            rows={4}
+            data-test-subj="alertManagerCreateAdRuleFilterQuery"
+          />
+        </AdFormattedFormRow>
+      </AdContentPanel>
+
+      <EuiSpacer />
+
+      <AdContentPanel
+        title={i18n.translate('observability.alerting.createAdRuleFlyout.timestampTitle', {
+          defaultMessage: 'Timestamp',
+        })}
+        subTitle={i18n.translate('observability.alerting.createAdRuleFlyout.timestampSubtitle', {
+          defaultMessage: 'Select the time field you want to use for the time filter.',
+        })}
+      >
+        <AdTimestampSelector
+          dsId={form.datasourceId}
+          indices={form.indices}
+          value={form.timeField}
+          onChange={(next) => updateForm('timeField', next)}
+          isInvalid={!!visibleErrors.timeField}
+          error={visibleErrors.timeField}
+        />
+      </AdContentPanel>
+
+      {isDetector && (
+        <>
+          <EuiSpacer />
+          <AdContentPanel
+            title={
+              <EuiTitle size="s" id="resultIndexField">
+                <h2>
+                  {i18n.translate('observability.alerting.createAdRuleFlyout.resultIndexTitle', {
+                    defaultMessage: 'Custom result index',
+                  })}
+                </h2>
+              </EuiTitle>
+            }
+            subTitle={
+              <EuiText className="content-panel-subTitle" style={{ lineHeight: 'normal' }}>
+                {i18n.translate('observability.alerting.createAdRuleFlyout.resultIndexSubtitle', {
+                  defaultMessage: 'Store detector results to your own index.',
+                })}{' '}
+                <AdLearnMore />
+              </EuiText>
+            }
+          >
+            <EuiFlexGroup direction="column">
+              <EuiFlexItem>
+                {customResultIndexRequired ? (
+                  <EuiCallOut
+                    data-test-subj="serverlessCustomResultIndexRequiredCallout"
+                    color="primary"
+                    iconType="iInCircle"
+                    size="s"
+                    title={i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.serverlessResultIndexRequired',
+                      {
+                        defaultMessage: 'Custom result index is required on OpenSearch Serverless.',
+                      }
+                    )}
+                  />
+                ) : (
+                  <EuiCheckbox
+                    id="resultIndexCheckbox"
+                    label={i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.enableResultIndex',
+                      { defaultMessage: 'Enable custom result index' }
+                    )}
+                    checked={form.customResultIndexEnabled}
+                    disabled={isEdit}
+                    onChange={(e) => {
+                      updateForm('customResultIndexEnabled', e.target.checked);
+                      if (!e.target.checked) updateForm('resultIndex', '');
+                    }}
+                  />
+                )}
+              </EuiFlexItem>
+              {resultIndexEnabled && (
+                <>
+                  <EuiFlexItem>
+                    <EuiCallOut
+                      color="warning"
+                      iconType="alert"
+                      size="s"
+                      title={i18n.translate(
+                        'observability.alerting.createAdRuleFlyout.resultIndexReadonlyWarning',
+                        {
+                          defaultMessage:
+                            "You can't change the custom result index after creating the detector. You can manage the result index using the following three settings inside Anomaly Detection plugin or with the Index Management plugin.",
+                        }
+                      )}
+                    />
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiFormRow
+                      label={i18n.translate(
+                        'observability.alerting.createAdRuleFlyout.resultIndexFieldLabel',
+                        { defaultMessage: 'Field' }
+                      )}
+                      helpText={i18n.translate(
+                        'observability.alerting.createAdRuleFlyout.resultIndexHelp',
+                        {
+                          defaultMessage:
+                            'Custom result index name must contain less than 255 characters including the prefix "opensearch-ad-plugin-result-". Valid characters are a-z, 0-9, -(hyphen) and _(underscore).',
+                        }
+                      )}
+                      isInvalid={!!visibleErrors.resultIndex}
+                      error={visibleErrors.resultIndex}
+                    >
+                      <EuiFieldText
+                        value={form.resultIndex}
+                        prepend={CUSTOM_AD_RESULT_INDEX_PREFIX}
+                        placeholder={i18n.translate(
+                          'observability.alerting.createAdRuleFlyout.resultIndexPlaceholder',
+                          { defaultMessage: 'Enter result index name' }
+                        )}
+                        disabled={isEdit}
+                        onChange={(e) => updateForm('resultIndex', e.target.value)}
+                        data-test-subj="alertManagerCreateAdRuleResultIndex"
+                      />
+                    </EuiFormRow>
+                  </EuiFlexItem>
+                </>
+              )}
+            </EuiFlexGroup>
+          </AdContentPanel>
+        </>
+      )}
+    </>
+  );
+
+  const renderFeatureFields = () => (
+    <EuiFlexGroup direction="column" style={{ margin: 0 }}>
+      {form.features.map((feature, index) => {
+        const featureNameError = visibleErrors[featureErrorKey(index, 'featureName')];
+        const aggregationOfError = visibleErrors[featureErrorKey(index, 'aggregationOf')];
+        const featureLimitError = visibleErrors[featureErrorKey(index, 'featureLimit')];
+
+        return (
+          <EuiFlexItem key={index}>
+            <EuiAccordion
+              id={`featureList.${index}`}
+              paddingSize="l"
+              initialIsOpen={index === form.features.length - 1}
+              buttonClassName={
+                index === 0 ? 'euiAccordionForm__noTopPaddingButton' : 'euiFormAccordion_button'
+              }
+              className="euiAccordion__noTopBorder"
+              buttonContent={
+                <div id={`featureAccordionHeaders.${index}`}>
+                  <EuiTitle size="xs" className="euiAccordionForm__title">
+                    <h5>{feature.featureName || 'Add feature'}</h5>
+                  </EuiTitle>
+                </div>
+              }
+              extraAction={
+                isDetector ? (
+                  <EuiButtonIcon
+                    aria-label={i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.deleteFeature',
+                      { defaultMessage: 'Delete feature' }
+                    )}
+                    size="s"
+                    iconType="trash"
+                    color="text"
+                    isDisabled={form.features.length <= 1}
+                    onClick={() => removeFeature(index)}
+                  />
+                ) : undefined
+              }
+            >
+              <EuiFormRow
+                label={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.featureNameLabel',
+                  {
+                    defaultMessage: 'Feature name',
+                  }
+                )}
+                helpText={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.featureNameHelp',
+                  {
+                    defaultMessage:
+                      'Enter a descriptive, unique name. The name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen) and _(underscore).',
+                  }
+                )}
+                isInvalid={!!featureNameError}
+                error={featureNameError}
+              >
+                <EuiFieldText
+                  value={feature.featureName}
+                  onChange={(e) => updateFeature(index, 'featureName', e.target.value)}
+                  placeholder={i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.featureNamePlaceholder',
+                    { defaultMessage: 'Enter feature name' }
+                  )}
+                  data-test-subj={`alertManagerCreateAdRuleFeatureName-${index}`}
+                />
+              </EuiFormRow>
+
+              <EuiFormRow
+                label={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.featureStateLabel',
+                  {
+                    defaultMessage: 'Feature state',
+                  }
+                )}
+              >
+                <EuiCheckbox
+                  id={`featureList.${index}.featureEnabled`}
+                  label={i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.enableFeatureLabel',
+                    {
+                      defaultMessage: 'Enable feature',
+                    }
+                  )}
+                  checked={feature.featureEnabled}
+                  onChange={(e) => updateFeature(index, 'featureEnabled', e.target.checked)}
+                />
+              </EuiFormRow>
+
+              <EuiFormRow
+                label={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.featureTypeLabel',
+                  {
+                    defaultMessage: 'Find anomalies based on',
+                  }
+                )}
+              >
+                <EuiSelect value={SIMPLE_FEATURE_TYPE} options={FEATURE_TYPE_OPTIONS} disabled />
+              </EuiFormRow>
+
+              <AdFormattedFormRow
+                title={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.aggregationLabel',
+                  {
+                    defaultMessage: 'Aggregation method',
+                  }
+                )}
+                hint={i18n.translate('observability.alerting.createAdRuleFlyout.aggregationHint', {
+                  defaultMessage: 'The aggregation method determines what constitutes an anomaly.',
+                })}
+                helpText={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.aggregationHelp',
+                  {
+                    defaultMessage:
+                      'E.g, if you choose min(), the detector focuses on finding anomalies based on the minimum values of your feature.',
+                  }
+                )}
+              >
+                <EuiSelect
+                  options={AGGREGATION_OPTIONS}
+                  value={feature.aggregationBy}
+                  onChange={(e) => {
+                    updateFeature(index, 'aggregationBy', e.target.value);
+                    updateFeature(index, 'aggregationOf', '');
+                  }}
+                  data-test-subj={`aggregationType-${index}`}
+                />
+              </AdFormattedFormRow>
+
+              <FeatureFieldSelector
+                dsId={form.datasourceId}
+                indices={form.indices}
+                aggregationBy={feature.aggregationBy}
+                value={feature.aggregationOf}
+                onChange={(next) => updateFeature(index, 'aggregationOf', next)}
+                isInvalid={!!aggregationOfError}
+                error={aggregationOfError}
+                dataTestSubj={`alertManagerCreateAdRuleFeatureField-${index}`}
+              />
+
+              <AdFormattedFormRow
+                title={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.anomalyCriteriaLabel',
+                  {
+                    defaultMessage: 'Anomaly criteria',
+                  }
+                )}
+                hint={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.anomalyCriteriaHint',
+                  {
+                    defaultMessage: 'Acceptable difference between the expected and actual values',
+                  }
+                )}
+              >
+                <EuiSelect
+                  value={feature.anomalyDirection}
+                  options={FEATURE_DIRECTION_OPTIONS}
+                  onChange={(e) => updateFeature(index, 'anomalyDirection', e.target.value)}
+                />
+              </AdFormattedFormRow>
+
+              {featureLimitError && (
+                <>
+                  <EuiSpacer size="s" />
+                  <EuiCallOut color="warning" iconType="alert" size="s" title={featureLimitError} />
+                </>
+              )}
+            </EuiAccordion>
+          </EuiFlexItem>
+        );
+      })}
+      {isDetector && (
+        <EuiFlexItem>
+          <EuiFlexGroup alignItems="center" style={{ padding: '12px 0px' }}>
+            <EuiFlexItem grow={false}>
+              <EuiSmallButton
+                data-test-subj="addFeature"
+                isDisabled={form.features.length >= MAX_FEATURE_NUM}
+                onClick={addFeature}
+              >
+                {i18n.translate('observability.alerting.createAdRuleFlyout.addFeatureButton', {
+                  defaultMessage: 'Add another feature',
+                })}
+              </EuiSmallButton>
+              <EuiText className="content-panel-subTitle">
+                <p>
+                  {i18n.translate('observability.alerting.createAdRuleFlyout.featuresRemaining', {
+                    defaultMessage: 'You can add up to {count} more features.',
+                    values: { count: Math.max(MAX_FEATURE_NUM - form.features.length, 0) },
+                  })}
+                </p>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  );
+
+  const renderCategoryFields = () => (
+    <CategoryFieldSelector
+      dsId={form.datasourceId}
+      indices={form.indices}
+      ruleType={ruleType}
+      enabled={form.categoryFieldEnabled}
+      selected={form.categoryField}
+      onEnabledChange={(next) => updateForm('categoryFieldEnabled', next)}
+      onChange={(next) => updateForm('categoryField', next)}
+      isInvalid={!!visibleErrors.categoryField}
+      error={visibleErrors.categoryField}
+    />
+  );
+
+  const renderDetectorOperationSettings = () => (
+    <AdContentPanel
+      title={i18n.translate('observability.alerting.createAdRuleFlyout.operationSettingsTitle', {
+        defaultMessage: 'Operation settings',
+      })}
+    >
+      <EuiSmallButton
+        data-test-subj="suggestParametersButton"
+        onClick={() => setShowSuggestDialog(true)}
+      >
+        {i18n.translate('observability.alerting.createAdRuleFlyout.suggestParametersButton', {
+          defaultMessage: 'Suggest parameters',
+        })}
+      </EuiSmallButton>
+      {showSuggestDialog && (
+        <SuggestParametersDialog
+          form={form}
+          onClose={() => setShowSuggestDialog(false)}
+          onUseSuggestedParameters={useSuggestedParameters}
+        />
+      )}
+      <EuiSpacer />
+      <AdFormattedFormRow
+        fullWidth
+        title={i18n.translate('observability.alerting.createAdRuleFlyout.intervalLabel', {
+          defaultMessage: 'Interval',
+        })}
+        hint={i18n.translate('observability.alerting.createAdRuleFlyout.intervalHint', {
+          defaultMessage:
+            'Interval sets the time window for summarizing and modeling data (e.g., 5 min to 1 hr), where too small creates noise, higher cost, and overreaction to fluctuations, while too large smooths out anomalies and delays detection.',
+        })}
+        isInvalid={!!visibleErrors.interval}
+        error={visibleErrors.interval}
+      >
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiFieldNumber
+              name="detectionInterval"
+              id="detectionInterval"
+              placeholder={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.intervalPlaceholder',
+                { defaultMessage: 'Interval' }
+              )}
+              value={form.interval}
+              min={1}
+              style={{ width: 140 }}
+              onChange={(e) => {
+                const next = parseNumberInputValue(e.target.value);
+                updateForm('interval', next);
+                if (form.frequency === form.interval) updateForm('frequency', next);
+              }}
+              data-test-subj="detectionInterval"
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText>
+              <p className="minutes">minutes</p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </AdFormattedFormRow>
+
+      <AdFormattedFormRow
+        fullWidth
+        title={i18n.translate('observability.alerting.createAdRuleFlyout.frequencyLabel', {
+          defaultMessage: 'Frequency',
+        })}
+        hint={i18n.translate('observability.alerting.createAdRuleFlyout.frequencyHint', {
+          defaultMessage:
+            'Frequency sets how often the detector queries and scores data, i.e. how often alerts may fire. It must be a multiple of the interval and defaults to the same value.',
+        })}
+        rowStyle={{ marginTop: 16 }}
+      >
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiFieldNumber
+              name="frequency"
+              id="frequency"
+              placeholder={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.frequencyPlaceholder',
+                { defaultMessage: 'Frequency' }
+              )}
+              value={form.frequency}
+              min={1}
+              style={{ width: 140 }}
+              onChange={(e) => updateForm('frequency', parseNumberInputValue(e.target.value))}
+              data-test-subj="frequency"
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText>
+              <p className="minutes">minutes</p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </AdFormattedFormRow>
+
+      <AdFormattedFormRow
+        fullWidth
+        title={i18n.translate('observability.alerting.createAdRuleFlyout.windowDelayLabel', {
+          defaultMessage: 'Window delay',
+        })}
+        hint={i18n.translate('observability.alerting.createAdRuleFlyout.windowDelayHint', {
+          defaultMessage:
+            'Specify a window of delay for a detector to fetch data, if you need to account for extra processing time.',
+        })}
+        rowStyle={{ marginTop: 16 }}
+      >
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiFieldNumber
+              name="windowDelay"
+              id="windowDelay"
+              placeholder={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.windowDelayPlaceholder',
+                { defaultMessage: 'Window delay' }
+              )}
+              value={form.windowDelay}
+              min={0}
+              style={{ width: 140 }}
+              onChange={(e) => updateForm('windowDelay', parseNumberInputValue(e.target.value))}
+              data-test-subj="windowDelay"
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText>
+              <p className="minutes">minutes</p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </AdFormattedFormRow>
+
+      <AdFormattedFormRow
+        fullWidth
+        title={i18n.translate('observability.alerting.createAdRuleFlyout.historyLabel', {
+          defaultMessage: 'History',
+        })}
+        hint={i18n.translate('observability.alerting.createAdRuleFlyout.historyHint', {
+          defaultMessage:
+            'How far back the model looks for training data. Minimum history is 40 intervals, maximum is 10,000 intervals, and the default is 40.',
+        })}
+        rowStyle={{ marginTop: 16 }}
+      >
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiFieldNumber
+              name="history"
+              id="history"
+              placeholder={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.historyPlaceholder',
+                { defaultMessage: 'History' }
+              )}
+              value={form.history}
+              min={40}
+              max={10000}
+              style={{ width: 140 }}
+              onChange={(e) => updateForm('history', parseNumberInputValue(e.target.value))}
+              data-test-subj="history"
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText>
+              <p className="minutes">intervals</p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </AdFormattedFormRow>
+    </AdContentPanel>
+  );
+
+  const renderAdvancedSettings = (settingsTitle: string) => (
+    <AdContentPanel
+      title={
+        <EuiFlexGroup direction="row" style={{ margin: 0 }}>
+          <EuiTitle size="s">
+            <h2>{settingsTitle} </h2>
+          </EuiTitle>
+          <EuiText
+            size="m"
+            style={{ marginLeft: 18, marginTop: 5 }}
+            onClick={() => setShowAdvancedSettings(!showAdvancedSettings)}
+          >
+            <EuiLink>
+              {showAdvancedSettings
+                ? i18n.translate('observability.alerting.createAdRuleFlyout.hideAdvanced', {
+                    defaultMessage: 'Hide',
+                  })
+                : i18n.translate('observability.alerting.createAdRuleFlyout.showAdvanced', {
+                    defaultMessage: 'Show',
+                  })}
+            </EuiLink>
+          </EuiText>
+        </EuiFlexGroup>
+      }
+      hideBody={!showAdvancedSettings}
+    >
+      {showAdvancedSettings && (
+        <>
+          <EuiSpacer size="m" />
+          <AdFormattedFormRow
+            title={i18n.translate('observability.alerting.createAdRuleFlyout.shingleSizeLabel', {
+              defaultMessage: 'Shingle size',
+            })}
+            hint={i18n.translate('observability.alerting.createAdRuleFlyout.shingleSizeHint', {
+              defaultMessage:
+                "Set the number of intervals to consider in a detection window for your model. The anomaly detector expects the shingle size to be in the range of 1 and 128. The default shingle size is 8. We recommend that you don't choose 1 unless you have two or more features.",
+            })}
+            isInvalid={!!visibleErrors.shingleSize}
+            error={visibleErrors.shingleSize}
+          >
+            <EuiFlexGroup gutterSize="s" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiFieldNumber
+                  id="shingleSize"
+                  placeholder={i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.shingleSizePlaceholder',
+                    { defaultMessage: 'Shingle size' }
+                  )}
+                  value={form.shingleSize}
+                  min={1}
+                  max={128}
+                  onChange={(e) => updateForm('shingleSize', Number(e.target.value))}
+                  data-test-subj="shingleSize"
+                />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiText>
+                  <p className="minutes">intervals</p>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </AdFormattedFormRow>
+        </>
+      )}
+    </AdContentPanel>
+  );
+
+  const renderDetectorModelStep = () => (
+    <>
+      <EuiText size="s">
+        <p>
+          {i18n.translate('observability.alerting.createAdRuleFlyout.detectorModelHelp', {
+            defaultMessage:
+              'Set the index fields that you want to find anomalies for by defining the model features. You can also set other model parameters such as categorical fields and shingle size.',
+          })}
+        </p>
+      </EuiText>
+      <EuiSpacer size="m" />
+      <AdContentPanel
+        title={i18n.translate('observability.alerting.createAdRuleFlyout.featuresTitle', {
+          defaultMessage: 'Features',
+        })}
+        subTitle={
+          <EuiText className="content-panel-subTitle" style={{ lineHeight: 'normal' }}>
+            {i18n.translate('observability.alerting.createAdRuleFlyout.featuresSubtitle', {
+              defaultMessage:
+                'A feature is the field in your index that you use to check for anomalies. You can add up to 5 features.',
+            })}{' '}
+            <AdLearnMore />
+          </EuiText>
+        }
+      >
+        {renderFeatureFields()}
+      </AdContentPanel>
+      <EuiSpacer size="m" />
+      {renderCategoryFields()}
+      <EuiSpacer size="m" />
+      {renderDetectorOperationSettings()}
+      <EuiSpacer size="m" />
+      {renderAdvancedSettings(
+        i18n.translate('observability.alerting.createAdRuleFlyout.advancedSettingsTitle', {
+          defaultMessage: 'Advanced settings',
+        })
+      )}
+    </>
+  );
+
+  const renderForecasterDefineStep = () => (
+    <>
+      {renderDefineStep()}
+      <EuiSpacer size="m" />
+      <AdContentPanel
+        title={i18n.translate('observability.alerting.createAdRuleFlyout.indicatorTitle', {
+          defaultMessage: 'Indicator',
+        })}
+        subTitle={i18n.translate('observability.alerting.createAdRuleFlyout.indicatorSubtitle', {
+          defaultMessage: 'Define the variable to use in your prediction.',
+        })}
+      >
+        {renderFeatureFields()}
+      </AdContentPanel>
+      <EuiSpacer size="m" />
+      {renderCategoryFields()}
+    </>
+  );
+
+  const renderForecastModelParametersStep = () => (
+    <>
+      <EuiText size="s">
+        <p>
+          {i18n.translate('observability.alerting.createAdRuleFlyout.forecasterModelHelp', {
+            defaultMessage:
+              'Define how often the forecast generates the next value based on historical data and how far to forecast into the future.',
+          })}
+        </p>
+      </EuiText>
+      <EuiSpacer size="m" />
+      <AdContentPanel
+        title={i18n.translate('observability.alerting.createAdRuleFlyout.coreParametersTitle', {
+          defaultMessage: 'Core parameters',
+        })}
+      >
+        <AdFormattedFormRow
+          fullWidth
+          title={i18n.translate('observability.alerting.createAdRuleFlyout.forecastIntervalLabel', {
+            defaultMessage: 'Forecasting interval',
+          })}
+          hint={i18n.translate('observability.alerting.createAdRuleFlyout.forecastIntervalHint', {
+            defaultMessage: 'How often the forecast runs to generate next value.',
+          })}
+          helpText={i18n.translate(
+            'observability.alerting.createAdRuleFlyout.forecastIntervalHelp',
+            { defaultMessage: 'The interval must be at least one minute.' }
+          )}
+          isInvalid={!!visibleErrors.interval}
+          error={visibleErrors.interval}
+        >
+          <EuiFlexGroup gutterSize="none" alignItems="center" style={{ maxWidth: 400 }}>
+            <EuiFlexItem grow={false}>
+              <div style={{ width: 140 }}>
+                <EuiFieldNumber
+                  value={form.interval}
+                  min={1}
+                  style={{ width: '100%' }}
+                  onChange={(e) => updateForm('interval', Number(e.target.value))}
+                />
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="default" className="unit-badge">
+                minutes
+              </EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </AdFormattedFormRow>
+
+        <EuiSpacer size="l" />
+
+        <AdFormattedFormRow
+          fullWidth
+          title={i18n.translate('observability.alerting.createAdRuleFlyout.windowDelayLabel', {
+            defaultMessage: 'Window delay',
+          })}
+          hint={i18n.translate(
+            'observability.alerting.createAdRuleFlyout.forecastWindowDelayHint',
+            {
+              defaultMessage:
+                'Specify a window of delay for a forecaster to fetch data, if you need to account for extra processing time.',
+            }
+          )}
+          isInvalid={!!visibleErrors.windowDelay}
+          error={visibleErrors.windowDelay}
+        >
+          <EuiFlexGroup gutterSize="none" alignItems="center" style={{ maxWidth: 400 }}>
+            <EuiFlexItem grow={false}>
+              <div style={{ width: 140 }}>
+                <EuiFieldNumber
+                  value={form.windowDelay}
+                  min={0}
+                  style={{ width: '100%' }}
+                  onChange={(e) => updateForm('windowDelay', Number(e.target.value))}
+                />
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="default" className="unit-badge">
+                minutes
+              </EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </AdFormattedFormRow>
+
+        <EuiSpacer size="l" />
+
+        <AdFormattedFormRow
+          fullWidth
+          title={i18n.translate('observability.alerting.createAdRuleFlyout.horizonLabel', {
+            defaultMessage: 'Horizon',
+          })}
+          hint={i18n.translate('observability.alerting.createAdRuleFlyout.horizonHint', {
+            defaultMessage: 'How far the forecast extends into the future.',
+          })}
+          helpText={i18n.translate('observability.alerting.createAdRuleFlyout.horizonHelp', {
+            defaultMessage: 'A valid horizon is between 1 and 180.',
+          })}
+          isInvalid={!!visibleErrors.horizon}
+          error={visibleErrors.horizon}
+        >
+          <EuiFlexGroup gutterSize="none" alignItems="center" style={{ maxWidth: 400 }}>
+            <EuiFlexItem grow={false}>
+              <div style={{ width: 140 }}>
+                <EuiFieldNumber
+                  value={form.horizon}
+                  min={1}
+                  max={180}
+                  style={{ width: '100%' }}
+                  onChange={(e) => updateForm('horizon', Number(e.target.value))}
+                />
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="default" className="unit-badge">
+                intervals
+              </EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </AdFormattedFormRow>
+
+        <EuiSpacer size="l" />
+
+        <AdFormattedFormRow
+          fullWidth
+          title={i18n.translate('observability.alerting.createAdRuleFlyout.historyLabel', {
+            defaultMessage: 'History',
+          })}
+          hint={i18n.translate('observability.alerting.createAdRuleFlyout.forecastHistoryHint', {
+            defaultMessage: 'How far back the model looks for training data.',
+          })}
+          helpText={i18n.translate(
+            'observability.alerting.createAdRuleFlyout.forecastHistoryHelp',
+            {
+              defaultMessage: 'Minimum history: 40 intervals.',
+            }
+          )}
+          isInvalid={!!visibleErrors.history}
+          error={visibleErrors.history}
+        >
+          <EuiFlexGroup gutterSize="none" alignItems="center" style={{ maxWidth: 400 }}>
+            <EuiFlexItem grow={false}>
+              <div style={{ width: 140 }}>
+                <EuiFieldNumber
+                  value={form.history}
+                  min={40}
+                  max={10000}
+                  style={{ width: '100%' }}
+                  onChange={(e) => updateForm('history', Number(e.target.value))}
+                />
+              </div>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge color="default" className="unit-badge">
+                intervals
+              </EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </AdFormattedFormRow>
+      </AdContentPanel>
+      <EuiSpacer size="m" />
+      {renderAdvancedSettings(
+        i18n.translate('observability.alerting.createAdRuleFlyout.advancedModelParametersTitle', {
+          defaultMessage: 'Advanced model parameters',
+        })
+      )}
+    </>
+  );
+
+  const renderJobsStep = () => (
+    <AdContentPanel
+      title={i18n.translate('observability.alerting.createAdRuleFlyout.realtimeJobTitle', {
+        defaultMessage: 'Real-time detection',
+      })}
+      subTitle={
+        <EuiText className="content-panel-subTitle" style={{ lineHeight: 'normal' }}>
+          {i18n.translate('observability.alerting.createAdRuleFlyout.realtimeJobDescription', {
+            defaultMessage:
+              'Real-time detection lets you find anomalies in your data in near real-time. To receive accurate and real-time anomalies, the detector needs to start and collect sufficient data to include your latest changes. The earlier the detector starts running, the sooner the real-time anomalies will be available.',
+          })}{' '}
+          <AdLearnMore />
+        </EuiText>
+      }
+    >
+      <EuiFlexItem>
+        <EuiCheckbox
+          id="realTimeCheckbox"
+          label={i18n.translate('observability.alerting.createAdRuleFlyout.startDetectorLabel', {
+            defaultMessage: 'Start real-time detector automatically (recommended)',
+          })}
+          checked={form.startAfterCreate}
+          onChange={(e) => updateForm('startAfterCreate', e.target.checked)}
+        />
+      </EuiFlexItem>
+    </AdContentPanel>
+  );
+
+  const renderReviewStep = () => {
+    const selectedDatasource = openSearchDatasources.find(
+      (datasource) => datasource.id === form.datasourceId
+    );
+    const featureSummary =
+      form.features
+        .filter((feature) => feature.featureName.trim())
+        .map(
+          (feature) =>
+            `${feature.featureName.trim()}: ${
+              feature.aggregationBy
+            }(${feature.aggregationOf.trim()})`
+        )
+        .join(', ') || '-';
+    const descriptionItems = [
+      {
+        title: i18n.translate('observability.alerting.createAdRuleFlyout.reviewDatasource', {
+          defaultMessage: 'Datasource',
+        }),
+        description: selectedDatasource?.name || form.datasourceId || '-',
+      },
+      {
+        title: i18n.translate('observability.alerting.createAdRuleFlyout.reviewIndices', {
+          defaultMessage: 'Indices',
+        }),
+        description: form.indices.join(', ') || '-',
+      },
+      {
+        title: i18n.translate('observability.alerting.createAdRuleFlyout.reviewTimeField', {
+          defaultMessage: 'Time field',
+        }),
+        description: form.timeField || '-',
+      },
+      {
+        title: i18n.translate('observability.alerting.createAdRuleFlyout.reviewFeatures', {
+          defaultMessage: 'Features',
+        }),
+        description: featureSummary,
+      },
+      {
+        title: i18n.translate('observability.alerting.createAdRuleFlyout.reviewCategoryField', {
+          defaultMessage: 'Category field',
+        }),
+        description: form.categoryField.join(', ') || '-',
+      },
+      {
+        title: i18n.translate('observability.alerting.createAdRuleFlyout.reviewSchedule', {
+          defaultMessage: 'Schedule',
+        }),
+        description: isDetector
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.reviewDetectorSchedule', {
+              defaultMessage:
+                'Detection interval: {interval}m, frequency: {frequency}m, window delay: {windowDelay}m',
+              values: {
+                interval: form.interval,
+                frequency: form.frequency,
+                windowDelay: form.windowDelay,
+              },
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.reviewForecasterSchedule', {
+              defaultMessage:
+                'Forecast interval: {interval}m, horizon: {horizon}, window delay: {windowDelay}m',
+              values: {
+                interval: form.interval,
+                horizon: form.horizon,
+                windowDelay: form.windowDelay,
+              },
+            }),
+      },
+    ];
+
+    return (
+      <>
+        {Object.keys(allErrors).length > 0 && (
+          <>
+            <EuiCallOut
+              color="warning"
+              iconType="alert"
+              title={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.reviewValidationTitle',
+                { defaultMessage: 'Some required fields need attention.' }
+              )}
+            />
+            <EuiSpacer size="m" />
+          </>
+        )}
+        <EuiDescriptionList type="column" listItems={descriptionItems} />
+        {!isEdit && (
+          <>
+            <EuiHorizontalRule margin="m" />
+            <EuiSwitch
+              label={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.reviewStartDetector',
+                {
+                  defaultMessage: 'Start real-time detector automatically (recommended)',
+                }
+              )}
+              checked={form.startAfterCreate}
+              onChange={(e) => updateForm('startAfterCreate', e.target.checked)}
+            />
+          </>
+        )}
+      </>
+    );
+  };
+
+  const renderStopForEditModal = () => {
+    if (!editLifecycleBlocker) return null;
+
+    if (editLifecycleBlocker === 'detector-running') {
+      const runningJobsLabel = getDetectorRunningJobsLabel(existingResource);
+      return (
+        <EuiOverlayMask>
+          <EuiModal onClose={handleStopForEditModalCancel}>
+            <EuiModalHeader>
+              <EuiModalHeaderTitle>
+                <EuiText size="s">
+                  <h2>
+                    {i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.stopDetectorToEditTitle',
+                      { defaultMessage: 'Stop detector to proceed?' }
+                    )}
+                  </h2>
+                </EuiText>
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+
+            <EuiModalBody>
+              <EuiText>
+                <p>
+                  {i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.stopDetectorToEditDescription',
+                    {
+                      defaultMessage:
+                        'You must stop the {runningJobsLabel} to change its configuration. After you reconfigure the detector, be sure to restart it.',
+                      values: { runningJobsLabel },
+                    }
+                  )}
+                </p>
+              </EuiText>
+            </EuiModalBody>
+
+            <EuiModalFooter>
+              <EuiSmallButtonEmpty
+                onClick={handleStopForEditModalCancel}
+                isDisabled={isStoppingForEdit}
+              >
+                {i18n.translate('observability.alerting.createAdRuleFlyout.stopEditCancelButton', {
+                  defaultMessage: 'Cancel',
+                })}
+              </EuiSmallButtonEmpty>
+              <EuiSmallButton
+                fill
+                color="primary"
+                onClick={handleStopAndProceedToEdit}
+                isLoading={isStoppingForEdit}
+              >
+                {i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.stopDetectorProceedButton',
+                  { defaultMessage: 'Stop and proceed to edit' }
+                )}
+              </EuiSmallButton>
+            </EuiModalFooter>
+          </EuiModal>
+        </EuiOverlayMask>
+      );
+    }
+
+    if (editLifecycleBlocker === 'forecaster-test') {
+      return (
+        <EuiOverlayMask>
+          <EuiModal onClose={handleStopForEditModalCancel}>
+            <EuiModalHeader>
+              <EuiModalHeaderTitle>
+                <EuiText size="s">
+                  <h2>
+                    {i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.waitForForecastTestTitle',
+                      { defaultMessage: 'Please wait for test initialization' }
+                    )}
+                  </h2>
+                </EuiText>
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+
+            <EuiModalBody>
+              <EuiCallOut
+                color="primary"
+                iconType="clock"
+                title={i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.forecastTestInProgressTitle',
+                  { defaultMessage: 'Test in progress' }
+                )}
+              >
+                <p>
+                  {i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.forecastTestInProgressDescription',
+                    {
+                      defaultMessage:
+                        'The initial test of your forecast configuration is currently running. Please wait for the test to complete before making any changes to the configuration.',
+                    }
+                  )}
+                </p>
+              </EuiCallOut>
+            </EuiModalBody>
+
+            <EuiModalFooter>
+              <EuiSmallButton fill color="primary" onClick={handleStopForEditModalCancel}>
+                {i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.forecastTestUnderstandButton',
+                  { defaultMessage: 'I understand' }
+                )}
+              </EuiSmallButton>
+            </EuiModalFooter>
+          </EuiModal>
+        </EuiOverlayMask>
+      );
+    }
+
+    const forecasterState = getResourceState(existingResource);
+    const isInitializingForecast = stateMatches(forecasterState, [
+      FORECASTER_INITIALIZING_FORECAST_STATE,
+      'INITIALIZING_FORECAST',
+    ]);
+    const isAwaitingDataToInit = stateMatches(forecasterState, [
+      FORECASTER_AWAITING_DATA_TO_INIT_STATE,
+      'AWAITING_DATA_TO_INIT',
+    ]);
+    const isAwaitingDataToRestart = stateMatches(forecasterState, [
+      FORECASTER_AWAITING_DATA_TO_RESTART_STATE,
+      'AWAITING_DATA_TO_RESTART',
+    ]);
+    const showForecastWarning =
+      isAwaitingDataToRestart || (!isInitializingForecast && !isAwaitingDataToInit);
+    const forecastModalTitle = isInitializingForecast
+      ? i18n.translate(
+          'observability.alerting.createAdRuleFlyout.cancelInitializingForecastTitle',
+          {
+            defaultMessage: 'Cancel initializing the forecast to edit?',
+          }
+        )
+      : isAwaitingDataToInit || isAwaitingDataToRestart
+      ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
+          defaultMessage: 'Cancel forecast to edit?',
+        })
+      : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
+          defaultMessage: 'Stop forecast to edit?',
+        });
+    const forecastModalDescription = (() => {
+      if (isInitializingForecast) {
+        return i18n.translate(
+          'observability.alerting.createAdRuleFlyout.cancelInitializingForecastDescription',
+          {
+            defaultMessage:
+              'You must cancel initializing the forecast before editing its configuration. After making change to the forecast, restart the forecast.',
+          }
+        );
+      }
+      if (isAwaitingDataToInit || isAwaitingDataToRestart) {
+        return i18n.translate(
+          'observability.alerting.createAdRuleFlyout.cancelForecastToEditDescription',
+          {
+            defaultMessage:
+              'You must cancel the forecast before editing its configuration. After making change to the forecast, restart the forecast.',
+          }
+        );
+      }
+      return i18n.translate(
+        'observability.alerting.createAdRuleFlyout.stopForecastToEditDescription',
+        {
+          defaultMessage:
+            'You must stop the forecast before editing its configuration. After making any changes, you can restart the forecast.',
+        }
+      );
+    })();
+    const forecastConfirmLabel =
+      isInitializingForecast || isAwaitingDataToInit || isAwaitingDataToRestart
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastEditButton', {
+            defaultMessage: 'Cancel and edit',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastEditButton', {
+            defaultMessage: 'Stop and edit',
+          });
+
+    return (
+      <EuiOverlayMask>
+        <EuiModal onClose={handleStopForEditModalCancel}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              <EuiText size="s">
+                <h2>{forecastModalTitle}</h2>
+              </EuiText>
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+
+          <EuiModalBody>
+            {showForecastWarning && (
+              <>
+                <EuiCallOut
+                  color="warning"
+                  iconType="alert"
+                  title={i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.forecastEditWipeWarningTitle',
+                    { defaultMessage: 'Editing forecast will wipe historical visualizations' }
+                  )}
+                >
+                  <p>
+                    {i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.forecastEditWipeWarningDescription',
+                      {
+                        defaultMessage:
+                          'Changing categorical variables or the custom index name affects the forecast results and wipes out any historical forecast visualizations.',
+                      }
+                    )}
+                  </p>
+                </EuiCallOut>
+                <EuiSpacer size="m" />
+              </>
+            )}
+            <EuiText>
+              <p>{forecastModalDescription}</p>
+            </EuiText>
+          </EuiModalBody>
+
+          <EuiModalFooter>
+            <EuiSmallButtonEmpty
+              onClick={handleStopForEditModalCancel}
+              isDisabled={isStoppingForEdit}
+            >
+              {i18n.translate('observability.alerting.createAdRuleFlyout.stopEditCancelButton', {
+                defaultMessage: 'Cancel',
+              })}
+            </EuiSmallButtonEmpty>
+            <EuiSmallButton
+              fill
+              color="primary"
+              onClick={handleStopAndProceedToEdit}
+              isLoading={isStoppingForEdit}
+            >
+              {forecastConfirmLabel}
+            </EuiSmallButton>
+          </EuiModalFooter>
+        </EuiModal>
+      </EuiOverlayMask>
+    );
+  };
+
+  const renderStartAfterEditPrompt = () => (
+    <EuiPanel paddingSize="l">
+      <EuiCallOut
+        color="success"
+        iconType="check"
+        title={i18n.translate(
+          'observability.alerting.createAdRuleFlyout.detectorUpdatedStartPromptTitle',
+          { defaultMessage: 'Anomaly detection rule updated' }
+        )}
+      >
+        <p>
+          {i18n.translate(
+            'observability.alerting.createAdRuleFlyout.detectorUpdatedStartPromptMessage',
+            {
+              defaultMessage:
+                'This detector was stopped so you could edit it. Start it again to resume real-time anomaly detection, or close this panel to leave it stopped.',
+            }
+          )}
+        </p>
+      </EuiCallOut>
+    </EuiPanel>
+  );
+
+  const renderStepContent = () => {
+    if (startAfterEditPrompt) return renderStartAfterEditPrompt();
+
+    if (isDetector) {
+      if (isDetectorModelEdit) return renderDetectorModelStep();
+      if (isDetectorSettingsEdit) return renderDefineStep();
+      if (currentStep === 0) return renderDefineStep();
+      if (currentStep === 1) return renderDetectorModelStep();
+      if (isEdit) return renderReviewStep();
+      if (currentStep === 2) return renderJobsStep();
+      return renderReviewStep();
+    }
+
+    if (currentStep === 0) return renderForecasterDefineStep();
+    return renderForecastModelParametersStep();
+  };
+
+  return (
+    <>
+      <EuiFlyout
+        onClose={startAfterEditPrompt ? handleCloseAfterEditPrompt : onCancel}
+        size="l"
+        ownFocus
+        aria-labelledby="createAdRuleFlyoutTitle"
+      >
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="m">
+            <h2 id="createAdRuleFlyoutTitle">{title}</h2>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiText size="xs" color="subdued">
+            {isEdit
+              ? isDetector
+                ? i18n.translate('observability.alerting.createAdRuleFlyout.editDetectorSubtitle', {
+                    defaultMessage:
+                      'Update this anomaly detection rule without leaving Alerts Manager.',
+                  })
+                : i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.editForecasterSubtitle',
+                    {
+                      defaultMessage:
+                        'Update this forecasting rule without leaving Alerts Manager.',
+                    }
+                  )
+              : isDetector
+              ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
+                  defaultMessage:
+                    'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
+                })
+              : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
+                  defaultMessage:
+                    'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
+                })}
+          </EuiText>
+        </EuiFlyoutHeader>
+
+        <EuiFlyoutBody>
+          {openSearchDatasources.length === 0 ? (
+            <EuiCallOut
+              color="warning"
+              iconType="alert"
+              title={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.noOpenSearchDatasourceTitle',
+                { defaultMessage: 'Select an OpenSearch datasource to create this rule.' }
+              )}
+            />
+          ) : isEdit && !isEditFormReady && !editDetailError ? (
+            <EuiFlexGroup justifyContent="center" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiLoadingSpinner size="xl" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : isEdit && editDetailError ? (
+            <EuiCallOut
+              color="danger"
+              iconType="alert"
+              title={i18n.translate('observability.alerting.createAdRuleFlyout.editLoadFailed', {
+                defaultMessage: 'Failed to load rule details.',
+              })}
+            >
+              <p>{editDetailError.message}</p>
+            </EuiCallOut>
+          ) : isEdit && !isEditFormReady ? (
+            <EuiCallOut
+              color="warning"
+              iconType="alert"
+              title={i18n.translate('observability.alerting.createAdRuleFlyout.editMissingDetail', {
+                defaultMessage: 'Rule details are not available for editing.',
+              })}
+            />
+          ) : (
+            <EuiFlexGroup gutterSize="l" alignItems="flexStart">
+              {!isSingleDetectorEdit && (
+                <EuiFlexItem grow={false} style={{ width: 240 }}>
+                  <EuiSteps steps={steps} />
+                </EuiFlexItem>
+              )}
+              <EuiFlexItem>
+                {submitError && (
+                  <>
+                    <EuiCallOut color="danger" iconType="alert" title={submitError} />
+                    <EuiSpacer size="m" />
+                  </>
+                )}
+                <EuiText size="s">
+                  <h1>
+                    {startAfterEditPrompt
+                      ? i18n.translate(
+                          'observability.alerting.createAdRuleFlyout.startDetectorAfterEditTitle',
+                          { defaultMessage: 'Start detector' }
+                        )
+                      : stepTitles[currentStep]}
+                  </h1>
+                </EuiText>
+                <EuiSpacer size="m" />
+                {renderStepContent()}
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
+        </EuiFlyoutBody>
+
+        <EuiFlyoutFooter>
+          {startAfterEditPrompt ? (
+            <EuiFlexGroup justifyContent="spaceBetween" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  onClick={handleCloseAfterEditPrompt}
+                  isDisabled={isStartingEditedDetector}
+                >
+                  {i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.closeAfterEditButton',
+                    { defaultMessage: 'Close' }
+                  )}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  fill
+                  onClick={() =>
+                    handleStartEditedDetector(
+                      startAfterEditPrompt.detectorId,
+                      startAfterEditPrompt.datasourceId
+                    )
+                  }
+                  isLoading={isStartingEditedDetector}
+                  data-test-subj="alertManagerStartDetectorAfterEditButton"
+                >
+                  {i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.startDetectorAfterEditButton',
+                    { defaultMessage: 'Start detector' }
+                  )}
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            <EuiFlexGroup justifyContent="spaceBetween" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty onClick={onCancel}>
+                  {i18n.translate('observability.alerting.createAdRuleFlyout.cancelButton', {
+                    defaultMessage: 'Cancel',
+                  })}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup gutterSize="s" responsive={false}>
+                  {currentStep > 0 && !isSingleDetectorEdit && (
+                    <EuiFlexItem grow={false}>
+                      <EuiButtonEmpty onClick={handlePrevious} isDisabled={isSaving}>
+                        {i18n.translate(
+                          'observability.alerting.createAdRuleFlyout.previousButton',
+                          {
+                            defaultMessage: 'Previous',
+                          }
+                        )}
+                      </EuiButtonEmpty>
+                    </EuiFlexItem>
+                  )}
+                  <EuiFlexItem grow={false}>
+                    {currentStep === finalStep ? (
+                      <EuiButton
+                        fill
+                        onClick={handleSubmit}
+                        isDisabled={
+                          Object.keys(submitBlockingErrors).length > 0 ||
+                          isSaving ||
+                          !isEditFormReady ||
+                          !!editLifecycleBlocker
+                        }
+                        isLoading={isSaving}
+                        data-test-subj="alertManagerCreateAdRuleSubmit"
+                      >
+                        {submitButtonLabel}
+                      </EuiButton>
+                    ) : (
+                      <EuiButton
+                        fill
+                        onClick={handleNext}
+                        isDisabled={
+                          openSearchDatasources.length === 0 ||
+                          !isEditFormReady ||
+                          !!editLifecycleBlocker
+                        }
+                      >
+                        {i18n.translate('observability.alerting.createAdRuleFlyout.nextButton', {
+                          defaultMessage: 'Next',
+                        })}
+                      </EuiButton>
+                    )}
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          )}
+        </EuiFlyoutFooter>
+      </EuiFlyout>
+      {showStopForEditModal && renderStopForEditModal()}
+    </>
+  );
+};

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -44,6 +44,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiPanel,
+  EuiRadio,
   EuiRadioGroup,
   EuiSmallButton,
   EuiSmallButtonEmpty,
@@ -104,6 +105,11 @@ interface CreateAdRuleFormState {
   filterQuery: string;
   customResultIndexEnabled: boolean;
   resultIndex: string;
+  resultIndexMinAge: NumericFormValue;
+  resultIndexMinSize: NumericFormValue;
+  resultIndexTtl: NumericFormValue;
+  customResultIndexLifecycleEnabled: boolean;
+  flattenCustomResultIndex: boolean;
   categoryFieldEnabled: boolean;
   categoryField: string[];
   features: CreateAdFeatureFormState[];
@@ -154,7 +160,10 @@ const MINUTES_UNIT = 'Minutes';
 const SIMPLE_FEATURE_TYPE = 'simple_aggs';
 const CUSTOM_FEATURE_TYPE = 'custom_aggs';
 const AD_DOCS_LINK = 'https://opensearch.org/docs/latest/observing-your-data/ad/index/';
+const FORECASTER_DOCS_LINK =
+  'https://opensearch.org/docs/latest/observing-your-data/forecast/index/';
 const CUSTOM_AD_RESULT_INDEX_PREFIX = 'opensearch-ad-plugin-result-';
+const CUSTOM_FORECASTER_RESULT_INDEX_PREFIX = 'opensearch-forecast-result-';
 
 const AGGREGATION_OPTIONS = [
   { value: 'avg', text: 'average()' },
@@ -189,6 +198,11 @@ const COUNTABLE_TYPES = [...NUMBER_TYPES, 'keyword', 'text', 'boolean', 'date', 
 const CATEGORY_TYPES = ['keyword', 'ip'];
 const MAX_FEATURE_NUM = 5;
 
+export const shouldAutoStartCreatedRule = (
+  ruleType: CreateAdRuleType,
+  startAfterCreate: boolean
+): boolean => ruleType === 'forecaster' || startAfterCreate;
+
 const createInitialFeature = (): CreateAdFeatureFormState => ({
   featureId: undefined,
   featureName: '',
@@ -211,6 +225,11 @@ const createInitialForm = (datasourceId: string): CreateAdRuleFormState => ({
   filterQuery: '',
   customResultIndexEnabled: false,
   resultIndex: '',
+  resultIndexMinAge: '',
+  resultIndexMinSize: '',
+  resultIndexTtl: '',
+  customResultIndexLifecycleEnabled: false,
+  flattenCustomResultIndex: false,
   categoryFieldEnabled: false,
   categoryField: [],
   features: [createInitialFeature()],
@@ -307,11 +326,9 @@ const getPeriodInterval = (
   return numberValue(period.interval) ?? '';
 };
 
-const stripResultIndexPrefix = (value: unknown): string => {
+const stripResultIndexPrefix = (value: unknown, prefix: string): string => {
   const resultIndex = stringValue(value);
-  return resultIndex.startsWith(CUSTOM_AD_RESULT_INDEX_PREFIX)
-    ? resultIndex.slice(CUSTOM_AD_RESULT_INDEX_PREFIX.length)
-    : resultIndex;
+  return resultIndex.startsWith(prefix) ? resultIndex.slice(prefix.length) : resultIndex;
 };
 
 const isMatchAllFilter = (filterQuery: Record<string, unknown>): boolean => {
@@ -514,9 +531,9 @@ const buildFeatureFormState = (
 };
 
 const getFeatureForms = (resource: Record<string, unknown>): CreateAdFeatureFormState[] => {
-  const features = asArray(getField(resource, 'feature_attributes', 'featureAttributes')).map(
-    (feature) => buildFeatureFormState(resource, feature)
-  );
+  const features = asArray(
+    getField(resource, 'feature_attributes', 'featureAttributes')
+  ).map((feature) => buildFeatureFormState(resource, feature));
   return features.length > 0 ? features : [createInitialFeature()];
 };
 
@@ -756,7 +773,16 @@ export const formFromAdResource = (
 ): CreateAdRuleFormState => {
   const rawResource = asRecord(resource);
   const categoryField = getCategoryFieldFromResource(rawResource);
-  const resultIndex = stripResultIndexPrefix(getField(rawResource, 'result_index', 'resultIndex'));
+  const resultIndex = stripResultIndexPrefix(
+    getField(rawResource, 'result_index', 'resultIndex'),
+    ruleType === 'detector' ? CUSTOM_AD_RESULT_INDEX_PREFIX : CUSTOM_FORECASTER_RESULT_INDEX_PREFIX
+  );
+  const resultIndexMinAge =
+    numberValue(getField(rawResource, 'result_index_min_age', 'resultIndexMinAge')) ?? '';
+  const resultIndexMinSize =
+    numberValue(getField(rawResource, 'result_index_min_size', 'resultIndexMinSize')) ?? '';
+  const resultIndexTtl =
+    numberValue(getField(rawResource, 'result_index_ttl', 'resultIndexTtl')) ?? '';
   const interval =
     ruleType === 'detector'
       ? getPeriodInterval(rawResource, 'detection_interval', 'detectionInterval')
@@ -775,6 +801,15 @@ export const formFromAdResource = (
     filterQuery: formatFilterQueryForForm(getField(rawResource, 'filter_query', 'filterQuery')),
     customResultIndexEnabled: !!resultIndex,
     resultIndex,
+    resultIndexMinAge,
+    resultIndexMinSize,
+    resultIndexTtl,
+    customResultIndexLifecycleEnabled:
+      resultIndexMinAge !== '' || resultIndexMinSize !== '' || resultIndexTtl !== '',
+    flattenCustomResultIndex: booleanValue(
+      getField(rawResource, 'flatten_custom_result_index', 'flattenCustomResultIndex'),
+      false
+    ),
     categoryFieldEnabled: categoryField.length > 0,
     categoryField,
     features: getFeatureForms(rawResource),
@@ -839,6 +874,26 @@ export const buildRulePayload = (
 
   return {
     ...commonPayload,
+    resultIndex: undefined,
+    resultIndexMinAge: undefined,
+    resultIndexMinSize: undefined,
+    resultIndexTtl: undefined,
+    flattenCustomResultIndex: undefined,
+    ...(form.customResultIndexEnabled && form.resultIndex.trim()
+      ? {
+          resultIndex: `${CUSTOM_FORECASTER_RESULT_INDEX_PREFIX}${form.resultIndex.trim()}`,
+          resultIndexMinAge: form.customResultIndexLifecycleEnabled
+            ? parsePositiveInt(form.resultIndexMinAge)
+            : undefined,
+          resultIndexMinSize: form.customResultIndexLifecycleEnabled
+            ? parsePositiveInt(form.resultIndexMinSize)
+            : undefined,
+          resultIndexTtl: form.customResultIndexLifecycleEnabled
+            ? parsePositiveInt(form.resultIndexTtl)
+            : undefined,
+          flattenCustomResultIndex: form.flattenCustomResultIndex,
+        }
+      : {}),
     forecastInterval: {
       period: { interval: Math.max(1, toPositiveInt(form.interval, 1)), unit: MINUTES_UNIT },
     },
@@ -933,12 +988,14 @@ export const validateForm = (
     );
   }
   if (form.features.length === 0) {
-    errors[featureErrorKey(0, 'featureName')] = i18n.translate(
-      'observability.alerting.createAdRuleFlyout.featureRequired',
-      {
-        defaultMessage: 'Add at least one feature.',
-      }
-    );
+    errors[featureErrorKey(0, 'featureName')] =
+      options.ruleType === 'detector'
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.featureRequired', {
+            defaultMessage: 'Add at least one feature.',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.indicatorRequired', {
+            defaultMessage: 'Add an indicator.',
+          });
   }
   if (form.features.length > MAX_FEATURE_NUM) {
     errors[featureErrorKey(0, 'featureLimit')] = i18n.translate(
@@ -957,27 +1014,33 @@ export const validateForm = (
   form.features.forEach((feature, index) => {
     const featureName = feature.featureName.trim();
     if (!featureName) {
-      errors[featureErrorKey(index, 'featureName')] = i18n.translate(
-        'observability.alerting.createAdRuleFlyout.featureNameRequired',
-        {
-          defaultMessage: 'Feature name is required.',
-        }
-      );
+      errors[featureErrorKey(index, 'featureName')] =
+        options.ruleType === 'detector'
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.featureNameRequired', {
+              defaultMessage: 'Feature name is required.',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.indicatorNameRequired', {
+              defaultMessage: 'Indicator name is required.',
+            });
     } else if (featureNameCounts[featureName.toLowerCase()] > 1) {
-      errors[featureErrorKey(index, 'featureName')] = i18n.translate(
-        'observability.alerting.createAdRuleFlyout.featureNameDuplicate',
-        {
-          defaultMessage: 'Duplicate feature name.',
-        }
-      );
+      errors[featureErrorKey(index, 'featureName')] =
+        options.ruleType === 'detector'
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.featureNameDuplicate', {
+              defaultMessage: 'Duplicate feature name.',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.indicatorNameDuplicate', {
+              defaultMessage: 'Duplicate indicator name.',
+            });
     }
     if (!feature.aggregationOf.trim()) {
-      errors[featureErrorKey(index, 'aggregationOf')] = i18n.translate(
-        'observability.alerting.createAdRuleFlyout.aggregationFieldRequired',
-        {
-          defaultMessage: 'Feature field is required.',
-        }
-      );
+      errors[featureErrorKey(index, 'aggregationOf')] =
+        options.ruleType === 'detector'
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.aggregationFieldRequired', {
+              defaultMessage: 'Feature field is required.',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.indicatorFieldRequired', {
+              defaultMessage: 'Indicator field is required.',
+            });
     }
   });
   if (form.categoryFieldEnabled && form.categoryField.length === 0) {
@@ -1013,6 +1076,9 @@ export const validateForm = (
   const windowDelayValue = parseNonNegativeInt(form.windowDelay);
   const historyValue = parsePositiveInt(form.history);
   const horizonValue = parsePositiveInt(form.horizon);
+  const resultIndexMinAgeValue = parsePositiveInt(form.resultIndexMinAge);
+  const resultIndexMinSizeValue = parsePositiveInt(form.resultIndexMinSize);
+  const resultIndexTtlValue = parsePositiveInt(form.resultIndexTtl);
 
   if (intervalValue === undefined) {
     errors.interval = i18n.translate('observability.alerting.createAdRuleFlyout.intervalInvalid', {
@@ -1060,6 +1126,33 @@ export const validateForm = (
       defaultMessage: 'Horizon must be an integer between 1 and 180.',
     });
   }
+  if (
+    options.ruleType === 'forecaster' &&
+    form.customResultIndexEnabled &&
+    form.customResultIndexLifecycleEnabled
+  ) {
+    if (form.resultIndexMinAge !== '' && resultIndexMinAgeValue === undefined) {
+      errors.resultIndexMinAge = i18n.translate(
+        'observability.alerting.createAdRuleFlyout.resultIndexMinAgeInvalid',
+        { defaultMessage: 'Minimum index age must be a positive integer.' }
+      );
+    }
+    if (
+      form.resultIndexMinSize !== '' &&
+      (resultIndexMinSizeValue === undefined || resultIndexMinSizeValue < 1000)
+    ) {
+      errors.resultIndexMinSize = i18n.translate(
+        'observability.alerting.createAdRuleFlyout.resultIndexMinSizeInvalid',
+        { defaultMessage: 'Minimum index size must be at least 1,000 MB.' }
+      );
+    }
+    if (form.resultIndexTtl !== '' && resultIndexTtlValue === undefined) {
+      errors.resultIndexTtl = i18n.translate(
+        'observability.alerting.createAdRuleFlyout.resultIndexTtlInvalid',
+        { defaultMessage: 'Index TTL must be a positive integer.' }
+      );
+    }
+  }
   if (form.shingleSize < 1 || form.shingleSize > 128) {
     errors.shingleSize = i18n.translate(
       'observability.alerting.createAdRuleFlyout.shingleInvalid',
@@ -1082,18 +1175,18 @@ const errorsForStep = (
       step === 0
         ? ['name', 'datasourceId', 'indices', 'timeField', 'filterQuery', 'resultIndex']
         : step === 1
-          ? [
-              'features',
-              'categoryField',
-              'interval',
-              'frequency',
-              'windowDelay',
-              'history',
-              'shingleSize',
-            ]
-          : step === 2
-            ? []
-            : Object.keys(errors);
+        ? [
+            'features',
+            'categoryField',
+            'interval',
+            'frequency',
+            'windowDelay',
+            'history',
+            'shingleSize',
+          ]
+        : step === 2
+        ? []
+        : Object.keys(errors);
   } else {
     stepFields =
       step === 0
@@ -1107,8 +1200,18 @@ const errorsForStep = (
             'categoryField',
           ]
         : step === 1
-          ? ['interval', 'windowDelay', 'history', 'horizon', 'shingleSize']
-          : Object.keys(errors);
+        ? [
+            'interval',
+            'windowDelay',
+            'history',
+            'horizon',
+            'shingleSize',
+            'resultIndex',
+            'resultIndexMinAge',
+            'resultIndexMinSize',
+            'resultIndexTtl',
+          ]
+        : Object.keys(errors);
   }
 
   return Object.fromEntries(
@@ -1638,8 +1741,8 @@ const SuggestParametersDialog: React.FC<{
         typeof intervalValue === 'number'
           ? intervalValue
           : typeof frequencyValue === 'number'
-            ? frequencyValue
-            : 10;
+          ? frequencyValue
+          : 10;
 
       const historyValue = payload.history;
       const windowDelayValue = payload.windowDelay?.period?.interval;
@@ -1906,12 +2009,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           defaultMessage: 'Edit forecasting rule',
         })
     : isDetector
-      ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
-          defaultMessage: 'Create anomaly detection rule',
-        })
-      : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
-          defaultMessage: 'Create forecasting rule',
-        });
+    ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorTitle', {
+        defaultMessage: 'Create anomaly detection rule',
+      })
+    : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterTitle', {
+        defaultMessage: 'Create forecasting rule',
+      });
   const detectorStepTitles = isEdit
     ? [
         isDetectorModelEdit
@@ -2337,7 +2440,8 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
 
       const createdId = extractCreatedId(response);
       let autoStartError: string | null = null;
-      if (!isEdit && isDetector && createdId && form.startAfterCreate) {
+      const shouldAutoStart = shouldAutoStartCreatedRule(ruleType, form.startAfterCreate);
+      if (!isEdit && createdId && shouldAutoStart) {
         try {
           const startResponse = await coreRefs.http?.post<ApiResponse>(
             withAdApiDataSource(
@@ -2364,12 +2468,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               defaultMessage: 'Forecasting rule updated successfully',
             })
         : isDetector
-          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
-              defaultMessage: 'Anomaly detection rule created successfully',
-            })
-          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
-              defaultMessage: 'Forecasting rule created successfully',
-            });
+        ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreatedToast', {
+            defaultMessage: 'Anomaly detection rule created successfully',
+          })
+        : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreatedToast', {
+            defaultMessage: 'Forecasting rule created successfully',
+          });
 
       if (isEdit && isDetector && shouldOfferStartDetectorAfterEdit && editTarget) {
         setStartAfterEditPrompt({
@@ -2387,12 +2491,19 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
         onCreated?.();
         if (autoStartError) {
           coreRefs.toasts?.addWarning({
-            title: i18n.translate(
-              'observability.alerting.createAdRuleFlyout.detectorCreatedStartFailed',
-              {
-                defaultMessage: 'Rule created but the detector could not be started',
-              }
-            ),
+            title: isDetector
+              ? i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.detectorCreatedStartFailed',
+                  {
+                    defaultMessage: 'Rule created but the detector could not be started',
+                  }
+                )
+              : i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.forecasterCreatedStartFailed',
+                  {
+                    defaultMessage: 'Rule created but the forecaster could not be started',
+                  }
+                ),
             text: autoStartError,
           });
         }
@@ -2410,12 +2521,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 defaultMessage: 'Failed to update forecasting rule',
               })
           : isDetector
-            ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
-                defaultMessage: 'Failed to create anomaly detection rule',
-              })
-            : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
-                defaultMessage: 'Failed to create forecasting rule',
-              }),
+          ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorCreateFailed', {
+              defaultMessage: 'Failed to create anomaly detection rule',
+            })
+          : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterCreateFailed', {
+              defaultMessage: 'Failed to create forecasting rule',
+            }),
         text: message,
       });
     } finally {
@@ -2779,7 +2890,18 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               buttonContent={
                 <div id={`featureAccordionHeaders.${index}`}>
                   <EuiTitle size="xs" className="euiAccordionForm__title">
-                    <h5>{feature.featureName || 'Add feature'}</h5>
+                    <h5>
+                      {feature.featureName ||
+                        (isDetector
+                          ? i18n.translate(
+                              'observability.alerting.createAdRuleFlyout.addFeatureHeading',
+                              { defaultMessage: 'Add feature' }
+                            )
+                          : i18n.translate(
+                              'observability.alerting.createAdRuleFlyout.addIndicatorHeading',
+                              { defaultMessage: 'Add indicator' }
+                            ))}
+                    </h5>
                   </EuiTitle>
                 </div>
               }
@@ -2802,19 +2924,27 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
               }
             >
               <EuiFormRow
-                label={i18n.translate(
-                  'observability.alerting.createAdRuleFlyout.featureNameLabel',
-                  {
-                    defaultMessage: 'Feature name',
-                  }
-                )}
-                helpText={i18n.translate(
-                  'observability.alerting.createAdRuleFlyout.featureNameHelp',
-                  {
-                    defaultMessage:
-                      'Enter a descriptive, unique name. The name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen) and _(underscore).',
-                  }
-                )}
+                label={
+                  isDetector
+                    ? i18n.translate('observability.alerting.createAdRuleFlyout.featureNameLabel', {
+                        defaultMessage: 'Feature name',
+                      })
+                    : i18n.translate(
+                        'observability.alerting.createAdRuleFlyout.indicatorNameLabel',
+                        { defaultMessage: 'Indicator name' }
+                      )
+                }
+                helpText={
+                  isDetector
+                    ? i18n.translate('observability.alerting.createAdRuleFlyout.featureNameHelp', {
+                        defaultMessage:
+                          'Enter a descriptive, unique name. The name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen) and _(underscore).',
+                      })
+                    : i18n.translate(
+                        'observability.alerting.createAdRuleFlyout.indicatorNameHelp',
+                        { defaultMessage: 'Enter a descriptive name (1-64 characters).' }
+                      )
+                }
                 isInvalid={!!featureNameError}
                 error={featureNameError}
               >
@@ -2822,44 +2952,55 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                   value={feature.featureName}
                   isInvalid={!!featureNameError}
                   onChange={(e) => updateFeature(index, 'featureName', e.target.value)}
-                  placeholder={i18n.translate(
-                    'observability.alerting.createAdRuleFlyout.featureNamePlaceholder',
-                    {
-                      defaultMessage: 'Enter feature name',
-                    }
-                  )}
+                  placeholder={
+                    isDetector
+                      ? i18n.translate(
+                          'observability.alerting.createAdRuleFlyout.featureNamePlaceholder',
+                          { defaultMessage: 'Enter feature name' }
+                        )
+                      : i18n.translate(
+                          'observability.alerting.createAdRuleFlyout.indicatorNamePlaceholder',
+                          { defaultMessage: 'Enter indicator name' }
+                        )
+                  }
                   data-test-subj={`alertManagerCreateAdRuleFeatureName-${index}`}
                 />
               </EuiFormRow>
 
-              <EuiFormRow
-                label={i18n.translate(
-                  'observability.alerting.createAdRuleFlyout.featureStateLabel',
-                  {
-                    defaultMessage: 'Feature state',
-                  }
-                )}
-              >
-                <EuiCheckbox
-                  id={`featureList.${index}.featureEnabled`}
+              {isDetector && (
+                <EuiFormRow
                   label={i18n.translate(
-                    'observability.alerting.createAdRuleFlyout.enableFeatureLabel',
+                    'observability.alerting.createAdRuleFlyout.featureStateLabel',
                     {
-                      defaultMessage: 'Enable feature',
+                      defaultMessage: 'Feature state',
                     }
                   )}
-                  checked={feature.featureEnabled}
-                  onChange={(e) => updateFeature(index, 'featureEnabled', e.target.checked)}
-                />
-              </EuiFormRow>
+                >
+                  <EuiCheckbox
+                    id={`featureList.${index}.featureEnabled`}
+                    label={i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.enableFeatureLabel',
+                      {
+                        defaultMessage: 'Enable feature',
+                      }
+                    )}
+                    checked={feature.featureEnabled}
+                    onChange={(e) => updateFeature(index, 'featureEnabled', e.target.checked)}
+                  />
+                </EuiFormRow>
+              )}
 
               <EuiFormRow
-                label={i18n.translate(
-                  'observability.alerting.createAdRuleFlyout.featureTypeLabel',
-                  {
-                    defaultMessage: 'Find anomalies based on',
-                  }
-                )}
+                label={
+                  isDetector
+                    ? i18n.translate('observability.alerting.createAdRuleFlyout.featureTypeLabel', {
+                        defaultMessage: 'Find anomalies based on',
+                      })
+                    : i18n.translate(
+                        'observability.alerting.createAdRuleFlyout.indicatorTypeLabel',
+                        { defaultMessage: 'Forecast based on' }
+                      )
+                }
               >
                 <EuiSelect value={SIMPLE_FEATURE_TYPE} options={FEATURE_TYPE_OPTIONS} disabled />
               </EuiFormRow>
@@ -2871,16 +3012,33 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     defaultMessage: 'Aggregation method',
                   }
                 )}
-                hint={i18n.translate('observability.alerting.createAdRuleFlyout.aggregationHint', {
-                  defaultMessage: 'The aggregation method determines what constitutes an anomaly.',
-                })}
-                helpText={i18n.translate(
-                  'observability.alerting.createAdRuleFlyout.aggregationHelp',
-                  {
-                    defaultMessage:
-                      'E.g, if you choose min(), the detector focuses on finding anomalies based on the minimum values of your feature.',
-                  }
-                )}
+                hint={
+                  isDetector
+                    ? i18n.translate('observability.alerting.createAdRuleFlyout.aggregationHint', {
+                        defaultMessage:
+                          'The aggregation method determines what constitutes an anomaly.',
+                      })
+                    : i18n.translate(
+                        'observability.alerting.createAdRuleFlyout.forecastAggregationHint',
+                        {
+                          defaultMessage: 'The aggregation method defines the value to forecast.',
+                        }
+                      )
+                }
+                helpText={
+                  isDetector
+                    ? i18n.translate('observability.alerting.createAdRuleFlyout.aggregationHelp', {
+                        defaultMessage:
+                          'E.g, if you choose min(), the detector focuses on finding anomalies based on the minimum values of your feature.',
+                      })
+                    : i18n.translate(
+                        'observability.alerting.createAdRuleFlyout.forecastAggregationHelp',
+                        {
+                          defaultMessage:
+                            'For example, choose average() to forecast the average value of the selected field.',
+                        }
+                      )
+                }
               >
                 <EuiSelect
                   options={AGGREGATION_OPTIONS}
@@ -2904,26 +3062,29 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                 dataTestSubj={`alertManagerCreateAdRuleFeatureField-${index}`}
               />
 
-              <AdFormattedFormRow
-                title={i18n.translate(
-                  'observability.alerting.createAdRuleFlyout.anomalyCriteriaLabel',
-                  {
-                    defaultMessage: 'Anomaly criteria',
-                  }
-                )}
-                hint={i18n.translate(
-                  'observability.alerting.createAdRuleFlyout.anomalyCriteriaHint',
-                  {
-                    defaultMessage: 'Acceptable difference between the expected and actual values',
-                  }
-                )}
-              >
-                <EuiSelect
-                  value={feature.anomalyDirection}
-                  options={FEATURE_DIRECTION_OPTIONS}
-                  onChange={(e) => updateFeature(index, 'anomalyDirection', e.target.value)}
-                />
-              </AdFormattedFormRow>
+              {isDetector && (
+                <AdFormattedFormRow
+                  title={i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.anomalyCriteriaLabel',
+                    {
+                      defaultMessage: 'Anomaly criteria',
+                    }
+                  )}
+                  hint={i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.anomalyCriteriaHint',
+                    {
+                      defaultMessage:
+                        'Acceptable difference between the expected and actual values',
+                    }
+                  )}
+                >
+                  <EuiSelect
+                    value={feature.anomalyDirection}
+                    options={FEATURE_DIRECTION_OPTIONS}
+                    onChange={(e) => updateFeature(index, 'anomalyDirection', e.target.value)}
+                  />
+                </AdFormattedFormRow>
+              )}
 
               {featureLimitError && (
                 <>
@@ -3283,6 +3444,242 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
     </>
   );
 
+  const renderForecasterStorageSettings = () => (
+    <AdContentPanel
+      title={i18n.translate('observability.alerting.createAdRuleFlyout.forecastStorageTitle', {
+        defaultMessage: 'Storage',
+      })}
+      subTitle={i18n.translate(
+        'observability.alerting.createAdRuleFlyout.forecastStorageSubtitle',
+        { defaultMessage: 'Define how to store and manage forecasting results.' }
+      )}
+    >
+      <EuiFlexGroup gutterSize="l">
+        <EuiFlexItem>
+          <EuiPanel hasBorder paddingSize="l">
+            <EuiRadio
+              id="alertManagerForecasterDefaultIndex"
+              label={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.defaultForecastIndexLabel',
+                { defaultMessage: 'Default index' }
+              )}
+              checked={!form.customResultIndexEnabled}
+              onChange={() =>
+                setForm((previous) => ({
+                  ...previous,
+                  customResultIndexEnabled: false,
+                  resultIndex: '',
+                  resultIndexMinAge: '',
+                  resultIndexMinSize: '',
+                  resultIndexTtl: '',
+                  customResultIndexLifecycleEnabled: false,
+                  flattenCustomResultIndex: false,
+                }))
+              }
+            />
+            <EuiSpacer size="s" />
+            <EuiText size="xs" color="subdued">
+              <p style={{ margin: 0 }}>
+                {i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.defaultForecastIndexDescription',
+                  {
+                    defaultMessage:
+                      'The forecasting results are retained automatically for at least 30 days.',
+                  }
+                )}
+              </p>
+            </EuiText>
+          </EuiPanel>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiPanel hasBorder paddingSize="l">
+            <EuiRadio
+              id="alertManagerForecasterCustomIndex"
+              label={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.customForecastIndexLabel',
+                { defaultMessage: 'Custom index' }
+              )}
+              checked={form.customResultIndexEnabled}
+              onChange={() =>
+                setForm((previous) => ({
+                  ...previous,
+                  customResultIndexEnabled: true,
+                  resultIndex: previous.resultIndex || 'my_custom_forecast_index',
+                }))
+              }
+            />
+            <EuiSpacer size="s" />
+            <EuiText size="xs" color="subdued">
+              <p style={{ margin: 0 }}>
+                {i18n.translate(
+                  'observability.alerting.createAdRuleFlyout.customForecastIndexDescription',
+                  {
+                    defaultMessage:
+                      'Route forecast results to your custom index. In a custom index, you set the retention period and resource allocation.',
+                  }
+                )}
+              </p>
+            </EuiText>
+          </EuiPanel>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      {form.customResultIndexEnabled && (
+        <>
+          <EuiSpacer size="l" />
+          <EuiHorizontalRule margin="none" />
+          <EuiSpacer size="l" />
+          <EuiTitle size="xs">
+            <h4>
+              {i18n.translate(
+                'observability.alerting.createAdRuleFlyout.customForecastResultIndexTitle',
+                { defaultMessage: 'Custom result index' }
+              )}
+            </h4>
+          </EuiTitle>
+          <EuiText size="xs" color="subdued">
+            <p>
+              {i18n.translate(
+                'observability.alerting.createAdRuleFlyout.customForecastResultIndexDescription',
+                { defaultMessage: 'Store forecaster results to your own index.' }
+              )}{' '}
+              <EuiLink href={FORECASTER_DOCS_LINK} target="_blank">
+                {i18n.translate('observability.alerting.createAdRuleFlyout.learnMore', {
+                  defaultMessage: 'Learn more',
+                })}
+              </EuiLink>
+            </p>
+          </EuiText>
+          <EuiSpacer size="m" />
+          <EuiFormRow
+            label={i18n.translate(
+              'observability.alerting.createAdRuleFlyout.forecastResultIndexFieldLabel',
+              { defaultMessage: 'Field' }
+            )}
+            helpText={i18n.translate(
+              'observability.alerting.createAdRuleFlyout.forecastResultIndexHelp',
+              {
+                defaultMessage:
+                  'Custom result index name must contain fewer than 255 characters including the prefix "opensearch-forecast-result-". Valid characters are a-z, 0-9, -(hyphen), and _(underscore).',
+              }
+            )}
+            isInvalid={!!visibleErrors.resultIndex}
+            error={visibleErrors.resultIndex}
+          >
+            <EuiFieldText
+              value={form.resultIndex}
+              prepend={CUSTOM_FORECASTER_RESULT_INDEX_PREFIX}
+              isInvalid={!!visibleErrors.resultIndex}
+              placeholder={i18n.translate(
+                'observability.alerting.createAdRuleFlyout.forecastResultIndexPlaceholder',
+                { defaultMessage: 'Enter result index name' }
+              )}
+              onChange={(event) => updateForm('resultIndex', event.target.value)}
+              data-test-subj="alertManagerCreateForecasterResultIndex"
+            />
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiCheckbox
+            id="alertManagerFlattenForecastResultIndex"
+            label={i18n.translate(
+              'observability.alerting.createAdRuleFlyout.flattenForecastResultIndexLabel',
+              { defaultMessage: 'Enable flattened custom result index' }
+            )}
+            checked={form.flattenCustomResultIndex}
+            onChange={(event) => updateForm('flattenCustomResultIndex', event.target.checked)}
+          />
+          <EuiText size="xs" color="subdued">
+            <p>
+              {i18n.translate(
+                'observability.alerting.createAdRuleFlyout.flattenForecastResultIndexHelp',
+                {
+                  defaultMessage:
+                    'Flattening the custom result index makes it easier to query on dashboards and supports term aggregations on categorical fields.',
+                }
+              )}
+            </p>
+          </EuiText>
+          <EuiSpacer size="m" />
+          <EuiCheckbox
+            id="alertManagerForecastResultIndexLifecycle"
+            label={i18n.translate(
+              'observability.alerting.createAdRuleFlyout.forecastResultIndexLifecycleLabel',
+              { defaultMessage: 'Enable custom result index lifecycle management' }
+            )}
+            checked={form.customResultIndexLifecycleEnabled}
+            onChange={(event) =>
+              updateForm('customResultIndexLifecycleEnabled', event.target.checked)
+            }
+          />
+          {form.customResultIndexLifecycleEnabled && (
+            <>
+              <EuiSpacer size="m" />
+              <EuiFlexGroup gutterSize="l">
+                <EuiFlexItem>
+                  <EuiFormRow
+                    label={i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.forecastResultIndexMinAgeLabel',
+                      { defaultMessage: 'Min index age (optional)' }
+                    )}
+                    isInvalid={!!visibleErrors.resultIndexMinAge}
+                    error={visibleErrors.resultIndexMinAge}
+                  >
+                    <EuiFieldNumber
+                      min={1}
+                      value={form.resultIndexMinAge}
+                      append="days"
+                      onChange={(event) =>
+                        updateForm('resultIndexMinAge', parseNumberInputValue(event.target.value))
+                      }
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiFormRow
+                    label={i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.forecastResultIndexMinSizeLabel',
+                      { defaultMessage: 'Min index size (optional)' }
+                    )}
+                    isInvalid={!!visibleErrors.resultIndexMinSize}
+                    error={visibleErrors.resultIndexMinSize}
+                  >
+                    <EuiFieldNumber
+                      min={1000}
+                      value={form.resultIndexMinSize}
+                      append="MB"
+                      onChange={(event) =>
+                        updateForm('resultIndexMinSize', parseNumberInputValue(event.target.value))
+                      }
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiFormRow
+                    label={i18n.translate(
+                      'observability.alerting.createAdRuleFlyout.forecastResultIndexTtlLabel',
+                      { defaultMessage: 'Index TTL (optional)' }
+                    )}
+                    isInvalid={!!visibleErrors.resultIndexTtl}
+                    error={visibleErrors.resultIndexTtl}
+                  >
+                    <EuiFieldNumber
+                      min={1}
+                      value={form.resultIndexTtl}
+                      append="days"
+                      onChange={(event) =>
+                        updateForm('resultIndexTtl', parseNumberInputValue(event.target.value))
+                      }
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </>
+          )}
+        </>
+      )}
+    </AdContentPanel>
+  );
+
   const renderForecastModelParametersStep = () => (
     <>
       <EuiText size="s">
@@ -3452,6 +3849,8 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           defaultMessage: 'Advanced model parameters',
         })
       )}
+      <EuiSpacer size="m" />
+      {renderForecasterStorageSettings()}
     </>
   );
 
@@ -3737,12 +4136,12 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           }
         )
       : isAwaitingDataToInit || isAwaitingDataToRestart
-        ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
-            defaultMessage: 'Cancel forecast to edit?',
-          })
-        : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
-            defaultMessage: 'Stop forecast to edit?',
-          });
+      ? i18n.translate('observability.alerting.createAdRuleFlyout.cancelForecastToEditTitle', {
+          defaultMessage: 'Cancel forecast to edit?',
+        })
+      : i18n.translate('observability.alerting.createAdRuleFlyout.stopForecastToEditTitle', {
+          defaultMessage: 'Stop forecast to edit?',
+        });
     const forecastModalDescription = (() => {
       if (isInitializingForecast) {
         return i18n.translate(
@@ -3913,14 +4312,14 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
                     }
                   )
               : isDetector
-                ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
-                    defaultMessage:
-                      'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
-                  })
-                : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
-                    defaultMessage:
-                      'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
-                  })}
+              ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorSubtitle', {
+                  defaultMessage:
+                    'Create an anomaly detection rule using the same model definition fields from the AD workflow.',
+                })
+              : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterSubtitle', {
+                  defaultMessage:
+                    'Create a forecasting rule using the same data source and model parameter fields from the Forecasting workflow.',
+                })}
           </EuiText>
         </EuiFlyoutHeader>
 

--- a/public/components/alerting/detector_detail_flyout.tsx
+++ b/public/components/alerting/detector_detail_flyout.tsx
@@ -214,11 +214,11 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
   onStop,
 }) => {
   const [lifecycleAction, setLifecycleAction] = useState<'start' | 'stop' | null>(null);
-  const {
-    data: detail,
-    isLoading,
-    error,
-  } = useRuleDetail(detector.datasourceId, detector.id, 'detector');
+  const { data: detail, isLoading, error, refetch } = useRuleDetail(
+    detector.datasourceId,
+    detector.id,
+    'detector'
+  );
   const rawDetector = (detail?.raw as ADDetector | undefined) || detectorFromSummary(detector);
   const description =
     detail?.description || rawDetector.description || detector.annotations.description || '';
@@ -249,6 +249,7 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
     setLifecycleAction(action);
     try {
       await handler(detector);
+      refetch();
     } finally {
       setLifecycleAction(null);
     }

--- a/public/components/alerting/detector_detail_flyout.tsx
+++ b/public/components/alerting/detector_detail_flyout.tsx
@@ -214,11 +214,11 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
   onStop,
 }) => {
   const [lifecycleAction, setLifecycleAction] = useState<'start' | 'stop' | null>(null);
-  const { data: detail, isLoading, error } = useRuleDetail(
-    detector.datasourceId,
-    detector.id,
-    'detector'
-  );
+  const {
+    data: detail,
+    isLoading,
+    error,
+  } = useRuleDetail(detector.datasourceId, detector.id, 'detector');
   const rawDetector = (detail?.raw as ADDetector | undefined) || detectorFromSummary(detector);
   const description =
     detail?.description || rawDetector.description || detector.annotations.description || '';
@@ -454,21 +454,27 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.settings.name',
-                      { defaultMessage: 'Name' }
+                      {
+                        defaultMessage: 'Name',
+                      }
                     ),
                     description: detector.name,
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.settings.detectorType',
-                      { defaultMessage: 'Detector type' }
+                      {
+                        defaultMessage: 'Detector type',
+                      }
                     ),
                     description: detectorType,
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.settings.dataSourceIndex',
-                      { defaultMessage: 'Data source index' }
+                      {
+                        defaultMessage: 'Data source index',
+                      }
                     ),
                     description: formatList(rawDetector.indices),
                   },
@@ -484,21 +490,27 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.settings.timestamp',
-                      { defaultMessage: 'Timestamp' }
+                      {
+                        defaultMessage: 'Timestamp',
+                      }
                     ),
                     description: stringValue(rawDetector.time_field),
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.settings.lastUpdated',
-                      { defaultMessage: 'Last updated' }
+                      {
+                        defaultMessage: 'Last updated',
+                      }
                     ),
                     description: formatTimestamp(rawDetector.last_update_time),
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.settings.customResultIndex',
-                      { defaultMessage: 'Custom result index' }
+                      {
+                        defaultMessage: 'Custom result index',
+                      }
                     ),
                     description: resultIndex,
                   },
@@ -572,21 +584,27 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.operational.detectorInterval',
-                      { defaultMessage: 'Detector interval' }
+                      {
+                        defaultMessage: 'Detector interval',
+                      }
                     ),
                     description: detectorIntervalDisplay,
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.operational.windowDelay',
-                      { defaultMessage: 'Window delay' }
+                      {
+                        defaultMessage: 'Window delay',
+                      }
                     ),
                     description: formatPeriod(rawDetector.window_delay),
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.operational.frequency',
-                      { defaultMessage: 'Frequency' }
+                      {
+                        defaultMessage: 'Frequency',
+                      }
                     ),
                     description:
                       frequencyDisplay === EMPTY_VALUE ? detectorIntervalDisplay : frequencyDisplay,
@@ -594,7 +612,9 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.operational.history',
-                      { defaultMessage: 'History' }
+                      {
+                        defaultMessage: 'History',
+                      }
                     ),
                     description: rawDetector.history
                       ? i18n.translate(
@@ -632,21 +652,27 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.additional.categoryField',
-                      { defaultMessage: 'Category field' }
+                      {
+                        defaultMessage: 'Category field',
+                      }
                     ),
                     description: categoryField,
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.additional.shingleSize',
-                      { defaultMessage: 'Shingle size' }
+                      {
+                        defaultMessage: 'Shingle size',
+                      }
                     ),
                     description: String(shingleSize),
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.additional.imputationMethod',
-                      { defaultMessage: 'Imputation method' }
+                      {
+                        defaultMessage: 'Imputation method',
+                      }
                     ),
                     description: buildImputationDisplay(rawDetector),
                   },
@@ -676,21 +702,27 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.job.realTimeJob',
-                      { defaultMessage: 'Real-time job' }
+                      {
+                        defaultMessage: 'Real-time job',
+                      }
                     ),
                     description: realTimeJobDisplay,
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.job.enabledTime',
-                      { defaultMessage: 'Enabled time' }
+                      {
+                        defaultMessage: 'Enabled time',
+                      }
                     ),
                     description: formatTimestamp(detectorJob.enabled_time),
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.detectorDetailFlyout.job.disabledTime',
-                      { defaultMessage: 'Disabled time' }
+                      {
+                        defaultMessage: 'Disabled time',
+                      }
                     ),
                     description: formatTimestamp(detectorJob.disabled_time),
                   },

--- a/public/components/alerting/detector_detail_flyout.tsx
+++ b/public/components/alerting/detector_detail_flyout.tsx
@@ -8,7 +8,7 @@
  * Rules table. Mirrors the monitor detail flyout shell while
  * grouping detector content like the AD detector configuration page.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EuiAccordion,
   EuiBadge,
@@ -35,11 +35,20 @@ import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import type { ADDetector, UnifiedRuleSummary } from '../../../common/types/alerting';
 import { useRuleDetail } from './hooks/use_rule_detail';
-import { HEALTH_COLORS, SEVERITY_COLORS, STATUS_COLORS } from './shared_constants';
+import {
+  HEALTH_COLORS,
+  isAdResourceRunning,
+  SEVERITY_COLORS,
+  STATUS_COLORS,
+} from './shared_constants';
 
 export interface DetectorDetailFlyoutProps {
   detector: UnifiedRuleSummary;
   onClose: () => void;
+  onEditSettings?: (detector: UnifiedRuleSummary) => void;
+  onEditFeatures?: (detector: UnifiedRuleSummary) => void;
+  onStart?: (detector: UnifiedRuleSummary) => Promise<void> | void;
+  onStop?: (detector: UnifiedRuleSummary) => Promise<void> | void;
 }
 
 interface FeatureRow {
@@ -199,7 +208,12 @@ const buildImputationDisplay = (detector: ADDetector): string => {
 export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
   detector,
   onClose,
+  onEditSettings,
+  onEditFeatures,
+  onStart,
+  onStop,
 }) => {
+  const [lifecycleAction, setLifecycleAction] = useState<'start' | 'stop' | null>(null);
   const { data: detail, isLoading, error } = useRuleDetail(
     detector.datasourceId,
     detector.id,
@@ -225,6 +239,20 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
   const frequencyDisplay = formatPeriod(rawDetector.frequency);
   const realTimeJobDisplay =
     typeof jobEnabled === 'boolean' ? (jobEnabled ? enabledLabel() : disabledLabel()) : EMPTY_VALUE;
+  const isRunning = isAdResourceRunning(detector);
+
+  const runLifecycleAction = async (
+    action: 'start' | 'stop',
+    handler?: (detectorToUpdate: UnifiedRuleSummary) => Promise<void> | void
+  ) => {
+    if (!handler) return;
+    setLifecycleAction(action);
+    try {
+      await handler(detector);
+    } finally {
+      setLifecycleAction(null);
+    }
+  };
 
   const featureColumns: Array<EuiBasicTableColumn<FeatureRow>> = [
     {
@@ -285,6 +313,86 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
+        {(onEditSettings || onEditFeatures || onStart || onStop) && (
+          <>
+            <EuiSpacer size="s" />
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              {isRunning
+                ? onStop && (
+                    <EuiFlexItem grow={false}>
+                      <EuiButtonEmpty
+                        size="s"
+                        iconType="cross"
+                        isLoading={lifecycleAction === 'stop'}
+                        onClick={() => {
+                          void runLifecycleAction('stop', onStop);
+                        }}
+                        data-test-subj="alertManagerDetectorDetailStop"
+                      >
+                        <FormattedMessage
+                          id="observability.alerting.detectorDetailFlyout.stopDetectorButton"
+                          defaultMessage="Stop detector"
+                        />
+                      </EuiButtonEmpty>
+                    </EuiFlexItem>
+                  )
+                : onStart && (
+                    <EuiFlexItem grow={false}>
+                      <EuiButtonEmpty
+                        size="s"
+                        iconType="play"
+                        isLoading={lifecycleAction === 'start'}
+                        onClick={() => {
+                          void runLifecycleAction('start', onStart);
+                        }}
+                        data-test-subj="alertManagerDetectorDetailStart"
+                      >
+                        <FormattedMessage
+                          id="observability.alerting.detectorDetailFlyout.startDetectorButton"
+                          defaultMessage="Start detector"
+                        />
+                      </EuiButtonEmpty>
+                    </EuiFlexItem>
+                  )}
+              {onEditSettings && (
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    size="s"
+                    iconType="pencil"
+                    onClick={() => {
+                      onClose();
+                      onEditSettings(detector);
+                    }}
+                    data-test-subj="alertManagerDetectorDetailEditSettings"
+                  >
+                    <FormattedMessage
+                      id="observability.alerting.detectorDetailFlyout.editSettingsButton"
+                      defaultMessage="Edit detector settings"
+                    />
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              )}
+              {onEditFeatures && (
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    size="s"
+                    iconType="controlsHorizontal"
+                    onClick={() => {
+                      onClose();
+                      onEditFeatures(detector);
+                    }}
+                    data-test-subj="alertManagerDetectorDetailEditFeatures"
+                  >
+                    <FormattedMessage
+                      id="observability.alerting.detectorDetailFlyout.editFeaturesButton"
+                      defaultMessage="Edit model configuration"
+                    />
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
+          </>
+        )}
       </EuiFlyoutHeader>
 
       <EuiFlyoutBody>

--- a/public/components/alerting/detector_detail_flyout.tsx
+++ b/public/components/alerting/detector_detail_flyout.tsx
@@ -214,11 +214,12 @@ export const DetectorDetailFlyout: React.FC<DetectorDetailFlyoutProps> = ({
   onStop,
 }) => {
   const [lifecycleAction, setLifecycleAction] = useState<'start' | 'stop' | null>(null);
-  const { data: detail, isLoading, error, refetch } = useRuleDetail(
-    detector.datasourceId,
-    detector.id,
-    'detector'
-  );
+  const {
+    data: detail,
+    isLoading,
+    error,
+    refetch,
+  } = useRuleDetail(detector.datasourceId, detector.id, 'detector');
   const rawDetector = (detail?.raw as ADDetector | undefined) || detectorFromSummary(detector);
   const description =
     detail?.description || rawDetector.description || detector.annotations.description || '';

--- a/public/components/alerting/forecaster_detail_flyout.tsx
+++ b/public/components/alerting/forecaster_detail_flyout.tsx
@@ -220,11 +220,11 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
   onStop,
 }) => {
   const [lifecycleAction, setLifecycleAction] = useState<'start' | 'stop' | null>(null);
-  const { data: detail, isLoading, error } = useRuleDetail(
-    forecaster.datasourceId,
-    forecaster.id,
-    'forecaster'
-  );
+  const {
+    data: detail,
+    isLoading,
+    error,
+  } = useRuleDetail(forecaster.datasourceId, forecaster.id, 'forecaster');
   const rawForecaster =
     (detail?.raw as ADForecaster | undefined) || forecasterFromSummary(forecaster);
   const description =
@@ -453,42 +453,54 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.settings.name',
-                      { defaultMessage: 'Name' }
+                      {
+                        defaultMessage: 'Name',
+                      }
                     ),
                     description: forecaster.name,
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.settings.forecasterType',
-                      { defaultMessage: 'Forecaster type' }
+                      {
+                        defaultMessage: 'Forecaster type',
+                      }
                     ),
                     description: forecasterType,
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.settings.dataSourceIndex',
-                      { defaultMessage: 'Data source index' }
+                      {
+                        defaultMessage: 'Data source index',
+                      }
                     ),
                     description: formatList(rawForecaster.indices),
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.settings.id',
-                      { defaultMessage: 'ID' }
+                      {
+                        defaultMessage: 'ID',
+                      }
                     ),
                     description: forecaster.id,
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.settings.timestamp',
-                      { defaultMessage: 'Timestamp' }
+                      {
+                        defaultMessage: 'Timestamp',
+                      }
                     ),
                     description: stringValue(rawForecaster.time_field || rawForecaster.timeField),
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.settings.lastUpdated',
-                      { defaultMessage: 'Last updated' }
+                      {
+                        defaultMessage: 'Last updated',
+                      }
                     ),
                     description: formatTimestamp(
                       rawForecaster.last_update_time || rawForecaster.lastUpdateTime
@@ -497,7 +509,9 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.settings.customResultIndex',
-                      { defaultMessage: 'Custom result index' }
+                      {
+                        defaultMessage: 'Custom result index',
+                      }
                     ),
                     description: resultIndex,
                   },
@@ -578,14 +592,18 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.operational.windowDelay',
-                      { defaultMessage: 'Window delay' }
+                      {
+                        defaultMessage: 'Window delay',
+                      }
                     ),
                     description: windowDelayDisplay,
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.operational.horizon',
-                      { defaultMessage: 'Horizon' }
+                      {
+                        defaultMessage: 'Horizon',
+                      }
                     ),
                     description: rawForecaster.horizon
                       ? String(rawForecaster.horizon)
@@ -594,7 +612,9 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.operational.history',
-                      { defaultMessage: 'History' }
+                      {
+                        defaultMessage: 'History',
+                      }
                     ),
                     description: rawForecaster.history
                       ? i18n.translate(
@@ -632,21 +652,27 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.additional.categoryField',
-                      { defaultMessage: 'Category field' }
+                      {
+                        defaultMessage: 'Category field',
+                      }
                     ),
                     description: formatList(categoryField),
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.additional.shingleSize',
-                      { defaultMessage: 'Shingle size' }
+                      {
+                        defaultMessage: 'Shingle size',
+                      }
                     ),
                     description: String(shingleSize),
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.additional.imputationMethod',
-                      { defaultMessage: 'Imputation method' }
+                      {
+                        defaultMessage: 'Imputation method',
+                      }
                     ),
                     description: buildImputationDisplay(rawForecaster),
                   },
@@ -676,7 +702,9 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.job.realTimeJob',
-                      { defaultMessage: 'Real-time job' }
+                      {
+                        defaultMessage: 'Real-time job',
+                      }
                     ),
                     description:
                       typeof jobEnabled === 'boolean'
@@ -688,21 +716,27 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.job.currentState',
-                      { defaultMessage: 'Current state' }
+                      {
+                        defaultMessage: 'Current state',
+                      }
                     ),
                     description: currentState,
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.job.enabledTime',
-                      { defaultMessage: 'Enabled time' }
+                      {
+                        defaultMessage: 'Enabled time',
+                      }
                     ),
                     description: formatTimestamp(forecasterJob.enabled_time),
                   },
                   {
                     title: i18n.translate(
                       'observability.alerting.forecasterDetailFlyout.job.disabledTime',
-                      { defaultMessage: 'Disabled time' }
+                      {
+                        defaultMessage: 'Disabled time',
+                      }
                     ),
                     description: formatTimestamp(forecasterJob.disabled_time),
                   },

--- a/public/components/alerting/forecaster_detail_flyout.tsx
+++ b/public/components/alerting/forecaster_detail_flyout.tsx
@@ -220,11 +220,12 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
   onStop,
 }) => {
   const [lifecycleAction, setLifecycleAction] = useState<'start' | 'stop' | null>(null);
-  const { data: detail, isLoading, error, refetch } = useRuleDetail(
-    forecaster.datasourceId,
-    forecaster.id,
-    'forecaster'
-  );
+  const {
+    data: detail,
+    isLoading,
+    error,
+    refetch,
+  } = useRuleDetail(forecaster.datasourceId, forecaster.id, 'forecaster');
   const rawForecaster =
     (detail?.raw as ADForecaster | undefined) || forecasterFromSummary(forecaster);
   const description =

--- a/public/components/alerting/forecaster_detail_flyout.tsx
+++ b/public/components/alerting/forecaster_detail_flyout.tsx
@@ -8,7 +8,7 @@
  * Rules table. It mirrors the detector flyout shell while keeping forecasting
  * terminology visible in the table-level unified experience.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EuiAccordion,
   EuiBadge,
@@ -35,11 +35,19 @@ import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import type { ADForecaster, UnifiedRuleSummary } from '../../../common/types/alerting';
 import { useRuleDetail } from './hooks/use_rule_detail';
-import { HEALTH_COLORS, SEVERITY_COLORS, STATUS_COLORS } from './shared_constants';
+import {
+  HEALTH_COLORS,
+  isAdResourceRunning,
+  SEVERITY_COLORS,
+  STATUS_COLORS,
+} from './shared_constants';
 
 export interface ForecasterDetailFlyoutProps {
   forecaster: UnifiedRuleSummary;
   onClose: () => void;
+  onEdit?: (forecaster: UnifiedRuleSummary) => void;
+  onStart?: (forecaster: UnifiedRuleSummary) => Promise<void> | void;
+  onStop?: (forecaster: UnifiedRuleSummary) => Promise<void> | void;
 }
 
 interface FeatureRow {
@@ -207,7 +215,11 @@ const buildImputationDisplay = (forecaster: ADForecaster): string => {
 export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
   forecaster,
   onClose,
+  onEdit,
+  onStart,
+  onStop,
 }) => {
+  const [lifecycleAction, setLifecycleAction] = useState<'start' | 'stop' | null>(null);
   const { data: detail, isLoading, error } = useRuleDetail(
     forecaster.datasourceId,
     forecaster.id,
@@ -242,6 +254,21 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
       asRecord(rawForecaster.realtime_task).state ||
       asRecord(rawForecaster.run_once_task).state
   );
+  const isRunning = isAdResourceRunning(forecaster);
+
+  const runLifecycleAction = async (
+    action: 'start' | 'stop',
+    handler?: (forecasterToUpdate: UnifiedRuleSummary) => Promise<void> | void
+  ) => {
+    if (!handler) return;
+    setLifecycleAction(action);
+    try {
+      await handler(forecaster);
+    } finally {
+      setLifecycleAction(null);
+    }
+  };
+
   const featureColumns: Array<EuiBasicTableColumn<FeatureRow>> = [
     {
       field: 'name',
@@ -303,6 +330,68 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
             </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
+        {(onEdit || onStart || onStop) && (
+          <>
+            <EuiSpacer size="s" />
+            <EuiFlexGroup gutterSize="s" responsive={false}>
+              {isRunning
+                ? onStop && (
+                    <EuiFlexItem grow={false}>
+                      <EuiButtonEmpty
+                        size="s"
+                        iconType="cross"
+                        isLoading={lifecycleAction === 'stop'}
+                        onClick={() => {
+                          void runLifecycleAction('stop', onStop);
+                        }}
+                        data-test-subj="alertManagerForecasterDetailStop"
+                      >
+                        <FormattedMessage
+                          id="observability.alerting.forecasterDetailFlyout.stopForecasterButton"
+                          defaultMessage="Stop forecaster"
+                        />
+                      </EuiButtonEmpty>
+                    </EuiFlexItem>
+                  )
+                : onStart && (
+                    <EuiFlexItem grow={false}>
+                      <EuiButtonEmpty
+                        size="s"
+                        iconType="play"
+                        isLoading={lifecycleAction === 'start'}
+                        onClick={() => {
+                          void runLifecycleAction('start', onStart);
+                        }}
+                        data-test-subj="alertManagerForecasterDetailStart"
+                      >
+                        <FormattedMessage
+                          id="observability.alerting.forecasterDetailFlyout.startForecasterButton"
+                          defaultMessage="Start forecaster"
+                        />
+                      </EuiButtonEmpty>
+                    </EuiFlexItem>
+                  )}
+              {onEdit && (
+                <EuiFlexItem grow={false}>
+                  <EuiButtonEmpty
+                    size="s"
+                    iconType="pencil"
+                    onClick={() => {
+                      onClose();
+                      onEdit(forecaster);
+                    }}
+                    data-test-subj="alertManagerForecasterDetailEdit"
+                  >
+                    <FormattedMessage
+                      id="observability.alerting.forecasterDetailFlyout.editButton"
+                      defaultMessage="Edit forecaster"
+                    />
+                  </EuiButtonEmpty>
+                </EuiFlexItem>
+              )}
+            </EuiFlexGroup>
+          </>
+        )}
       </EuiFlyoutHeader>
 
       <EuiFlyoutBody>

--- a/public/components/alerting/forecaster_detail_flyout.tsx
+++ b/public/components/alerting/forecaster_detail_flyout.tsx
@@ -220,11 +220,11 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
   onStop,
 }) => {
   const [lifecycleAction, setLifecycleAction] = useState<'start' | 'stop' | null>(null);
-  const {
-    data: detail,
-    isLoading,
-    error,
-  } = useRuleDetail(forecaster.datasourceId, forecaster.id, 'forecaster');
+  const { data: detail, isLoading, error, refetch } = useRuleDetail(
+    forecaster.datasourceId,
+    forecaster.id,
+    'forecaster'
+  );
   const rawForecaster =
     (detail?.raw as ADForecaster | undefined) || forecasterFromSummary(forecaster);
   const description =
@@ -264,6 +264,7 @@ export const ForecasterDetailFlyout: React.FC<ForecasterDetailFlyoutProps> = ({
     setLifecycleAction(action);
     try {
       await handler(forecaster);
+      refetch();
     } finally {
       setLifecycleAction(null);
     }

--- a/public/components/alerting/hooks/__tests__/use_datasources.test.ts
+++ b/public/components/alerting/hooks/__tests__/use_datasources.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mapSavedObjectsToDatasources } from '../use_datasources';
+
+describe('mapSavedObjectsToDatasources', () => {
+  it('preserves OpenSearch engine and version metadata used by create gating', () => {
+    const datasources = mapSavedObjectsToDatasources(
+      [
+        {
+          id: 'os-1',
+          type: 'data-source',
+          references: [],
+          attributes: {
+            title: 'Serverless',
+            endpoint: 'https://example.aoss.amazonaws.com',
+            dataSourceEngineType: 'OpenSearch Serverless',
+            dataSourceVersion: '3.8.0',
+          },
+        },
+      ] as never,
+      []
+    );
+
+    expect(datasources[0]).toEqual(
+      expect.objectContaining({
+        id: 'os-1',
+        mdsId: 'os-1',
+        engineType: 'OpenSearch Serverless',
+        version: '3.8.0',
+      })
+    );
+  });
+});

--- a/public/components/alerting/hooks/__tests__/use_datasources.test.ts
+++ b/public/components/alerting/hooks/__tests__/use_datasources.test.ts
@@ -6,7 +6,7 @@
 import { mapSavedObjectsToDatasources } from '../use_datasources';
 
 describe('mapSavedObjectsToDatasources', () => {
-  it('preserves OpenSearch engine and version metadata used by create gating', () => {
+  it('preserves OpenSearch engine metadata used by AD and Forecasting create gating', () => {
     const datasources = mapSavedObjectsToDatasources(
       [
         {
@@ -17,7 +17,6 @@ describe('mapSavedObjectsToDatasources', () => {
             title: 'Serverless',
             endpoint: 'https://example.aoss.amazonaws.com',
             dataSourceEngineType: 'OpenSearch Serverless',
-            dataSourceVersion: '3.8.0',
           },
         },
       ] as never,
@@ -29,7 +28,6 @@ describe('mapSavedObjectsToDatasources', () => {
         id: 'os-1',
         mdsId: 'os-1',
         engineType: 'OpenSearch Serverless',
-        version: '3.8.0',
       })
     );
   });

--- a/public/components/alerting/hooks/use_datasources.ts
+++ b/public/components/alerting/hooks/use_datasources.ts
@@ -36,6 +36,8 @@ import type { Datasource } from '../../../../common/types/alerting';
 interface DataSourceSOAttributes {
   title?: string;
   endpoint?: string;
+  dataSourceEngineType?: string;
+  dataSourceVersion?: string;
 }
 
 interface DataConnectionSOAttributes {
@@ -69,6 +71,8 @@ export function mapSavedObjectsToDatasources(
     url: so.id,
     enabled: true,
     mdsId: so.id,
+    engineType: so.attributes.dataSourceEngineType,
+    version: so.attributes.dataSourceVersion,
   }));
   const localRows: Datasource[] =
     osDiscovered.length > 0

--- a/public/components/alerting/hooks/use_datasources.ts
+++ b/public/components/alerting/hooks/use_datasources.ts
@@ -182,10 +182,8 @@ export function useDatasources(): UseDatasourcesResult {
     };
   }, [refreshToken]);
 
-  return useMemo(() => ({ datasources, isLoading, error, refresh }), [
-    datasources,
-    isLoading,
-    error,
-    refresh,
-  ]);
+  return useMemo(
+    () => ({ datasources, isLoading, error, refresh }),
+    [datasources, isLoading, error, refresh]
+  );
 }

--- a/public/components/alerting/hooks/use_datasources.ts
+++ b/public/components/alerting/hooks/use_datasources.ts
@@ -37,7 +37,6 @@ interface DataSourceSOAttributes {
   title?: string;
   endpoint?: string;
   dataSourceEngineType?: string;
-  dataSourceVersion?: string;
 }
 
 interface DataConnectionSOAttributes {
@@ -72,7 +71,6 @@ export function mapSavedObjectsToDatasources(
     enabled: true,
     mdsId: so.id,
     engineType: so.attributes.dataSourceEngineType,
-    version: so.attributes.dataSourceVersion,
   }));
   const localRows: Datasource[] =
     osDiscovered.length > 0

--- a/public/components/alerting/hooks/use_monitor_mutations.ts
+++ b/public/components/alerting/hooks/use_monitor_mutations.ts
@@ -36,12 +36,12 @@ export interface UseMonitorMutationsResult {
     groupName: string,
     ruleName?: string
   ) => Promise<{ success: boolean }>;
-  deleteDetector: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
-  startDetector: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
-  stopDetector: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
-  deleteForecaster: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
-  startForecaster: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
-  stopForecaster: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
+  deleteDetector: (id: string, dsId: string) => Promise<AdResourceActionResponse>;
+  startDetector: (id: string, dsId: string) => Promise<AdResourceActionResponse>;
+  stopDetector: (id: string, dsId: string) => Promise<AdResourceActionResponse>;
+  deleteForecaster: (id: string, dsId: string) => Promise<AdResourceActionResponse>;
+  startForecaster: (id: string, dsId: string) => Promise<AdResourceActionResponse>;
+  stopForecaster: (id: string, dsId: string) => Promise<AdResourceActionResponse>;
   acknowledgeAlert: (
     alertId: string,
     datasourceId?: string,

--- a/public/components/alerting/hooks/use_monitor_mutations.ts
+++ b/public/components/alerting/hooks/use_monitor_mutations.ts
@@ -13,6 +13,7 @@ import { useMemo } from 'react';
 import { MonitorMutationsClient } from '../mutations/monitor_mutations_client';
 import type {
   AcknowledgeAlertResponse,
+  AdResourceActionResponse,
   MonitorDeleteResponse,
   MonitorResponse,
   PrometheusRuleResponse,
@@ -35,6 +36,12 @@ export interface UseMonitorMutationsResult {
     groupName: string,
     ruleName?: string
   ) => Promise<{ success: boolean }>;
+  deleteDetector: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
+  startDetector: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
+  stopDetector: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
+  deleteForecaster: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
+  startForecaster: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
+  stopForecaster: (id: string, dsId?: string) => Promise<AdResourceActionResponse>;
   acknowledgeAlert: (
     alertId: string,
     datasourceId?: string,
@@ -52,6 +59,12 @@ export function useMonitorMutations(): UseMonitorMutationsResult {
       createPrometheusRule: (data, dsId) => client.createPrometheusRule(data, dsId),
       deletePrometheusRule: (dsId, groupName, ruleName) =>
         client.deletePrometheusRule(dsId, groupName, ruleName),
+      deleteDetector: (id, dsId) => client.deleteDetector(id, dsId),
+      startDetector: (id, dsId) => client.startDetector(id, dsId),
+      stopDetector: (id, dsId) => client.stopDetector(id, dsId),
+      deleteForecaster: (id, dsId) => client.deleteForecaster(id, dsId),
+      startForecaster: (id, dsId) => client.startForecaster(id, dsId),
+      stopForecaster: (id, dsId) => client.stopForecaster(id, dsId),
       acknowledgeAlert: (alertId, datasourceId, monitorId) =>
         client.acknowledgeAlert(alertId, datasourceId, monitorId),
     }),

--- a/public/components/alerting/hooks/use_rule_detail.ts
+++ b/public/components/alerting/hooks/use_rule_detail.ts
@@ -12,6 +12,7 @@ export interface UseRuleDetailResult {
   data: UnifiedRule | null;
   isLoading: boolean;
   error: Error | null;
+  refetch: () => void;
 }
 
 export function useRuleDetail(
@@ -23,6 +24,8 @@ export function useRuleDetail(
   const [data, setData] = useState<UnifiedRule | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+  const refetch = () => setRefreshToken((token) => token + 1);
 
   useEffect(() => {
     if (!dsId || !ruleId) {
@@ -45,7 +48,7 @@ export function useRuleDetail(
     return () => {
       cancelled = true;
     };
-  }, [service, dsId, ruleId, definitionType]);
+  }, [service, dsId, ruleId, definitionType, refreshToken]);
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, refetch };
 }

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -19,8 +19,8 @@
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { EuiResizableContainer } from '@elastic/eui';
-import semver from 'semver';
 import { Datasource, UnifiedRuleSummary } from '../../../../common/types/alerting';
+import { isVersionAtLeast } from '../../../../common/utils/shared';
 import { coreRefs } from '../../../framework/core_refs';
 import { useFacetCollapse } from '../facet_filter_panel';
 import { BASE_PPL_ALERTING_SUPPORTED_VERSION } from '../shared_constants';
@@ -231,8 +231,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
       if (d.engineType === 'OpenSearch Serverless') return true;
       if (isAnalyticEngineEnabled(d.id)) return true;
       if (!d.version) return false;
-      const coerced = semver.coerce(d.version);
-      return coerced ? semver.gte(coerced, BASE_PPL_ALERTING_SUPPORTED_VERSION) : false;
+      return isVersionAtLeast(d.version, BASE_PPL_ALERTING_SUPPORTED_VERSION);
     });
     return !hasSupportedDs;
   }, [selectedDatasources, isAnalyticEngineEnabled]);

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -19,12 +19,15 @@
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { EuiResizableContainer } from '@elastic/eui';
+import semver from 'semver';
 import { Datasource, UnifiedRuleSummary } from '../../../../common/types/alerting';
+import { coreRefs } from '../../../framework/core_refs';
 import { useFacetCollapse } from '../facet_filter_panel';
+import { BASE_PPL_ALERTING_SUPPORTED_VERSION } from '../shared_constants';
 import {
   buildTableColumns,
   DEFAULT_VISIBLE,
-  isReadOnlyRuleDefinition,
+  isSelectableRuleDefinition,
 } from './monitors_table_columns';
 import {
   buildSuggestions,
@@ -48,12 +51,19 @@ interface MonitorsTableProps {
   onDelete: (ids: string[]) => void;
   onClone?: (monitor: UnifiedRuleSummary) => void;
   onEdit?: (monitor: UnifiedRuleSummary) => void;
+  onEditDetectorSettings?: (detector: UnifiedRuleSummary) => void;
+  onEditDetectorFeatures?: (detector: UnifiedRuleSummary) => void;
+  onEditForecaster?: (forecaster: UnifiedRuleSummary) => void;
+  onStartResources?: (resources: UnifiedRuleSummary[]) => Promise<void> | void;
+  onStopResources?: (resources: UnifiedRuleSummary[]) => Promise<void> | void;
   /**
    * Optional Disable / Enable handler. Forwarded to the detail flyout.
    * Wired only for PPL monitors at the page layer.
    */
   onToggleEnabled?: (monitor: UnifiedRuleSummary) => Promise<void> | void;
-  onCreateMonitor?: (type: 'logs' | 'prometheus' | 'metrics' | 'slo') => void;
+  onCreateMonitor?: (
+    type: 'logs' | 'prometheus' | 'metrics' | 'slo' | 'detector' | 'forecaster'
+  ) => void;
   /** Currently selected datasource IDs */
   selectedDsIds: string[];
   /** Callback when datasource selection changes */
@@ -70,6 +80,15 @@ interface MonitorsTableProps {
   initialSearchQuery?: string;
 }
 
+interface AlertingSettingsResponse {
+  ok?: boolean;
+  resp?: {
+    transient?: { cluster?: { pluggable?: Record<string, unknown> } };
+    persistent?: { cluster?: { pluggable?: Record<string, unknown> } };
+    defaults?: { cluster?: { pluggable?: Record<string, unknown> } };
+  };
+}
+
 // ============================================================================
 // Main Component
 // ============================================================================
@@ -81,6 +100,11 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   onDelete,
   onClone,
   onEdit,
+  onEditDetectorSettings,
+  onEditDetectorFeatures,
+  onEditForecaster,
+  onStartResources,
+  onStopResources,
   onToggleEnabled,
   onCreateMonitor,
   selectedDsIds,
@@ -139,23 +163,99 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
 
   const dsNameMap = useMemo(() => new Map(datasources.map((d) => [d.id, d.name])), [datasources]);
 
+  // Prefetch AnalyticEngine status for OpenSearch datasources.
+  // An AnalyticEngine domain has cluster.pluggable.dataformat.enabled === true.
+  const [analyticEngineCache, setAnalyticEngineCache] = useState<Map<string, boolean>>(new Map());
+  useEffect(() => {
+    const http = coreRefs.http;
+    if (!http) return;
+    const osDs = datasources.filter(
+      (d) => d.type === 'opensearch' && d.engineType !== 'OpenSearch Serverless' && d.mdsId
+    );
+    if (osDs.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      const cache = new Map<string, boolean>();
+      await Promise.all(
+        osDs.map(async (ds) => {
+          try {
+            const resp = await http.get<AlertingSettingsResponse>('../api/alerting/_settings', {
+              query: { dataSourceId: ds.mdsId },
+            });
+            if (resp?.ok && resp.resp) {
+              const val =
+                resp.resp.transient?.cluster?.pluggable?.['dataformat.enabled'] ??
+                resp.resp.persistent?.cluster?.pluggable?.['dataformat.enabled'] ??
+                resp.resp.defaults?.cluster?.pluggable?.['dataformat.enabled'];
+              cache.set(ds.id, val === 'true' || val === true);
+            } else {
+              cache.set(ds.id, false);
+            }
+          } catch {
+            cache.set(ds.id, false);
+          }
+        })
+      );
+      if (!cancelled) setAnalyticEngineCache(cache);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [datasources]);
+
+  const isAnalyticEngineEnabled = useCallback(
+    (datasourceId: string) => analyticEngineCache.get(datasourceId) || false,
+    [analyticEngineCache]
+  );
+
+  const selectedDatasources = useMemo(
+    () =>
+      selectedDsIds
+        .map((id) => datasources.find((d) => d.id === id))
+        .filter((d): d is Datasource => !!d),
+    [datasources, selectedDsIds]
+  );
+
   // Logs / Metrics popover entries are grayed out when the parent's selection
-  // can't satisfy them: Logs needs at least one OpenSearch datasource, Metrics
-  // needs at least one Prometheus. The empty-selection case is "no datasource
-  // selected → no create options viable", so gate both. When a selection
-  // exists, each option is disabled iff EVERY selected datasource is the wrong
-  // type for it — i.e. only-Prometheus disables Logs, only-OpenSearch disables
-  // Metrics (symmetric).
-  const [logsCreateDisabled, metricsCreateDisabled] = useMemo(() => {
-    const selected = selectedDsIds
-      .map((id) => datasources.find((d) => d.id === id))
-      .filter((d): d is Datasource => !!d);
-    if (selected.length === 0) return [true, true];
-    return [
-      selected.every((d) => d.type === 'prometheus'),
-      selected.every((d) => d.type === 'opensearch'),
-    ];
-  }, [datasources, selectedDsIds]);
+  // can't satisfy them: Logs needs at least one OpenSearch datasource with
+  // version >= 3.5.0 (or serverless), Metrics needs at least one Prometheus.
+  // The empty-selection case used to fall through to "both enabled", but the
+  // spec is "no datasource selected → no create options viable" — Logs without
+  // a supported OS DS is undefined, Metrics without a Prometheus DS is
+  // undefined. Gate both so the user can't enter a flyout that will silently
+  // re-default the datasource on them.
+  const [logsCreateDisabled, logsDisabledReason] = useMemo(() => {
+    if (selectedDatasources.length === 0) return [true, 'no_selection'] as const;
+    const osSelected = selectedDatasources.filter((d) => d.type === 'opensearch');
+    if (osSelected.length === 0) return [true, 'no_os_datasource'] as const;
+    // Check if any selected OS datasource supports PPL alerting
+    const hasSupportedDs = osSelected.some((d) => {
+      if (!d.mdsId) return true; // Local cluster — no version metadata available
+      if (d.engineType === 'OpenSearch Serverless') return true;
+      if (isAnalyticEngineEnabled(d.id)) return true;
+      if (!d.version) return false;
+      const coerced = semver.coerce(d.version);
+      return coerced ? semver.gte(coerced, BASE_PPL_ALERTING_SUPPORTED_VERSION) : false;
+    });
+    if (!hasSupportedDs) return [true, 'version_unsupported'] as const;
+    return [false, ''] as const;
+  }, [selectedDatasources, isAnalyticEngineEnabled]);
+
+  const metricsCreateDisabled = useMemo(() => {
+    if (selectedDatasources.length === 0) return true;
+    // Always allow Metrics creation when at least one datasource is selected —
+    // the Prometheus data-connection may exist on the cluster without a
+    // corresponding MDS saved object (discovered via SQL plugin API, not SO).
+    return false;
+  }, [selectedDatasources]);
+
+  const detectorCreateDisabled = useMemo(() => {
+    return !selectedDatasources.some((d) => d.type === 'opensearch');
+  }, [selectedDatasources]);
+
+  const forecasterCreateDisabled = useMemo(() => {
+    return !selectedDatasources.some((d) => d.type === 'opensearch');
+  }, [selectedDatasources]);
 
   // Build selectable datasource entries for the filter facet — alpha by name
   const datasourceEntries = useMemo(
@@ -197,7 +297,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
     [rules, searchQuery, filters]
   );
   const selectableIds = useMemo(
-    () => new Set(rules.filter((r) => !isReadOnlyRuleDefinition(r)).map((r) => r.id)),
+    () => new Set(rules.filter(isSelectableRuleDefinition).map((r) => r.id)),
     [rules]
   );
   useEffect(() => {
@@ -238,7 +338,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
     setSelectedIds(next);
   };
   const toggleSelectAll = () => {
-    const selectableFiltered = filtered.filter((r) => !isReadOnlyRuleDefinition(r));
+    const selectableFiltered = filtered.filter(isSelectableRuleDefinition);
     const allSelected =
       selectableFiltered.length > 0 && selectableFiltered.every((r) => selectedIds.has(r.id));
     const next = new Set(selectedIds);
@@ -267,6 +367,18 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
     setSelectedIds(new Set());
     setShowDeleteConfirm(false);
   };
+
+  const handleLifecycleAction = useCallback(
+    async (
+      resources: UnifiedRuleSummary[],
+      handler?: (resourcesToUpdate: UnifiedRuleSummary[]) => Promise<void> | void
+    ) => {
+      if (!handler || resources.length === 0) return;
+      await handler(resources);
+      setSelectedIds(new Set());
+    },
+    []
+  );
 
   // Build table columns from visible set
   const tableColumns = useMemo(() => {
@@ -445,6 +557,8 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
                 onCreateMonitor={onCreateMonitor}
                 logsCreateDisabled={logsCreateDisabled}
                 metricsCreateDisabled={metricsCreateDisabled}
+                detectorCreateDisabled={detectorCreateDisabled}
+                forecasterCreateDisabled={forecasterCreateDisabled}
                 noDatasourceSelected={selectedDsIds.length === 0}
                 showCreatePopover={showCreatePopover}
                 setShowCreatePopover={setShowCreatePopover}
@@ -456,6 +570,11 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
                 onDelete={onDelete}
                 onClone={onClone}
                 onEdit={onEdit}
+                onEditDetectorSettings={onEditDetectorSettings}
+                onEditDetectorFeatures={onEditDetectorFeatures}
+                onEditForecaster={onEditForecaster}
+                onStartResources={(resources) => handleLifecycleAction(resources, onStartResources)}
+                onStopResources={(resources) => handleLifecycleAction(resources, onStopResources)}
                 onToggleEnabled={onToggleEnabled}
               />
             </EuiResizablePanel>

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -23,7 +23,10 @@ import { Datasource, UnifiedRuleSummary } from '../../../../common/types/alertin
 import { isVersionAtLeast } from '../../../../common/utils/shared';
 import { coreRefs } from '../../../framework/core_refs';
 import { useFacetCollapse } from '../facet_filter_panel';
-import { BASE_PPL_ALERTING_SUPPORTED_VERSION } from '../shared_constants';
+import {
+  BASE_PPL_ALERTING_SUPPORTED_VERSION,
+  isStandardOpenSearchDatasource,
+} from '../shared_constants';
 import { buildTableColumns, DEFAULT_VISIBLE } from './monitors_table_columns';
 import {
   buildSuggestions,
@@ -238,7 +241,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
 
   const metricsCreateDisabled = !selectedDatasources.some((d) => d.type === 'prometheus');
 
-  const adCreateDisabled = !selectedDatasources.some((d) => d.type === 'opensearch');
+  const adCreateDisabled = !selectedDatasources.some(isStandardOpenSearchDatasource);
 
   // Build selectable datasource entries for the filter facet — alpha by name
   const datasourceEntries = useMemo(

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -24,11 +24,7 @@ import { Datasource, UnifiedRuleSummary } from '../../../../common/types/alertin
 import { coreRefs } from '../../../framework/core_refs';
 import { useFacetCollapse } from '../facet_filter_panel';
 import { BASE_PPL_ALERTING_SUPPORTED_VERSION } from '../shared_constants';
-import {
-  buildTableColumns,
-  DEFAULT_VISIBLE,
-  isSelectableRuleDefinition,
-} from './monitors_table_columns';
+import { buildTableColumns, DEFAULT_VISIBLE } from './monitors_table_columns';
 import {
   buildSuggestions,
   collectLabelKeys,
@@ -134,6 +130,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   const [activeSuggestion, setActiveSuggestion] = useState(-1);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({ ...DEFAULT_WIDTHS });
   const [selectedMonitor, setSelectedMonitor] = useState<UnifiedRuleSummary | null>(null);
+  const [lifecycleActionPending, setLifecycleActionPending] = useState(false);
   // Keep `selectedMonitor` in sync with the latest version of itself in the
   // rules list. Without this, an optimistic update at the page level (e.g.
   // toggling `enabled` from the detail flyout) wouldn't reflect back into
@@ -224,10 +221,10 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   // a supported OS DS is undefined, Metrics without a Prometheus DS is
   // undefined. Gate both so the user can't enter a flyout that will silently
   // re-default the datasource on them.
-  const [logsCreateDisabled] = useMemo(() => {
-    if (selectedDatasources.length === 0) return [true, 'no_selection'] as const;
+  const logsCreateDisabled = useMemo(() => {
+    if (selectedDatasources.length === 0) return true;
     const osSelected = selectedDatasources.filter((d) => d.type === 'opensearch');
-    if (osSelected.length === 0) return [true, 'no_os_datasource'] as const;
+    if (osSelected.length === 0) return true;
     // Check if any selected OS datasource supports PPL alerting
     const hasSupportedDs = osSelected.some((d) => {
       if (!d.mdsId) return true; // Local cluster — no version metadata available
@@ -237,25 +234,12 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
       const coerced = semver.coerce(d.version);
       return coerced ? semver.gte(coerced, BASE_PPL_ALERTING_SUPPORTED_VERSION) : false;
     });
-    if (!hasSupportedDs) return [true, 'version_unsupported'] as const;
-    return [false, ''] as const;
+    return !hasSupportedDs;
   }, [selectedDatasources, isAnalyticEngineEnabled]);
 
-  const metricsCreateDisabled = useMemo(() => {
-    if (selectedDatasources.length === 0) return true;
-    // Always allow Metrics creation when at least one datasource is selected —
-    // the Prometheus data-connection may exist on the cluster without a
-    // corresponding MDS saved object (discovered via SQL plugin API, not SO).
-    return false;
-  }, [selectedDatasources]);
+  const metricsCreateDisabled = !selectedDatasources.some((d) => d.type === 'prometheus');
 
-  const detectorCreateDisabled = useMemo(() => {
-    return !selectedDatasources.some((d) => d.type === 'opensearch');
-  }, [selectedDatasources]);
-
-  const forecasterCreateDisabled = useMemo(() => {
-    return !selectedDatasources.some((d) => d.type === 'opensearch');
-  }, [selectedDatasources]);
+  const adCreateDisabled = !selectedDatasources.some((d) => d.type === 'opensearch');
 
   // Build selectable datasource entries for the filter facet — alpha by name
   const datasourceEntries = useMemo(
@@ -296,10 +280,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
     () => rules.filter((r) => matchesSearch(r, searchQuery) && matchesFilters(r, filters)),
     [rules, searchQuery, filters]
   );
-  const selectableIds = useMemo(
-    () => new Set(rules.filter(isSelectableRuleDefinition).map((r) => r.id)),
-    [rules]
-  );
+  const selectableIds = useMemo(() => new Set(rules.map((r) => r.id)), [rules]);
   useEffect(() => {
     setSelectedIds((prev) => {
       const next = new Set(Array.from(prev).filter((id) => selectableIds.has(id)));
@@ -338,7 +319,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
     setSelectedIds(next);
   };
   const toggleSelectAll = () => {
-    const selectableFiltered = filtered.filter(isSelectableRuleDefinition);
+    const selectableFiltered = filtered;
     const allSelected =
       selectableFiltered.length > 0 && selectableFiltered.every((r) => selectedIds.has(r.id));
     const next = new Set(selectedIds);
@@ -373,11 +354,16 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
       resources: UnifiedRuleSummary[],
       handler?: (resourcesToUpdate: UnifiedRuleSummary[]) => Promise<void> | void
     ) => {
-      if (!handler || resources.length === 0) return;
-      await handler(resources);
-      setSelectedIds(new Set());
+      if (!handler || resources.length === 0 || lifecycleActionPending) return;
+      setLifecycleActionPending(true);
+      try {
+        await handler(resources);
+        setSelectedIds(new Set());
+      } finally {
+        setLifecycleActionPending(false);
+      }
     },
-    []
+    [lifecycleActionPending]
   );
 
   // Build table columns from visible set
@@ -557,8 +543,8 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
                 onCreateMonitor={onCreateMonitor}
                 logsCreateDisabled={logsCreateDisabled}
                 metricsCreateDisabled={metricsCreateDisabled}
-                detectorCreateDisabled={detectorCreateDisabled}
-                forecasterCreateDisabled={forecasterCreateDisabled}
+                detectorCreateDisabled={adCreateDisabled}
+                forecasterCreateDisabled={adCreateDisabled}
                 noDatasourceSelected={selectedDsIds.length === 0}
                 showCreatePopover={showCreatePopover}
                 setShowCreatePopover={setShowCreatePopover}
@@ -575,6 +561,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
                 onEditForecaster={onEditForecaster}
                 onStartResources={(resources) => handleLifecycleAction(resources, onStartResources)}
                 onStopResources={(resources) => handleLifecycleAction(resources, onStopResources)}
+                lifecycleActionPending={lifecycleActionPending}
                 onToggleEnabled={onToggleEnabled}
               />
             </EuiResizablePanel>

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -20,13 +20,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { EuiResizableContainer } from '@elastic/eui';
 import { Datasource, UnifiedRuleSummary } from '../../../../common/types/alerting';
-import { isVersionAtLeast } from '../../../../common/utils/shared';
-import { coreRefs } from '../../../framework/core_refs';
 import { useFacetCollapse } from '../facet_filter_panel';
-import {
-  BASE_PPL_ALERTING_SUPPORTED_VERSION,
-  isStandardOpenSearchDatasource,
-} from '../shared_constants';
+import { isStandardOpenSearchDatasource } from '../shared_constants';
 import { buildTableColumns, DEFAULT_VISIBLE } from './monitors_table_columns';
 import {
   buildSuggestions,
@@ -77,15 +72,6 @@ interface MonitorsTableProps {
    * without typing it. Empty / undefined leaves the box blank.
    */
   initialSearchQuery?: string;
-}
-
-interface AlertingSettingsResponse {
-  ok?: boolean;
-  resp?: {
-    transient?: { cluster?: { pluggable?: Record<string, unknown> } };
-    persistent?: { cluster?: { pluggable?: Record<string, unknown> } };
-    defaults?: { cluster?: { pluggable?: Record<string, unknown> } };
-  };
 }
 
 // ============================================================================
@@ -163,51 +149,6 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
 
   const dsNameMap = useMemo(() => new Map(datasources.map((d) => [d.id, d.name])), [datasources]);
 
-  // Prefetch AnalyticEngine status for OpenSearch datasources.
-  // An AnalyticEngine domain has cluster.pluggable.dataformat.enabled === true.
-  const [analyticEngineCache, setAnalyticEngineCache] = useState<Map<string, boolean>>(new Map());
-  useEffect(() => {
-    const http = coreRefs.http;
-    if (!http) return;
-    const osDs = datasources.filter(
-      (d) => d.type === 'opensearch' && d.engineType !== 'OpenSearch Serverless' && d.mdsId
-    );
-    if (osDs.length === 0) return;
-    let cancelled = false;
-    (async () => {
-      const cache = new Map<string, boolean>();
-      await Promise.all(
-        osDs.map(async (ds) => {
-          try {
-            const resp = await http.get<AlertingSettingsResponse>('../api/alerting/_settings', {
-              query: { dataSourceId: ds.mdsId },
-            });
-            if (resp?.ok && resp.resp) {
-              const val =
-                resp.resp.transient?.cluster?.pluggable?.['dataformat.enabled'] ??
-                resp.resp.persistent?.cluster?.pluggable?.['dataformat.enabled'] ??
-                resp.resp.defaults?.cluster?.pluggable?.['dataformat.enabled'];
-              cache.set(ds.id, val === 'true' || val === true);
-            } else {
-              cache.set(ds.id, false);
-            }
-          } catch {
-            cache.set(ds.id, false);
-          }
-        })
-      );
-      if (!cancelled) setAnalyticEngineCache(cache);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [datasources]);
-
-  const isAnalyticEngineEnabled = useCallback(
-    (datasourceId: string) => analyticEngineCache.get(datasourceId) || false,
-    [analyticEngineCache]
-  );
-
   const selectedDatasources = useMemo(
     () =>
       selectedDsIds
@@ -217,29 +158,22 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   );
 
   // Logs / Metrics popover entries are grayed out when the parent's selection
-  // can't satisfy them: Logs needs at least one OpenSearch datasource with
-  // version >= 3.5.0 (or serverless), Metrics needs at least one Prometheus.
-  // The empty-selection case used to fall through to "both enabled", but the
-  // spec is "no datasource selected → no create options viable" — Logs without
-  // a supported OS DS is undefined, Metrics without a Prometheus DS is
-  // undefined. Gate both so the user can't enter a flyout that will silently
-  // re-default the datasource on them.
-  const logsCreateDisabled = useMemo(() => {
-    if (selectedDatasources.length === 0) return true;
-    const osSelected = selectedDatasources.filter((d) => d.type === 'opensearch');
-    if (osSelected.length === 0) return true;
-    // Check if any selected OS datasource supports PPL alerting
-    const hasSupportedDs = osSelected.some((d) => {
-      if (!d.mdsId) return true; // Local cluster — no version metadata available
-      if (d.engineType === 'OpenSearch Serverless') return true;
-      if (isAnalyticEngineEnabled(d.id)) return true;
-      if (!d.version) return false;
-      return isVersionAtLeast(d.version, BASE_PPL_ALERTING_SUPPORTED_VERSION);
-    });
-    return !hasSupportedDs;
-  }, [selectedDatasources, isAnalyticEngineEnabled]);
-
-  const metricsCreateDisabled = !selectedDatasources.some((d) => d.type === 'prometheus');
+  // can't satisfy them: Logs needs at least one OpenSearch datasource, Metrics
+  // needs at least one Prometheus. The empty-selection case is "no datasource
+  // selected → no create options viable", so gate both. When a selection
+  // exists, each option is disabled iff EVERY selected datasource is the wrong
+  // type for it — i.e. only-Prometheus disables Logs, only-OpenSearch disables
+  // Metrics (symmetric).
+  const [logsCreateDisabled, metricsCreateDisabled] = useMemo(() => {
+    const selected = selectedDsIds
+      .map((id) => datasources.find((d) => d.id === id))
+      .filter((d): d is Datasource => !!d);
+    if (selected.length === 0) return [true, true];
+    return [
+      selected.every((d) => d.type === 'prometheus'),
+      selected.every((d) => d.type === 'opensearch'),
+    ];
+  }, [datasources, selectedDsIds]);
 
   const adCreateDisabled = !selectedDatasources.some(isStandardOpenSearchDatasource);
 

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -224,7 +224,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   // a supported OS DS is undefined, Metrics without a Prometheus DS is
   // undefined. Gate both so the user can't enter a flyout that will silently
   // re-default the datasource on them.
-  const [logsCreateDisabled, logsDisabledReason] = useMemo(() => {
+  const [logsCreateDisabled] = useMemo(() => {
     if (selectedDatasources.length === 0) return [true, 'no_selection'] as const;
     const osSelected = selectedDatasources.filter((d) => d.type === 'opensearch');
     if (osSelected.length === 0) return [true, 'no_os_datasource'] as const;

--- a/public/components/alerting/monitors_table/monitors_main_panel.tsx
+++ b/public/components/alerting/monitors_table/monitors_main_panel.tsx
@@ -116,6 +116,7 @@ export interface MonitorsMainPanelProps {
   onEditForecaster?: (forecaster: UnifiedRuleSummary) => void;
   onStartResources?: (resources: UnifiedRuleSummary[]) => Promise<void> | void;
   onStopResources?: (resources: UnifiedRuleSummary[]) => Promise<void> | void;
+  lifecycleActionPending?: boolean;
   /**
    * Forwarded to {@link MonitorDetailFlyout.onToggleEnabled}. Page provides
    * an awaitable handler that PUTs the monitor with `enabled` flipped; the
@@ -164,6 +165,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
   onEditForecaster,
   onStartResources,
   onStopResources,
+  lifecycleActionPending = false,
   onToggleEnabled,
 }) => {
   const selectedRules = filtered.filter((rule) => selectedIds.has(rule.id));
@@ -518,6 +520,8 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                     <EuiButton
                       size="s"
                       iconType="play"
+                      isLoading={lifecycleActionPending}
+                      isDisabled={lifecycleActionPending}
                       onClick={() => {
                         void onStartResources(selectedStartableResources);
                       }}
@@ -536,6 +540,8 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                     <EuiButton
                       size="s"
                       iconType="cross"
+                      isLoading={lifecycleActionPending}
+                      isDisabled={lifecycleActionPending}
                       onClick={() => {
                         void onStopResources(selectedStoppableResources);
                       }}

--- a/public/components/alerting/monitors_table/monitors_main_panel.tsx
+++ b/public/components/alerting/monitors_table/monitors_main_panel.tsx
@@ -316,7 +316,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                           'observability.alerting.monitorsTable.mainPanel.detectorDisabledTooltip',
                           {
                             defaultMessage:
-                              'Anomaly detection rules require an OpenSearch datasource. Select one to enable.',
+                              'Anomaly detection rules require a standard OpenSearch datasource. OpenSearch Serverless is not supported.',
                           }
                         )}
                       >
@@ -363,7 +363,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                           'observability.alerting.monitorsTable.mainPanel.forecasterDisabledTooltip',
                           {
                             defaultMessage:
-                              'Forecasting rules require an OpenSearch datasource. Select one to enable.',
+                              'Forecasting rules require a standard OpenSearch datasource. OpenSearch Serverless is not supported.',
                           }
                         )}
                       >

--- a/public/components/alerting/monitors_table/monitors_main_panel.tsx
+++ b/public/components/alerting/monitors_table/monitors_main_panel.tsx
@@ -34,6 +34,7 @@ import { DeleteModal } from '../../common/helpers/delete_modal';
 import { DetectorDetailFlyout } from '../detector_detail_flyout';
 import { ForecasterDetailFlyout } from '../forecaster_detail_flyout';
 import { MonitorDetailFlyout } from '../monitor_detail_flyout';
+import { isAdResourceRunning } from '../shared_constants';
 import { isDetectorDefinition, isForecasterDefinition } from './monitors_table_columns';
 import { MonitorsEuiTable } from './monitors_eui_table';
 
@@ -42,7 +43,6 @@ export interface MonitorsMainPanelProps {
   rules: UnifiedRuleSummary[];
   filtered: UnifiedRuleSummary[];
   loading: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- EuiInMemoryTable column type is complex
   tableColumns: any[];
   rowProps: (item: UnifiedRuleSummary) => React.HTMLAttributes<HTMLTableRowElement>;
   tableWrapperRef: React.RefObject<HTMLDivElement | null>;
@@ -65,7 +65,7 @@ export interface MonitorsMainPanelProps {
   setSelectedIds: React.Dispatch<React.SetStateAction<Set<string>>>;
 
   // Create
-  onCreateMonitor?: (type: 'logs' | 'prometheus' | 'metrics') => void;
+  onCreateMonitor?: (type: 'logs' | 'prometheus' | 'metrics' | 'detector' | 'forecaster') => void;
   /**
    * When true, the "Logs" popover entry is disabled with a hint that an
    * OpenSearch datasource is needed. Triggered when the parent's selection
@@ -78,6 +78,17 @@ export interface MonitorsMainPanelProps {
    * Metrics monitor can't be created without changing the selection.
    */
   metricsCreateDisabled?: boolean;
+  /**
+   * Detector authoring uses the AD plugin flow, which only targets
+   * OpenSearch datasources.
+   */
+  detectorCreateDisabled?: boolean;
+  /**
+   * Forecaster authoring uses the Forecasting plugin flow, which only targets
+   * OpenSearch datasources. Kept separate from detectorCreateDisabled so the
+   * two rule types can diverge if their backend support rules differ.
+   */
+  forecasterCreateDisabled?: boolean;
   /**
    * The parent's datasource filter is empty. Distinguishes the empty-state
    * "No monitors configured yet" copy from "Select a datasource to see
@@ -99,6 +110,11 @@ export interface MonitorsMainPanelProps {
   onDelete: (ids: string[]) => void;
   onClone?: (monitor: UnifiedRuleSummary) => void;
   onEdit?: (monitor: UnifiedRuleSummary) => void;
+  onEditDetectorSettings?: (detector: UnifiedRuleSummary) => void;
+  onEditDetectorFeatures?: (detector: UnifiedRuleSummary) => void;
+  onEditForecaster?: (forecaster: UnifiedRuleSummary) => void;
+  onStartResources?: (resources: UnifiedRuleSummary[]) => Promise<void> | void;
+  onStopResources?: (resources: UnifiedRuleSummary[]) => Promise<void> | void;
   /**
    * Forwarded to {@link MonitorDetailFlyout.onToggleEnabled}. Page provides
    * an awaitable handler that PUTs the monitor with `enabled` flipped; the
@@ -129,6 +145,8 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
   onCreateMonitor,
   logsCreateDisabled = false,
   metricsCreateDisabled = false,
+  detectorCreateDisabled = false,
+  forecasterCreateDisabled = false,
   noDatasourceSelected = false,
   showCreatePopover,
   setShowCreatePopover,
@@ -140,8 +158,22 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
   onDelete,
   onClone,
   onEdit,
+  onEditDetectorSettings,
+  onEditDetectorFeatures,
+  onEditForecaster,
+  onStartResources,
+  onStopResources,
   onToggleEnabled,
 }) => {
+  const selectedRules = filtered.filter((rule) => selectedIds.has(rule.id));
+  const selectedAdResources = selectedRules.filter(
+    (rule) => isDetectorDefinition(rule) || isForecasterDefinition(rule)
+  );
+  const selectedStartableResources = selectedAdResources.filter(
+    (resource) => !isAdResourceRunning(resource)
+  );
+  const selectedStoppableResources = selectedAdResources.filter(isAdResourceRunning);
+
   return (
     <>
       <EuiPanel
@@ -166,10 +198,11 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                       iconType="plusInCircle"
                       size="s"
                       onClick={() => setShowCreatePopover((prev) => !prev)}
+                      data-test-subj="alertManagerCreateResourceButton"
                     >
                       <FormattedMessage
                         id="observability.alerting.monitorsTable.mainPanel.createMonitor"
-                        defaultMessage="Create alert rule"
+                        defaultMessage="Create"
                       />
                     </EuiButton>
                   }
@@ -178,7 +211,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                   panelPaddingSize="none"
                   anchorPosition="downRight"
                 >
-                  <EuiListGroup flush style={{ width: 200 }}>
+                  <EuiListGroup flush style={{ width: 220 }}>
                     {logsCreateDisabled ? (
                       <EuiToolTip
                         position="left"
@@ -194,7 +227,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                           label={i18n.translate(
                             'observability.alerting.monitorsTable.mainPanel.logsOption',
                             {
-                              defaultMessage: 'Logs',
+                              defaultMessage: 'Logs alert rule',
                             }
                           )}
                           isDisabled
@@ -211,7 +244,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                         label={i18n.translate(
                           'observability.alerting.monitorsTable.mainPanel.logsOption',
                           {
-                            defaultMessage: 'Logs',
+                            defaultMessage: 'Logs alert rule',
                           }
                         )}
                         onClick={() => {
@@ -241,7 +274,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                           label={i18n.translate(
                             'observability.alerting.monitorsTable.mainPanel.metricsOption',
                             {
-                              defaultMessage: 'Metrics',
+                              defaultMessage: 'Metrics alert rule',
                             }
                           )}
                           isDisabled
@@ -258,7 +291,7 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                         label={i18n.translate(
                           'observability.alerting.monitorsTable.mainPanel.metricsOption',
                           {
-                            defaultMessage: 'Metrics',
+                            defaultMessage: 'Metrics alert rule',
                           }
                         )}
                         onClick={() => {
@@ -269,6 +302,100 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
                           'observability.alerting.monitorsTable.mainPanel.createMetricsAriaLabel',
                           {
                             defaultMessage: 'Create metrics rule',
+                          }
+                        )}
+                      />
+                    )}
+                    {detectorCreateDisabled ? (
+                      <EuiToolTip
+                        position="left"
+                        content={i18n.translate(
+                          'observability.alerting.monitorsTable.mainPanel.detectorDisabledTooltip',
+                          {
+                            defaultMessage:
+                              'Anomaly detection rules require an OpenSearch datasource. Select one to enable.',
+                          }
+                        )}
+                      >
+                        <EuiListGroupItem
+                          label={i18n.translate(
+                            'observability.alerting.monitorsTable.mainPanel.detectorOption',
+                            {
+                              defaultMessage: 'Anomaly detection rule',
+                            }
+                          )}
+                          isDisabled
+                          aria-label={i18n.translate(
+                            'observability.alerting.monitorsTable.mainPanel.createDetectorAriaLabel',
+                            {
+                              defaultMessage: 'Create anomaly detection rule',
+                            }
+                          )}
+                        />
+                      </EuiToolTip>
+                    ) : (
+                      <EuiListGroupItem
+                        label={i18n.translate(
+                          'observability.alerting.monitorsTable.mainPanel.detectorOption',
+                          {
+                            defaultMessage: 'Anomaly detection rule',
+                          }
+                        )}
+                        onClick={() => {
+                          setShowCreatePopover(false);
+                          onCreateMonitor('detector');
+                        }}
+                        aria-label={i18n.translate(
+                          'observability.alerting.monitorsTable.mainPanel.createDetectorAriaLabel',
+                          {
+                            defaultMessage: 'Create anomaly detection rule',
+                          }
+                        )}
+                      />
+                    )}
+                    {forecasterCreateDisabled ? (
+                      <EuiToolTip
+                        position="left"
+                        content={i18n.translate(
+                          'observability.alerting.monitorsTable.mainPanel.forecasterDisabledTooltip',
+                          {
+                            defaultMessage:
+                              'Forecasting rules require an OpenSearch datasource. Select one to enable.',
+                          }
+                        )}
+                      >
+                        <EuiListGroupItem
+                          label={i18n.translate(
+                            'observability.alerting.monitorsTable.mainPanel.forecasterOption',
+                            {
+                              defaultMessage: 'Forecasting rule',
+                            }
+                          )}
+                          isDisabled
+                          aria-label={i18n.translate(
+                            'observability.alerting.monitorsTable.mainPanel.createForecasterAriaLabel',
+                            {
+                              defaultMessage: 'Create forecasting rule',
+                            }
+                          )}
+                        />
+                      </EuiToolTip>
+                    ) : (
+                      <EuiListGroupItem
+                        label={i18n.translate(
+                          'observability.alerting.monitorsTable.mainPanel.forecasterOption',
+                          {
+                            defaultMessage: 'Forecasting rule',
+                          }
+                        )}
+                        onClick={() => {
+                          setShowCreatePopover(false);
+                          onCreateMonitor('forecaster');
+                        }}
+                        aria-label={i18n.translate(
+                          'observability.alerting.monitorsTable.mainPanel.createForecasterAriaLabel',
+                          {
+                            defaultMessage: 'Create forecasting rule',
                           }
                         )}
                       />
@@ -385,6 +512,42 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiFlexGroup gutterSize="s">
+                {selectedStartableResources.length > 0 && onStartResources && (
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      size="s"
+                      iconType="play"
+                      onClick={() => {
+                        void onStartResources(selectedStartableResources);
+                      }}
+                      data-test-subj="alertManagerStartSelectedResources"
+                    >
+                      <FormattedMessage
+                        id="observability.alerting.monitorsTable.mainPanel.startSelectedButton"
+                        defaultMessage="Start ({count})"
+                        values={{ count: selectedStartableResources.length }}
+                      />
+                    </EuiButton>
+                  </EuiFlexItem>
+                )}
+                {selectedStoppableResources.length > 0 && onStopResources && (
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      size="s"
+                      iconType="cross"
+                      onClick={() => {
+                        void onStopResources(selectedStoppableResources);
+                      }}
+                      data-test-subj="alertManagerStopSelectedResources"
+                    >
+                      <FormattedMessage
+                        id="observability.alerting.monitorsTable.mainPanel.stopSelectedButton"
+                        defaultMessage="Stop ({count})"
+                        values={{ count: selectedStoppableResources.length }}
+                      />
+                    </EuiButton>
+                  </EuiFlexItem>
+                )}
                 {selectedIds.size > 0 && (
                   <EuiFlexItem grow={false}>
                     <EuiButton
@@ -485,14 +648,14 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
       {showDeleteConfirm && (
         <DeleteModal
           title={i18n.translate('observability.alerting.monitorsTable.mainPanel.deleteModalTitle', {
-            defaultMessage: 'Delete {count} {count, plural, one {rule} other {rules}}?',
+            defaultMessage:
+              'Delete {count} selected {count, plural, one {resource} other {resources}}?',
             values: { count: selectedIds.size },
           })}
           message={i18n.translate(
             'observability.alerting.monitorsTable.mainPanel.deleteModalMessage',
             {
-              defaultMessage:
-                'This will remove the selected {count, plural, one {monitor} other {monitors}} from the current view.',
+              defaultMessage: 'This will remove the selected resources from Alerts Manager.',
               values: { count: selectedIds.size },
             }
           )}
@@ -503,11 +666,21 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
 
       {/* Rule / detector detail flyout */}
       {selectedMonitor && isDetectorDefinition(selectedMonitor) ? (
-        <DetectorDetailFlyout detector={selectedMonitor} onClose={() => setSelectedMonitor(null)} />
+        <DetectorDetailFlyout
+          detector={selectedMonitor}
+          onClose={() => setSelectedMonitor(null)}
+          onEditSettings={onEditDetectorSettings}
+          onEditFeatures={onEditDetectorFeatures}
+          onStart={onStartResources ? (detector) => onStartResources([detector]) : undefined}
+          onStop={onStopResources ? (detector) => onStopResources([detector]) : undefined}
+        />
       ) : selectedMonitor && isForecasterDefinition(selectedMonitor) ? (
         <ForecasterDetailFlyout
           forecaster={selectedMonitor}
           onClose={() => setSelectedMonitor(null)}
+          onEdit={onEditForecaster}
+          onStart={onStartResources ? (forecaster) => onStartResources([forecaster]) : undefined}
+          onStop={onStopResources ? (forecaster) => onStopResources([forecaster]) : undefined}
         />
       ) : selectedMonitor ? (
         <MonitorDetailFlyout

--- a/public/components/alerting/monitors_table/monitors_main_panel.tsx
+++ b/public/components/alerting/monitors_table/monitors_main_panel.tsx
@@ -37,13 +37,14 @@ import { MonitorDetailFlyout } from '../monitor_detail_flyout';
 import { isAdResourceRunning } from '../shared_constants';
 import { isDetectorDefinition, isForecasterDefinition } from './monitors_table_columns';
 import { MonitorsEuiTable } from './monitors_eui_table';
+import type { MonitorsEuiTableProps } from './monitors_eui_table';
 
 export interface MonitorsMainPanelProps {
   // Data
   rules: UnifiedRuleSummary[];
   filtered: UnifiedRuleSummary[];
   loading: boolean;
-  tableColumns: any[];
+  tableColumns: MonitorsEuiTableProps['columns'];
   rowProps: (item: UnifiedRuleSummary) => React.HTMLAttributes<HTMLTableRowElement>;
   tableWrapperRef: React.RefObject<HTMLDivElement | null>;
 

--- a/public/components/alerting/monitors_table/monitors_table_columns.tsx
+++ b/public/components/alerting/monitors_table/monitors_table_columns.tsx
@@ -76,8 +76,6 @@ export const isDetectorDefinition = (item: UnifiedRuleSummary): boolean => isDet
 
 export const isForecasterDefinition = (item: UnifiedRuleSummary): boolean => isForecasterRule(item);
 
-export const isSelectableRuleDefinition = (_item: UnifiedRuleSummary): boolean => true;
-
 // ============================================================================
 // Column builder — factory producing the EuiInMemoryTable column array.
 // Cell renderers close over the component state bits passed in (selectedIds,
@@ -107,7 +105,7 @@ export function buildTableColumns({
   setSelectedMonitor,
 }: BuildTableColumnsParams): Array<Record<string, unknown>> {
   const w = (id: string) => `${columnWidths[id] || DEFAULT_WIDTHS[id] || 120}px`;
-  const selectable = filtered.filter(isSelectableRuleDefinition);
+  const selectable = filtered;
   const allSelectableSelected =
     selectable.length > 0 && selectable.every((item) => selectedIds.has(item.id));
 
@@ -130,12 +128,10 @@ export function buildTableColumns({
       ),
       width: '32px',
       render: (_: unknown, item: UnifiedRuleSummary) => {
-        const isSelectable = isSelectableRuleDefinition(item);
         return (
           <input
             type="checkbox"
-            checked={isSelectable && selectedIds.has(item.id)}
-            disabled={!isSelectable}
+            checked={selectedIds.has(item.id)}
             onChange={() => toggleSelect(item.id)}
             aria-label={i18n.translate(
               'observability.alerting.monitorsTable.columns.selectRowAriaLabel',

--- a/public/components/alerting/monitors_table/monitors_table_columns.tsx
+++ b/public/components/alerting/monitors_table/monitors_table_columns.tsx
@@ -33,7 +33,14 @@ import {
   UnifiedAlertSeverity,
   UnifiedRuleSummary,
 } from '../../../../common/types/alerting';
-import { HEALTH_COLORS, SEVERITY_COLORS, STATUS_COLORS, TYPE_LABELS } from '../shared_constants';
+import {
+  HEALTH_COLORS,
+  isDetectorRule,
+  isForecasterRule,
+  SEVERITY_COLORS,
+  STATUS_COLORS,
+  TYPE_LABELS,
+} from '../shared_constants';
 import { DEFAULT_WIDTHS } from './resizable_columns';
 
 // ============================================================================
@@ -65,14 +72,11 @@ export const DEFAULT_VISIBLE: ColumnId[] = [
   'datasource',
 ];
 
-export const isDetectorDefinition = (item: UnifiedRuleSummary): boolean =>
-  item.definitionType === 'detector' || item.monitorType === 'detector';
+export const isDetectorDefinition = (item: UnifiedRuleSummary): boolean => isDetectorRule(item);
 
-export const isForecasterDefinition = (item: UnifiedRuleSummary): boolean =>
-  item.definitionType === 'forecaster' || item.monitorType === 'forecaster';
+export const isForecasterDefinition = (item: UnifiedRuleSummary): boolean => isForecasterRule(item);
 
-export const isReadOnlyRuleDefinition = (item: UnifiedRuleSummary): boolean =>
-  isDetectorDefinition(item) || isForecasterDefinition(item);
+export const isSelectableRuleDefinition = (_item: UnifiedRuleSummary): boolean => true;
 
 // ============================================================================
 // Column builder — factory producing the EuiInMemoryTable column array.
@@ -103,7 +107,7 @@ export function buildTableColumns({
   setSelectedMonitor,
 }: BuildTableColumnsParams): Array<Record<string, unknown>> {
   const w = (id: string) => `${columnWidths[id] || DEFAULT_WIDTHS[id] || 120}px`;
-  const selectable = filtered.filter((item) => !isReadOnlyRuleDefinition(item));
+  const selectable = filtered.filter(isSelectableRuleDefinition);
   const allSelectableSelected =
     selectable.length > 0 && selectable.every((item) => selectedIds.has(item.id));
 
@@ -126,12 +130,12 @@ export function buildTableColumns({
       ),
       width: '32px',
       render: (_: unknown, item: UnifiedRuleSummary) => {
-        const isReadOnly = isReadOnlyRuleDefinition(item);
+        const isSelectable = isSelectableRuleDefinition(item);
         return (
           <input
             type="checkbox"
-            checked={!isReadOnly && selectedIds.has(item.id)}
-            disabled={isReadOnly}
+            checked={isSelectable && selectedIds.has(item.id)}
+            disabled={!isSelectable}
             onChange={() => toggleSelect(item.id)}
             aria-label={i18n.translate(
               'observability.alerting.monitorsTable.columns.selectRowAriaLabel',

--- a/public/components/alerting/mutations/__tests__/monitor_mutations_client.test.ts
+++ b/public/components/alerting/mutations/__tests__/monitor_mutations_client.test.ts
@@ -107,6 +107,14 @@ describe('MonitorMutationsClient', () => {
         '/api/anomaly_detectors/detectors/det-1/stop/false'
       );
     });
+
+    it('rejects detector action responses that report an application-level failure', async () => {
+      mockDelete.mockResolvedValueOnce({ ok: false, error: 'Detector must be stopped first' });
+
+      await expect(client.deleteDetector('det-1', 'ds-1')).rejects.toThrow(
+        'Detector must be stopped first'
+      );
+    });
   });
 
   describe('forecaster lifecycle', () => {
@@ -140,6 +148,14 @@ describe('MonitorMutationsClient', () => {
       expect(mockDelete).toHaveBeenCalledWith('/api/forecasting/forecasters/forecast-1');
       expect(mockPost).toHaveBeenNthCalledWith(1, '/api/forecasting/forecasters/forecast-1/start');
       expect(mockPost).toHaveBeenNthCalledWith(2, '/api/forecasting/forecasters/forecast-1/stop');
+    });
+
+    it('rejects forecaster action responses that report an application-level failure', async () => {
+      mockDelete.mockResolvedValueOnce({ ok: false, error: 'Forecaster must be stopped first' });
+
+      await expect(client.deleteForecaster('forecast-1', 'ds-1')).rejects.toThrow(
+        'Forecaster must be stopped first'
+      );
     });
   });
 

--- a/public/components/alerting/mutations/__tests__/monitor_mutations_client.test.ts
+++ b/public/components/alerting/mutations/__tests__/monitor_mutations_client.test.ts
@@ -72,6 +72,48 @@ describe('MonitorMutationsClient', () => {
     });
   });
 
+  describe('detector lifecycle', () => {
+    it('uses the AD detector lifecycle routes with encoded ids', async () => {
+      mockDelete.mockResolvedValueOnce({ ok: true });
+      mockPost.mockResolvedValue({ ok: true });
+
+      await client.deleteDetector('det/1', 'ds 1');
+      await client.startDetector('det/1', 'ds 1');
+      await client.stopDetector('det/1', 'ds 1');
+
+      expect(mockDelete).toHaveBeenCalledWith('/api/anomaly_detectors/detectors/det%2F1/ds%201');
+      expect(mockPost).toHaveBeenNthCalledWith(
+        1,
+        '/api/anomaly_detectors/detectors/det%2F1/start/ds%201'
+      );
+      expect(mockPost).toHaveBeenNthCalledWith(
+        2,
+        '/api/anomaly_detectors/detectors/det%2F1/stop/false/ds%201'
+      );
+    });
+  });
+
+  describe('forecaster lifecycle', () => {
+    it('uses the forecasting lifecycle routes with encoded ids', async () => {
+      mockDelete.mockResolvedValueOnce({ ok: true });
+      mockPost.mockResolvedValue({ ok: true });
+
+      await client.deleteForecaster('forecast/1', 'ds 1');
+      await client.startForecaster('forecast/1', 'ds 1');
+      await client.stopForecaster('forecast/1', 'ds 1');
+
+      expect(mockDelete).toHaveBeenCalledWith('/api/forecasting/forecasters/forecast%2F1/ds%201');
+      expect(mockPost).toHaveBeenNthCalledWith(
+        1,
+        '/api/forecasting/forecasters/forecast%2F1/start/ds%201'
+      );
+      expect(mockPost).toHaveBeenNthCalledWith(
+        2,
+        '/api/forecasting/forecasters/forecast%2F1/stop/ds%201'
+      );
+    });
+  });
+
   describe('acknowledgeAlert', () => {
     it('rejects when alertId is missing', async () => {
       await expect(client.acknowledgeAlert('', 'ds-1', 'mon-1')).rejects.toThrow(

--- a/public/components/alerting/mutations/__tests__/monitor_mutations_client.test.ts
+++ b/public/components/alerting/mutations/__tests__/monitor_mutations_client.test.ts
@@ -91,6 +91,22 @@ describe('MonitorMutationsClient', () => {
         '/api/anomaly_detectors/detectors/det%2F1/stop/false/ds%201'
       );
     });
+
+    it('omits Alert Manager local-cluster from detector lifecycle routes', async () => {
+      mockDelete.mockResolvedValueOnce({ ok: true });
+      mockPost.mockResolvedValue({ ok: true });
+
+      await client.deleteDetector('det-1', 'local-cluster');
+      await client.startDetector('det-1', 'local-cluster');
+      await client.stopDetector('det-1', 'local-cluster');
+
+      expect(mockDelete).toHaveBeenCalledWith('/api/anomaly_detectors/detectors/det-1');
+      expect(mockPost).toHaveBeenNthCalledWith(1, '/api/anomaly_detectors/detectors/det-1/start');
+      expect(mockPost).toHaveBeenNthCalledWith(
+        2,
+        '/api/anomaly_detectors/detectors/det-1/stop/false'
+      );
+    });
   });
 
   describe('forecaster lifecycle', () => {
@@ -111,6 +127,19 @@ describe('MonitorMutationsClient', () => {
         2,
         '/api/forecasting/forecasters/forecast%2F1/stop/ds%201'
       );
+    });
+
+    it('omits Alert Manager local-cluster from forecaster lifecycle routes', async () => {
+      mockDelete.mockResolvedValueOnce({ ok: true });
+      mockPost.mockResolvedValue({ ok: true });
+
+      await client.deleteForecaster('forecast-1', 'local-cluster');
+      await client.startForecaster('forecast-1', 'local-cluster');
+      await client.stopForecaster('forecast-1', 'local-cluster');
+
+      expect(mockDelete).toHaveBeenCalledWith('/api/forecasting/forecasters/forecast-1');
+      expect(mockPost).toHaveBeenNthCalledWith(1, '/api/forecasting/forecasters/forecast-1/start');
+      expect(mockPost).toHaveBeenNthCalledWith(2, '/api/forecasting/forecasters/forecast-1/stop');
     });
   });
 

--- a/public/components/alerting/mutations/monitor_mutations_client.ts
+++ b/public/components/alerting/mutations/monitor_mutations_client.ts
@@ -33,10 +33,21 @@ export interface AcknowledgeAlertResponse {
 export interface AdResourceActionResponse {
   ok?: boolean;
   response?: unknown;
+  error?: string;
   message?: string;
   id?: string;
   deleted?: boolean;
 }
+
+const assertAdResourceActionSucceeded = (
+  response: AdResourceActionResponse | undefined,
+  fallbackMessage: string
+): AdResourceActionResponse => {
+  if (!response || response.ok === false) {
+    throw new Error(response?.error || response?.message || fallbackMessage);
+  }
+  return response;
+};
 
 export class MonitorMutationsClient {
   private requireHttp() {
@@ -92,44 +103,50 @@ export class MonitorMutationsClient {
 
   async deleteDetector(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/anomaly_detectors/detectors/${encodeURIComponent(id)}`;
-    return (await this.requireHttp().delete(
+    const response = (await this.requireHttp().delete(
       withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
+    return assertAdResourceActionSucceeded(response, 'Failed to delete anomaly detector');
   }
 
   async startDetector(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/anomaly_detectors/detectors/${encodeURIComponent(id)}/start`;
-    return (await this.requireHttp().post(
+    const response = (await this.requireHttp().post(
       withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
+    return assertAdResourceActionSucceeded(response, 'Failed to start anomaly detector');
   }
 
   async stopDetector(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/anomaly_detectors/detectors/${encodeURIComponent(id)}/stop/false`;
-    return (await this.requireHttp().post(
+    const response = (await this.requireHttp().post(
       withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
+    return assertAdResourceActionSucceeded(response, 'Failed to stop anomaly detector');
   }
 
   async deleteForecaster(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/forecasting/forecasters/${encodeURIComponent(id)}`;
-    return (await this.requireHttp().delete(
+    const response = (await this.requireHttp().delete(
       withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
+    return assertAdResourceActionSucceeded(response, 'Failed to delete forecaster');
   }
 
   async startForecaster(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/forecasting/forecasters/${encodeURIComponent(id)}/start`;
-    return (await this.requireHttp().post(
+    const response = (await this.requireHttp().post(
       withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
+    return assertAdResourceActionSucceeded(response, 'Failed to start forecaster');
   }
 
   async stopForecaster(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/forecasting/forecasters/${encodeURIComponent(id)}/stop`;
-    return (await this.requireHttp().post(
+    const response = (await this.requireHttp().post(
       withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
+    return assertAdResourceActionSucceeded(response, 'Failed to stop forecaster');
   }
 
   async acknowledgeAlert(

--- a/public/components/alerting/mutations/monitor_mutations_client.ts
+++ b/public/components/alerting/mutations/monitor_mutations_client.ts
@@ -29,11 +29,23 @@ export interface AcknowledgeAlertResponse {
   acknowledged: boolean;
 }
 
+export interface AdResourceActionResponse {
+  ok?: boolean;
+  response?: unknown;
+  message?: string;
+  id?: string;
+  deleted?: boolean;
+}
+
 export class MonitorMutationsClient {
   private requireHttp() {
     const http = coreRefs.http;
     if (!http) throw new Error('HTTP client not available');
     return http;
+  }
+
+  private withOptionalDatasource(basePath: string, dsId?: string): string {
+    return dsId ? `${basePath}/${encodeURIComponent(dsId)}` : basePath;
   }
 
   async createMonitor(data: Record<string, unknown>, dsId: string): Promise<MonitorResponse> {
@@ -79,6 +91,48 @@ export class MonitorMutationsClient {
       `/api/alerting/prometheus/${encodeURIComponent(dsId)}/rules/${encodeURIComponent(groupName)}`,
       ruleName ? { query: { ruleName } } : undefined
     )) as { success: boolean };
+  }
+
+  async deleteDetector(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+    const basePath = `/api/anomaly_detectors/detectors/${encodeURIComponent(id)}`;
+    return (await this.requireHttp().delete(
+      this.withOptionalDatasource(basePath, dsId)
+    )) as AdResourceActionResponse;
+  }
+
+  async startDetector(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+    const basePath = `/api/anomaly_detectors/detectors/${encodeURIComponent(id)}/start`;
+    return (await this.requireHttp().post(
+      this.withOptionalDatasource(basePath, dsId)
+    )) as AdResourceActionResponse;
+  }
+
+  async stopDetector(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+    const basePath = `/api/anomaly_detectors/detectors/${encodeURIComponent(id)}/stop/false`;
+    return (await this.requireHttp().post(
+      this.withOptionalDatasource(basePath, dsId)
+    )) as AdResourceActionResponse;
+  }
+
+  async deleteForecaster(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+    const basePath = `/api/forecasting/forecasters/${encodeURIComponent(id)}`;
+    return (await this.requireHttp().delete(
+      this.withOptionalDatasource(basePath, dsId)
+    )) as AdResourceActionResponse;
+  }
+
+  async startForecaster(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+    const basePath = `/api/forecasting/forecasters/${encodeURIComponent(id)}/start`;
+    return (await this.requireHttp().post(
+      this.withOptionalDatasource(basePath, dsId)
+    )) as AdResourceActionResponse;
+  }
+
+  async stopForecaster(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+    const basePath = `/api/forecasting/forecasters/${encodeURIComponent(id)}/stop`;
+    return (await this.requireHttp().post(
+      this.withOptionalDatasource(basePath, dsId)
+    )) as AdResourceActionResponse;
   }
 
   async acknowledgeAlert(

--- a/public/components/alerting/mutations/monitor_mutations_client.ts
+++ b/public/components/alerting/mutations/monitor_mutations_client.ts
@@ -12,6 +12,7 @@
  * Replaces the mutation surface of the deleted `alarms_client.ts`.
  */
 import { coreRefs } from '../../../framework/core_refs';
+import { withAdApiDataSource } from '../utils/ad_api_paths';
 
 export interface MonitorResponse {
   id: string;
@@ -42,10 +43,6 @@ export class MonitorMutationsClient {
     const http = coreRefs.http;
     if (!http) throw new Error('HTTP client not available');
     return http;
-  }
-
-  private withOptionalDatasource(basePath: string, dsId?: string): string {
-    return dsId ? `${basePath}/${encodeURIComponent(dsId)}` : basePath;
   }
 
   async createMonitor(data: Record<string, unknown>, dsId: string): Promise<MonitorResponse> {
@@ -93,45 +90,45 @@ export class MonitorMutationsClient {
     )) as { success: boolean };
   }
 
-  async deleteDetector(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+  async deleteDetector(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/anomaly_detectors/detectors/${encodeURIComponent(id)}`;
     return (await this.requireHttp().delete(
-      this.withOptionalDatasource(basePath, dsId)
+      withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
   }
 
-  async startDetector(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+  async startDetector(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/anomaly_detectors/detectors/${encodeURIComponent(id)}/start`;
     return (await this.requireHttp().post(
-      this.withOptionalDatasource(basePath, dsId)
+      withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
   }
 
-  async stopDetector(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+  async stopDetector(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/anomaly_detectors/detectors/${encodeURIComponent(id)}/stop/false`;
     return (await this.requireHttp().post(
-      this.withOptionalDatasource(basePath, dsId)
+      withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
   }
 
-  async deleteForecaster(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+  async deleteForecaster(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/forecasting/forecasters/${encodeURIComponent(id)}`;
     return (await this.requireHttp().delete(
-      this.withOptionalDatasource(basePath, dsId)
+      withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
   }
 
-  async startForecaster(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+  async startForecaster(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/forecasting/forecasters/${encodeURIComponent(id)}/start`;
     return (await this.requireHttp().post(
-      this.withOptionalDatasource(basePath, dsId)
+      withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
   }
 
-  async stopForecaster(id: string, dsId?: string): Promise<AdResourceActionResponse> {
+  async stopForecaster(id: string, dsId: string): Promise<AdResourceActionResponse> {
     const basePath = `/api/forecasting/forecasters/${encodeURIComponent(id)}/stop`;
     return (await this.requireHttp().post(
-      this.withOptionalDatasource(basePath, dsId)
+      withAdApiDataSource(basePath, dsId)
     )) as AdResourceActionResponse;
   }
 

--- a/public/components/alerting/shared_constants.ts
+++ b/public/components/alerting/shared_constants.ts
@@ -110,7 +110,7 @@ export const TYPE_LABELS: Record<string, string> = {
   synthetics: 'Synthetics',
   ppl: 'PPL',
   anomaly_detector_monitor: 'Anomaly detector monitor',
-  detector: 'Detector',
+  detector: 'Anomaly Detector',
   forecaster: 'Forecaster',
 };
 

--- a/public/components/alerting/shared_constants.ts
+++ b/public/components/alerting/shared_constants.ts
@@ -4,6 +4,7 @@
  */
 
 import { i18n } from '@osd/i18n';
+import type { MonitorStatus, UnifiedRuleSummary } from '../../../common/types/alerting';
 
 /**
  * Shared color maps, formatting utilities, and style constants
@@ -58,6 +59,24 @@ export const STATUS_COLORS: Record<string, string> = {
   pending: 'warning',
   muted: 'default',
   disabled: 'subdued',
+  Running: 'success',
+  Stopped: 'subdued',
+  Initializing: 'primary',
+  Finished: 'success',
+  'Feature required': 'warning',
+  'Initialization failure': 'danger',
+  'Unexpected failure': 'danger',
+  Failed: 'danger',
+  'Inactive stopped': 'subdued',
+  'Inactive not started': 'subdued',
+  'Awaiting data to init': 'warning',
+  'Awaiting data to restart': 'warning',
+  'Initializing test': 'primary',
+  'Initializing forecast': 'primary',
+  'Test complete': 'success',
+  'Init forecast failure': 'danger',
+  'Forecast failure': 'danger',
+  'Init test failure': 'danger',
 };
 
 // ============================================================================
@@ -93,6 +112,50 @@ export const TYPE_LABELS: Record<string, string> = {
   anomaly_detector_monitor: 'Anomaly detector monitor',
   detector: 'Detector',
   forecaster: 'Forecaster',
+};
+
+// ============================================================================
+// Anomaly detection / forecasting lifecycle helpers
+// ============================================================================
+
+export const isDetectorRule = (rule: UnifiedRuleSummary): boolean =>
+  rule.definitionType === 'detector' || rule.monitorType === 'detector';
+
+export const isForecasterRule = (rule: UnifiedRuleSummary): boolean =>
+  rule.definitionType === 'forecaster' || rule.monitorType === 'forecaster';
+
+export const isAdResourceRule = (rule: UnifiedRuleSummary): boolean =>
+  isDetectorRule(rule) || isForecasterRule(rule);
+
+const AD_RESOURCE_STOP_ACTION_STATUSES = new Set<MonitorStatus>([
+  'Running',
+  'Initializing',
+  'Awaiting data to init',
+  'Awaiting data to restart',
+  'Initializing test',
+  'Initializing forecast',
+]);
+
+const AD_RESOURCE_START_ACTION_STATUSES = new Set<MonitorStatus>([
+  'Stopped',
+  'Finished',
+  'Inactive stopped',
+  'Inactive not started',
+  'Test complete',
+  'Feature required',
+  'Initialization failure',
+  'Unexpected failure',
+  'Failed',
+  'Init forecast failure',
+  'Forecast failure',
+  'Init test failure',
+]);
+
+export const isAdResourceRunning = (rule: UnifiedRuleSummary): boolean => {
+  if (!isAdResourceRule(rule)) return false;
+  if (AD_RESOURCE_STOP_ACTION_STATUSES.has(rule.status)) return true;
+  if (AD_RESOURCE_START_ACTION_STATUSES.has(rule.status)) return false;
+  return rule.enabled;
 };
 
 // ============================================================================

--- a/public/components/alerting/shared_constants.ts
+++ b/public/components/alerting/shared_constants.ts
@@ -114,6 +114,8 @@ export const TYPE_LABELS: Record<string, string> = {
   forecaster: 'Forecaster',
 };
 
+export const BASE_PPL_ALERTING_SUPPORTED_VERSION = '3.5.0';
+
 // ============================================================================
 // Anomaly detection / forecasting lifecycle helpers
 // ============================================================================

--- a/public/components/alerting/shared_constants.ts
+++ b/public/components/alerting/shared_constants.ts
@@ -114,8 +114,6 @@ export const TYPE_LABELS: Record<string, string> = {
   forecaster: 'Forecaster',
 };
 
-export const BASE_PPL_ALERTING_SUPPORTED_VERSION = '3.5.0';
-
 /**
  * AD and Forecasting creation only support standard OpenSearch data sources.
  * The synthetic local cluster has no engine metadata and remains eligible.

--- a/public/components/alerting/shared_constants.ts
+++ b/public/components/alerting/shared_constants.ts
@@ -4,7 +4,7 @@
  */
 
 import { i18n } from '@osd/i18n';
-import type { MonitorStatus, UnifiedRuleSummary } from '../../../common/types/alerting';
+import type { Datasource, MonitorStatus, UnifiedRuleSummary } from '../../../common/types/alerting';
 
 /**
  * Shared color maps, formatting utilities, and style constants
@@ -115,6 +115,14 @@ export const TYPE_LABELS: Record<string, string> = {
 };
 
 export const BASE_PPL_ALERTING_SUPPORTED_VERSION = '3.5.0';
+
+/**
+ * AD and Forecasting creation only support standard OpenSearch data sources.
+ * The synthetic local cluster has no engine metadata and remains eligible.
+ */
+export const isStandardOpenSearchDatasource = (datasource: Datasource): boolean =>
+  datasource.type === 'opensearch' &&
+  (!datasource.engineType || datasource.engineType === 'OpenSearch');
 
 // ============================================================================
 // Anomaly detection / forecasting lifecycle helpers

--- a/public/components/alerting/utils/ad_api_paths.ts
+++ b/public/components/alerting/utils/ad_api_paths.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const ALERT_MANAGER_LOCAL_DATASOURCE_ID = 'local-cluster';
+
+/** Translate Alert Manager's datasource identity to the AD/Forecasting route contract. */
+export const toAdApiDataSourceId = (datasourceId: string): string =>
+  datasourceId === ALERT_MANAGER_LOCAL_DATASOURCE_ID ? '' : datasourceId;
+
+export const withAdApiDataSource = (basePath: string, datasourceId: string): string => {
+  const apiDatasourceId = toAdApiDataSourceId(datasourceId);
+  return apiDatasourceId ? `${basePath}/${encodeURIComponent(apiDatasourceId)}` : basePath;
+};

--- a/server/services/alerting/__tests__/alert_service.routing.test.ts
+++ b/server/services/alerting/__tests__/alert_service.routing.test.ts
@@ -532,6 +532,11 @@ describe('MultiBackendAlertService — routing & list', () => {
           },
         };
       }
+      if (
+        path === '/_plugins/_forecast/forecasters/forecaster-1/_profile/init_progress,state,error'
+      ) {
+        return { body: { state: 'AWAITING_DATA_TO_INIT' } };
+      }
       throw new Error(`Unexpected request: ${path}`);
     });
 
@@ -549,6 +554,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       name: 'CPU forecast',
       definitionType: 'forecaster',
       monitorType: 'forecaster',
+      status: 'Awaiting data to init',
     });
   });
 

--- a/server/services/alerting/__tests__/alert_service.routing.test.ts
+++ b/server/services/alerting/__tests__/alert_service.routing.test.ts
@@ -134,7 +134,7 @@ describe('MultiBackendAlertService — routing & list', () => {
         value: '',
       },
     ]);
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     const response = await svc.getUnifiedAlerts(resolver);
     expect(response.results).toHaveLength(2);
     expect(response.totalDatasources).toBe(2);
@@ -249,7 +249,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       async () =>
         ({
           transport: { request: transportRequest },
-        } as never),
+        }) as never,
       { dsIds: ['ds-os'] }
     );
 
@@ -365,7 +365,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       async () =>
         ({
           transport: { request: transportRequest },
-        } as never),
+        }) as never,
       { dsIds: ['ds-os'] }
     );
 
@@ -475,7 +475,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       async () =>
         ({
           transport: { request: transportRequest },
-        } as never),
+        }) as never,
       { dsIds: ['ds-os'], startTime: 'now-24h', endTime: 'now' }
     );
 
@@ -487,7 +487,7 @@ describe('MultiBackendAlertService — routing & list', () => {
   it('getUnifiedAlerts isolates errors per datasource', async () => {
     mockOsBackend.getAlerts.mockRejectedValueOnce(new Error('OS down'));
     mockPromBackend.getAlerts.mockResolvedValueOnce([]);
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     const response = await svc.getUnifiedAlerts(resolver);
     // Prom succeeded, OS failed — still returns results
     expect(response.completedDatasources).toBe(1);
@@ -497,7 +497,7 @@ describe('MultiBackendAlertService — routing & list', () => {
   // ---- getUnifiedRules ----
   it('getUnifiedRules filters by dsIds when provided', async () => {
     mockPromBackend.getRuleGroups.mockResolvedValueOnce([]);
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     const response = await svc.getUnifiedRules(resolver, { dsIds: ['ds-prom'] });
     // Only prom datasource should be fetched
     expect(response.totalDatasources).toBe(1);
@@ -544,7 +544,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       async () =>
         ({
           transport: { request: transportRequest },
-        } as never),
+        }) as never,
       { dsIds: ['ds-os'] }
     );
 
@@ -563,7 +563,7 @@ describe('MultiBackendAlertService — routing & list', () => {
     const disabledDs = { ...promDatasource, enabled: false };
     mockDsSvc.list.mockResolvedValueOnce([osDatasource, disabledDs]);
     mockOsBackend.getAlerts.mockResolvedValueOnce({ alerts: [], totalAlerts: 0, truncated: false });
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     const response = await svc.getUnifiedAlerts(resolver);
     expect(response.totalDatasources).toBe(1);
   });
@@ -577,7 +577,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       truncated: false,
     });
     mockPromBackend.getAlerts.mockResolvedValueOnce([]);
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     await svc.getUnifiedAlerts(resolver, {
       startTime: 'now-1h',
       endTime: 'now',
@@ -599,7 +599,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       truncated: false,
     });
     mockPromBackend.getHistoricalAlerts.mockResolvedValueOnce({ alerts: [] });
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     await svc.getUnifiedAlerts(
       resolver,
       {
@@ -624,7 +624,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       truncated: false,
     });
     mockPromBackend.getHistoricalAlerts.mockResolvedValueOnce({ alerts: [] });
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     await svc.getUnifiedAlerts(
       resolver,
       {
@@ -649,7 +649,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       truncated: false,
     });
     mockPromBackend.getHistoricalAlerts.mockResolvedValueOnce({ alerts: [] });
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     await svc.getUnifiedAlerts(
       resolver,
       {
@@ -669,7 +669,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       truncated: false,
     });
     mockPromBackend.getAlerts.mockResolvedValueOnce([]);
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     await svc.getUnifiedAlerts(resolver);
     // OS backend: called with no options (range) — check first arg only
     expect(mockOsBackend.getAlerts).toHaveBeenCalledWith(expect.anything());
@@ -685,7 +685,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       truncated: true,
     });
     mockPromBackend.getHistoricalAlerts.mockResolvedValueOnce({ alerts: [] });
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     const response = await svc.getUnifiedAlerts(resolver, {
       startTime: 'now-1h',
       endTime: 'now',
@@ -732,7 +732,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       async () =>
         ({
           transport: { request: transportRequest },
-        } as never),
+        }) as never,
       { dsIds: ['ds-os'], startTime: 'now-1h', endTime: 'now' }
     );
 
@@ -766,7 +766,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       async () =>
         ({
           transport: { request: transportRequest },
-        } as never),
+        }) as never,
       { dsIds: ['ds-os'] }
     );
 
@@ -802,7 +802,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       async () =>
         ({
           transport: { request: transportRequest },
-        } as never),
+        }) as never,
       { dsIds: ['ds-os'] }
     );
 
@@ -820,7 +820,7 @@ describe('MultiBackendAlertService — routing & list', () => {
     // unified request. `Promise.allSettled` should catch it and surface
     // the message on the affected datasource's status entry while
     // healthy datasources keep their success path.
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     // Expect no throw. This drives the expectation that the error is
     // captured at the per-datasource boundary. The exact surfacing
     // mechanism is tested downstream — here we only assert the request
@@ -843,7 +843,7 @@ describe('MultiBackendAlertService — routing & list', () => {
       alerts: [],
       fallback: 'prometheus-alerts-current-only',
     });
-    const resolver = jest.fn(async () => ({} as never));
+    const resolver = jest.fn(async () => ({}) as never);
     const response = await svc.getUnifiedAlerts(resolver, {
       startTime: 'now-1h',
       endTime: 'now',

--- a/server/services/alerting/__tests__/alert_utils.test.ts
+++ b/server/services/alerting/__tests__/alert_utils.test.ts
@@ -15,13 +15,15 @@
  *   - `truncatedStart` flag ⇒ `annotations.truncatedStart = 'true'`.
  */
 import {
+  adDetectorToUnifiedRuleSummary,
   adForecasterToUnifiedRuleSummary,
   extractADAnomalyResultIdsFromMonitor,
   osAlertToUnified,
   osMonitorToUnifiedRuleSummary,
   promEpisodeToUnified,
+  runtimeStateToMonitorStatus,
 } from '../alert_utils';
-import type { OSMonitor } from '../../../../common/types/alerting';
+import type { MonitorStatus, OSMonitor } from '../../../../common/types/alerting';
 
 describe('promEpisodeToUnified', () => {
   const START = Date.UTC(2024, 0, 15, 12, 0, 0);
@@ -356,5 +358,63 @@ describe('adForecasterToUnifiedRuleSummary', () => {
     expect(rule.evaluationInterval).toBe('5 minutes');
     expect(rule.pendingPeriod).toBe('1 minutes');
     expect(rule.createdBy).toBe('admin');
+  });
+
+  it('uses the forecaster runtime state as the unified rule status', () => {
+    const rule = adForecasterToUnifiedRuleSummary(
+      {
+        id: 'forecaster-1',
+        name: 'CPU forecast',
+        curState: 'INITIALIZING_FORECAST' as MonitorStatus,
+        indices: ['metrics-*'],
+      },
+      'ds-os'
+    );
+
+    expect(rule.status).toBe('Initializing forecast');
+    expect(rule.healthStatus).toBe('healthy');
+  });
+});
+
+describe('adDetectorToUnifiedRuleSummary', () => {
+  it('uses the detector runtime state as the unified rule status', () => {
+    const rule = adDetectorToUnifiedRuleSummary(
+      {
+        id: 'detector-1',
+        name: 'Flight detector',
+        curState: 'RUNNING' as MonitorStatus,
+        indices: ['flights'],
+      },
+      'ds-os'
+    );
+
+    expect(rule.status).toBe('Running');
+    expect(rule.enabled).toBe(true);
+    expect(rule.healthStatus).toBe('healthy');
+  });
+
+  it('marks stopped detectors as disabled/no data', () => {
+    const rule = adDetectorToUnifiedRuleSummary(
+      {
+        id: 'detector-1',
+        name: 'Flight detector',
+        curState: 'DISABLED' as MonitorStatus,
+        indices: ['flights'],
+      },
+      'ds-os'
+    );
+
+    expect(rule.status).toBe('Stopped');
+    expect(rule.enabled).toBe(false);
+    expect(rule.healthStatus).toBe('no_data');
+  });
+});
+
+describe('runtimeStateToMonitorStatus', () => {
+  it('normalizes AD profile state keys to display labels', () => {
+    expect(runtimeStateToMonitorStatus('INIT')).toBe('Initializing');
+    expect(runtimeStateToMonitorStatus('Awaiting data to restart')).toBe(
+      'Awaiting data to restart'
+    );
   });
 });

--- a/server/services/alerting/__tests__/alert_utils.test.ts
+++ b/server/services/alerting/__tests__/alert_utils.test.ts
@@ -223,7 +223,7 @@ describe('osAlertToUnified', () => {
 
 describe('osMonitorToUnifiedRuleSummary — monitorType derivation', () => {
   function buildMonitor(indices: string[]): OSMonitor {
-    return ({
+    return {
       id: 'mon-1',
       type: 'monitor',
       monitor_type: 'query_level_monitor',
@@ -240,7 +240,7 @@ describe('osMonitorToUnifiedRuleSummary — monitorType derivation', () => {
       ],
       triggers: [],
       last_update_time: 1700000000000,
-    } as unknown) as OSMonitor;
+    } as unknown as OSMonitor;
   }
 
   it.each([['logs-2024.01.15'], ['logs-prod-app'], ['ss4o_logs-myapp'], ['ss4o_logs']])(

--- a/server/services/alerting/__tests__/alert_utils.test.ts
+++ b/server/services/alerting/__tests__/alert_utils.test.ts
@@ -223,7 +223,7 @@ describe('osAlertToUnified', () => {
 
 describe('osMonitorToUnifiedRuleSummary — monitorType derivation', () => {
   function buildMonitor(indices: string[]): OSMonitor {
-    return {
+    return ({
       id: 'mon-1',
       type: 'monitor',
       monitor_type: 'query_level_monitor',
@@ -240,7 +240,7 @@ describe('osMonitorToUnifiedRuleSummary — monitorType derivation', () => {
       ],
       triggers: [],
       last_update_time: 1700000000000,
-    } as unknown as OSMonitor;
+    } as unknown) as OSMonitor;
   }
 
   it.each([['logs-2024.01.15'], ['logs-prod-app'], ['ss4o_logs-myapp'], ['ss4o_logs']])(
@@ -407,6 +407,37 @@ describe('adDetectorToUnifiedRuleSummary', () => {
     expect(rule.status).toBe('Stopped');
     expect(rule.enabled).toBe(false);
     expect(rule.healthStatus).toBe('no_data');
+  });
+
+  it('does not report a detector as running when runtime and job state are unavailable', () => {
+    const rule = adDetectorToUnifiedRuleSummary(
+      {
+        id: 'detector-1',
+        name: 'Never-started detector',
+        indices: ['flights'],
+      },
+      'ds-os'
+    );
+
+    expect(rule.status).toBe('Inactive not started');
+    expect(rule.enabled).toBe(false);
+    expect(rule.healthStatus).toBe('no_data');
+  });
+
+  it('uses the detector job state when runtime profile state is unavailable', () => {
+    const rule = adDetectorToUnifiedRuleSummary(
+      {
+        id: 'detector-1',
+        name: 'Running detector',
+        indices: ['flights'],
+        anomaly_detector_job: { enabled: true },
+      },
+      'ds-os'
+    );
+
+    expect(rule.status).toBe('Running');
+    expect(rule.enabled).toBe(true);
+    expect(rule.healthStatus).toBe('healthy');
   });
 });
 

--- a/server/services/alerting/alert_service.ts
+++ b/server/services/alerting/alert_service.ts
@@ -200,8 +200,9 @@ function getErrorType(value: unknown): string | undefined {
   };
   if (typeof typedError.type === 'string') return typedError.type;
 
-  const rootCauseType = typedError.root_cause?.find((cause) => typeof cause.type === 'string')
-    ?.type;
+  const rootCauseType = typedError.root_cause?.find(
+    (cause) => typeof cause.type === 'string'
+  )?.type;
   if (rootCauseType) return rootCauseType;
 
   return typeof typedError.reason === 'string' ? typedError.reason : undefined;
@@ -578,9 +579,7 @@ export class MultiBackendAlertService {
 
     if (allRules.length === 0 && warnings.length === datasources.length && datasources.length > 0) {
       throw new Error(
-        `All datasources failed: ${warnings
-          .map((w) => `${w.datasourceName}: ${w.error}`)
-          .join('; ')}`
+        `All datasources failed: ${warnings.map((w) => `${w.datasourceName}: ${w.error}`).join('; ')}`
       );
     }
 
@@ -639,9 +638,7 @@ export class MultiBackendAlertService {
       datasources.length > 0
     ) {
       throw new Error(
-        `All datasources failed: ${warnings
-          .map((w) => `${w.datasourceName}: ${w.error}`)
-          .join('; ')}`
+        `All datasources failed: ${warnings.map((w) => `${w.datasourceName}: ${w.error}`).join('; ')}`
       );
     }
 
@@ -830,22 +827,18 @@ export class MultiBackendAlertService {
   ): Promise<FetchAlertsRawResult> {
     if (ds.type === 'opensearch' && this.osBackend) {
       const partialErrors: string[] = [];
-      const [
-        alertSettled,
-        anomalySettled,
-        detectorSettled,
-        monitorSettled,
-      ] = await Promise.allSettled([
-        range
-          ? this.osBackend.getAlerts(client, {
-              startMs: range.startMs,
-              endMs: range.endMs,
-            })
-          : this.osBackend.getAlerts(client),
-        this.fetchADAnomalies(client, range),
-        this.fetchADDetectors(client),
-        this.osBackend.getMonitors(client),
-      ] as const);
+      const [alertSettled, anomalySettled, detectorSettled, monitorSettled] =
+        await Promise.allSettled([
+          range
+            ? this.osBackend.getAlerts(client, {
+                startMs: range.startMs,
+                endMs: range.endMs,
+              })
+            : this.osBackend.getAlerts(client),
+          this.fetchADAnomalies(client, range),
+          this.fetchADDetectors(client),
+          this.osBackend.getMonitors(client),
+        ] as const);
 
       if (alertSettled.status === 'rejected') {
         throw alertSettled.reason;

--- a/server/services/alerting/alert_service.ts
+++ b/server/services/alerting/alert_service.ts
@@ -158,12 +158,27 @@ interface ADSearchResponse<TSource> {
   };
 }
 
+interface ADRuntimeProfileResponse {
+  state?: unknown;
+  response?: {
+    state?: unknown;
+  };
+}
+
 interface ADAnomalyFetchResult {
   anomalies: ADAnomalyResult[];
   truncated: boolean;
 }
 
 const ALERT_ANOMALY_LINK_TOLERANCE_MS = 60 * 60 * 1000;
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+
+function getRuntimeProfileState(body: ADRuntimeProfileResponse | undefined): string | undefined {
+  const state = body?.state ?? asRecord(body?.response).state;
+  return typeof state === 'string' && state.trim().length > 0 ? state : undefined;
+}
 
 function getErrorType(value: unknown): string | undefined {
   if (!value || typeof value !== 'object') return undefined;
@@ -1178,10 +1193,11 @@ export class MultiBackendAlertService {
         sort: [{ last_update_time: { order: 'desc', unmapped_type: 'long' } }],
       },
     });
-    return (response.body.hits?.hits || []).map((hit) => ({
+    const detectors = (response.body.hits?.hits || []).map((hit) => ({
       ...(hit._source || {}),
       id: hit._id,
     }));
+    return this.enrichADDetectorRuntimeStates(client, detectors);
   }
 
   private async fetchADForecasters(client: AlertingOSClient): Promise<ADForecaster[]> {
@@ -1194,10 +1210,53 @@ export class MultiBackendAlertService {
         sort: [{ last_update_time: { order: 'desc', unmapped_type: 'long' } }],
       },
     });
-    return (response.body.hits?.hits || []).map((hit) => ({
+    const forecasters = (response.body.hits?.hits || []).map((hit) => ({
       ...(hit._source || {}),
       id: hit._id,
     }));
+    return this.enrichADForecasterRuntimeStates(client, forecasters);
+  }
+
+  private async enrichADDetectorRuntimeStates(
+    client: AlertingOSClient,
+    detectors: ADDetector[]
+  ): Promise<ADDetector[]> {
+    const results = await runWithConcurrencyLimit(
+      detectors.map((detector) => async () => {
+        const response = await client.transport.request<ADRuntimeProfileResponse>({
+          method: 'GET',
+          path: `/_plugins/_anomaly_detection/detectors/${encodeURIComponent(
+            detector.id
+          )}/_profile/init_progress,state,error`,
+        });
+        const state = getRuntimeProfileState(response.body);
+        return state ? { ...detector, curState: state as ADDetector['curState'] } : detector;
+      })
+    );
+    return results.map((result, index) =>
+      result.status === 'fulfilled' ? result.value : detectors[index]
+    );
+  }
+
+  private async enrichADForecasterRuntimeStates(
+    client: AlertingOSClient,
+    forecasters: ADForecaster[]
+  ): Promise<ADForecaster[]> {
+    const results = await runWithConcurrencyLimit(
+      forecasters.map((forecaster) => async () => {
+        const response = await client.transport.request<ADRuntimeProfileResponse>({
+          method: 'GET',
+          path: `/_plugins/_forecast/forecasters/${encodeURIComponent(
+            forecaster.id
+          )}/_profile/init_progress,state,error`,
+        });
+        const state = getRuntimeProfileState(response.body);
+        return state ? { ...forecaster, curState: state as ADForecaster['curState'] } : forecaster;
+      })
+    );
+    return results.map((result, index) =>
+      result.status === 'fulfilled' ? result.value : forecasters[index]
+    );
   }
 
   private async fetchADAnomalies(

--- a/server/services/alerting/alert_utils.ts
+++ b/server/services/alerting/alert_utils.ts
@@ -55,8 +55,7 @@ import {
  */
 export function extractTimestampField(query: Record<string, unknown>): string | undefined {
   const innerQuery = (query as Record<string, unknown>).query as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
   const target = innerQuery || query;
   const bool = target?.bool as Record<string, unknown> | undefined;
   if (!bool) return undefined;
@@ -861,7 +860,7 @@ export function osMonitorToUnifiedRuleSummary(m: OSMonitor, dsId: string): Unifi
   } else {
     // query-level: derive from index patterns. See LOG_INDEX_PREFIXES /
     // APM_INDEX_PREFIXES at module scope for the schema list.
-    const indices = input && 'search' in input ? input.search.indices ?? [] : [];
+    const indices = input && 'search' in input ? (input.search.indices ?? []) : [];
     monitorType = inferMonitorTypeFromIndices(indices);
   }
 

--- a/server/services/alerting/alert_utils.ts
+++ b/server/services/alerting/alert_utils.ts
@@ -302,6 +302,99 @@ function formatPeriod(period?: { period?: { interval?: number; unit?: string } }
   return `${interval} ${unit.toLowerCase()}`;
 }
 
+const AD_RUNTIME_STATUS_BY_KEY: Record<string, MonitorStatus> = {
+  DISABLED: 'Stopped',
+  STOPPED: 'Stopped',
+  CREATED: 'Initializing',
+  INIT: 'Initializing',
+  INITIALIZING: 'Initializing',
+  RUNNING: 'Running',
+  FINISHED: 'Finished',
+  FEATURE_REQUIRED: 'Feature required',
+  INIT_FAILURE: 'Initialization failure',
+  INITIALIZATION_FAILURE: 'Initialization failure',
+  UNEXPECTED_FAILURE: 'Unexpected failure',
+  FAILED: 'Failed',
+  INACTIVE_STOPPED: 'Inactive stopped',
+  INACTIVE_NOT_STARTED: 'Inactive not started',
+  AWAITING_DATA_TO_INIT: 'Awaiting data to init',
+  AWAITING_DATA_TO_RESTART: 'Awaiting data to restart',
+  INITIALIZING_TEST: 'Initializing test',
+  INIT_TEST: 'Initializing test',
+  INITIALIZING_FORECAST: 'Initializing forecast',
+  TEST_COMPLETE: 'Test complete',
+  INIT_FORECAST_FAILURE: 'Init forecast failure',
+  FORECAST_FAILURE: 'Forecast failure',
+  INIT_TEST_FAILURE: 'Init test failure',
+};
+
+const RUNTIME_FAILURE_STATUSES = new Set<MonitorStatus>([
+  'Initialization failure',
+  'Unexpected failure',
+  'Failed',
+  'Init forecast failure',
+  'Forecast failure',
+  'Init test failure',
+]);
+
+const RUNTIME_INACTIVE_STATUSES = new Set<MonitorStatus>([
+  'Stopped',
+  'Finished',
+  'Inactive stopped',
+  'Inactive not started',
+]);
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+
+const getField = (value: unknown, ...keys: string[]): unknown => {
+  const record = asRecord(value);
+  for (const key of keys) {
+    if (record[key] !== undefined) return record[key];
+  }
+  return undefined;
+};
+
+const getNestedBoolean = (value: unknown, jobKey: string, field: string): boolean | undefined => {
+  const rootValue = getField(value, field);
+  if (typeof rootValue === 'boolean') return rootValue;
+
+  const jobValue = getField(getField(value, jobKey), field);
+  return typeof jobValue === 'boolean' ? jobValue : undefined;
+};
+
+export function runtimeStateToMonitorStatus(state: unknown): MonitorStatus | undefined {
+  if (typeof state !== 'string') return undefined;
+
+  const trimmed = state.trim();
+  if (!trimmed) return undefined;
+
+  const key = trimmed.replace(/[\s-]+/g, '_').toUpperCase();
+  return AD_RUNTIME_STATUS_BY_KEY[key] || (trimmed as MonitorStatus);
+}
+
+function getRuntimeStatus(resource: unknown): MonitorStatus | undefined {
+  return runtimeStateToMonitorStatus(
+    getField(resource, 'curState', 'cur_state', 'state', 'taskState', 'task_state')
+  );
+}
+
+function getADResourceEnabled(
+  resource: unknown,
+  jobKey: string,
+  fallbackStatus: MonitorStatus
+): boolean {
+  const enabled = getNestedBoolean(resource, jobKey, 'enabled');
+  if (enabled !== undefined) return enabled;
+  return !RUNTIME_INACTIVE_STATUSES.has(fallbackStatus) && fallbackStatus !== 'disabled';
+}
+
+function getADResourceHealthStatus(status: MonitorStatus): 'healthy' | 'failing' | 'no_data' {
+  if (RUNTIME_FAILURE_STATUSES.has(status)) return 'failing';
+  if (RUNTIME_INACTIVE_STATUSES.has(status) || status === 'disabled') return 'no_data';
+  return 'healthy';
+}
+
 function anomalySeverity(grade?: number, score?: number): UnifiedAlertSeverity {
   if ((grade ?? 0) >= 0.9 || (score ?? 0) >= 10) return 'critical';
   if ((grade ?? 0) >= 0.5 || (score ?? 0) >= 5) return 'high';
@@ -827,6 +920,8 @@ export function adDetectorToUnifiedRuleSummary(
   const indices = detector.indices || [];
   const evalInterval = formatPeriod(detector.detection_interval) || 'unknown interval';
   const windowDelay = formatPeriod(detector.window_delay) || 'none';
+  const status = getRuntimeStatus(detector) || 'Running';
+  const enabled = getADResourceEnabled(detector, 'anomaly_detector_job', status);
   const labels: Record<string, string> = {
     source: 'anomaly_detection',
     detector_type: detector.detector_type || 'detector',
@@ -841,7 +936,7 @@ export function adDetectorToUnifiedRuleSummary(
     datasourceType: 'opensearch',
     definitionType: 'detector',
     name: detector.name || detector.id,
-    enabled: true,
+    enabled,
     severity: 'info',
     query: indices.length > 0 ? indices.join(', ') : '(no indices)',
     condition: `${features.length} feature${features.length === 1 ? '' : 's'} analyzed`,
@@ -858,8 +953,8 @@ export function adDetectorToUnifiedRuleSummary(
         : {}),
     },
     monitorType: 'detector',
-    status: 'active',
-    healthStatus: 'healthy',
+    status,
+    healthStatus: getADResourceHealthStatus(status),
     createdBy: detector.user?.name || '',
     createdAt: new Date(detector.last_update_time || Date.now()).toISOString(),
     lastModified: new Date(detector.last_update_time || Date.now()).toISOString(),
@@ -897,7 +992,10 @@ export function adForecasterToUnifiedRuleSummary(
         feature.feature_name || feature.featureName || feature.feature_id || feature.featureId
     )
     .filter((name): name is string => typeof name === 'string' && name.trim().length > 0);
-  const enabled = forecaster.enabled !== false;
+  const fallbackStatus: MonitorStatus =
+    forecaster.enabled === false ? 'Inactive stopped' : 'Running';
+  const status = getRuntimeStatus(forecaster) || fallbackStatus;
+  const enabled = getADResourceEnabled(forecaster, 'forecaster_job', status);
 
   return {
     id: forecaster.id,
@@ -916,8 +1014,8 @@ export function adForecasterToUnifiedRuleSummary(
       ...(featureNames.length > 0 ? { features: featureNames.join(', ') } : {}),
     },
     monitorType: 'forecaster',
-    status: enabled ? 'active' : 'disabled',
-    healthStatus: enabled ? 'healthy' : 'no_data',
+    status,
+    healthStatus: getADResourceHealthStatus(status),
     createdBy: forecaster.user?.name || '',
     createdAt: new Date(lastUpdateTime).toISOString(),
     lastModified: new Date(lastUpdateTime).toISOString(),

--- a/server/services/alerting/alert_utils.ts
+++ b/server/services/alerting/alert_utils.ts
@@ -55,8 +55,7 @@ import {
  */
 export function extractTimestampField(query: Record<string, unknown>): string | undefined {
   const innerQuery = (query as Record<string, unknown>).query as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
   const target = innerQuery || query;
   const bool = target?.bool as Record<string, unknown> | undefined;
   if (!bool) return undefined;
@@ -861,7 +860,7 @@ export function osMonitorToUnifiedRuleSummary(m: OSMonitor, dsId: string): Unifi
   } else {
     // query-level: derive from index patterns. See LOG_INDEX_PREFIXES /
     // APM_INDEX_PREFIXES at module scope for the schema list.
-    const indices = input && 'search' in input ? input.search.indices ?? [] : [];
+    const indices = input && 'search' in input ? (input.search.indices ?? []) : [];
     monitorType = inferMonitorTypeFromIndices(indices);
   }
 
@@ -926,8 +925,8 @@ export function adDetectorToUnifiedRuleSummary(
     detectorJobEnabled === true
       ? 'Running'
       : detectorJobEnabled === false
-      ? 'Stopped'
-      : 'Inactive not started';
+        ? 'Stopped'
+        : 'Inactive not started';
   const status = getRuntimeStatus(detector) || fallbackStatus;
   const enabled = getADResourceEnabled(detector, 'anomaly_detector_job', status);
   const labels: Record<string, string> = {

--- a/server/services/alerting/alert_utils.ts
+++ b/server/services/alerting/alert_utils.ts
@@ -55,7 +55,8 @@ import {
  */
 export function extractTimestampField(query: Record<string, unknown>): string | undefined {
   const innerQuery = (query as Record<string, unknown>).query as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   const target = innerQuery || query;
   const bool = target?.bool as Record<string, unknown> | undefined;
   if (!bool) return undefined;
@@ -860,7 +861,7 @@ export function osMonitorToUnifiedRuleSummary(m: OSMonitor, dsId: string): Unifi
   } else {
     // query-level: derive from index patterns. See LOG_INDEX_PREFIXES /
     // APM_INDEX_PREFIXES at module scope for the schema list.
-    const indices = input && 'search' in input ? (input.search.indices ?? []) : [];
+    const indices = input && 'search' in input ? input.search.indices ?? [] : [];
     monitorType = inferMonitorTypeFromIndices(indices);
   }
 
@@ -919,7 +920,15 @@ export function adDetectorToUnifiedRuleSummary(
   const indices = detector.indices || [];
   const evalInterval = formatPeriod(detector.detection_interval) || 'unknown interval';
   const windowDelay = formatPeriod(detector.window_delay) || 'none';
-  const status = getRuntimeStatus(detector) || 'Running';
+  const detectorJobEnabled =
+    getNestedBoolean(detector, 'anomaly_detector_job', 'enabled') ?? detector.enabled;
+  const fallbackStatus: MonitorStatus =
+    detectorJobEnabled === true
+      ? 'Running'
+      : detectorJobEnabled === false
+      ? 'Stopped'
+      : 'Inactive not started';
+  const status = getRuntimeStatus(detector) || fallbackStatus;
   const enabled = getADResourceEnabled(detector, 'anomaly_detector_job', status);
   const labels: Record<string, string> = {
     source: 'anomaly_detection',

--- a/server/services/alerting/saved_object_datasource_service.ts
+++ b/server/services/alerting/saved_object_datasource_service.ts
@@ -31,6 +31,8 @@ import type {
 interface DataSourceSOAttributes {
   title?: string;
   endpoint?: string;
+  dataSourceEngineType?: string;
+  dataSourceVersion?: string;
 }
 
 interface DataConnectionSOAttributes {
@@ -60,6 +62,8 @@ export class SavedObjectDatasourceService implements DatasourceService {
           url: so.attributes.endpoint || '',
           enabled: true,
           mdsId: so.id,
+          engineType: so.attributes.dataSourceEngineType,
+          version: so.attributes.dataSourceVersion,
         });
         osCount++;
       }

--- a/server/services/alerting/saved_object_datasource_service.ts
+++ b/server/services/alerting/saved_object_datasource_service.ts
@@ -31,8 +31,6 @@ import type {
 interface DataSourceSOAttributes {
   title?: string;
   endpoint?: string;
-  dataSourceEngineType?: string;
-  dataSourceVersion?: string;
 }
 
 interface DataConnectionSOAttributes {
@@ -62,8 +60,6 @@ export class SavedObjectDatasourceService implements DatasourceService {
           url: so.attributes.endpoint || '',
           enabled: true,
           mdsId: so.id,
-          engineType: so.attributes.dataSourceEngineType,
-          version: so.attributes.dataSourceVersion,
         });
         osCount++;
       }


### PR DESCRIPTION
## Summary
Adds detector and forecaster management to Alerts Manager so anomaly detection and forecasting rules can be viewed and managed without jumping back to the legacy plugin pages.

https://github.com/user-attachments/assets/6206dc21-3776-4061-876f-81805c8522a4


## Changes
- Adds anomaly detection and forecasting create flows in the Alerts Manager Rules tab.
- Adds detector and forecaster detail flyouts with edit, start, stop, and delete display/actions aligned with existing rule flyout patterns.
- Adds AOS/AOSS datasource gating for detector and forecaster creation, including AOSS custom result index handling.
- Threads detector/forecaster state, health, and mutation support through the Alerts Manager table and backend service layer.
- Adds tests for detector/forecaster flyouts, monitor table behavior, mutation client behavior, and alert service routing/utilities.

## Validation
- `git diff --check origin/main...HEAD`
- `yarn lint:es` against changed TS/TSX/JS files

Note: this PR branch was rebuilt from current `main` as a single signed-off commit so CI compares against the intended base and excludes unrelated package/build-script artifacts.