### PR TITLE
feat(alerting): unify Create metrics rule flyouts across Alert Manager and Metrics page

### DIFF
--- a/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
@@ -95,8 +95,6 @@ describe('CreateMetricsMonitor', () => {
     expect(body).toMatchObject({
       name: 'my-test-rule',
       query: expect.any(String),
-      operator: '>',
-      threshold: expect.any(Number),
       forDuration: expect.any(String),
       evaluationInterval: expect.any(String),
       enabled: true,
@@ -104,6 +102,10 @@ describe('CreateMetricsMonitor', () => {
     });
     expect(body).toHaveProperty('labels');
     expect(body).toHaveProperty('annotations');
+    // The PromQL expression is the complete alert condition — no separate
+    // operator/threshold is sent (Trigger condition section was removed)
+    expect(body).not.toHaveProperty('operator');
+    expect(body).not.toHaveProperty('threshold');
 
     // Should call onSave and show success toast
     expect(onSave).toHaveBeenCalled();

--- a/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
@@ -96,6 +96,25 @@ describe('CreateMetricsMonitor', () => {
     expect(createBtn.disabled).toBe(true);
   });
 
+  it('shows the "Build query in metrics" link only when requested (Alert Manager)', () => {
+    const { unmount } = render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasourceId="prom-1"
+        showBuildInMetricsLink
+      />
+    );
+    expect(
+      document.querySelector('[data-test-subj="alertManagerOpenInMetricsLink"]')
+    ).not.toBeNull();
+    unmount();
+
+    // Metrics Explore page context: link must be absent (circular hop)
+    render(<CreateMetricsMonitor onCancel={jest.fn()} onSave={jest.fn()} datasourceId="prom-1" />);
+    expect(document.querySelector('[data-test-subj="alertManagerOpenInMetricsLink"]')).toBeNull();
+  });
+
   it('POSTs the correct payload shape on save', async () => {
     const mockPost = jest.fn().mockResolvedValue({});
     const onSave = jest.fn();

--- a/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
@@ -24,6 +24,14 @@ jest.mock('../promql_editor', () => ({
 jest.mock('../metric_browser', () => ({
   MetricBrowser: () => <div data-test-subj="metricBrowserMock" />,
 }));
+// Stub the shared builder with a button that emits a query, so tests can
+// simulate an explicit builder selection (the form seeds query: '' and the
+// Create button stays disabled until the builder produces one)
+jest.mock('../create_monitor/prom_query_builder', () => ({
+  PromQueryBuilder: ({ onQueryChange }: { onQueryChange: (q: string) => void }) => (
+    <button data-test-subj="mockBuilderSetQuery" onClick={() => onQueryChange('up{job="api"}')} />
+  ),
+}));
 
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
@@ -131,9 +139,11 @@ describe('CreateMetricsMonitor', () => {
       />
     );
 
-    // Fill in required fields: monitorName
+    // Fill in required fields: monitorName + an explicit builder selection
+    // (the form seeds query: '' — no invisible default expression)
     const nameInput = document.querySelector('input[aria-label="Rule name"]') as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: 'my-test-rule' } });
+    fireEvent.click(document.querySelector('[data-test-subj="mockBuilderSetQuery"]')!);
 
     // Click Create button
     const createBtn = document.querySelector(

--- a/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
@@ -57,6 +57,45 @@ describe('CreateMetricsMonitor', () => {
     expect(createBtn!.disabled).toBe(true);
   });
 
+  it('defaults to the first Prometheus datasource from a provided list (Alert Manager)', () => {
+    render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasources={[
+          { id: 'os-1', name: 'SomeOpenSearch', type: 'opensearch' },
+          { id: 'prom-1', name: 'MyPrometheus', type: 'prometheus' },
+          { id: 'prom-2', name: 'OtherProm', type: 'prometheus' },
+        ]}
+      />
+    );
+    // The first prometheus datasource is preselected and shown in the picker
+    expect(document.body.textContent).toContain('MyPrometheus');
+    expect(document.body.textContent).not.toContain('SomeOpenSearch');
+  });
+
+  it('blocks save and shows an error for duplicate rule names', () => {
+    render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasourceId="prom-1"
+        isNameTaken={(name) => name === 'taken-name'}
+      />
+    );
+    const nameInput = document.querySelector('input[aria-label="Rule name"]') as HTMLInputElement;
+    expect(nameInput).not.toBeNull();
+    fireEvent.change(nameInput, { target: { value: 'taken-name' } });
+
+    expect(document.body.textContent).toContain(
+      'A rule with this name already exists on the selected datasource.'
+    );
+    const createBtn = document.querySelector(
+      'button[class*="euiButton--fill"]'
+    ) as HTMLButtonElement;
+    expect(createBtn.disabled).toBe(true);
+  });
+
   it('POSTs the correct payload shape on save', async () => {
     const mockPost = jest.fn().mockResolvedValue({});
     const onSave = jest.fn();

--- a/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
@@ -26,6 +26,9 @@ jest.mock('../monitor_form_components', () => ({
   LabelEditor: jest.fn(() => <div data-test-subj="label-editor" />),
   AnnotationEditor: () => <div data-test-subj="annotation-editor" />,
 }));
+jest.mock('../echarts_render', () => ({
+  EchartsRender: () => <div data-test-subj="echarts-render" />,
+}));
 jest.mock('../query_services/alerting_prom_resources_service', () => ({
   AlertingPromResourcesService: jest.fn().mockImplementation(() => ({
     listMetricNames: jest.fn().mockResolvedValue({ metrics: ['up', 'http_requests_total'] }),
@@ -110,6 +113,25 @@ describe('PrometheusFormSection — simplified layout', () => {
       'threshold',
       expect.objectContaining({ forDuration: '10m' })
     );
+  });
+
+  it('shows preview results after clicking Run preview', () => {
+    render(
+      <PrometheusFormSection
+        form={baseForm}
+        onUpdate={jest.fn()}
+        validationErrors={{}}
+        hasSubmitted={false}
+      />
+    );
+
+    // No results until requested
+    expect(screen.queryByTestId('echarts-render')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('prometheusRunPreviewButton'));
+
+    expect(screen.getByTestId('echarts-render')).toBeInTheDocument();
+    expect(screen.getByText('Sample data — run the rule to see real results')).toBeInTheDocument();
   });
 
   it('renders the "Build query in metrics" link in the query panel header', () => {

--- a/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
@@ -17,10 +17,8 @@
  */
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import {
-  parseBuilderQuery,
-  PrometheusFormSection,
-} from '../create_monitor/prometheus_form_section';
+import { PrometheusFormSection } from '../create_monitor/prometheus_form_section';
+import { parseBuilderQuery } from '../create_monitor/prom_query_builder';
 import type { PrometheusFormState } from '../create_monitor/create_monitor_types';
 
 // Mock dependencies that PrometheusFormSection uses
@@ -156,10 +154,29 @@ describe('PrometheusFormSection — rule group', () => {
       />
     );
 
+    expect(screen.getByText('Rule details')).toBeInTheDocument();
     expect(screen.getByText('Rule group')).toBeInTheDocument();
+    // Namespace is fixed and read-only
+    expect(screen.getByDisplayValue('observability-alerting')).toBeInTheDocument();
     expect(
-      screen.getByText('Select an existing group or type a new name to create one.')
+      screen.getByText(
+        'Rules within a group share an evaluation interval and are evaluated together.'
+      )
     ).toBeInTheDocument();
+  });
+
+  it('renders the shell-provided rule name field inside Rule details', () => {
+    render(
+      <PrometheusFormSection
+        form={baseForm}
+        onUpdate={jest.fn()}
+        validationErrors={{}}
+        hasSubmitted={false}
+        ruleNameField={<input data-test-subj="shellRuleNameField" />}
+      />
+    );
+
+    expect(screen.getByTestId('shellRuleNameField')).toBeInTheDocument();
   });
 
   it('propagates rule group selection via the _ruleGroup metadata label', () => {
@@ -174,11 +191,11 @@ describe('PrometheusFormSection — rule group', () => {
       />
     );
 
-    // Builder has 3 combo boxes (metric, label name, label value);
-    // the rule group combo box is the 4th and last
+    // Rule details renders first, so the rule group combo box is the 1st;
+    // the builder's 3 combo boxes (metric, label name, label value) follow
     const comboInputs = container.querySelectorAll('[data-test-subj="comboBoxSearchInput"]');
     expect(comboInputs.length).toBe(4);
-    const input = comboInputs[comboInputs.length - 1];
+    const input = comboInputs[0];
 
     fireEvent.change(input, { target: { value: 'my-group' } });
     fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });

--- a/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
@@ -114,6 +114,20 @@ describe('PrometheusFormSection — simplified layout', () => {
     );
   });
 
+  it('renders the "Build query in metrics" link in the query panel header', () => {
+    render(
+      <PrometheusFormSection
+        form={baseForm}
+        onUpdate={jest.fn()}
+        validationErrors={{}}
+        hasSubmitted={false}
+      />
+    );
+
+    expect(screen.getByTestId('alertManagerOpenInMetricsLink')).toBeInTheDocument();
+    expect(screen.getByText('Build query in metrics →')).toBeInTheDocument();
+  });
+
   it('shows the datasource selector when datasources are provided', () => {
     render(
       <PrometheusFormSection

--- a/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
@@ -397,7 +397,7 @@ describe('PrometheusFormSection — edit mode seeding', () => {
 });
 
 describe('PrometheusFormSection — notification routing', () => {
-  it('renders Alertmanager routing guidance', () => {
+  it('does not render a Notification routing section (matches the Metrics page flyout)', () => {
     render(
       <PrometheusFormSection
         form={baseForm}
@@ -407,7 +407,8 @@ describe('PrometheusFormSection — notification routing', () => {
       />
     );
 
-    expect(screen.getByText('Notification routing')).toBeInTheDocument();
-    expect(screen.getByText('Alertmanager')).toBeInTheDocument();
+    expect(screen.queryByText('Notification routing')).not.toBeInTheDocument();
+    // The Labels section hint still conveys the routing relationship
+    expect(screen.getByText('Categorize and route alerts')).toBeInTheDocument();
   });
 });

--- a/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
@@ -282,6 +282,31 @@ describe('PrometheusFormSection — rule group', () => {
   });
 });
 
+describe('PrometheusFormSection — dynamic labels', () => {
+  it('single-quotes templated label values in the YAML preview', () => {
+    const { container } = render(
+      <PrometheusFormSection
+        form={{
+          ...baseForm,
+          labels: [
+            {
+              key: 'severity',
+              value: '{{ if gt $value 0.9 }}critical{{ else }}warning{{ end }}',
+              isDynamic: true,
+            },
+          ],
+        }}
+        onUpdate={jest.fn()}
+        validationErrors={{}}
+        hasSubmitted={false}
+      />
+    );
+
+    const yaml = container.querySelector('pre')!.textContent || '';
+    expect(yaml).toContain("severity: '{{ if gt $value 0.9 }}critical{{ else }}warning{{ end }}'");
+  });
+});
+
 describe('PrometheusFormSection — YAML preview', () => {
   it('uses the query as the complete expression and hides _ruleGroup', () => {
     const { container } = render(

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -1277,6 +1277,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           onSave={handleMetricsRuleSaved}
           datasources={datasources.filter((d) => d.type === 'prometheus')}
           isNameTaken={isNameTakenForCreate}
+          showBuildInMetricsLink
           http={coreRefs.http}
           addToast={(title, color) => addToast(title, color)}
         />

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -40,6 +40,7 @@ import { MonitorsTable } from './monitors_table';
 import { CreateMonitor, MonitorFormState } from './create_monitor';
 import type { PrometheusFormState } from './create_monitor/create_monitor_types';
 import { EditMonitor } from './create_monitor/edit_monitor';
+import { CreateMetricsMonitor, MetricsMonitorFormState } from './create_metrics_monitor';
 import { AlertsDashboard } from './alerts_dashboard';
 import { AlertDetailFlyout } from './alert_detail_flyout';
 import { AnomalyDetailFlyout } from './anomaly_detail_flyout';
@@ -941,6 +942,54 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     }
   };
 
+  /**
+   * Post-save handler for the shared CreateMetricsMonitor flyout (the same
+   * component the Metrics Explore page uses). The flyout persists the rule
+   * itself via the http client; this handler only reconciles the page:
+   * optimistic insert, close, and a delayed refetch to bridge Cortex's
+   * eventual consistency (~30-60s propagation).
+   */
+  const handleMetricsRuleSaved = (form: MetricsMonitorFormState) => {
+    // Mirror of the server's promSeverityFromLabels for the optimistic row
+    const sev = form.labels.find((l) => l.key === 'severity')?.value || '';
+    const severity: PrometheusFormState['severity'] =
+      sev === 'critical' || sev === 'high' || sev === 'medium' || sev === 'low'
+        ? sev
+        : sev === 'warning'
+          ? 'medium'
+          : sev === 'page'
+            ? 'critical'
+            : 'info';
+    // Adapt the flyout's form shape to the PrometheusFormState that
+    // formStateToRule understands, for the optimistic table row
+    const promForm: PrometheusFormState = {
+      name: form.monitorName,
+      datasourceId: form.datasourceId,
+      datasourceType: 'prometheus',
+      query: form.query,
+      threshold: { operator: '>', value: 0, unit: '', forDuration: form.forDuration },
+      evaluationInterval: form.evalInterval,
+      pendingPeriod: form.forDuration,
+      firingPeriod: form.forDuration,
+      labels: form.labels,
+      annotations: form.description.trim()
+        ? [
+            ...form.annotations.filter((a) => a.key !== 'description'),
+            { key: 'description', value: form.description.trim() },
+          ]
+        : form.annotations,
+      severity,
+      enabled: true,
+    };
+    const newRule = buildOptimisticRule(promForm);
+    setShowCreateMonitor(false);
+    setCreateBackendType(null);
+    setRules((prev) => [newRule, ...prev]);
+    setRulesTotal((prev) => prev + 1);
+    refetchRules();
+    refetchTimerRef.current = setTimeout(() => refetchRules(), 15000);
+  };
+
   const handleEditMonitor = async (formState: MonitorFormState, ruleId: string) => {
     const dsId = resolveDatasourceId(formState);
     if (!dsId) return;
@@ -1214,7 +1263,24 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         />
       </div>
       {renderTable()}
-      {showCreateMonitor && (
+      {/* Metrics rules use the SAME flyout component as the Metrics Explore
+          page ("Create alert rule" action) so the two surfaces can never
+          drift. It persists the rule itself; handleMetricsRuleSaved only
+          reconciles the table. Logs (PPL) rules keep the CreateMonitor
+          shell. */}
+      {showCreateMonitor && createBackendType === 'prometheus' ? (
+        <CreateMetricsMonitor
+          onCancel={() => {
+            setShowCreateMonitor(false);
+            setCreateBackendType(null);
+          }}
+          onSave={handleMetricsRuleSaved}
+          datasources={datasources.filter((d) => d.type === 'prometheus')}
+          isNameTaken={isNameTakenForCreate}
+          http={coreRefs.http}
+          addToast={(title, color) => addToast(title, color)}
+        />
+      ) : showCreateMonitor ? (
         <CreateMonitor
           onSave={handleCreateMonitor}
           onBatchSave={handleBatchCreateMonitors}
@@ -1230,7 +1296,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           submitError={pplSubmitError ? { pplMessage: pplSubmitError } : undefined}
           onClearPplSubmitError={() => setPplSubmitError(null)}
         />
-      )}
+      ) : null}
       {editTarget && (
         <EditMonitor
           dsId={editTarget.dsId}

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -41,9 +41,8 @@ import {
   EuiConfirmModal,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import { FormattedMessage } from '@osd/i18n/react';
-import { EchartsRender } from './echarts_render';
 import { PromQueryBuilder } from './create_monitor/prom_query_builder';
+import { QueryPreviewResults } from './query_preview_results';
 
 // ============================================================================
 // Types
@@ -67,14 +66,10 @@ export interface MetricsMonitorFormState {
   groupName: string;
   query: string;
   datasourceId: string;
-  // Trigger condition
-  operator: '>' | '>=' | '<' | '<=' | '==' | '!=';
-  thresholdValue: number;
+  /** The rule's `for:` clause — pending window before the alert fires. */
   forDuration: string;
-  // Evaluation settings
+  /** Group-level evaluation cadence sent with the payload (not per-rule UI). */
   evalInterval: string;
-  pendingPeriod: string;
-  firingPeriod: string;
   // Labels & annotations
   labels: LabelEntry[];
   annotations: AnnotationEntry[];
@@ -98,45 +93,6 @@ export interface CreateMetricsMonitorProps {
 // ============================================================================
 // Constants
 // ============================================================================
-
-const OPERATOR_OPTIONS = [
-  {
-    value: '>',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.operatorGt', {
-      defaultMessage: '> (greater than)',
-    }),
-  },
-  {
-    value: '>=',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.operatorGte', {
-      defaultMessage: '>= (greater or equal)',
-    }),
-  },
-  {
-    value: '<',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.operatorLt', {
-      defaultMessage: '< (less than)',
-    }),
-  },
-  {
-    value: '<=',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.operatorLte', {
-      defaultMessage: '<= (less or equal)',
-    }),
-  },
-  {
-    value: '==',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.operatorEq', {
-      defaultMessage: '== (equal)',
-    }),
-  },
-  {
-    value: '!=',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.operatorNeq', {
-      defaultMessage: '!= (not equal)',
-    }),
-  },
-];
 
 const FOR_DURATION_OPTIONS = [
   {
@@ -177,152 +133,7 @@ const FOR_DURATION_OPTIONS = [
   },
 ];
 
-const FIRING_PERIOD_OPTIONS = [
-  {
-    value: '0s',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.firingNone', {
-      defaultMessage: 'None (resolve immediately)',
-    }),
-  },
-  {
-    value: '30s',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.firing30s', {
-      defaultMessage: '30 seconds',
-    }),
-  },
-  {
-    value: '1m',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.firing1m', {
-      defaultMessage: '1 minute',
-    }),
-  },
-  {
-    value: '5m',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.firing5m', {
-      defaultMessage: '5 minutes',
-    }),
-  },
-  {
-    value: '10m',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.firing10m', {
-      defaultMessage: '10 minutes',
-    }),
-  },
-  {
-    value: '15m',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.firing15m', {
-      defaultMessage: '15 minutes',
-    }),
-  },
-  {
-    value: '30m',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.firing30m', {
-      defaultMessage: '30 minutes',
-    }),
-  },
-  {
-    value: '1h',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.firing1h', {
-      defaultMessage: '1 hour',
-    }),
-  },
-];
-
-const EVAL_INTERVAL_OPTIONS = [
-  {
-    value: '30s',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.eval30s', {
-      defaultMessage: '30 seconds',
-    }),
-  },
-  {
-    value: '1m',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.eval1m', {
-      defaultMessage: '1 minute',
-    }),
-  },
-  {
-    value: '5m',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.eval5m', {
-      defaultMessage: '5 minutes',
-    }),
-  },
-  {
-    value: '10m',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.eval10m', {
-      defaultMessage: '10 minutes',
-    }),
-  },
-  {
-    value: '15m',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.eval15m', {
-      defaultMessage: '15 minutes',
-    }),
-  },
-  {
-    value: '30m',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.eval30m', {
-      defaultMessage: '30 minutes',
-    }),
-  },
-  {
-    value: '1h',
-    text: i18n.translate('observability.alerting.createMetricsMonitor.eval1h', {
-      defaultMessage: '1 hour',
-    }),
-  },
-];
-
 const DEFAULT_PROMQL = 'rate(http_requests_total{status=~"5.."}[5m])';
-
-// Mock preview data — line chart
-const PREVIEW_TIMESTAMPS = ['04:00', '06:00', '08:00', '10:00', '12:00', '14:00', '16:00', '17:00'];
-const PREVIEW_VALUES = [0.02, 0.03, 0.01, 0.06, 0.04, 0.07, 0.05, 0.08];
-
-// ============================================================================
-// Chart helpers
-// ============================================================================
-
-const PREVIEW_CHART_OPTION: Record<string, unknown> = {
-  grid: { left: 48, right: 16, top: 16, bottom: 32 },
-  tooltip: { trigger: 'axis' },
-  xAxis: { type: 'category', data: PREVIEW_TIMESTAMPS },
-  yAxis: { type: 'value' },
-  series: [
-    {
-      type: 'line',
-      data: PREVIEW_VALUES,
-      smooth: true,
-      itemStyle: { color: '#006BB4' },
-      areaStyle: { color: 'rgba(0,107,180,0.1)' },
-    },
-  ],
-};
-
-function buildThresholdChartOption(thresholdValue: number): Record<string, unknown> {
-  return {
-    grid: { left: 48, right: 16, top: 16, bottom: 32 },
-    tooltip: { trigger: 'axis' },
-    xAxis: { type: 'category', data: PREVIEW_TIMESTAMPS },
-    yAxis: { type: 'value' },
-    series: [
-      {
-        type: 'line',
-        data: PREVIEW_VALUES,
-        smooth: true,
-        itemStyle: { color: '#006BB4' },
-        areaStyle: { color: 'rgba(0,107,180,0.1)' },
-        markLine: {
-          silent: true,
-          symbol: 'none',
-          lineStyle: { type: 'dashed', color: '#BD271E', width: 2 },
-          data: [{ yAxis: thresholdValue }],
-          label: { formatter: `Threshold: ${thresholdValue}`, position: 'insideEndTop' },
-        },
-      },
-    ],
-  };
-}
 
 // ============================================================================
 // Sub-components
@@ -569,112 +380,23 @@ const QuerySection = React.memo<{
           query={form.query}
           onQueryChange={(q) => onUpdate({ query: q })}
         />
-      </EuiPanel>
 
-      {/* Preview Results */}
-      {showPreview && (
-        <>
-          <EuiSpacer size="m" />
-          <EuiAccordion
-            id="prom-preview-results"
-            buttonContent={
-              <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-                <EuiFlexItem grow={false}>
-                  <strong>
-                    <FormattedMessage
-                      id="observability.alerting.createMetricsMonitor.resultsTitle"
-                      defaultMessage="Results ({count})"
-                      values={{ count: PREVIEW_VALUES.length }}
-                    />
-                  </strong>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            }
-            initialIsOpen
-            paddingSize="s"
-          >
-            <EuiCallOut size="s" color="warning" iconType="iInCircle">
-              <EuiText size="xs">
-                {i18n.translate('observability.alerting.createMetricsMonitor.sampleDataCallout', {
-                  defaultMessage: 'Sample data — run the rule to see real results',
-                })}
-              </EuiText>
-            </EuiCallOut>
-            <EuiSpacer size="s" />
-            <EuiText size="xs" color="subdued">
-              http_requests_total
-            </EuiText>
-            <EuiSpacer size="s" />
-            <EchartsRender spec={PREVIEW_CHART_OPTION} height={200} />
-          </EuiAccordion>
-        </>
-      )}
-    </EuiAccordion>
-  );
-});
+        <EuiSpacer size="m" />
 
-/** Section 3: Trigger Condition */
-const TriggerConditionSection = React.memo<{
-  form: MetricsMonitorFormState;
-  onUpdate: (patch: Partial<MetricsMonitorFormState>) => void;
-}>(({ form, onUpdate }) => (
-  <EuiAccordion
-    id="prom-trigger-condition"
-    buttonContent={
-      <strong>
-        {i18n.translate('observability.alerting.createMetricsMonitor.triggerConditionTitle', {
-          defaultMessage: 'Trigger condition',
-        })}
-      </strong>
-    }
-    initialIsOpen
-    paddingSize="m"
-  >
-    <EuiFlexGroup gutterSize="s" wrap>
-      <EuiFlexItem style={{ minWidth: 160 }}>
-        <EuiFormRow
-          label={i18n.translate('observability.alerting.createMetricsMonitor.operatorLabel', {
-            defaultMessage: 'Operator',
-          })}
-          display="rowCompressed"
-        >
-          <EuiSelect
-            options={OPERATOR_OPTIONS}
-            value={form.operator}
-            onChange={(e) =>
-              onUpdate({ operator: e.target.value as MetricsMonitorFormState['operator'] })
-            }
-            compressed
-            aria-label={i18n.translate(
-              'observability.alerting.createMetricsMonitor.thresholdOperatorAriaLabel',
-              { defaultMessage: 'Threshold operator' }
-            )}
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem style={{ minWidth: 100 }}>
-        <EuiFormRow
-          label={i18n.translate('observability.alerting.createMetricsMonitor.valueLabel', {
-            defaultMessage: 'Value',
-          })}
-          display="rowCompressed"
-        >
-          <EuiFieldNumber
-            value={form.thresholdValue}
-            onChange={(e) => onUpdate({ thresholdValue: parseFloat(e.target.value) || 0 })}
-            compressed
-            aria-label={i18n.translate(
-              'observability.alerting.createMetricsMonitor.thresholdValueAriaLabel',
-              { defaultMessage: 'Threshold value' }
-            )}
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem style={{ minWidth: 160 }}>
+        {/* For duration — the rule's `for:` clause. Kept per-rule (unlike
+            the group-level evaluation interval): the condition must hold
+            continuously for this long before the alert fires. */}
         <EuiFormRow
           label={i18n.translate('observability.alerting.createMetricsMonitor.forDurationLabel', {
             defaultMessage: 'For duration',
           })}
+          helpText={i18n.translate(
+            'observability.alerting.createMetricsMonitor.forDurationHelpText',
+            {
+              defaultMessage:
+                'How long the condition must stay true before the alert fires. The alert is "pending" during this window.',
+            }
+          )}
           display="rowCompressed"
         >
           <EuiSelect
@@ -686,147 +408,21 @@ const TriggerConditionSection = React.memo<{
               'observability.alerting.createMetricsMonitor.forDurationAriaLabel',
               { defaultMessage: 'For duration' }
             )}
+            data-test-subj="metricsMonitorForDurationSelect"
           />
         </EuiFormRow>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+      </EuiPanel>
 
-    <EuiSpacer size="s" />
-
-    {/* Condition summary callout */}
-    <EuiCallOut size="s" color="primary" iconType="iInCircle">
-      <EuiText size="xs">
-        <FormattedMessage
-          id="observability.alerting.createMetricsMonitor.alertFiresMessage"
-          defaultMessage="Alert fires when: {expression} for {forDuration}"
-          values={{
-            expression: (
-              <code>
-                {form.query || '<query>'} {form.operator} {form.thresholdValue}
-              </code>
-            ),
-            forDuration: form.forDuration,
-          }}
-        />
-      </EuiText>
-    </EuiCallOut>
-
-    <EuiSpacer size="m" />
-
-    {/* Threshold visualization */}
-    <EuiCallOut size="s" color="warning" iconType="iInCircle">
-      <EuiText size="xs">
-        {i18n.translate('observability.alerting.createMetricsMonitor.thresholdSampleDataCallout', {
-          defaultMessage: 'Sample data — run the rule to see real results',
-        })}
-      </EuiText>
-    </EuiCallOut>
-    <EuiSpacer size="xs" />
-    <EuiText size="xs">
-      <strong>
-        {i18n.translate('observability.alerting.createMetricsMonitor.thresholdResultsLabel', {
-          defaultMessage: 'Results',
-        })}
-      </strong>
-    </EuiText>
-    <EuiText size="xs" color="subdued">
-      http_requests_total
-    </EuiText>
-    <EuiSpacer size="xs" />
-    <EchartsRender spec={buildThresholdChartOption(form.thresholdValue)} height={200} />
-  </EuiAccordion>
-));
-
-/** Section 4: Evaluation Settings */
-const EvaluationSettingsSection = React.memo<{
-  form: MetricsMonitorFormState;
-  onUpdate: (patch: Partial<MetricsMonitorFormState>) => void;
-}>(({ form, onUpdate }) => (
-  <EuiAccordion
-    id="prom-evaluation-settings"
-    buttonContent={
-      <strong>
-        {i18n.translate('observability.alerting.createMetricsMonitor.evaluationSettingsTitle', {
-          defaultMessage: 'Evaluation settings',
-        })}
-      </strong>
-    }
-    initialIsOpen={false}
-    paddingSize="m"
-  >
-    <EuiFlexGroup gutterSize="s" wrap>
-      <EuiFlexItem style={{ minWidth: 160 }}>
-        <EuiFormRow
-          label={i18n.translate('observability.alerting.createMetricsMonitor.evalIntervalLabel', {
-            defaultMessage: 'Eval interval',
-          })}
-          helpText={i18n.translate(
-            'observability.alerting.createMetricsMonitor.evalIntervalHelpText',
-            { defaultMessage: 'How often evaluated' }
-          )}
-          display="rowCompressed"
-        >
-          <EuiSelect
-            options={EVAL_INTERVAL_OPTIONS}
-            value={form.evalInterval}
-            onChange={(e) => onUpdate({ evalInterval: e.target.value })}
-            compressed
-            aria-label={i18n.translate(
-              'observability.alerting.createMetricsMonitor.evaluationIntervalAriaLabel',
-              { defaultMessage: 'Evaluation interval' }
-            )}
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem style={{ minWidth: 160 }}>
-        <EuiFormRow
-          label={i18n.translate('observability.alerting.createMetricsMonitor.pendingPeriodLabel', {
-            defaultMessage: 'Pending period',
-          })}
-          helpText={i18n.translate(
-            'observability.alerting.createMetricsMonitor.pendingPeriodHelpText',
-            { defaultMessage: 'Before firing' }
-          )}
-          display="rowCompressed"
-        >
-          <EuiSelect
-            options={EVAL_INTERVAL_OPTIONS}
-            value={form.pendingPeriod}
-            onChange={(e) => onUpdate({ pendingPeriod: e.target.value })}
-            compressed
-            aria-label={i18n.translate(
-              'observability.alerting.createMetricsMonitor.pendingPeriodAriaLabel',
-              { defaultMessage: 'Pending period' }
-            )}
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem style={{ minWidth: 160 }}>
-        <EuiFormRow
-          label={i18n.translate('observability.alerting.createMetricsMonitor.firingPeriodLabel', {
-            defaultMessage: 'Firing period',
-          })}
-          helpText={i18n.translate(
-            'observability.alerting.createMetricsMonitor.firingPeriodHelpText',
-            { defaultMessage: 'Keep firing after condition clears' }
-          )}
-          display="rowCompressed"
-        >
-          <EuiSelect
-            options={FIRING_PERIOD_OPTIONS}
-            value={form.firingPeriod}
-            onChange={(e) => onUpdate({ firingPeriod: e.target.value })}
-            compressed
-            aria-label={i18n.translate(
-              'observability.alerting.createMetricsMonitor.firingPeriodAriaLabel',
-              { defaultMessage: 'Firing period' }
-            )}
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </EuiAccordion>
-));
+      {/* Preview Results */}
+      {showPreview && (
+        <>
+          <EuiSpacer size="m" />
+          <QueryPreviewResults query={form.query} />
+        </>
+      )}
+    </EuiAccordion>
+  );
+});
 
 /** Section 5: Labels */
 const LabelsSection = React.memo<{
@@ -1071,9 +667,8 @@ const RulePreviewSection = React.memo<{
     const labels = form.labels.filter((l) => l.key && l.value);
     const annotations = form.annotations.filter((a) => a.key && a.value);
     let out = `- alert: "${esc(form.monitorName || '<monitor-name>')}"\n`;
-    out += `  expr: "${esc(
-      `${form.query || '<promql-expression>'} ${form.operator} ${form.thresholdValue}`
-    )}"\n`;
+    // The PromQL expression is the complete alert condition
+    out += `  expr: "${esc(form.query || '<promql-expression>')}"\n`;
     out += `  for: ${form.forDuration}\n`;
     if (labels.length > 0) {
       out += `  labels:\n`;
@@ -1088,15 +683,7 @@ const RulePreviewSection = React.memo<{
       }
     }
     return out;
-  }, [
-    form.monitorName,
-    form.query,
-    form.operator,
-    form.thresholdValue,
-    form.forDuration,
-    form.labels,
-    form.annotations,
-  ]);
+  }, [form.monitorName, form.query, form.forDuration, form.labels, form.annotations]);
 
   return (
     <EuiAccordion
@@ -1166,12 +753,8 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
     groupName: '',
     query: DEFAULT_PROMQL,
     datasourceId: contextDatasourceId || '',
-    operator: '>',
-    thresholdValue: 0.05,
     forDuration: '5m',
     evalInterval: '1m',
-    pendingPeriod: '5m',
-    firingPeriod: '0s',
     labels: [{ key: 'severity', value: 'critical', isDynamic: false }],
     annotations: [],
   });
@@ -1227,11 +810,11 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
 
     setIsSaving(true);
     try {
+      // The PromQL expression is the complete alert condition — no
+      // operator/threshold appended server-side.
       const payload = {
         name: form.monitorName,
         query: form.query,
-        operator: form.operator,
-        threshold: form.thresholdValue,
         forDuration: form.forDuration,
         evaluationInterval: form.evalInterval,
         labels: Object.fromEntries(
@@ -1299,15 +882,13 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
         />
         <EuiHorizontalRule margin="l" />
 
-        {/* Section 3: Trigger Condition */}
-        <TriggerConditionSection form={form} onUpdate={updateForm} />
-        <EuiHorizontalRule margin="l" />
+        {/* Trigger condition and per-rule evaluation settings are
+            intentionally absent: the PromQL expression is the complete
+            alert condition, and evaluation cadence is a rule-group-level
+            concern in managed Prometheus. The per-rule `for:` duration
+            lives in the Query section. */}
 
-        {/* Section 4: Evaluation Settings */}
-        <EvaluationSettingsSection form={form} onUpdate={updateForm} />
-        <EuiHorizontalRule margin="l" />
-
-        {/* Section 5: Labels */}
+        {/* Section 3: Labels */}
         <LabelsSection labels={form.labels} onUpdate={handleLabelsUpdate} />
         <EuiHorizontalRule margin="l" />
 

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -43,8 +43,7 @@ import {
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { EchartsRender } from './echarts_render';
-import { PromQLEditor } from './promql_editor';
-import { MetricBrowser } from './metric_browser';
+import { PromQueryBuilder } from './create_monitor/prom_query_builder';
 
 // ============================================================================
 // Types
@@ -61,14 +60,11 @@ interface AnnotationEntry {
   value: string;
 }
 
-interface ActionState {
-  id: string;
-  name: string;
-}
-
 export interface MetricsMonitorFormState {
   monitorName: string;
   description: string;
+  namespace: string;
+  groupName: string;
   query: string;
   datasourceId: string;
   // Trigger condition
@@ -82,8 +78,6 @@ export interface MetricsMonitorFormState {
   // Labels & annotations
   labels: LabelEntry[];
   annotations: AnnotationEntry[];
-  // Actions
-  actions: ActionState[];
 }
 
 export interface CreateMetricsMonitorProps {
@@ -279,33 +273,6 @@ const EVAL_INTERVAL_OPTIONS = [
   },
 ];
 
-const MOCK_SAMPLE_QUERIES = [
-  {
-    label: i18n.translate('observability.alerting.createMetricsMonitor.sampleHighCpu', {
-      defaultMessage: 'High CPU usage',
-    }),
-    query: 'rate(node_cpu_seconds_total{mode!="idle"}[5m]) > 0.8',
-  },
-  {
-    label: i18n.translate('observability.alerting.createMetricsMonitor.sampleHighMemory', {
-      defaultMessage: 'High memory usage',
-    }),
-    query: '(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) > 0.9',
-  },
-  {
-    label: i18n.translate('observability.alerting.createMetricsMonitor.sampleHighErrorRate', {
-      defaultMessage: 'High error rate',
-    }),
-    query: 'rate(http_requests_total{status=~"5.."}[5m]) / rate(http_requests_total[5m]) > 0.05',
-  },
-  {
-    label: i18n.translate('observability.alerting.createMetricsMonitor.sampleDiskFull', {
-      defaultMessage: 'Disk almost full',
-    }),
-    query: '(1 - node_filesystem_avail_bytes / node_filesystem_size_bytes) > 0.85',
-  },
-];
-
 const DEFAULT_PROMQL = 'rate(http_requests_total{status=~"5.."}[5m])';
 
 // Mock preview data — line chart
@@ -379,6 +346,41 @@ const MonitorDetailsSection = React.memo<{
     paddingSize="m"
   >
     <EuiFormRow
+      label={i18n.translate('observability.alerting.createMetricsMonitor.namespaceLabel', {
+        defaultMessage: 'Namespace',
+      })}
+      helpText={i18n.translate('observability.alerting.createMetricsMonitor.namespaceHelp', {
+        defaultMessage:
+          'Logical grouping for rule groups. All rules created here are stored under the "observability-alerting" namespace.',
+      })}
+      fullWidth
+    >
+      <EuiFieldText value="observability-alerting" readOnly fullWidth compressed />
+    </EuiFormRow>
+    <EuiSpacer size="m" />
+    <EuiFormRow
+      label={i18n.translate('observability.alerting.createMetricsMonitor.groupNameLabel', {
+        defaultMessage: 'Rule group',
+      })}
+      helpText={i18n.translate('observability.alerting.createMetricsMonitor.groupNameHelp', {
+        defaultMessage:
+          'Rules within a group share an evaluation interval and are evaluated together.',
+      })}
+      fullWidth
+    >
+      <EuiFieldText
+        placeholder={i18n.translate(
+          'observability.alerting.createMetricsMonitor.groupNamePlaceholder',
+          { defaultMessage: 'Enter a rule group name (defaults to rule name)' }
+        )}
+        value={form.groupName}
+        onChange={(e) => onUpdate({ groupName: e.target.value })}
+        fullWidth
+        compressed
+      />
+    </EuiFormRow>
+    <EuiSpacer size="m" />
+    <EuiFormRow
       label={i18n.translate('observability.alerting.createMetricsMonitor.monitorNameLabel', {
         defaultMessage: 'Rule name',
       })}
@@ -399,6 +401,15 @@ const MonitorDetailsSection = React.memo<{
         )}
       />
     </EuiFormRow>
+    <EuiSpacer size="s" />
+    <EuiText size="xs" color="subdued">
+      {i18n.translate('observability.alerting.createMetricsMonitor.hierarchyExplanation', {
+        defaultMessage:
+          'Prometheus rules are organized as: Namespace → Rule Group → Rule. ' +
+          'A namespace contains one or more rule groups, and each group contains one or more rules ' +
+          'that share the same evaluation interval.',
+      })}
+    </EuiText>
     <EuiSpacer size="m" />
     <EuiFormRow
       label={
@@ -444,8 +455,6 @@ const QuerySection = React.memo<{
   onRunPreview: () => void;
   contextDatasourceName?: string;
 }>(({ form, onUpdate, showPreview, onRunPreview, contextDatasourceName }) => {
-  const [showMetricBrowser, setShowMetricBrowser] = useState(false);
-  const [showQueryLibrary, setShowQueryLibrary] = useState(false);
   const [showDatasourcePicker, setShowDatasourcePicker] = useState(false);
 
   // Use the real datasource from the Explore page context. When no
@@ -466,19 +475,6 @@ const QuerySection = React.memo<{
             defaultMessage: 'No Prometheus datasource attached',
           }),
         };
-
-  const handleMetricSelect = (metricName: string) => {
-    const newQuery = form.query
-      ? form.query + (form.query.endsWith(' ') ? '' : ' ') + metricName
-      : metricName;
-    onUpdate({ query: newQuery });
-    setShowMetricBrowser(false);
-  };
-
-  const handleQueryLibrarySelect = (query: string) => {
-    onUpdate({ query });
-    setShowQueryLibrary(false);
-  };
 
   return (
     <EuiAccordion
@@ -560,127 +556,19 @@ const QuerySection = React.memo<{
               ))}
             </EuiPopover>
           </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiPopover
-              button={
-                <EuiButtonEmpty
-                  size="xs"
-                  iconType="starEmpty"
-                  iconSide="left"
-                  onClick={() => setShowQueryLibrary(!showQueryLibrary)}
-                  aria-label={i18n.translate(
-                    'observability.alerting.createMetricsMonitor.queryLibraryAriaLabel',
-                    { defaultMessage: 'Query library' }
-                  )}
-                >
-                  <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-                    <EuiFlexItem grow={false}>
-                      {i18n.translate(
-                        'observability.alerting.createMetricsMonitor.queryLibraryLabel',
-                        { defaultMessage: 'Query library' }
-                      )}
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiIcon type="arrowDown" size="s" />
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiButtonEmpty>
-              }
-              isOpen={showQueryLibrary}
-              closePopover={() => setShowQueryLibrary(false)}
-              panelPaddingSize="s"
-            >
-              {MOCK_SAMPLE_QUERIES.map((sq, i) => (
-                <EuiButtonEmpty
-                  key={i}
-                  size="xs"
-                  onClick={() => handleQueryLibrarySelect(sq.query)}
-                  style={{ display: 'block', width: '100%', textAlign: 'left' }}
-                >
-                  {sq.label}
-                </EuiButtonEmpty>
-              ))}
-            </EuiPopover>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiPopover
-              button={
-                <EuiButtonEmpty
-                  size="xs"
-                  onClick={() => setShowMetricBrowser(!showMetricBrowser)}
-                  aria-label={i18n.translate(
-                    'observability.alerting.createMetricsMonitor.metricBrowserAriaLabel',
-                    { defaultMessage: 'Metric browser' }
-                  )}
-                >
-                  <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-                    <EuiFlexItem grow={false}>
-                      {i18n.translate(
-                        'observability.alerting.createMetricsMonitor.metricBrowserLabel',
-                        { defaultMessage: 'Metric browser' }
-                      )}
-                    </EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiIcon type="arrowDown" size="s" />
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiButtonEmpty>
-              }
-              isOpen={showMetricBrowser}
-              closePopover={() => setShowMetricBrowser(false)}
-              panelPaddingSize="s"
-              style={{ width: 600 }}
-            >
-              <div style={{ width: 560, maxHeight: 400, overflow: 'auto' }}>
-                <MetricBrowser
-                  onSelectMetric={handleMetricSelect}
-                  currentQuery={form.query}
-                  datasourceId={form.datasourceId}
-                />
-              </div>
-            </EuiPopover>
-          </EuiFlexItem>
         </EuiFlexGroup>
 
-        <EuiSpacer size="s" />
+        <EuiSpacer size="m" />
 
-        {/* PromQL editor */}
-        <div style={{ position: 'relative' }}>
-          <PromQLEditor
-            value={form.query}
-            onChange={(v) => onUpdate({ query: v })}
-            height={56}
-            showLineNumbers
-            hideToolbar
-          />
-          <div
-            style={{ position: 'absolute', top: 4, right: 4, zIndex: 2, display: 'flex', gap: 2 }}
-          >
-            <EuiToolTip
-              content={i18n.translate(
-                'observability.alerting.createMetricsMonitor.copyQueryTooltip',
-                { defaultMessage: 'Copy query' }
-              )}
-            >
-              <EuiButtonIcon
-                iconType="copy"
-                size="s"
-                color="subdued"
-                onClick={() => {
-                  try {
-                    navigator.clipboard.writeText(form.query);
-                  } catch (_) {
-                    /* clipboard unavailable */
-                  }
-                }}
-                aria-label={i18n.translate(
-                  'observability.alerting.createMetricsMonitor.copyQueryAriaLabel',
-                  { defaultMessage: 'Copy query' }
-                )}
-              />
-            </EuiToolTip>
-          </div>
-        </div>
+        {/* Point-and-click builder — same component as the Alert Manager
+            "Create metrics rule" flyout. Seeds from the pre-filled Explore
+            query when it is builder-representable; complex expressions leave
+            the builder inert so the seeded query is preserved. */}
+        <PromQueryBuilder
+          datasourceId={form.datasourceId}
+          query={form.query}
+          onQueryChange={(q) => onUpdate({ query: q })}
+        />
       </EuiPanel>
 
       {/* Preview Results */}
@@ -1174,100 +1062,6 @@ const AnnotationsSection = React.memo<{
     </EuiAccordion>
   );
 });
-
-/** Section 7: Matched Notification Actions */
-const ActionsSection = React.memo<{
-  actions: ActionState[];
-  onDeleteAction: (id: string) => void;
-  onAddAction: () => void;
-}>(({ actions, onDeleteAction, onAddAction }) => (
-  <section
-    aria-label={i18n.translate(
-      'observability.alerting.createMetricsMonitor.matchedActionsAriaLabel',
-      { defaultMessage: 'Matched notification actions' }
-    )}
-  >
-    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-      <EuiFlexItem grow={false}>
-        <EuiTitle size="xs">
-          <h3>
-            <FormattedMessage
-              id="observability.alerting.createMetricsMonitor.matchedActionsTitle"
-              defaultMessage="Matched notification actions ({count})"
-              values={{ count: actions.length }}
-            />
-          </h3>
-        </EuiTitle>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-    <EuiSpacer size="s" />
-    {actions.map((action, idx) => (
-      <React.Fragment key={action.id}>
-        {idx > 0 && <EuiSpacer size="xs" />}
-        <EuiPanel paddingSize="s" hasBorder>
-          <EuiAccordion
-            id={`action-${action.id}`}
-            buttonContent={
-              <span>
-                {idx + 1}. {action.name}
-              </span>
-            }
-            paddingSize="s"
-            extraAction={
-              <EuiButtonEmpty
-                size="xs"
-                color="danger"
-                onClick={() => onDeleteAction(action.id)}
-                aria-label={i18n.translate(
-                  'observability.alerting.createMetricsMonitor.deleteActionAriaLabel',
-                  { defaultMessage: 'Delete action {name}', values: { name: action.name } }
-                )}
-              >
-                {i18n.translate('observability.alerting.createMetricsMonitor.deleteActionButton', {
-                  defaultMessage: 'Delete',
-                })}
-              </EuiButtonEmpty>
-            }
-          >
-            <EuiCallOut
-              size="s"
-              color="primary"
-              iconType="iInCircle"
-              title={i18n.translate(
-                'observability.alerting.createMetricsMonitor.comingSoonCalloutTitle',
-                { defaultMessage: 'Coming soon' }
-              )}
-            >
-              <EuiText size="xs">
-                {i18n.translate(
-                  'observability.alerting.createMetricsMonitor.comingSoonCalloutBody',
-                  {
-                    defaultMessage:
-                      'Full action configuration (notification channel, message template, throttling) will be available in a future update.',
-                  }
-                )}
-              </EuiText>
-            </EuiCallOut>
-          </EuiAccordion>
-        </EuiPanel>
-      </React.Fragment>
-    ))}
-    <EuiSpacer size="s" />
-    <EuiButtonEmpty
-      size="s"
-      iconType="plusInCircle"
-      onClick={onAddAction}
-      aria-label={i18n.translate('observability.alerting.createMetricsMonitor.addActionAriaLabel', {
-        defaultMessage: 'Add another action',
-      })}
-    >
-      {i18n.translate('observability.alerting.createMetricsMonitor.addActionButton', {
-        defaultMessage: 'Add another action',
-      })}
-    </EuiButtonEmpty>
-  </section>
-));
-
 /** Section 8: Rule Preview (YAML) */
 const RulePreviewSection = React.memo<{
   form: MetricsMonitorFormState;
@@ -1368,6 +1162,8 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
   const [form, setForm] = useState<MetricsMonitorFormState>({
     monitorName: '',
     description: '',
+    namespace: 'default',
+    groupName: '',
     query: DEFAULT_PROMQL,
     datasourceId: contextDatasourceId || '',
     operator: '>',
@@ -1378,7 +1174,6 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
     firingPeriod: '0s',
     labels: [{ key: 'severity', value: 'critical', isDynamic: false }],
     annotations: [],
-    actions: [],
   });
   const [showPreview, setShowPreview] = useState(false);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
@@ -1402,34 +1197,15 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
     setForm((prev) => ({ ...prev, ...patch }));
   }, []);
 
-  const handleLabelsUpdate = useCallback((labels: LabelEntry[]) => updateForm({ labels }), [
-    updateForm,
-  ]);
+  const handleLabelsUpdate = useCallback(
+    (labels: LabelEntry[]) => updateForm({ labels }),
+    [updateForm]
+  );
 
   const handleAnnotationsUpdate = useCallback(
     (annotations: AnnotationEntry[]) => updateForm({ annotations }),
     [updateForm]
   );
-
-  const deleteAction = useCallback((id: string) => {
-    setForm((prev) => ({
-      ...prev,
-      actions: prev.actions.filter((a) => a.id !== id),
-    }));
-  }, []);
-
-  const addAction = useCallback(() => {
-    setForm((prev) => ({
-      ...prev,
-      actions: [
-        ...prev.actions,
-        {
-          id: `action-${Date.now()}-${prev.actions.length}`,
-          name: `action_${prev.actions.length + 1}`,
-        },
-      ],
-    }));
-  }, []);
 
   const handleRunPreview = useCallback(() => {
     setShowPreview(true);
@@ -1465,7 +1241,7 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
           form.annotations.filter((a) => a.key.trim()).map((a) => [a.key, a.value])
         ),
         enabled: true,
-        groupName: form.monitorName,
+        groupName: form.groupName || form.monitorName,
       };
       await http.post(`/api/alerting/prometheus/${encodeURIComponent(form.datasourceId)}/rules`, {
         body: JSON.stringify(payload),
@@ -1539,15 +1315,10 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
         <AnnotationsSection annotations={form.annotations} onUpdate={handleAnnotationsUpdate} />
         <EuiHorizontalRule margin="l" />
 
-        {/* Section 7: Matched Notification Actions */}
-        <ActionsSection
-          actions={form.actions}
-          onDeleteAction={deleteAction}
-          onAddAction={addAction}
-        />
-        <EuiHorizontalRule margin="l" />
+        {/* Notification actions are intentionally absent: routing for
+            Prometheus alerts is Alertmanager's job, driven by labels. */}
 
-        {/* Section 8: Rule Preview (YAML) */}
+        {/* Section 7: Rule Preview (YAML) */}
         <RulePreviewSection form={form} />
       </EuiFlyoutBody>
 

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -31,12 +31,15 @@ import {
   EuiFlyoutFooter,
   EuiTitle,
   EuiHorizontalRule,
+  EuiLink,
+  EuiToolTip,
   EuiPopover,
   EuiIcon,
   EuiBetaBadge,
   EuiConfirmModal,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
+import { coreRefs } from '../../framework/core_refs';
 import { PromQueryBuilder } from './create_monitor/prom_query_builder';
 import { RuleGroupSelector } from './create_monitor/rule_group_selector';
 import { QueryPreviewResults } from './query_preview_results';
@@ -82,6 +85,14 @@ export interface CreateMetricsMonitorProps {
    * by the Alert Manager Rules page which knows the existing rules.
    */
   isNameTaken?: (name: string, dsId: string) => boolean;
+  /**
+   * Show the "Build query in metrics →" round-trip link in the Query
+   * section header. Set by the Alert Manager Rules page; must stay off on
+   * the Metrics Explore page, where the link would be a circular hop back
+   * to the page the user came from (same rationale as the logs flyout's
+   * hideBuildInLogsLink, inverted).
+   */
+  showBuildInMetricsLink?: boolean;
   /** HTTP client for persisting rules */
   http?: {
     post: (path: string, options: { body: string }) => Promise<unknown>;
@@ -268,168 +279,211 @@ const QuerySection = React.memo<{
   contextDatasourceName?: string;
   /** Selectable datasources (Alert Manager); absent = pinned context ds. */
   datasources?: Array<{ id: string; name: string; type: string }>;
-}>(({ form, onUpdate, showPreview, onRunPreview, contextDatasourceName, datasources }) => {
-  const [showDatasourcePicker, setShowDatasourcePicker] = useState(false);
+  /** Render the "Build query in metrics →" link (Alert Manager only). */
+  showBuildInMetricsLink?: boolean;
+}>(
+  ({
+    form,
+    onUpdate,
+    showPreview,
+    onRunPreview,
+    contextDatasourceName,
+    datasources,
+    showBuildInMetricsLink,
+  }) => {
+    const [showDatasourcePicker, setShowDatasourcePicker] = useState(false);
 
-  // With an explicit datasource list (Alert Manager) the picker offers all
-  // Prometheus datasources; otherwise it is pinned to the Explore page's
-  // context datasource.
-  const datasourceOptions = useMemo(() => {
-    if (datasources && datasources.length > 0) {
-      return datasources
-        .filter((ds) => ds.type === 'prometheus')
-        .map((ds) => ({ id: ds.id, name: ds.name }));
-    }
-    if (form.datasourceId) {
-      return [{ id: form.datasourceId, name: contextDatasourceName || form.datasourceId }];
-    }
-    return [];
-  }, [datasources, form.datasourceId, contextDatasourceName]);
-
-  const selectedDs = datasourceOptions.find((ds) => ds.id === form.datasourceId) ||
-    datasourceOptions[0] || {
-      id: '',
-      name: i18n.translate('observability.alerting.createMetricsMonitor.noDatasourceAttached', {
-        defaultMessage: 'No Prometheus datasource attached',
-      }),
-    };
-
-  return (
-    <EuiAccordion
-      id="prom-query-section"
-      buttonContent={
-        <strong>
-          {i18n.translate('observability.alerting.createMetricsMonitor.queryTitle', {
-            defaultMessage: 'Query',
-          })}
-        </strong>
+    // With an explicit datasource list (Alert Manager) the picker offers all
+    // Prometheus datasources; otherwise it is pinned to the Explore page's
+    // context datasource.
+    const datasourceOptions = useMemo(() => {
+      if (datasources && datasources.length > 0) {
+        return datasources
+          .filter((ds) => ds.type === 'prometheus')
+          .map((ds) => ({ id: ds.id, name: ds.name }));
       }
-      initialIsOpen
-      paddingSize="m"
-      extraAction={
-        <EuiButton
-          size="s"
-          onClick={onRunPreview}
-          aria-label={i18n.translate(
-            'observability.alerting.createMetricsMonitor.runPreviewAriaLabel',
-            { defaultMessage: 'Run preview' }
-          )}
-        >
-          {i18n.translate('observability.alerting.createMetricsMonitor.runPreviewButton', {
-            defaultMessage: 'Run preview',
-          })}
-        </EuiButton>
+      if (form.datasourceId) {
+        return [{ id: form.datasourceId, name: contextDatasourceName || form.datasourceId }];
       }
-    >
-      {/* Toolbar: language badge, datasource, query library, metric browser */}
-      <EuiPanel paddingSize="s" hasBorder style={{ borderRadius: 4 }}>
-        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
-          <EuiFlexItem grow={false}>
-            <EuiBetaBadge
-              label="PromQL"
-              tooltipContent={i18n.translate(
-                'observability.alerting.createMetricsMonitor.promqlTooltip',
-                { defaultMessage: 'Prometheus Query Language' }
-              )}
-              size="s"
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiPopover
-              button={
-                <EuiButtonEmpty
-                  size="xs"
-                  iconType="database"
-                  iconSide="left"
-                  onClick={() => setShowDatasourcePicker(!showDatasourcePicker)}
-                  aria-label={i18n.translate(
-                    'observability.alerting.createMetricsMonitor.pickDatasourceAriaLabel',
-                    { defaultMessage: 'Pick data source' }
+      return [];
+    }, [datasources, form.datasourceId, contextDatasourceName]);
+
+    const selectedDs = datasourceOptions.find((ds) => ds.id === form.datasourceId) ||
+      datasourceOptions[0] || {
+        id: '',
+        name: i18n.translate('observability.alerting.createMetricsMonitor.noDatasourceAttached', {
+          defaultMessage: 'No Prometheus datasource attached',
+        }),
+      };
+
+    return (
+      <EuiAccordion
+        id="prom-query-section"
+        buttonContent={
+          <strong>
+            {i18n.translate('observability.alerting.createMetricsMonitor.queryTitle', {
+              defaultMessage: 'Query',
+            })}
+          </strong>
+        }
+        initialIsOpen
+        paddingSize="m"
+        extraAction={
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            {showBuildInMetricsLink && (
+              <EuiFlexItem grow={false}>
+                {/* Mirrors the logs flyout's "Build query in logs →" round-trip:
+                  author/validate the query against live data in the Metrics
+                  app, then return via its Create alert rule action. Same-tab
+                  navigation — unsaved form state here is lost. */}
+                <EuiToolTip
+                  position="left"
+                  content={i18n.translate(
+                    'observability.alerting.createMetricsMonitor.openInMetricsTooltip',
+                    {
+                      defaultMessage:
+                        'Build and validate your query against live data in metrics, then click Create alert rule to come back here pre-filled. Unsaved changes will be lost.',
+                    }
                   )}
                 >
-                  <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
-                    <EuiFlexItem grow={false}>{selectedDs.name}</EuiFlexItem>
-                    <EuiFlexItem grow={false}>
-                      <EuiIcon type="arrowDown" size="s" />
-                    </EuiFlexItem>
-                  </EuiFlexGroup>
-                </EuiButtonEmpty>
-              }
-              isOpen={showDatasourcePicker}
-              closePopover={() => setShowDatasourcePicker(false)}
-              panelPaddingSize="s"
-            >
-              {datasourceOptions.map((ds) => (
-                <EuiButtonEmpty
-                  key={ds.id}
-                  size="xs"
-                  onClick={() => {
-                    onUpdate({ datasourceId: ds.id });
-                    setShowDatasourcePicker(false);
-                  }}
-                  style={{ display: 'block', width: '100%', textAlign: 'left' }}
-                >
-                  {ds.name}
-                </EuiButtonEmpty>
-              ))}
-            </EuiPopover>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+                  <EuiLink
+                    onClick={() => coreRefs?.application?.navigateToApp('explore/metrics')}
+                    data-test-subj="alertManagerOpenInMetricsLink"
+                  >
+                    {i18n.translate('observability.alerting.createMetricsMonitor.openInMetrics', {
+                      defaultMessage: 'Build query in metrics →',
+                    })}
+                  </EuiLink>
+                </EuiToolTip>
+              </EuiFlexItem>
+            )}
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                size="s"
+                onClick={onRunPreview}
+                aria-label={i18n.translate(
+                  'observability.alerting.createMetricsMonitor.runPreviewAriaLabel',
+                  { defaultMessage: 'Run preview' }
+                )}
+              >
+                {i18n.translate('observability.alerting.createMetricsMonitor.runPreviewButton', {
+                  defaultMessage: 'Run preview',
+                })}
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+      >
+        {/* Toolbar: language badge, datasource, query library, metric browser */}
+        <EuiPanel paddingSize="s" hasBorder style={{ borderRadius: 4 }}>
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+            <EuiFlexItem grow={false}>
+              <EuiBetaBadge
+                label="PromQL"
+                tooltipContent={i18n.translate(
+                  'observability.alerting.createMetricsMonitor.promqlTooltip',
+                  { defaultMessage: 'Prometheus Query Language' }
+                )}
+                size="s"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiPopover
+                button={
+                  <EuiButtonEmpty
+                    size="xs"
+                    iconType="database"
+                    iconSide="left"
+                    onClick={() => setShowDatasourcePicker(!showDatasourcePicker)}
+                    aria-label={i18n.translate(
+                      'observability.alerting.createMetricsMonitor.pickDatasourceAriaLabel',
+                      { defaultMessage: 'Pick data source' }
+                    )}
+                  >
+                    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                      <EuiFlexItem grow={false}>{selectedDs.name}</EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiIcon type="arrowDown" size="s" />
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  </EuiButtonEmpty>
+                }
+                isOpen={showDatasourcePicker}
+                closePopover={() => setShowDatasourcePicker(false)}
+                panelPaddingSize="s"
+              >
+                {datasourceOptions.map((ds) => (
+                  <EuiButtonEmpty
+                    key={ds.id}
+                    size="xs"
+                    onClick={() => {
+                      onUpdate({ datasourceId: ds.id });
+                      setShowDatasourcePicker(false);
+                    }}
+                    style={{ display: 'block', width: '100%', textAlign: 'left' }}
+                  >
+                    {ds.name}
+                  </EuiButtonEmpty>
+                ))}
+              </EuiPopover>
+            </EuiFlexItem>
+          </EuiFlexGroup>
 
-        <EuiSpacer size="m" />
+          <EuiSpacer size="m" />
 
-        {/* Point-and-click builder — same component as the Alert Manager
+          {/* Point-and-click builder — same component as the Alert Manager
             "Create metrics rule" flyout. Seeds from the pre-filled Explore
             query when it is builder-representable; complex expressions leave
             the builder inert so the seeded query is preserved. */}
-        <PromQueryBuilder
-          datasourceId={form.datasourceId}
-          query={form.query}
-          onQueryChange={(q) => onUpdate({ query: q })}
-        />
+          <PromQueryBuilder
+            datasourceId={form.datasourceId}
+            query={form.query}
+            onQueryChange={(q) => onUpdate({ query: q })}
+          />
 
-        <EuiSpacer size="m" />
+          <EuiSpacer size="m" />
 
-        {/* For duration — the rule's `for:` clause. Kept per-rule (unlike
+          {/* For duration — the rule's `for:` clause. Kept per-rule (unlike
             the group-level evaluation interval): the condition must hold
             continuously for this long before the alert fires. */}
-        <EuiFormRow
-          label={i18n.translate('observability.alerting.createMetricsMonitor.forDurationLabel', {
-            defaultMessage: 'For duration',
-          })}
-          helpText={i18n.translate(
-            'observability.alerting.createMetricsMonitor.forDurationHelpText',
-            {
-              defaultMessage:
-                'How long the condition must stay true before the alert fires. The alert is "pending" during this window.',
-            }
-          )}
-          display="rowCompressed"
-        >
-          <EuiSelect
-            options={FOR_DURATION_OPTIONS}
-            value={form.forDuration}
-            onChange={(e) => onUpdate({ forDuration: e.target.value })}
-            compressed
-            aria-label={i18n.translate(
-              'observability.alerting.createMetricsMonitor.forDurationAriaLabel',
-              { defaultMessage: 'For duration' }
+          <EuiFormRow
+            label={i18n.translate('observability.alerting.createMetricsMonitor.forDurationLabel', {
+              defaultMessage: 'For duration',
+            })}
+            helpText={i18n.translate(
+              'observability.alerting.createMetricsMonitor.forDurationHelpText',
+              {
+                defaultMessage:
+                  'How long the condition must stay true before the alert fires. The alert is "pending" during this window.',
+              }
             )}
-            data-test-subj="metricsMonitorForDurationSelect"
-          />
-        </EuiFormRow>
-      </EuiPanel>
+            display="rowCompressed"
+          >
+            <EuiSelect
+              options={FOR_DURATION_OPTIONS}
+              value={form.forDuration}
+              onChange={(e) => onUpdate({ forDuration: e.target.value })}
+              compressed
+              aria-label={i18n.translate(
+                'observability.alerting.createMetricsMonitor.forDurationAriaLabel',
+                { defaultMessage: 'For duration' }
+              )}
+              data-test-subj="metricsMonitorForDurationSelect"
+            />
+          </EuiFormRow>
+        </EuiPanel>
 
-      {/* Preview Results */}
-      {showPreview && (
-        <>
-          <EuiSpacer size="m" />
-          <QueryPreviewResults query={form.query} />
-        </>
-      )}
-    </EuiAccordion>
-  );
-});
+        {/* Preview Results */}
+        {showPreview && (
+          <>
+            <EuiSpacer size="m" />
+            <QueryPreviewResults query={form.query} />
+          </>
+        )}
+      </EuiAccordion>
+    );
+  }
+);
 
 /** Section 5: Labels — shared LabelEditor keeps parity with the Alert Manager flyout */
 const LabelsSection = React.memo<{
@@ -649,6 +703,7 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
   datasourceName: contextDatasourceName,
   datasources,
   isNameTaken,
+  showBuildInMetricsLink,
   http,
   addToast,
 }) => {
@@ -814,6 +869,7 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
           onRunPreview={handleRunPreview}
           contextDatasourceName={contextDatasourceName}
           datasources={datasources}
+          showBuildInMetricsLink={showBuildInMetricsLink}
         />
         <EuiHorizontalRule margin="l" />
 

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -71,6 +71,17 @@ export interface CreateMetricsMonitorProps {
   datasourceId?: string;
   /** Datasource display name from the current Explore page context */
   datasourceName?: string;
+  /**
+   * Selectable Prometheus datasources. Provided by the Alert Manager Rules
+   * page (no page context there); when absent, the flyout is pinned to the
+   * context datasource (Metrics Explore page behavior).
+   */
+  datasources?: Array<{ id: string; name: string; type: string }>;
+  /**
+   * Duplicate-name guard, checked against the selected datasource. Provided
+   * by the Alert Manager Rules page which knows the existing rules.
+   */
+  isNameTaken?: (name: string, dsId: string) => boolean;
   /** HTTP client for persisting rules */
   http?: {
     post: (path: string, options: { body: string }) => Promise<unknown>;
@@ -132,7 +143,9 @@ const DEFAULT_PROMQL = 'rate(http_requests_total{status=~"5.."}[5m])';
 const MonitorDetailsSection = React.memo<{
   form: MetricsMonitorFormState;
   onUpdate: (patch: Partial<MetricsMonitorFormState>) => void;
-}>(({ form, onUpdate }) => (
+  /** Duplicate-name error surfaced on the Rule name row. */
+  nameError?: string;
+}>(({ form, onUpdate, nameError }) => (
   <EuiAccordion
     id="prom-monitor-details"
     buttonContent={
@@ -181,12 +194,15 @@ const MonitorDetailsSection = React.memo<{
         defaultMessage: 'Rule name',
       })}
       fullWidth
+      isInvalid={!!nameError}
+      error={nameError}
     >
       <EuiFieldText
         placeholder={i18n.translate(
           'observability.alerting.createMetricsMonitor.monitorNamePlaceholder',
           { defaultMessage: 'Enter a rule name' }
         )}
+        isInvalid={!!nameError}
         value={form.monitorName}
         onChange={(e) => onUpdate({ monitorName: e.target.value })}
         fullWidth
@@ -243,34 +259,40 @@ const MonitorDetailsSection = React.memo<{
   </EuiAccordion>
 ));
 
-/** Section 2: Query — PromQL editor with datasource picker, query library, metric browser */
+/** Section 2: Query — shared PromQL builder with datasource picker */
 const QuerySection = React.memo<{
   form: MetricsMonitorFormState;
   onUpdate: (patch: Partial<MetricsMonitorFormState>) => void;
   showPreview: boolean;
   onRunPreview: () => void;
   contextDatasourceName?: string;
-}>(({ form, onUpdate, showPreview, onRunPreview, contextDatasourceName }) => {
+  /** Selectable datasources (Alert Manager); absent = pinned context ds. */
+  datasources?: Array<{ id: string; name: string; type: string }>;
+}>(({ form, onUpdate, showPreview, onRunPreview, contextDatasourceName, datasources }) => {
   const [showDatasourcePicker, setShowDatasourcePicker] = useState(false);
 
-  // Use the real datasource from the Explore page context. When no
-  // datasource is provided (e.g. standalone usage), show a placeholder.
+  // With an explicit datasource list (Alert Manager) the picker offers all
+  // Prometheus datasources; otherwise it is pinned to the Explore page's
+  // context datasource.
   const datasourceOptions = useMemo(() => {
+    if (datasources && datasources.length > 0) {
+      return datasources
+        .filter((ds) => ds.type === 'prometheus')
+        .map((ds) => ({ id: ds.id, name: ds.name }));
+    }
     if (form.datasourceId) {
       return [{ id: form.datasourceId, name: contextDatasourceName || form.datasourceId }];
     }
     return [];
-  }, [form.datasourceId, contextDatasourceName]);
+  }, [datasources, form.datasourceId, contextDatasourceName]);
 
-  const selectedDs =
-    datasourceOptions.length > 0
-      ? datasourceOptions[0]
-      : {
-          id: '',
-          name: i18n.translate('observability.alerting.createMetricsMonitor.noDatasourceAttached', {
-            defaultMessage: 'No Prometheus datasource attached',
-          }),
-        };
+  const selectedDs = datasourceOptions.find((ds) => ds.id === form.datasourceId) ||
+    datasourceOptions[0] || {
+      id: '',
+      name: i18n.translate('observability.alerting.createMetricsMonitor.noDatasourceAttached', {
+        defaultMessage: 'No Prometheus datasource attached',
+      }),
+    };
 
   return (
     <EuiAccordion
@@ -625,16 +647,22 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
   onSave,
   datasourceId: contextDatasourceId,
   datasourceName: contextDatasourceName,
+  datasources,
+  isNameTaken,
   http,
   addToast,
 }) => {
+  // Without a page-context datasource (Alert Manager), default to the first
+  // Prometheus datasource in the provided list.
+  const defaultDatasourceId =
+    contextDatasourceId || datasources?.find((ds) => ds.type === 'prometheus')?.id || '';
   const [form, setForm] = useState<MetricsMonitorFormState>({
     monitorName: '',
     description: '',
     namespace: 'default',
     groupName: '',
     query: DEFAULT_PROMQL,
-    datasourceId: contextDatasourceId || '',
+    datasourceId: defaultDatasourceId,
     forDuration: '5m',
     evalInterval: '1m',
     // `warning` by default — escalation to `critical` (paging) should be a
@@ -678,8 +706,23 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
     setShowPreview(true);
   }, []);
 
+  const duplicateName = !!(
+    isNameTaken &&
+    form.monitorName.trim() !== '' &&
+    form.datasourceId !== '' &&
+    isNameTaken(form.monitorName.trim(), form.datasourceId)
+  );
+  const nameError = duplicateName
+    ? i18n.translate('observability.alerting.createMetricsMonitor.nameDuplicate', {
+        defaultMessage: 'A rule with this name already exists on the selected datasource.',
+      })
+    : undefined;
+
   const isValid =
-    form.monitorName.trim() !== '' && form.query.trim() !== '' && form.datasourceId !== '';
+    form.monitorName.trim() !== '' &&
+    form.query.trim() !== '' &&
+    form.datasourceId !== '' &&
+    !duplicateName;
 
   const [isSaving, setIsSaving] = useState(false);
 
@@ -704,9 +747,16 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
         labels: Object.fromEntries(
           form.labels.filter((l) => l.key.trim()).map((l) => [l.key, l.value])
         ),
-        annotations: Object.fromEntries(
-          form.annotations.filter((a) => a.key.trim()).map((a) => [a.key, a.value])
-        ),
+        annotations: Object.fromEntries([
+          ...form.annotations
+            .filter((a) => a.key.trim())
+            .map((a) => [a.key, a.value] as [string, string]),
+          // The Rule details Description field persists as the standard
+          // `description` annotation (the server's rule builder reads it)
+          ...(form.description.trim()
+            ? [['description', form.description.trim()] as [string, string]]
+            : []),
+        ]),
         enabled: true,
         groupName: form.groupName || form.monitorName,
       };
@@ -753,7 +803,7 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
 
       <EuiFlyoutBody>
         {/* Section 1: Monitor Details */}
-        <MonitorDetailsSection form={form} onUpdate={updateForm} />
+        <MonitorDetailsSection form={form} onUpdate={updateForm} nameError={nameError} />
         <EuiHorizontalRule margin="l" />
 
         {/* Section 2: Query */}
@@ -763,6 +813,7 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
           showPreview={showPreview}
           onRunPreview={handleRunPreview}
           contextDatasourceName={contextDatasourceName}
+          datasources={datasources}
         />
         <EuiHorizontalRule margin="l" />
 

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -552,8 +552,10 @@ const RulePreviewSection = React.memo<{
     out += `  for: ${form.forDuration}\n`;
     if (labels.length > 0) {
       out += `  labels:\n`;
+      // Template values are single-quoted, matching the server's js-yaml
+      // serialization (unquoted `{{ ... }}` would be invalid YAML)
       for (const l of labels) {
-        out += `    "${esc(l.key)}": ${l.isDynamic ? l.value : `"${esc(l.value)}"`}\n`;
+        out += `    "${esc(l.key)}": ${l.isDynamic ? `'${l.value}'` : `"${esc(l.value)}"`}\n`;
       }
     }
     if (annotations.length > 0) {

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -4,10 +4,16 @@
  */
 
 /**
- * Create Metrics Monitor — flyout form for Prometheus alerting rules.
- * Sections: Monitor Details, Query (PromQL + datasource + metric browser),
- * Trigger Condition, Evaluation Settings, Labels, Annotations,
- * Matched Notification Actions, Rule Preview (YAML), and a sticky footer.
+ * Create Metrics Monitor — the single shared flyout for creating Prometheus
+ * alerting rules, mounted by both the Metrics Explore page ("Create alert
+ * rule" action) and the Alert Manager Rules page.
+ *
+ * Sections: Rule details (namespace / rule group / name / description),
+ * Query (shared PromQL builder + per-rule `for:` duration + Run preview),
+ * Labels, Annotations, Rule Preview (YAML), and a sticky footer. The PromQL
+ * expression is the complete alert condition — there is no separate trigger
+ * condition, and evaluation cadence is a rule-group-level concern in
+ * managed Prometheus.
  */
 import React, { useState, useCallback, useMemo, useRef } from 'react';
 import {
@@ -144,7 +150,8 @@ const FOR_DURATION_OPTIONS = [
   },
 ];
 
-const DEFAULT_PROMQL = 'rate(http_requests_total{status=~"5.."}[5m])';
+/** The namespace all rules created from this flyout are stored under. */
+const USER_RULES_NAMESPACE = 'observability-alerting';
 
 // ============================================================================
 // Sub-components
@@ -158,7 +165,7 @@ const MonitorDetailsSection = React.memo<{
   nameError?: string;
 }>(({ form, onUpdate, nameError }) => (
   <EuiAccordion
-    id="prom-monitor-details"
+    id="cmm-rule-details"
     buttonContent={
       <strong>
         {i18n.translate('observability.alerting.createMetricsMonitor.monitorDetailsTitle', {
@@ -179,7 +186,7 @@ const MonitorDetailsSection = React.memo<{
       })}
       fullWidth
     >
-      <EuiFieldText value="observability-alerting" readOnly fullWidth compressed />
+      <EuiFieldText value={USER_RULES_NAMESPACE} readOnly fullWidth compressed />
     </EuiFormRow>
     <EuiSpacer size="m" />
     <EuiFormRow
@@ -318,7 +325,7 @@ const QuerySection = React.memo<{
 
     return (
       <EuiAccordion
-        id="prom-query-section"
+        id="cmm-query"
         buttonContent={
           <strong>
             {i18n.translate('observability.alerting.createMetricsMonitor.queryTitle', {
@@ -477,7 +484,7 @@ const QuerySection = React.memo<{
         {showPreview && (
           <>
             <EuiSpacer size="m" />
-            <QueryPreviewResults query={form.query} />
+            <QueryPreviewResults id="cmm-preview-results" query={form.query} />
           </>
         )}
       </EuiAccordion>
@@ -491,7 +498,7 @@ const LabelsSection = React.memo<{
   onUpdate: (labels: LabelEntry[]) => void;
 }>(({ labels, onUpdate }) => (
   <EuiAccordion
-    id="prom-labels"
+    id="cmm-labels"
     buttonContent={
       <strong>
         {i18n.translate('observability.alerting.createMetricsMonitor.labelsTitle', {
@@ -528,7 +535,7 @@ const AnnotationsSection = React.memo<{
 
   return (
     <EuiAccordion
-      id="prom-annotations"
+      id="cmm-annotations"
       buttonContent={
         <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
           <EuiFlexItem grow={false}>
@@ -621,7 +628,15 @@ const RulePreviewSection = React.memo<{
   const yaml = useMemo(() => {
     const esc = (s: string) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
     const labels = form.labels.filter((l) => l.key && l.value);
-    const annotations = form.annotations.filter((a) => a.key && a.value);
+    // Mirror the save path: the Rule details Description field persists as
+    // the `description` annotation (and wins over a manually-typed one), so
+    // the preview must show exactly what will be saved
+    const annotations = [
+      ...form.annotations.filter(
+        (a) => a.key && a.value && !(form.description.trim() && a.key === 'description')
+      ),
+      ...(form.description.trim() ? [{ key: 'description', value: form.description.trim() }] : []),
+    ];
     let out = `- alert: "${esc(form.monitorName || '<monitor-name>')}"\n`;
     // The PromQL expression is the complete alert condition
     out += `  expr: "${esc(form.query || '<promql-expression>')}"\n`;
@@ -636,16 +651,26 @@ const RulePreviewSection = React.memo<{
     }
     if (annotations.length > 0) {
       out += `  annotations:\n`;
+      // Annotations lack the isDynamic flag — detect template syntax to
+      // single-quote like the server's js-yaml serialization does
       for (const a of annotations) {
-        out += `    "${esc(a.key)}": "${esc(a.value)}"\n`;
+        const value = /\{\{.*\}\}/.test(a.value) ? `'${a.value}'` : `"${esc(a.value)}"`;
+        out += `    "${esc(a.key)}": ${value}\n`;
       }
     }
     return out;
-  }, [form.monitorName, form.query, form.forDuration, form.labels, form.annotations]);
+  }, [
+    form.monitorName,
+    form.query,
+    form.forDuration,
+    form.labels,
+    form.annotations,
+    form.description,
+  ]);
 
   return (
     <EuiAccordion
-      id="prom-rule-preview"
+      id="cmm-rule-preview"
       buttonContent={
         <strong>
           {i18n.translate('observability.alerting.createMetricsMonitor.rulePreviewTitle', {
@@ -714,9 +739,13 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
   const [form, setForm] = useState<MetricsMonitorFormState>({
     monitorName: '',
     description: '',
-    namespace: 'default',
+    namespace: USER_RULES_NAMESPACE,
     groupName: '',
-    query: DEFAULT_PROMQL,
+    // Empty on purpose: the query must come from an explicit builder
+    // selection. A pre-seeded expression would be submittable while the
+    // builder renders empty (it cannot represent complex expressions),
+    // silently creating a rule for a metric the user never chose.
+    query: '',
     datasourceId: defaultDatasourceId,
     forDuration: '5m',
     evalInterval: '1m',
@@ -727,13 +756,12 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
   });
   const [showPreview, setShowPreview] = useState(false);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
-  const initialFormRef = useRef(form);
+  // JSON snapshot so ANY field edit (description, group, duration,
+  // datasource, label/annotation content) arms the discard-confirm modal —
+  // same approach as the CreateMonitor shell
+  const initialFormJson = useRef(JSON.stringify(form));
 
-  const isDirty =
-    form.monitorName !== '' ||
-    form.query !== initialFormRef.current.query ||
-    form.labels.length !== initialFormRef.current.labels.length ||
-    form.annotations.length !== initialFormRef.current.annotations.length;
+  const isDirty = JSON.stringify(form) !== initialFormJson.current;
 
   const handleClose = useCallback(() => {
     if (isDirty) {

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -17,7 +17,6 @@ import {
   EuiFlexItem,
   EuiFormRow,
   EuiFieldText,
-  EuiFieldNumber,
   EuiTextArea,
   EuiSelect,
   EuiButton,
@@ -32,7 +31,6 @@ import {
   EuiFlyoutFooter,
   EuiTitle,
   EuiHorizontalRule,
-  EuiCallOut,
   EuiSwitch,
   EuiToolTip,
   EuiPopover,
@@ -42,6 +40,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { PromQueryBuilder } from './create_monitor/prom_query_builder';
+import { RuleGroupSelector } from './create_monitor/rule_group_selector';
 import { QueryPreviewResults } from './query_preview_results';
 
 // ============================================================================
@@ -179,15 +178,11 @@ const MonitorDetailsSection = React.memo<{
       })}
       fullWidth
     >
-      <EuiFieldText
-        placeholder={i18n.translate(
-          'observability.alerting.createMetricsMonitor.groupNamePlaceholder',
-          { defaultMessage: 'Enter a rule group name (defaults to rule name)' }
-        )}
+      <RuleGroupSelector
+        datasourceId={form.datasourceId}
         value={form.groupName}
-        onChange={(e) => onUpdate({ groupName: e.target.value })}
-        fullWidth
-        compressed
+        onChange={(groupName) => onUpdate({ groupName })}
+        data-test-subj="metricsMonitorRuleGroupSelector"
       />
     </EuiFormRow>
     <EuiSpacer size="m" />

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -459,7 +459,8 @@ const LabelsSection = React.memo<{
           responsive={false}
           style={{ marginBottom: 4 }}
         >
-          <EuiFlexItem grow={2}>
+          {/* Equal grow keeps the key and value boxes visually aligned */}
+          <EuiFlexItem grow={1}>
             <EuiFieldText
               placeholder={i18n.translate(
                 'observability.alerting.createMetricsMonitor.labelKeyPlaceholder',
@@ -474,7 +475,7 @@ const LabelsSection = React.memo<{
               )}
             />
           </EuiFlexItem>
-          <EuiFlexItem grow={3}>
+          <EuiFlexItem grow={1}>
             <EuiFieldText
               placeholder={
                 label.isDynamic

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -31,8 +31,6 @@ import {
   EuiFlyoutFooter,
   EuiTitle,
   EuiHorizontalRule,
-  EuiSwitch,
-  EuiToolTip,
   EuiPopover,
   EuiIcon,
   EuiBetaBadge,
@@ -42,21 +40,13 @@ import { i18n } from '@osd/i18n';
 import { PromQueryBuilder } from './create_monitor/prom_query_builder';
 import { RuleGroupSelector } from './create_monitor/rule_group_selector';
 import { QueryPreviewResults } from './query_preview_results';
+// Shared label editor + entry types keep both flyouts' Labels sections in sync
+import { LabelEditor } from './monitor_form_components';
+import type { LabelEntry, AnnotationEntry } from '../../../common/services/alerting/validators';
 
 // ============================================================================
 // Types
 // ============================================================================
-
-interface LabelEntry {
-  key: string;
-  value: string;
-  isDynamic: boolean;
-}
-
-interface AnnotationEntry {
-  key: string;
-  value: string;
-}
 
 export interface MetricsMonitorFormState {
   monitorName: string;
@@ -419,139 +409,33 @@ const QuerySection = React.memo<{
   );
 });
 
-/** Section 5: Labels */
+/** Section 5: Labels — shared LabelEditor keeps parity with the Alert Manager flyout */
 const LabelsSection = React.memo<{
   labels: LabelEntry[];
   onUpdate: (labels: LabelEntry[]) => void;
-}>(({ labels, onUpdate }) => {
-  const addLabel = () => onUpdate([...labels, { key: '', value: '', isDynamic: false }]);
-  const removeLabel = (i: number) => onUpdate(labels.filter((_, idx) => idx !== i));
-  const updateLabel = (i: number, patch: Partial<LabelEntry>) => {
-    const next = [...labels];
-    next[i] = { ...next[i], ...patch };
-    onUpdate(next);
-  };
-
-  return (
-    <EuiAccordion
-      id="prom-labels"
-      buttonContent={
-        <strong>
-          {i18n.translate('observability.alerting.createMetricsMonitor.labelsTitle', {
-            defaultMessage: 'Labels',
-          })}
-        </strong>
-      }
-      initialIsOpen
-      paddingSize="m"
-    >
+}>(({ labels, onUpdate }) => (
+  <EuiAccordion
+    id="prom-labels"
+    buttonContent={
+      <strong>
+        {i18n.translate('observability.alerting.createMetricsMonitor.labelsTitle', {
+          defaultMessage: 'Labels',
+        })}
+      </strong>
+    }
+    initialIsOpen
+    paddingSize="m"
+    extraAction={
       <EuiText size="xs" color="subdued">
         {i18n.translate('observability.alerting.createMetricsMonitor.labelsDescription', {
           defaultMessage: 'Categorize and route alerts',
         })}
       </EuiText>
-      <EuiSpacer size="s" />
-      {labels.map((label, i) => (
-        <EuiFlexGroup
-          key={i}
-          gutterSize="s"
-          alignItems="center"
-          responsive={false}
-          style={{ marginBottom: 4 }}
-        >
-          {/* Equal grow keeps the key and value boxes visually aligned */}
-          <EuiFlexItem grow={1}>
-            <EuiFieldText
-              placeholder={i18n.translate(
-                'observability.alerting.createMetricsMonitor.labelKeyPlaceholder',
-                { defaultMessage: 'e.g. severity, team, service' }
-              )}
-              value={label.key}
-              onChange={(e) => updateLabel(i, { key: e.target.value })}
-              compressed
-              aria-label={i18n.translate(
-                'observability.alerting.createMetricsMonitor.labelKeyAriaLabel',
-                { defaultMessage: 'Label key {index}', values: { index: i + 1 } }
-              )}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={1}>
-            <EuiFieldText
-              placeholder={
-                label.isDynamic
-                  ? '{{ $value }}'
-                  : i18n.translate(
-                      'observability.alerting.createMetricsMonitor.labelValuePlaceholder',
-                      { defaultMessage: 'Value' }
-                    )
-              }
-              value={label.value}
-              onChange={(e) => updateLabel(i, { value: e.target.value })}
-              compressed
-              aria-label={i18n.translate(
-                'observability.alerting.createMetricsMonitor.labelValueAriaLabel',
-                { defaultMessage: 'Label value {index}', values: { index: i + 1 } }
-              )}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiToolTip
-              content={
-                label.isDynamic
-                  ? i18n.translate(
-                      'observability.alerting.createMetricsMonitor.labelDynamicTooltip',
-                      { defaultMessage: 'Dynamic (Go template)' }
-                    )
-                  : i18n.translate(
-                      'observability.alerting.createMetricsMonitor.labelStaticTooltip',
-                      { defaultMessage: 'Static value' }
-                    )
-              }
-            >
-              <EuiSwitch
-                label={i18n.translate(
-                  'observability.alerting.createMetricsMonitor.labelDynamicSwitch',
-                  { defaultMessage: 'Dynamic' }
-                )}
-                checked={label.isDynamic}
-                onChange={(e) => updateLabel(i, { isDynamic: e.target.checked })}
-                compressed
-                aria-label={i18n.translate(
-                  'observability.alerting.createMetricsMonitor.labelToggleDynamicAriaLabel',
-                  {
-                    defaultMessage: 'Toggle dynamic for label {index}',
-                    values: { index: i + 1 },
-                  }
-                )}
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="trash"
-              color="danger"
-              size="s"
-              onClick={() => removeLabel(i)}
-              aria-label={i18n.translate(
-                'observability.alerting.createMetricsMonitor.deleteLabelAriaLabel',
-                {
-                  defaultMessage: 'Delete label {label}',
-                  values: { label: label.key || i + 1 },
-                }
-              )}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      ))}
-      <EuiSpacer size="xs" />
-      <EuiButtonEmpty size="xs" iconType="plusInCircle" onClick={addLabel}>
-        {i18n.translate('observability.alerting.createMetricsMonitor.addLabelButton', {
-          defaultMessage: 'Add label',
-        })}
-      </EuiButtonEmpty>
-    </EuiAccordion>
-  );
-});
+    }
+  >
+    <LabelEditor labels={labels} onChange={onUpdate} />
+  </EuiAccordion>
+));
 
 /** Section 6: Annotations */
 const AnnotationsSection = React.memo<{
@@ -751,7 +635,9 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
     datasourceId: contextDatasourceId || '',
     forDuration: '5m',
     evalInterval: '1m',
-    labels: [{ key: 'severity', value: 'critical', isDynamic: false }],
+    // `warning` by default — escalation to `critical` (paging) should be a
+    // deliberate choice, matching the Alert Manager flyout's default
+    labels: [{ key: 'severity', value: 'warning', isDynamic: false }],
     annotations: [],
   });
   const [showPreview, setShowPreview] = useState(false);

--- a/public/components/alerting/create_monitor/create_monitor_types.ts
+++ b/public/components/alerting/create_monitor/create_monitor_types.ts
@@ -117,7 +117,10 @@ export const DEFAULT_PROM_FORM: PrometheusFormState = {
   evaluationInterval: '1m',
   pendingPeriod: '5m',
   firingPeriod: '10m',
-  labels: [{ key: 'severity', value: 'warning', isDynamic: true }],
+  // Severity as a static label — the Prometheus convention Alertmanager
+  // routing matches on (critical/warning/info). `warning` by default so a
+  // new rule never pages anyone unless deliberately escalated.
+  labels: [{ key: 'severity', value: 'warning', isDynamic: false }],
   annotations: [
     { key: 'summary', value: '' },
     { key: 'description', value: '' },

--- a/public/components/alerting/create_monitor/edit_monitor.tsx
+++ b/public/components/alerting/create_monitor/edit_monitor.tsx
@@ -169,7 +169,9 @@ export const EditMonitor: React.FC<EditMonitorProps> = ({
       // label is extracted into groupName (and stripped) on submission.
       const seededLabels = Object.entries(rawLabels)
         .filter(([key]) => key !== '_ruleGroup')
-        .map(([key, value]) => ({ key, value }));
+        // Infer the dynamic flag from template syntax so the editor's bolt
+        // toggle round-trips (the flag is UI-only and never persisted)
+        .map(([key, value]) => ({ key, value, isDynamic: /\{\{.*\}\}/.test(value) }));
       if (data.group) {
         seededLabels.push({ key: '_ruleGroup', value: data.group });
       }

--- a/public/components/alerting/create_monitor/index.tsx
+++ b/public/components/alerting/create_monitor/index.tsx
@@ -179,10 +179,10 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
       ? 'prometheus'
       : 'opensearch'
     : initialBackendType
-    ? initialBackendType
-    : initialDs?.type === 'opensearch'
-    ? 'opensearch'
-    : 'prometheus';
+      ? initialBackendType
+      : initialDs?.type === 'opensearch'
+        ? 'opensearch'
+        : 'prometheus';
 
   const [creationMode, setCreationMode] = useState<CreationMode>('manual');
   const [backendType, setBackendType] = useState<MonitorBackendType>(initialType);
@@ -312,6 +312,58 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
         defaultMessage: 'A rule with this name already exists on the selected datasource.',
       })
     : undefined;
+
+  // Rule name row — built once so the validation/dup-check wiring stays in
+  // the shell. For Prometheus it renders inside the form section's
+  // "Rule details" accordion (mirroring the Metrics page flyout); for Logs
+  // it stays at the top of the flyout.
+  const ruleNameRow = (
+    <EuiFormRow
+      label={i18n.translate('observability.alerting.createMonitor.monitorNameLabel', {
+        defaultMessage: 'Rule name',
+      })}
+      fullWidth
+      isInvalid={
+        duplicateName ||
+        (hasSubmitted && (!!validationErrors.name || activeForm.name.trim() === ''))
+      }
+      error={
+        duplicateNameError ||
+        (hasSubmitted
+          ? validationErrors.name ||
+            (activeForm.name.trim() === ''
+              ? i18n.translate('observability.alerting.createMonitor.nameRequired', {
+                  defaultMessage: 'Name is required',
+                })
+              : undefined)
+          : undefined)
+      }
+    >
+      <EuiFieldText
+        isInvalid={
+          duplicateName ||
+          (hasSubmitted && (!!validationErrors.name || activeForm.name.trim() === ''))
+        }
+        placeholder={
+          backendType === 'prometheus'
+            ? i18n.translate(
+                'observability.alerting.createMonitor.monitorNamePlaceholderPrometheus',
+                { defaultMessage: 'Enter a rule name' }
+              )
+            : i18n.translate(
+                'observability.alerting.createMonitor.monitorNamePlaceholderOpensearch',
+                { defaultMessage: 'e.g. High Error Rate, Disk Usage Alert' }
+              )
+        }
+        value={activeForm.name}
+        onChange={(e) => updateName(e.target.value)}
+        fullWidth
+        aria-label={i18n.translate('observability.alerting.createMonitor.monitorNameAriaLabel', {
+          defaultMessage: 'Rule name',
+        })}
+      />
+    </EuiFormRow>
+  );
   const isValid =
     trimmedName !== '' &&
     activeForm.datasourceId !== '' &&
@@ -417,12 +469,12 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
                       defaultMessage: 'Create metrics rule',
                     })
                 : isEdit
-                ? i18n.translate('observability.alerting.createMonitor.editTitleLogs', {
-                    defaultMessage: 'Edit logs rule',
-                  })
-                : i18n.translate('observability.alerting.createMonitor.titleLogs', {
-                    defaultMessage: 'Create logs rule',
-                  })}
+                  ? i18n.translate('observability.alerting.createMonitor.editTitleLogs', {
+                      defaultMessage: 'Edit logs rule',
+                    })
+                  : i18n.translate('observability.alerting.createMonitor.titleLogs', {
+                      defaultMessage: 'Create logs rule',
+                    })}
             </h2>
           </EuiTitle>
           <EuiSpacer size="s" />
@@ -508,56 +560,14 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
             </>
           )}
 
-          {/* Monitor Name. Severity is intentionally not exposed here — each
-              PPL trigger already carries its own severity, and the form-level
-              severity field was redundant (the saved monitor's severity is
-              derived from its triggers, not from this dropdown). */}
-          <EuiFormRow
-            label={i18n.translate('observability.alerting.createMonitor.monitorNameLabel', {
-              defaultMessage: 'Rule name',
-            })}
-            fullWidth
-            isInvalid={
-              duplicateName ||
-              (hasSubmitted && (!!validationErrors.name || activeForm.name.trim() === ''))
-            }
-            error={
-              duplicateNameError ||
-              (hasSubmitted
-                ? validationErrors.name ||
-                  (activeForm.name.trim() === ''
-                    ? i18n.translate('observability.alerting.createMonitor.nameRequired', {
-                        defaultMessage: 'Name is required',
-                      })
-                    : undefined)
-                : undefined)
-            }
-          >
-            <EuiFieldText
-              placeholder={
-                backendType === 'prometheus'
-                  ? i18n.translate(
-                      'observability.alerting.createMonitor.monitorNamePlaceholderPrometheus',
-                      { defaultMessage: 'e.g. HighCpuUsage, PaymentErrorRate' }
-                    )
-                  : i18n.translate(
-                      'observability.alerting.createMonitor.monitorNamePlaceholderOpensearch',
-                      { defaultMessage: 'e.g. High Error Rate, Disk Usage Alert' }
-                    )
-              }
-              value={activeForm.name}
-              onChange={(e) => updateName(e.target.value)}
-              fullWidth
-              aria-label={i18n.translate(
-                'observability.alerting.createMonitor.monitorNameAriaLabel',
-                {
-                  defaultMessage: 'Rule name',
-                }
-              )}
-            />
-          </EuiFormRow>
-
-          <EuiSpacer size="m" />
+          {/* Monitor Name — rendered here for Logs; inside the Prometheus
+              form section's "Rule details" accordion for metrics rules. */}
+          {backendType !== 'prometheus' && (
+            <>
+              {ruleNameRow}
+              <EuiSpacer size="m" />
+            </>
+          )}
 
           {/* Enabled toggle — full row directly under Monitor Name. The
               footer save button reads this state to decide between
@@ -590,6 +600,7 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
               context={context}
               datasourceId={promForm.datasourceId}
               datasources={datasources.filter((d) => d.type === 'prometheus')}
+              ruleNameField={ruleNameRow}
             />
           ) : (
             <OpenSearchFormSection
@@ -637,16 +648,16 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
                       defaultMessage: 'Creating in Prometheus...',
                     })
                   : isEdit
-                  ? i18n.translate('observability.alerting.createMonitor.saveChangesButton', {
-                      defaultMessage: 'Save Changes',
-                    })
-                  : activeForm.enabled
-                  ? i18n.translate('observability.alerting.createMonitor.saveAndEnableButton', {
-                      defaultMessage: 'Save & enable',
-                    })
-                  : i18n.translate('observability.alerting.createMonitor.saveMonitorButton', {
-                      defaultMessage: 'Save rule',
-                    })}
+                    ? i18n.translate('observability.alerting.createMonitor.saveChangesButton', {
+                        defaultMessage: 'Save Changes',
+                      })
+                    : activeForm.enabled
+                      ? i18n.translate('observability.alerting.createMonitor.saveAndEnableButton', {
+                          defaultMessage: 'Save & enable',
+                        })
+                      : i18n.translate('observability.alerting.createMonitor.saveMonitorButton', {
+                          defaultMessage: 'Save rule',
+                        })}
               </EuiButton>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/components/alerting/create_monitor/prom_query_builder.tsx
+++ b/public/components/alerting/create_monitor/prom_query_builder.tsx
@@ -1,0 +1,283 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * PromQueryBuilder — the shared point-and-click PromQL builder used by both
+ * the Alert Manager "Create metrics rule" flyout and the Metrics page
+ * "Create alert rule" flyout.
+ *
+ * Builds expressions of the shape `metric` or `metric{label OP "value"}`
+ * from live metadata (metric names, label names/values) fetched from the
+ * datasource. Seeds its selections from an existing query when that query
+ * is builder-representable; complex expressions leave the builder empty and
+ * inert so a seeded query is never clobbered unless the user explicitly
+ * picks a new metric.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  EuiButtonIcon,
+  EuiComboBox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSelect,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { AlertingPromResourcesService } from '../query_services/alerting_prom_resources_service';
+
+interface ParsedBuilderQuery {
+  metric: string;
+  labelName?: string;
+  labelOperator?: string;
+  labelValue?: string;
+}
+
+/**
+ * Parse a PromQL expression back into builder selections, when the expression
+ * has the exact shape the builder produces: `metric` or
+ * `metric{label OP "value"}`. Returns null for anything more complex
+ * (aggregations, comparisons, multiple matchers) — those cannot be
+ * represented by the builder, so its fields stay empty and the builder→query
+ * sync stays inert until the user makes a selection.
+ */
+export function parseBuilderQuery(query: string): ParsedBuilderQuery | null {
+  const match = (query || '')
+    .trim()
+    .match(
+      /^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*(=~|!~|!=|=)\s*"((?:[^"\\]|\\.)*)"\s*\})?$/
+    );
+  if (!match) return null;
+  const [, metric, labelName, labelOperator, escapedValue] = match;
+  if (!labelName) return { metric };
+  // Reverse the escaping applied by the builder→query sync
+  const labelValue = escapedValue.replace(/\\(["\\])/g, '$1');
+  return { metric, labelName, labelOperator, labelValue };
+}
+
+export const PromQueryBuilder: React.FC<{
+  /** Datasource to fetch metric/label metadata from. */
+  datasourceId?: string;
+  /** Current query, used to seed builder selections on mount. */
+  query: string;
+  /** Fired whenever builder selections produce (or clear) a query. */
+  onQueryChange: (query: string) => void;
+}> = ({ datasourceId, query, onQueryChange }) => {
+  // Seeded once on mount — complex expressions yield null and an inert builder
+  const [seededBuilder] = useState(() => parseBuilderQuery(query));
+  const [metricOptions, setMetricOptions] = useState<Array<{ label: string }>>([]);
+  const [selectedMetric, setSelectedMetric] = useState<Array<{ label: string }>>(
+    seededBuilder ? [{ label: seededBuilder.metric }] : []
+  );
+  const [labelNameOptions, setLabelNameOptions] = useState<Array<{ label: string }>>([]);
+  const [selectedLabelName, setSelectedLabelName] = useState<Array<{ label: string }>>(
+    seededBuilder?.labelName ? [{ label: seededBuilder.labelName }] : []
+  );
+  const [labelValueOptions, setLabelValueOptions] = useState<Array<{ label: string }>>([]);
+  const [selectedLabelValue, setSelectedLabelValue] = useState<Array<{ label: string }>>(
+    seededBuilder?.labelValue ? [{ label: seededBuilder.labelValue }] : []
+  );
+  const [labelOperator, setLabelOperator] = useState(seededBuilder?.labelOperator || '=');
+
+  // Fetch metric names when datasource changes. The `stale` flag guards
+  // against out-of-order responses overwriting current options.
+  useEffect(() => {
+    if (!datasourceId) return;
+    let stale = false;
+    const service = new AlertingPromResourcesService(datasourceId);
+    service
+      .listMetricNames()
+      .then(({ metrics }) => {
+        if (!stale) setMetricOptions(metrics.map((m) => ({ label: m })));
+      })
+      .catch(() => {
+        /* non-critical */
+      });
+    return () => {
+      stale = true;
+    };
+  }, [datasourceId]);
+
+  // Fetch label names when metric changes
+  useEffect(() => {
+    if (!datasourceId || selectedMetric.length === 0) {
+      setLabelNameOptions([]);
+      return;
+    }
+    let stale = false;
+    const service = new AlertingPromResourcesService(datasourceId);
+    service
+      .listLabelNames(selectedMetric[0].label)
+      .then(({ labels }) => {
+        if (!stale) setLabelNameOptions(labels.map((l) => ({ label: l })));
+      })
+      .catch(() => {
+        /* non-critical */
+      });
+    return () => {
+      stale = true;
+    };
+  }, [datasourceId, selectedMetric]);
+
+  // Fetch label values when label name changes
+  useEffect(() => {
+    if (!datasourceId || selectedLabelName.length === 0) {
+      setLabelValueOptions([]);
+      return;
+    }
+    let stale = false;
+    const metric = selectedMetric.length > 0 ? selectedMetric[0].label : undefined;
+    const selector = metric ? `{__name__="${metric}"}` : undefined;
+    const service = new AlertingPromResourcesService(datasourceId);
+    service
+      .listLabelValues(selectedLabelName[0].label, selector)
+      .then(({ values }) => {
+        if (!stale) setLabelValueOptions(values.map((v) => ({ label: v })));
+      })
+      .catch(() => {
+        /* non-critical */
+      });
+    return () => {
+      stale = true;
+    };
+  }, [datasourceId, selectedLabelName, selectedMetric]);
+
+  // Tracks whether the current query was authored by the builder. Only then
+  // may clearing the metric clear the query — a complex seeded expression
+  // the builder never produced must not be wiped.
+  const builderOwnsQuery = useRef(false);
+
+  const syncBuilderToQuery = useCallback(() => {
+    if (selectedMetric.length === 0) return;
+    const metric = selectedMetric[0].label;
+    let next = metric;
+    if (selectedLabelName.length > 0 && selectedLabelValue.length > 0) {
+      // Escape backslashes and quotes so the value is a valid PromQL string literal
+      const escapedValue = selectedLabelValue[0].label.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      const labelFilter = `${selectedLabelName[0].label}${labelOperator}"${escapedValue}"`;
+      next = `${metric}{${labelFilter}}`;
+    }
+    builderOwnsQuery.current = true;
+    onQueryChange(next);
+  }, [selectedMetric, selectedLabelName, selectedLabelValue, labelOperator, onQueryChange]);
+
+  // Sync when builder field selections change; clearing the metric clears a
+  // builder-authored query so the two stay consistent
+  useEffect(() => {
+    if (selectedMetric.length > 0) {
+      syncBuilderToQuery();
+    } else if (builderOwnsQuery.current) {
+      builderOwnsQuery.current = false;
+      onQueryChange('');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedMetric, selectedLabelName, selectedLabelValue, labelOperator]);
+
+  return (
+    <>
+      <EuiFlexGroup gutterSize="m" alignItems="flexEnd" responsive={false}>
+        <EuiFlexItem grow={3}>
+          <EuiFormRow
+            label={i18n.translate('observability.alerting.promQueryBuilder.metricLabel', {
+              defaultMessage: 'Metric',
+            })}
+            display="rowCompressed"
+          >
+            <EuiComboBox
+              placeholder={i18n.translate(
+                'observability.alerting.promQueryBuilder.metricPlaceholder',
+                { defaultMessage: 'Select metric name' }
+              )}
+              options={metricOptions}
+              selectedOptions={selectedMetric}
+              onChange={(opts) => setSelectedMetric(opts)}
+              singleSelection={{ asPlainText: true }}
+              compressed
+              isClearable
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem grow={3}>
+          <EuiFormRow
+            label={i18n.translate('observability.alerting.promQueryBuilder.labelNameLabel', {
+              defaultMessage: 'Label name',
+            })}
+            display="rowCompressed"
+          >
+            <EuiComboBox
+              placeholder={i18n.translate(
+                'observability.alerting.promQueryBuilder.labelNamePlaceholder',
+                { defaultMessage: 'Label name' }
+              )}
+              options={labelNameOptions}
+              selectedOptions={selectedLabelName}
+              onChange={(opts) => setSelectedLabelName(opts)}
+              singleSelection={{ asPlainText: true }}
+              compressed
+              isClearable
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false} style={{ width: 60 }}>
+          <EuiFormRow label=" " display="rowCompressed">
+            <EuiSelect
+              options={[
+                { value: '=', text: '=' },
+                { value: '!=', text: '!=' },
+                { value: '=~', text: '=~' },
+                { value: '!~', text: '!~' },
+              ]}
+              value={labelOperator}
+              onChange={(e) => setLabelOperator(e.target.value)}
+              compressed
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem grow={3}>
+          <EuiFormRow
+            label={i18n.translate('observability.alerting.promQueryBuilder.labelValueLabel', {
+              defaultMessage: 'Label value',
+            })}
+            display="rowCompressed"
+          >
+            <EuiComboBox
+              placeholder={i18n.translate(
+                'observability.alerting.promQueryBuilder.labelValuePlaceholder',
+                { defaultMessage: 'Label value' }
+              )}
+              options={labelValueOptions}
+              selectedOptions={selectedLabelValue}
+              onChange={(opts) => setSelectedLabelValue(opts)}
+              singleSelection={{ asPlainText: true }}
+              compressed
+              isClearable
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            iconType="cross"
+            aria-label={i18n.translate(
+              'observability.alerting.promQueryBuilder.clearFilterAriaLabel',
+              { defaultMessage: 'Clear filter' }
+            )}
+            color="subdued"
+            onClick={() => {
+              setSelectedLabelName([]);
+              setSelectedLabelValue([]);
+            }}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="s" />
+      <EuiText size="xs" color="subdued">
+        {i18n.translate('observability.alerting.promQueryBuilder.helpText', {
+          defaultMessage: 'Select a metric to start.',
+        })}
+      </EuiText>
+    </>
+  );
+};

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -7,26 +7,29 @@
  * Prometheus form section of the Create Monitor flyout — simplified for
  * managed Prometheus (AMP) customers.
  *
- * The query builder alone defines the alert expression:
- *   - Builder: metric dropdown + label name/value filters
- *   - Rule group configuration
- *   - Labels & annotations
- *   - YAML preview
+ * Section layout mirrors the Metrics page "Create alert rule" flyout:
+ *   - Rule details (namespace, rule group, description)
+ *   - Query (point-and-click builder — the PromQL expression is the
+ *     complete alert condition — plus per-rule `for:` duration)
+ *   - Labels
+ *   - Notification routing guidance (Alertmanager)
+ *   - Annotations
+ *   - Rule Preview (YAML)
  *
  * Removed (not applicable to managed Prometheus):
- *   - "Unit" field in threshold
- *   - "Evaluation Settings" section (managed at rule group level in AMP)
- *   - Trigger condition (the PromQL expression itself defines the condition)
+ *   - "Unit" field / Trigger condition (the query defines the condition)
+ *   - "Evaluation Settings" (managed at rule group level in AMP)
  *   - Code mode / freeform PromQL editor
+ *   - Matched notification actions (routing is Alertmanager's job)
  */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState, useEffect } from 'react';
 import {
   EuiAccordion,
   EuiBadge,
   EuiBetaBadge,
-  EuiButtonIcon,
   EuiCallOut,
   EuiComboBox,
+  EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
@@ -35,7 +38,7 @@ import {
   EuiSelect,
   EuiSpacer,
   EuiText,
-  EuiTitle,
+  EuiTextArea,
   EuiToolTip,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
@@ -43,40 +46,11 @@ import { i18n } from '@osd/i18n';
 import { coreRefs } from '../../../framework/core_refs';
 import { AnnotationEditor, LabelEditor } from '../monitor_form_components';
 import { AlertingPromResourcesService } from '../query_services/alerting_prom_resources_service';
+import { PromQueryBuilder } from './prom_query_builder';
 import { DURATION_OPTIONS, PrometheusFormState } from './create_monitor_types';
 
-// ============================================================================
-// Helpers
-// ============================================================================
-
-interface ParsedBuilderQuery {
-  metric: string;
-  labelName?: string;
-  labelOperator?: string;
-  labelValue?: string;
-}
-
-/**
- * Parse a PromQL expression back into builder selections, when the expression
- * has the exact shape the builder produces: `metric` or
- * `metric{label OP "value"}`. Returns null for anything more complex
- * (aggregations, comparisons, multiple matchers) — those cannot be
- * represented by the builder, so its fields stay empty and the builder→query
- * sync stays inert until the user makes a selection.
- */
-export function parseBuilderQuery(query: string): ParsedBuilderQuery | null {
-  const match = (query || '')
-    .trim()
-    .match(
-      /^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*(=~|!~|!=|=)\s*"((?:[^"\\]|\\.)*)"\s*\})?$/
-    );
-  if (!match) return null;
-  const [, metric, labelName, labelOperator, escapedValue] = match;
-  if (!labelName) return { metric };
-  // Reverse the escaping applied by syncBuilderToQuery
-  const labelValue = escapedValue.replace(/\\(["\\])/g, '$1');
-  return { metric, labelName, labelOperator, labelValue };
-}
+/** The namespace all rules created from this form are stored under. */
+const USER_RULES_NAMESPACE = 'observability-alerting';
 
 // ============================================================================
 // Component
@@ -90,6 +64,12 @@ export const PrometheusFormSection: React.FC<{
   context?: { service?: string; team?: string };
   datasourceId?: string;
   datasources?: Array<{ id: string; name: string; type: string }>;
+  /**
+   * The shell-owned Rule name row (validation/dup-check wired there),
+   * rendered inside the Rule details accordion to mirror the Metrics
+   * page flyout layout.
+   */
+  ruleNameField?: React.ReactNode;
 }> = ({
   form,
   onUpdate,
@@ -98,27 +78,8 @@ export const PrometheusFormSection: React.FC<{
   context,
   datasourceId,
   datasources = [],
+  ruleNameField,
 }) => {
-  // Builder state — seeded from the existing query (edit mode) when the
-  // expression has a builder-representable shape. Complex expressions leave
-  // the builder empty and untouched, so the seeded query is never clobbered
-  // unless the user explicitly picks a new metric. useState's lazy
-  // initializer parses once on mount instead of on every render.
-  const [seededBuilder] = useState(() => parseBuilderQuery(form.query));
-  const [metricOptions, setMetricOptions] = useState<Array<{ label: string }>>([]);
-  const [selectedMetric, setSelectedMetric] = useState<Array<{ label: string }>>(
-    seededBuilder ? [{ label: seededBuilder.metric }] : []
-  );
-  const [labelNameOptions, setLabelNameOptions] = useState<Array<{ label: string }>>([]);
-  const [selectedLabelName, setSelectedLabelName] = useState<Array<{ label: string }>>(
-    seededBuilder?.labelName ? [{ label: seededBuilder.labelName }] : []
-  );
-  const [labelValueOptions, setLabelValueOptions] = useState<Array<{ label: string }>>([]);
-  const [selectedLabelValue, setSelectedLabelValue] = useState<Array<{ label: string }>>(
-    seededBuilder?.labelValue ? [{ label: seededBuilder.labelValue }] : []
-  );
-  const [labelOperator, setLabelOperator] = useState(seededBuilder?.labelOperator || '=');
-
   // Rule group state — kept separate from form.name (which is the alert rule name).
   // Initialized from an existing _ruleGroup label so edits round-trip correctly.
   const [ruleGroupName, setRuleGroupName] = useState(
@@ -161,22 +122,25 @@ export const PrometheusFormSection: React.FC<{
     [onUpdate]
   );
 
-  // Fetch metric names and existing rule groups when datasource changes.
-  // The `stale` flag guards against out-of-order responses: a slower
-  // response from a previous datasource/metric selection must not
-  // overwrite options fetched for the current one.
+  // Description is stored as the `description` annotation — the server's rule
+  // builder reads annotations.description, so no new form field is needed.
+  const formAnnotationsRef = useRef(form.annotations);
+  formAnnotationsRef.current = form.annotations;
+  const description = form.annotations.find((a) => a.key === 'description')?.value || '';
+  const handleDescriptionChange = useCallback(
+    (value: string) => {
+      const others = formAnnotationsRef.current.filter((a) => a.key !== 'description');
+      onUpdate('annotations', value ? [...others, { key: 'description', value }] : others);
+    },
+    [onUpdate]
+  );
+
+  // Fetch existing rule groups when datasource changes. The `stale` flag
+  // guards against out-of-order responses overwriting current options.
   useEffect(() => {
     if (!datasourceId) return;
     let stale = false;
     const service = new AlertingPromResourcesService(datasourceId);
-    service
-      .listMetricNames()
-      .then(({ metrics }) => {
-        if (!stale) setMetricOptions(metrics.map((m) => ({ label: m })));
-      })
-      .catch(() => {
-        /* non-critical */
-      });
     service
       .listRuleGroupNames()
       .then(({ groups }) => {
@@ -189,82 +153,6 @@ export const PrometheusFormSection: React.FC<{
       stale = true;
     };
   }, [datasourceId]);
-
-  // Fetch label names when metric changes
-  useEffect(() => {
-    if (!datasourceId || selectedMetric.length === 0) {
-      setLabelNameOptions([]);
-      return;
-    }
-    let stale = false;
-    const service = new AlertingPromResourcesService(datasourceId);
-    service
-      .listLabelNames(selectedMetric[0].label)
-      .then(({ labels }) => {
-        if (!stale) setLabelNameOptions(labels.map((l) => ({ label: l })));
-      })
-      .catch(() => {
-        /* non-critical */
-      });
-    return () => {
-      stale = true;
-    };
-  }, [datasourceId, selectedMetric]);
-
-  // Fetch label values when label name changes
-  useEffect(() => {
-    if (!datasourceId || selectedLabelName.length === 0) {
-      setLabelValueOptions([]);
-      return;
-    }
-    let stale = false;
-    const metric = selectedMetric.length > 0 ? selectedMetric[0].label : undefined;
-    const selector = metric ? `{__name__="${metric}"}` : undefined;
-    const service = new AlertingPromResourcesService(datasourceId);
-    service
-      .listLabelValues(selectedLabelName[0].label, selector)
-      .then(({ values }) => {
-        if (!stale) setLabelValueOptions(values.map((v) => ({ label: v })));
-      })
-      .catch(() => {
-        /* non-critical */
-      });
-    return () => {
-      stale = true;
-    };
-  }, [datasourceId, selectedLabelName, selectedMetric]);
-
-  // Tracks whether the current form.query was authored by the builder. Only
-  // then may clearing the metric clear the query — a complex seeded
-  // expression the builder never produced must not be wiped.
-  const builderOwnsQuery = useRef(false);
-
-  // Sync builder selections to the PromQL query
-  const syncBuilderToQuery = useCallback(() => {
-    if (selectedMetric.length === 0) return;
-    const metric = selectedMetric[0].label;
-    let query = metric;
-    if (selectedLabelName.length > 0 && selectedLabelValue.length > 0) {
-      // Escape backslashes and quotes so the value is a valid PromQL string literal
-      const escapedValue = selectedLabelValue[0].label.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      const labelFilter = `${selectedLabelName[0].label}${labelOperator}"${escapedValue}"`;
-      query = `${metric}{${labelFilter}}`;
-    }
-    builderOwnsQuery.current = true;
-    onUpdate('query', query);
-  }, [selectedMetric, selectedLabelName, selectedLabelValue, labelOperator, onUpdate]);
-
-  // Sync when builder field selections change; clearing the metric clears a
-  // builder-authored query so the two stay consistent
-  useEffect(() => {
-    if (selectedMetric.length > 0) {
-      syncBuilderToQuery();
-    } else if (builderOwnsQuery.current) {
-      builderOwnsQuery.current = false;
-      onUpdate('query', '');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedMetric, selectedLabelName, selectedLabelValue, labelOperator]);
 
   // Memoize filtered datasources to avoid re-filtering on every render
   const promDatasources = useMemo(() => {
@@ -286,7 +174,7 @@ export const PrometheusFormSection: React.FC<{
     const labels = form.labels.filter((l) => l.key && l.value && l.key !== '_ruleGroup');
     const annotations = form.annotations.filter((a) => a.key && a.value);
     const groupName = ruleGroupName || form.name || '<group-name>';
-    let yaml = `# Rule Group Namespace\nname: ${groupName}\nrules:\n`;
+    let yaml = `# Namespace: ${USER_RULES_NAMESPACE}\nname: ${groupName}\nrules:\n`;
     yaml += `  - alert: ${form.name || '<rule-name>'}\n`;
     yaml += `    expr: ${form.query || '<promql-expression>'}\n`;
     yaml += `    for: ${form.threshold.forDuration}\n`;
@@ -304,51 +192,148 @@ export const PrometheusFormSection: React.FC<{
   return (
     <>
       {/* ================================================================
-          Query Section — Builder (metric + label filters)
+          Rule details — namespace / rule group / description. Mirrors the
+          Metrics page flyout's Rule details section; Rule name and Enabled
+          are owned by the flyout shell directly above.
           ================================================================ */}
       <EuiPanel paddingSize="m" color="subdued">
-        <EuiFlexGroup
-          alignItems="center"
-          justifyContent="spaceBetween"
-          responsive={false}
-          gutterSize="s"
+        <EuiAccordion
+          id="prom-rule-details"
+          buttonContent={
+            <strong>
+              {i18n.translate('observability.alerting.prometheusFormSection.ruleDetailsTitle', {
+                defaultMessage: 'Rule details',
+              })}
+            </strong>
+          }
+          initialIsOpen={true}
+          paddingSize="none"
         >
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-              <EuiFlexItem grow={false}>
-                <EuiBetaBadge
-                  label="PromQL"
-                  size="s"
-                  tooltipContent={i18n.translate(
-                    'observability.alerting.prometheusFormSection.promqlTooltip',
-                    { defaultMessage: 'Prometheus Query Language' }
+          <EuiSpacer size="s" />
+          <EuiFormRow
+            label={i18n.translate('observability.alerting.prometheusFormSection.namespaceLabel', {
+              defaultMessage: 'Namespace',
+            })}
+            helpText={i18n.translate(
+              'observability.alerting.prometheusFormSection.namespaceHelpText',
+              {
+                defaultMessage:
+                  'Logical grouping for rule groups. All rules created here are stored under the "{namespace}" namespace.',
+                values: { namespace: USER_RULES_NAMESPACE },
+              }
+            )}
+            fullWidth
+          >
+            <EuiFieldText value={USER_RULES_NAMESPACE} readOnly fullWidth compressed />
+          </EuiFormRow>
+          <EuiSpacer size="s" />
+          <EuiFormRow
+            label={i18n.translate('observability.alerting.prometheusFormSection.groupNameLabel', {
+              defaultMessage: 'Rule group',
+            })}
+            helpText={i18n.translate(
+              'observability.alerting.prometheusFormSection.groupNameHelpText',
+              {
+                defaultMessage:
+                  'Rules within a group share an evaluation interval and are evaluated together.',
+              }
+            )}
+            fullWidth
+          >
+            <EuiComboBox
+              placeholder={i18n.translate(
+                'observability.alerting.prometheusFormSection.groupNamePlaceholder',
+                { defaultMessage: 'Enter a rule group name (defaults to rule name)' }
+              )}
+              options={ruleGroupOptions}
+              selectedOptions={ruleGroupName ? [{ label: ruleGroupName }] : []}
+              onChange={(opts) => handleRuleGroupChange(opts.length > 0 ? opts[0].label : '')}
+              onCreateOption={(value) => handleRuleGroupChange(value)}
+              singleSelection={{ asPlainText: true }}
+              compressed
+              isClearable
+              fullWidth
+              // Double templating on purpose: i18n substitutes the literal
+              // '{searchValue}' back in, yielding the exact template string
+              // EUI interpolates with the user's typed text at render time.
+              customOptionText={i18n.translate(
+                'observability.alerting.prometheusFormSection.createGroupOptionText',
+                {
+                  defaultMessage: 'Create group: {searchValue}',
+                  values: { searchValue: '{searchValue}' },
+                }
+              )}
+            />
+          </EuiFormRow>
+          {ruleNameField && (
+            <>
+              <EuiSpacer size="s" />
+              {ruleNameField}
+            </>
+          )}
+          <EuiSpacer size="s" />
+          <EuiText size="xs" color="subdued">
+            {i18n.translate('observability.alerting.prometheusFormSection.hierarchyExplanation', {
+              defaultMessage:
+                'Prometheus rules are organized as: Namespace → Rule Group → Rule. A namespace contains one or more rule groups, and each group contains one or more rules that share the same evaluation interval.',
+            })}
+          </EuiText>
+          <EuiSpacer size="s" />
+          <EuiFormRow
+            label={
+              <span>
+                {i18n.translate('observability.alerting.prometheusFormSection.descriptionLabel', {
+                  defaultMessage: 'Description',
+                })}{' '}
+                <EuiText size="xs" color="subdued" style={{ display: 'inline' }}>
+                  {i18n.translate(
+                    'observability.alerting.prometheusFormSection.descriptionOptional',
+                    { defaultMessage: '— optional' }
                   )}
-                />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiSelect
-                  options={[
-                    ...promDatasources.map((ds) => ({ value: ds.id, text: ds.name })),
-                    ...(datasourceId && !promDatasources.find((ds) => ds.id === datasourceId)
-                      ? [{ value: datasourceId, text: selectedDsName }]
-                      : []),
-                  ]}
-                  value={datasourceId || ''}
-                  onChange={(e) => onUpdate('datasourceId', e.target.value)}
-                  compressed
-                  prepend={i18n.translate(
-                    'observability.alerting.prometheusFormSection.datasourcePrepend',
-                    { defaultMessage: 'Datasource' }
-                  )}
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            {/* Mirrors the logs flyout's "Build query in logs →" round-trip:
-                author/validate the query against live data in the Metrics
-                app, then return via its Create alert rule action. Same-tab
-                navigation — unsaved form state here is lost. */}
+                </EuiText>
+              </span>
+            }
+            fullWidth
+          >
+            <EuiTextArea
+              placeholder={i18n.translate(
+                'observability.alerting.prometheusFormSection.descriptionPlaceholder',
+                { defaultMessage: 'Describe this rule' }
+              )}
+              value={description}
+              onChange={(e) => handleDescriptionChange(e.target.value)}
+              rows={2}
+              fullWidth
+              compressed
+              data-test-subj="prometheusRuleDescription"
+            />
+          </EuiFormRow>
+        </EuiAccordion>
+      </EuiPanel>
+
+      <EuiSpacer size="m" />
+
+      {/* ================================================================
+          Query — point-and-click builder; the expression is the complete
+          alert condition. Per-rule `for:` duration lives here too.
+          ================================================================ */}
+      <EuiPanel paddingSize="m" color="subdued">
+        <EuiAccordion
+          id="prom-query"
+          buttonContent={
+            <strong>
+              {i18n.translate('observability.alerting.prometheusFormSection.queryTitle', {
+                defaultMessage: 'Query',
+              })}
+            </strong>
+          }
+          initialIsOpen={true}
+          paddingSize="none"
+          extraAction={
+            /* Mirrors the logs flyout's "Build query in logs →" round-trip:
+               author/validate the query against live data in the Metrics
+               app, then return via its Create alert rule action. Same-tab
+               navigation — unsaved form state here is lost. */
             <EuiToolTip
               position="left"
               content={i18n.translate(
@@ -368,198 +353,77 @@ export const PrometheusFormSection: React.FC<{
                 })}
               </EuiLink>
             </EuiToolTip>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-
-        <EuiSpacer size="m" />
-
-        <EuiFlexGroup gutterSize="m" alignItems="flexEnd" responsive={false}>
-          <EuiFlexItem grow={3}>
-            <EuiFormRow
-              label={i18n.translate('observability.alerting.prometheusFormSection.metricLabel', {
-                defaultMessage: 'Metric',
-              })}
-              display="rowCompressed"
-            >
-              <EuiComboBox
-                placeholder={i18n.translate(
-                  'observability.alerting.prometheusFormSection.metricPlaceholder',
-                  { defaultMessage: 'Select metric name' }
+          }
+        >
+          <EuiSpacer size="s" />
+          <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+            <EuiFlexItem grow={false}>
+              <EuiBetaBadge
+                label="PromQL"
+                size="s"
+                tooltipContent={i18n.translate(
+                  'observability.alerting.prometheusFormSection.promqlTooltip',
+                  { defaultMessage: 'Prometheus Query Language' }
                 )}
-                options={metricOptions}
-                selectedOptions={selectedMetric}
-                onChange={(opts) => setSelectedMetric(opts)}
-                singleSelection={{ asPlainText: true }}
-                compressed
-                isClearable
               />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem grow={3}>
-            <EuiFormRow
-              label={i18n.translate('observability.alerting.prometheusFormSection.labelNameLabel', {
-                defaultMessage: 'Label name',
-              })}
-              display="rowCompressed"
-            >
-              <EuiComboBox
-                placeholder={i18n.translate(
-                  'observability.alerting.prometheusFormSection.labelNamePlaceholder',
-                  { defaultMessage: 'Label name' }
-                )}
-                options={labelNameOptions}
-                selectedOptions={selectedLabelName}
-                onChange={(opts) => setSelectedLabelName(opts)}
-                singleSelection={{ asPlainText: true }}
-                compressed
-                isClearable
-              />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false} style={{ width: 60 }}>
-            <EuiFormRow label=" " display="rowCompressed">
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
               <EuiSelect
                 options={[
-                  { value: '=', text: '=' },
-                  { value: '!=', text: '!=' },
-                  { value: '=~', text: '=~' },
-                  { value: '!~', text: '!~' },
+                  ...promDatasources.map((ds) => ({ value: ds.id, text: ds.name })),
+                  ...(datasourceId && !promDatasources.find((ds) => ds.id === datasourceId)
+                    ? [{ value: datasourceId, text: selectedDsName }]
+                    : []),
                 ]}
-                value={labelOperator}
-                onChange={(e) => setLabelOperator(e.target.value)}
+                value={datasourceId || ''}
+                onChange={(e) => onUpdate('datasourceId', e.target.value)}
                 compressed
-              />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem grow={3}>
-            <EuiFormRow
-              label={i18n.translate(
-                'observability.alerting.prometheusFormSection.labelValueLabel',
-                { defaultMessage: 'Label value' }
-              )}
-              display="rowCompressed"
-            >
-              <EuiComboBox
-                placeholder={i18n.translate(
-                  'observability.alerting.prometheusFormSection.labelValuePlaceholder',
-                  { defaultMessage: 'Label value' }
+                prepend={i18n.translate(
+                  'observability.alerting.prometheusFormSection.datasourcePrepend',
+                  { defaultMessage: 'Datasource' }
                 )}
-                options={labelValueOptions}
-                selectedOptions={selectedLabelValue}
-                onChange={(opts) => setSelectedLabelValue(opts)}
-                singleSelection={{ asPlainText: true }}
-                compressed
-                isClearable
               />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="cross"
-              aria-label={i18n.translate(
-                'observability.alerting.prometheusFormSection.clearFilterAriaLabel',
-                { defaultMessage: 'Clear filter' }
-              )}
-              color="subdued"
-              onClick={() => {
-                setSelectedLabelName([]);
-                setSelectedLabelValue([]);
-              }}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer size="s" />
-        <EuiText size="xs" color="subdued">
-          {i18n.translate('observability.alerting.prometheusFormSection.builderHelpText', {
-            defaultMessage: 'Select a metric to start.',
-          })}
-        </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
 
-        <EuiSpacer size="m" />
+          <EuiSpacer size="m" />
 
-        {/* For duration — the rule's `for:` clause. Kept per-rule (unlike the
-            group-level evaluation interval): the condition must hold
-            continuously for this long before the alert transitions from
-            pending to firing. */}
-        <EuiFormRow
-          label={i18n.translate('observability.alerting.prometheusFormSection.forDurationLabel', {
-            defaultMessage: 'For duration',
-          })}
-          helpText={i18n.translate(
-            'observability.alerting.prometheusFormSection.forDurationHelpText',
-            {
-              defaultMessage:
-                'How long the condition must stay true before the alert fires. The alert is "pending" during this window. Choose "Immediately (0s)" to fire on the first evaluation.',
-            }
-          )}
-          display="rowCompressed"
-        >
-          <EuiSelect
-            options={DURATION_OPTIONS}
-            value={form.threshold.forDuration}
-            onChange={(e) =>
-              onUpdate('threshold', { ...form.threshold, forDuration: e.target.value })
-            }
-            compressed
-            data-test-subj="prometheusForDurationSelect"
+          <PromQueryBuilder
+            datasourceId={datasourceId}
+            query={form.query}
+            onQueryChange={(q) => onUpdate('query', q)}
           />
-        </EuiFormRow>
-      </EuiPanel>
 
-      <EuiSpacer size="m" />
+          <EuiSpacer size="m" />
 
-      {/* ================================================================
-          Rule Group — where this rule lives in AMP
-          ================================================================ */}
-      <EuiPanel paddingSize="m" color="subdued">
-        <EuiTitle size="xs">
-          <h3>
-            {i18n.translate('observability.alerting.prometheusFormSection.ruleGroupTitle', {
-              defaultMessage: 'Rule group',
+          {/* For duration — the rule's `for:` clause. Kept per-rule (unlike the
+              group-level evaluation interval): the condition must hold
+              continuously for this long before the alert transitions from
+              pending to firing. */}
+          <EuiFormRow
+            label={i18n.translate('observability.alerting.prometheusFormSection.forDurationLabel', {
+              defaultMessage: 'For duration',
             })}
-          </h3>
-        </EuiTitle>
-        <EuiText size="xs" color="subdued">
-          {i18n.translate('observability.alerting.prometheusFormSection.ruleGroupDescription', {
-            defaultMessage:
-              'Alert rules are organized into groups. Rules in the same group share an evaluation interval and are evaluated together.',
-          })}
-        </EuiText>
-        <EuiSpacer size="s" />
-        <EuiFormRow
-          label={i18n.translate('observability.alerting.prometheusFormSection.groupNameLabel', {
-            defaultMessage: 'Group name',
-          })}
-          helpText={i18n.translate(
-            'observability.alerting.prometheusFormSection.groupNameHelpText',
-            { defaultMessage: 'Select an existing group or type a new name to create one.' }
-          )}
-          display="rowCompressed"
-        >
-          <EuiComboBox
-            placeholder={i18n.translate(
-              'observability.alerting.prometheusFormSection.groupNamePlaceholder',
-              { defaultMessage: 'Type or select a rule group' }
-            )}
-            options={ruleGroupOptions}
-            selectedOptions={ruleGroupName ? [{ label: ruleGroupName }] : []}
-            onChange={(opts) => handleRuleGroupChange(opts.length > 0 ? opts[0].label : '')}
-            onCreateOption={(value) => handleRuleGroupChange(value)}
-            singleSelection={{ asPlainText: true }}
-            compressed
-            isClearable
-            // Double templating on purpose: i18n substitutes the literal
-            // '{searchValue}' back in, yielding the exact template string
-            // EUI interpolates with the user's typed text at render time.
-            customOptionText={i18n.translate(
-              'observability.alerting.prometheusFormSection.createGroupOptionText',
+            helpText={i18n.translate(
+              'observability.alerting.prometheusFormSection.forDurationHelpText',
               {
-                defaultMessage: 'Create group: {searchValue}',
-                values: { searchValue: '{searchValue}' },
+                defaultMessage:
+                  'How long the condition must stay true before the alert fires. The alert is "pending" during this window. Choose "Immediately (0s)" to fire on the first evaluation.',
               }
             )}
-          />
-        </EuiFormRow>
+            display="rowCompressed"
+          >
+            <EuiSelect
+              options={DURATION_OPTIONS}
+              value={form.threshold.forDuration}
+              onChange={(e) =>
+                onUpdate('threshold', { ...form.threshold, forDuration: e.target.value })
+              }
+              compressed
+              data-test-subj="prometheusForDurationSelect"
+            />
+          </EuiFormRow>
+        </EuiAccordion>
       </EuiPanel>
 
       <EuiSpacer size="m" />
@@ -568,26 +432,28 @@ export const PrometheusFormSection: React.FC<{
           Labels
           ================================================================ */}
       <EuiPanel paddingSize="m" color="subdued">
-        <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-          <EuiFlexItem>
-            <EuiTitle size="xs">
-              <h3>
-                {i18n.translate('observability.alerting.prometheusFormSection.labelsTitle', {
-                  defaultMessage: 'Labels',
-                })}
-              </h3>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
+        <EuiAccordion
+          id="prom-labels"
+          buttonContent={
+            <strong>
+              {i18n.translate('observability.alerting.prometheusFormSection.labelsTitle', {
+                defaultMessage: 'Labels',
+              })}
+            </strong>
+          }
+          initialIsOpen={true}
+          paddingSize="none"
+          extraAction={
             <EuiText size="xs" color="subdued">
               {i18n.translate('observability.alerting.prometheusFormSection.labelsDescription', {
                 defaultMessage: 'Categorize and route alerts',
               })}
             </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-        <EuiSpacer size="s" />
-        <LabelEditor labels={visibleLabels} onChange={handleLabelsChange} context={context} />
+          }
+        >
+          <EuiSpacer size="s" />
+          <LabelEditor labels={visibleLabels} onChange={handleLabelsChange} context={context} />
+        </EuiAccordion>
       </EuiPanel>
 
       <EuiSpacer size="m" />
@@ -596,31 +462,35 @@ export const PrometheusFormSection: React.FC<{
           Notification Routing — how alerts get routed in Prometheus
           ================================================================ */}
       <EuiPanel paddingSize="m" color="subdued">
-        <EuiTitle size="xs">
-          <h3>
-            {i18n.translate(
-              'observability.alerting.prometheusFormSection.notificationRoutingTitle',
-              {
-                defaultMessage: 'Notification routing',
-              }
-            )}
-          </h3>
-        </EuiTitle>
-        <EuiSpacer size="s" />
-        <EuiCallOut size="s" iconType="bell" color="primary">
-          <EuiText size="xs">
-            <p>
-              <FormattedMessage
-                id="observability.alerting.prometheusFormSection.notificationRoutingBody"
-                defaultMessage="Notifications for Prometheus alerts are managed through {alertmanager}. The labels you define above (e.g. {severityCode}) determine which receiver handles this alert based on your Alertmanager routing configuration."
-                values={{
-                  alertmanager: <strong>Alertmanager</strong>,
-                  severityCode: <code>severity</code>,
-                }}
-              />
-            </p>
-          </EuiText>
-        </EuiCallOut>
+        <EuiAccordion
+          id="prom-notification-routing"
+          buttonContent={
+            <strong>
+              {i18n.translate(
+                'observability.alerting.prometheusFormSection.notificationRoutingTitle',
+                { defaultMessage: 'Notification routing' }
+              )}
+            </strong>
+          }
+          initialIsOpen={true}
+          paddingSize="none"
+        >
+          <EuiSpacer size="s" />
+          <EuiCallOut size="s" iconType="bell" color="primary">
+            <EuiText size="xs">
+              <p>
+                <FormattedMessage
+                  id="observability.alerting.prometheusFormSection.notificationRoutingBody"
+                  defaultMessage="Notifications for Prometheus alerts are managed through {alertmanager}. The labels you define above (e.g. {severityCode}) determine which receiver handles this alert based on your Alertmanager routing configuration."
+                  values={{
+                    alertmanager: <strong>Alertmanager</strong>,
+                    severityCode: <code>severity</code>,
+                  }}
+                />
+              </p>
+            </EuiText>
+          </EuiCallOut>
+        </EuiAccordion>
       </EuiPanel>
 
       <EuiSpacer size="m" />
@@ -649,7 +519,7 @@ export const PrometheusFormSection: React.FC<{
               </EuiFlexItem>
             </EuiFlexGroup>
           }
-          initialIsOpen={true}
+          initialIsOpen={false}
           paddingSize="none"
         >
           <EuiSpacer size="s" />

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -30,14 +30,17 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFormRow,
+  EuiLink,
   EuiPanel,
   EuiSelect,
   EuiSpacer,
   EuiText,
   EuiTitle,
+  EuiToolTip,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { i18n } from '@osd/i18n';
+import { coreRefs } from '../../../framework/core_refs';
 import { AnnotationEditor, LabelEditor } from '../monitor_form_components';
 import { AlertingPromResourcesService } from '../query_services/alerting_prom_resources_service';
 import { DURATION_OPTIONS, PrometheusFormState } from './create_monitor_types';
@@ -304,33 +307,67 @@ export const PrometheusFormSection: React.FC<{
           Query Section — Builder (metric + label filters)
           ================================================================ */}
       <EuiPanel paddingSize="m" color="subdued">
-        <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+        <EuiFlexGroup
+          alignItems="center"
+          justifyContent="spaceBetween"
+          responsive={false}
+          gutterSize="s"
+        >
           <EuiFlexItem grow={false}>
-            <EuiBetaBadge
-              label="PromQL"
-              size="s"
-              tooltipContent={i18n.translate(
-                'observability.alerting.prometheusFormSection.promqlTooltip',
-                { defaultMessage: 'Prometheus Query Language' }
-              )}
-            />
+            <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiBetaBadge
+                  label="PromQL"
+                  size="s"
+                  tooltipContent={i18n.translate(
+                    'observability.alerting.prometheusFormSection.promqlTooltip',
+                    { defaultMessage: 'Prometheus Query Language' }
+                  )}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiSelect
+                  options={[
+                    ...promDatasources.map((ds) => ({ value: ds.id, text: ds.name })),
+                    ...(datasourceId && !promDatasources.find((ds) => ds.id === datasourceId)
+                      ? [{ value: datasourceId, text: selectedDsName }]
+                      : []),
+                  ]}
+                  value={datasourceId || ''}
+                  onChange={(e) => onUpdate('datasourceId', e.target.value)}
+                  compressed
+                  prepend={i18n.translate(
+                    'observability.alerting.prometheusFormSection.datasourcePrepend',
+                    { defaultMessage: 'Datasource' }
+                  )}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiSelect
-              options={[
-                ...promDatasources.map((ds) => ({ value: ds.id, text: ds.name })),
-                ...(datasourceId && !promDatasources.find((ds) => ds.id === datasourceId)
-                  ? [{ value: datasourceId, text: selectedDsName }]
-                  : []),
-              ]}
-              value={datasourceId || ''}
-              onChange={(e) => onUpdate('datasourceId', e.target.value)}
-              compressed
-              prepend={i18n.translate(
-                'observability.alerting.prometheusFormSection.datasourcePrepend',
-                { defaultMessage: 'Datasource' }
+            {/* Mirrors the logs flyout's "Build query in logs →" round-trip:
+                author/validate the query against live data in the Metrics
+                app, then return via its Create alert rule action. Same-tab
+                navigation — unsaved form state here is lost. */}
+            <EuiToolTip
+              position="left"
+              content={i18n.translate(
+                'observability.alerting.prometheusFormSection.openInMetricsTooltip',
+                {
+                  defaultMessage:
+                    'Build and validate your query against live data in metrics, then click Create alert rule to come back here pre-filled. Unsaved changes will be lost.',
+                }
               )}
-            />
+            >
+              <EuiLink
+                onClick={() => coreRefs?.application?.navigateToApp('explore/metrics')}
+                data-test-subj="alertManagerOpenInMetricsLink"
+              >
+                {i18n.translate('observability.alerting.prometheusFormSection.openInMetrics', {
+                  defaultMessage: 'Build query in metrics →',
+                })}
+              </EuiLink>
+            </EuiToolTip>
           </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -27,6 +27,7 @@ import {
   EuiAccordion,
   EuiBadge,
   EuiBetaBadge,
+  EuiButton,
   EuiCallOut,
   EuiComboBox,
   EuiFieldText,
@@ -46,6 +47,7 @@ import { i18n } from '@osd/i18n';
 import { coreRefs } from '../../../framework/core_refs';
 import { AnnotationEditor, LabelEditor } from '../monitor_form_components';
 import { AlertingPromResourcesService } from '../query_services/alerting_prom_resources_service';
+import { QueryPreviewResults } from '../query_preview_results';
 import { PromQueryBuilder } from './prom_query_builder';
 import { DURATION_OPTIONS, PrometheusFormState } from './create_monitor_types';
 
@@ -86,6 +88,7 @@ export const PrometheusFormSection: React.FC<{
     () => form.labels.find((l) => l.key === '_ruleGroup')?.value || ''
   );
   const [ruleGroupOptions, setRuleGroupOptions] = useState<Array<{ label: string }>>([]);
+  const [showPreview, setShowPreview] = useState(false);
 
   // Use a ref for form.labels to avoid circular dependency:
   // handleRuleGroupChange → onUpdate('labels') → parent re-renders → new form.labels → new callback
@@ -330,29 +333,48 @@ export const PrometheusFormSection: React.FC<{
           initialIsOpen={true}
           paddingSize="none"
           extraAction={
-            /* Mirrors the logs flyout's "Build query in logs →" round-trip:
-               author/validate the query against live data in the Metrics
-               app, then return via its Create alert rule action. Same-tab
-               navigation — unsaved form state here is lost. */
-            <EuiToolTip
-              position="left"
-              content={i18n.translate(
-                'observability.alerting.prometheusFormSection.openInMetricsTooltip',
-                {
-                  defaultMessage:
-                    'Build and validate your query against live data in metrics, then click Create alert rule to come back here pre-filled. Unsaved changes will be lost.',
-                }
-              )}
-            >
-              <EuiLink
-                onClick={() => coreRefs?.application?.navigateToApp('explore/metrics')}
-                data-test-subj="alertManagerOpenInMetricsLink"
-              >
-                {i18n.translate('observability.alerting.prometheusFormSection.openInMetrics', {
-                  defaultMessage: 'Build query in metrics →',
-                })}
-              </EuiLink>
-            </EuiToolTip>
+            <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+              <EuiFlexItem grow={false}>
+                {/* Mirrors the logs flyout's "Build query in logs →" round-trip:
+                    author/validate the query against live data in the Metrics
+                    app, then return via its Create alert rule action. Same-tab
+                    navigation — unsaved form state here is lost. */}
+                <EuiToolTip
+                  position="left"
+                  content={i18n.translate(
+                    'observability.alerting.prometheusFormSection.openInMetricsTooltip',
+                    {
+                      defaultMessage:
+                        'Build and validate your query against live data in metrics, then click Create alert rule to come back here pre-filled. Unsaved changes will be lost.',
+                    }
+                  )}
+                >
+                  <EuiLink
+                    onClick={() => coreRefs?.application?.navigateToApp('explore/metrics')}
+                    data-test-subj="alertManagerOpenInMetricsLink"
+                  >
+                    {i18n.translate('observability.alerting.prometheusFormSection.openInMetrics', {
+                      defaultMessage: 'Build query in metrics →',
+                    })}
+                  </EuiLink>
+                </EuiToolTip>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  size="s"
+                  onClick={() => setShowPreview(true)}
+                  data-test-subj="prometheusRunPreviewButton"
+                  aria-label={i18n.translate(
+                    'observability.alerting.prometheusFormSection.runPreviewAriaLabel',
+                    { defaultMessage: 'Run preview' }
+                  )}
+                >
+                  {i18n.translate('observability.alerting.prometheusFormSection.runPreviewButton', {
+                    defaultMessage: 'Run preview',
+                  })}
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
           }
         >
           <EuiSpacer size="s" />
@@ -423,6 +445,13 @@ export const PrometheusFormSection: React.FC<{
               data-test-subj="prometheusForDurationSelect"
             />
           </EuiFormRow>
+
+          {showPreview && (
+            <>
+              <EuiSpacer size="m" />
+              <QueryPreviewResults query={form.query} />
+            </>
+          )}
         </EuiAccordion>
       </EuiPanel>
 

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -166,7 +166,12 @@ export const PrometheusFormSection: React.FC<{
     }
     if (annotations.length > 0) {
       yaml += `    annotations:\n`;
-      for (const a of annotations) yaml += `      ${a.key}: "${a.value}"\n`;
+      // Annotations lack the isDynamic flag — detect template syntax to
+      // single-quote like the server's js-yaml serialization does
+      for (const a of annotations) {
+        const value = /\{\{.*\}\}/.test(a.value) ? `'${a.value}'` : `"${a.value}"`;
+        yaml += `      ${a.key}: ${value}\n`;
+      }
     }
     return yaml;
   }, [form, ruleGroupName]);

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -12,7 +12,6 @@
  *   - Query (point-and-click builder — the PromQL expression is the
  *     complete alert condition — plus per-rule `for:` duration)
  *   - Labels
- *   - Notification routing guidance (Alertmanager)
  *   - Annotations
  *   - Rule Preview (YAML)
  *
@@ -28,7 +27,6 @@ import {
   EuiBadge,
   EuiBetaBadge,
   EuiButton,
-  EuiCallOut,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -41,7 +39,6 @@ import {
   EuiTextArea,
   EuiToolTip,
 } from '@elastic/eui';
-import { FormattedMessage } from '@osd/i18n/react';
 import { i18n } from '@osd/i18n';
 import { coreRefs } from '../../../framework/core_refs';
 import { AnnotationEditor, LabelEditor } from '../monitor_form_components';
@@ -448,42 +445,9 @@ export const PrometheusFormSection: React.FC<{
 
       <EuiSpacer size="m" />
 
-      {/* ================================================================
-          Notification Routing — how alerts get routed in Prometheus
-          ================================================================ */}
-      <EuiPanel paddingSize="m" color="subdued">
-        <EuiAccordion
-          id="prom-notification-routing"
-          buttonContent={
-            <strong>
-              {i18n.translate(
-                'observability.alerting.prometheusFormSection.notificationRoutingTitle',
-                { defaultMessage: 'Notification routing' }
-              )}
-            </strong>
-          }
-          initialIsOpen={true}
-          paddingSize="none"
-        >
-          <EuiSpacer size="s" />
-          <EuiCallOut size="s" iconType="bell" color="primary">
-            <EuiText size="xs">
-              <p>
-                <FormattedMessage
-                  id="observability.alerting.prometheusFormSection.notificationRoutingBody"
-                  defaultMessage="Notifications for Prometheus alerts are managed through {alertmanager}. The labels you define above (e.g. {severityCode}) determine which receiver handles this alert based on your Alertmanager routing configuration."
-                  values={{
-                    alertmanager: <strong>Alertmanager</strong>,
-                    severityCode: <code>severity</code>,
-                  }}
-                />
-              </p>
-            </EuiText>
-          </EuiCallOut>
-        </EuiAccordion>
-      </EuiPanel>
-
-      <EuiSpacer size="m" />
+      {/* Notification routing guidance intentionally absent — matches the
+          Metrics page flyout; the "Categorize and route alerts" hint on the
+          Labels section covers the Alertmanager relationship. */}
 
       {/* ================================================================
           Annotations

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -159,7 +159,10 @@ export const PrometheusFormSection: React.FC<{
     yaml += `    for: ${form.threshold.forDuration}\n`;
     if (labels.length > 0) {
       yaml += `    labels:\n`;
-      for (const l of labels) yaml += `      ${l.key}: ${l.isDynamic ? l.value : `"${l.value}"`}\n`;
+      // Template values are single-quoted, matching the server's js-yaml
+      // serialization (unquoted `{{ ... }}` would be invalid YAML)
+      for (const l of labels)
+        yaml += `      ${l.key}: ${l.isDynamic ? `'${l.value}'` : `"${l.value}"`}\n`;
     }
     if (annotations.length > 0) {
       yaml += `    annotations:\n`;

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -22,14 +22,13 @@
  *   - Code mode / freeform PromQL editor
  *   - Matched notification actions (routing is Alertmanager's job)
  */
-import React, { useCallback, useMemo, useRef, useState, useEffect } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   EuiAccordion,
   EuiBadge,
   EuiBetaBadge,
   EuiButton,
   EuiCallOut,
-  EuiComboBox,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -46,7 +45,7 @@ import { FormattedMessage } from '@osd/i18n/react';
 import { i18n } from '@osd/i18n';
 import { coreRefs } from '../../../framework/core_refs';
 import { AnnotationEditor, LabelEditor } from '../monitor_form_components';
-import { AlertingPromResourcesService } from '../query_services/alerting_prom_resources_service';
+import { RuleGroupSelector } from './rule_group_selector';
 import { QueryPreviewResults } from '../query_preview_results';
 import { PromQueryBuilder } from './prom_query_builder';
 import { DURATION_OPTIONS, PrometheusFormState } from './create_monitor_types';
@@ -87,7 +86,6 @@ export const PrometheusFormSection: React.FC<{
   const [ruleGroupName, setRuleGroupName] = useState(
     () => form.labels.find((l) => l.key === '_ruleGroup')?.value || ''
   );
-  const [ruleGroupOptions, setRuleGroupOptions] = useState<Array<{ label: string }>>([]);
   const [showPreview, setShowPreview] = useState(false);
 
   // Use a ref for form.labels to avoid circular dependency:
@@ -137,25 +135,6 @@ export const PrometheusFormSection: React.FC<{
     },
     [onUpdate]
   );
-
-  // Fetch existing rule groups when datasource changes. The `stale` flag
-  // guards against out-of-order responses overwriting current options.
-  useEffect(() => {
-    if (!datasourceId) return;
-    let stale = false;
-    const service = new AlertingPromResourcesService(datasourceId);
-    service
-      .listRuleGroupNames()
-      .then(({ groups }) => {
-        if (!stale) setRuleGroupOptions(groups.map((g) => ({ label: g })));
-      })
-      .catch(() => {
-        /* non-critical — user can still type a new group name */
-      });
-    return () => {
-      stale = true;
-    };
-  }, [datasourceId]);
 
   // Memoize filtered datasources to avoid re-filtering on every render
   const promDatasources = useMemo(() => {
@@ -243,29 +222,11 @@ export const PrometheusFormSection: React.FC<{
             )}
             fullWidth
           >
-            <EuiComboBox
-              placeholder={i18n.translate(
-                'observability.alerting.prometheusFormSection.groupNamePlaceholder',
-                { defaultMessage: 'Enter a rule group name (defaults to rule name)' }
-              )}
-              options={ruleGroupOptions}
-              selectedOptions={ruleGroupName ? [{ label: ruleGroupName }] : []}
-              onChange={(opts) => handleRuleGroupChange(opts.length > 0 ? opts[0].label : '')}
-              onCreateOption={(value) => handleRuleGroupChange(value)}
-              singleSelection={{ asPlainText: true }}
-              compressed
-              isClearable
-              fullWidth
-              // Double templating on purpose: i18n substitutes the literal
-              // '{searchValue}' back in, yielding the exact template string
-              // EUI interpolates with the user's typed text at render time.
-              customOptionText={i18n.translate(
-                'observability.alerting.prometheusFormSection.createGroupOptionText',
-                {
-                  defaultMessage: 'Create group: {searchValue}',
-                  values: { searchValue: '{searchValue}' },
-                }
-              )}
+            <RuleGroupSelector
+              datasourceId={datasourceId}
+              value={ruleGroupName}
+              onChange={handleRuleGroupChange}
+              data-test-subj="prometheusRuleGroupSelector"
             />
           </EuiFormRow>
           {ruleNameField && (

--- a/public/components/alerting/create_monitor/rule_group_selector.tsx
+++ b/public/components/alerting/create_monitor/rule_group_selector.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * RuleGroupSelector — the shared rule group combo box used by both the
+ * Alert Manager "Create metrics rule" flyout and the Metrics page
+ * "Create alert rule" flyout.
+ *
+ * Offers existing rule groups (fetched live from the datasource's ruler)
+ * as dropdown options and lets the user type a new name to create one.
+ */
+import React, { useEffect, useState } from 'react';
+import { EuiComboBox } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { AlertingPromResourcesService } from '../query_services/alerting_prom_resources_service';
+
+export const RuleGroupSelector: React.FC<{
+  /** Datasource to fetch existing rule group names from. */
+  datasourceId?: string;
+  /** Currently selected/typed group name ('' = none). */
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  fullWidth?: boolean;
+  'data-test-subj'?: string;
+}> = ({ datasourceId, value, onChange, placeholder, fullWidth = true, ...rest }) => {
+  const [options, setOptions] = useState<Array<{ label: string }>>([]);
+
+  // Fetch existing rule groups when the datasource changes. The `stale`
+  // flag guards against out-of-order responses; the try/catch tolerates
+  // environments without an http client (the dropdown is progressive
+  // enhancement — typing a new group name always works).
+  useEffect(() => {
+    if (!datasourceId) return;
+    let stale = false;
+    try {
+      const service = new AlertingPromResourcesService(datasourceId);
+      service
+        .listRuleGroupNames()
+        .then(({ groups }) => {
+          if (!stale) setOptions(groups.map((g) => ({ label: g })));
+        })
+        .catch(() => {
+          /* non-critical — user can still type a new group name */
+        });
+    } catch (_e) {
+      /* http client unavailable — same fallback */
+    }
+    return () => {
+      stale = true;
+    };
+  }, [datasourceId]);
+
+  return (
+    <EuiComboBox
+      placeholder={
+        placeholder ||
+        i18n.translate('observability.alerting.ruleGroupSelector.placeholder', {
+          defaultMessage: 'Enter a rule group name (defaults to rule name)',
+        })
+      }
+      options={options}
+      selectedOptions={value ? [{ label: value }] : []}
+      onChange={(opts) => onChange(opts.length > 0 ? opts[0].label : '')}
+      onCreateOption={(created) => onChange(created)}
+      singleSelection={{ asPlainText: true }}
+      compressed
+      isClearable
+      fullWidth={fullWidth}
+      // Double templating on purpose: i18n substitutes the literal
+      // '{searchValue}' back in, yielding the exact template string
+      // EUI interpolates with the user's typed text at render time.
+      customOptionText={i18n.translate('observability.alerting.ruleGroupSelector.createOption', {
+        defaultMessage: 'Create group: {searchValue}',
+        values: { searchValue: '{searchValue}' },
+      })}
+      {...rest}
+    />
+  );
+};

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -661,11 +661,11 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                               });
                               window.dispatchEvent(new HashChangeEvent('hashchange'));
                             }}
-                            data-test-subj="monitorDetailConfigureRoutingLink"
+                            data-test-subj="monitorDetailViewRoutingLink"
                           >
                             <FormattedMessage
-                              id="observability.alerting.monitorDetailFlyout.configureRoutingLink"
-                              defaultMessage="Configure notification routing →"
+                              id="observability.alerting.monitorDetailFlyout.viewRoutingLink"
+                              defaultMessage="View notification routing →"
                             />
                           </EuiLink>
                         </p>

--- a/public/components/alerting/monitor_form_components.tsx
+++ b/public/components/alerting/monitor_form_components.tsx
@@ -101,7 +101,8 @@ export const LabelEditor: React.FC<{
           responsive={false}
           style={{ marginBottom: 4 }}
         >
-          <EuiFlexItem grow={2}>
+          {/* Equal grow keeps the key and value boxes visually aligned */}
+          <EuiFlexItem grow={1}>
             <EuiFieldText
               placeholder={i18n.translate(
                 'observability.alerting.monitorFormComponents.labelKeyPlaceholder',
@@ -124,7 +125,7 @@ export const LabelEditor: React.FC<{
           <EuiFlexItem grow={false}>
             <EuiText size="s">=</EuiText>
           </EuiFlexItem>
-          <EuiFlexItem grow={3}>
+          <EuiFlexItem grow={1}>
             <EuiFieldText
               placeholder={
                 label.isDynamic

--- a/public/components/alerting/query_preview_results.tsx
+++ b/public/components/alerting/query_preview_results.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * QueryPreviewResults — the "Run preview" results block shared by the
+ * Metrics page "Create alert rule" flyout and the Alert Manager
+ * "Create metrics rule" flyout.
+ *
+ * Currently renders representative sample data (line chart) with a callout
+ * making that explicit; a follow-up wires it to a live range query.
+ */
+import React from 'react';
+import {
+  EuiAccordion,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { FormattedMessage } from '@osd/i18n/react';
+import { i18n } from '@osd/i18n';
+import { EchartsRender } from './echarts_render';
+
+const PREVIEW_TIMESTAMPS = ['04:00', '06:00', '08:00', '10:00', '12:00', '14:00', '16:00', '17:00'];
+const PREVIEW_VALUES = [0.02, 0.03, 0.01, 0.06, 0.04, 0.07, 0.05, 0.08];
+
+const PREVIEW_CHART_OPTION: Record<string, unknown> = {
+  grid: { left: 48, right: 16, top: 16, bottom: 32 },
+  tooltip: { trigger: 'axis' },
+  xAxis: { type: 'category', data: PREVIEW_TIMESTAMPS },
+  yAxis: { type: 'value' },
+  series: [
+    {
+      type: 'line',
+      data: PREVIEW_VALUES,
+      smooth: true,
+      itemStyle: { color: '#006BB4' },
+      areaStyle: { color: 'rgba(0,107,180,0.1)' },
+    },
+  ],
+};
+
+export const QueryPreviewResults: React.FC<{
+  /** The query being previewed — shown as the series caption. */
+  query: string;
+}> = ({ query }) => (
+  <EuiAccordion
+    id="prom-preview-results"
+    buttonContent={
+      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+        <EuiFlexItem grow={false}>
+          <strong>
+            <FormattedMessage
+              id="observability.alerting.queryPreviewResults.resultsTitle"
+              defaultMessage="Results ({count})"
+              values={{ count: PREVIEW_VALUES.length }}
+            />
+          </strong>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    }
+    initialIsOpen
+    paddingSize="s"
+  >
+    <EuiCallOut size="s" color="warning" iconType="iInCircle">
+      <EuiText size="xs">
+        {i18n.translate('observability.alerting.queryPreviewResults.sampleDataCallout', {
+          defaultMessage: 'Sample data — run the rule to see real results',
+        })}
+      </EuiText>
+    </EuiCallOut>
+    <EuiSpacer size="s" />
+    <EuiText size="xs" color="subdued">
+      {query || 'http_requests_total'}
+    </EuiText>
+    <EuiSpacer size="s" />
+    <EchartsRender spec={PREVIEW_CHART_OPTION} height={200} />
+  </EuiAccordion>
+);

--- a/public/components/alerting/query_preview_results.tsx
+++ b/public/components/alerting/query_preview_results.tsx
@@ -46,9 +46,11 @@ const PREVIEW_CHART_OPTION: Record<string, unknown> = {
 export const QueryPreviewResults: React.FC<{
   /** The query being previewed — shown as the series caption. */
   query: string;
-}> = ({ query }) => (
+  /** Unique accordion id — pass a distinct one per mount point. */
+  id?: string;
+}> = ({ query, id = 'prom-preview-results' }) => (
   <EuiAccordion
-    id="prom-preview-results"
+    id={id}
     buttonContent={
       <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
### Description

Unifies the two "Create metrics rule" surfaces — the Alert Manager Rules page flyout and the Metrics (Explore) page's Create alert rule action — into **a single shared component**, so the two can never drift again.

 #### One flyout component (`CreateMetricsMonitor`) 

The Alert Manager Rules page now mounts the same `CreateMetricsMonitor` component the Metrics Explore page uses. Two optional props adapt it to the Alert Manager context (both inert on the Metrics page): - `datasources`: selectable Prometheus datasource list for the query panel picker, defaulting to the first entry (the Metrics page stays pinned to its Explore context datasource) - `isNameTaken`: duplicate-name guard surfacing an inline error on the Rule name row and disabling Create The flyout persists the rule itself; the Rules page reconciles with an optimistic row plus immediate and 15s-delayed refetches (Cortex propagation). Logs (PPL) creates keep the `CreateMonitor` shell, which also still serves Prometheus **edit** seeding (edit-flyout unification is a noted follow-up).

 #### Shared building blocks (used by both mount points) - 

**`PromQueryBuilder`** — point-and-click metric/label/operator/value selectors backed by live datasource metadata, with stale-response guards, PromQL escaping, and seeding from an existing expression (complex expressions leave the builder inert so a seeded query is never clobbered) - **`RuleGroupSelector`** — rule group combo box offering existing groups fetched live from the ruler API; type to create a new one - **`QueryPreviewResults`** — the Run preview results block (sample data for now; live range query as follow-up) - **`LabelEditor`** — shared label rows (equal-width key/value inputs, `=` separator, dynamic bolt toggle, quick-add chips) 

#### Flyout structure

 **Rule details**: read-only namespace (`observability-alerting`), rule group selector, rule name, hierarchy explanation, optional description (persisted as the `description` annotation — previously silently dropped on save; fixed) - **Query**: shared builder + per-rule `for:` duration + Run preview - **Labels / Annotations / Rule Preview (YAML)** - **Removed**: Trigger condition (the PromQL expression is the complete alert condition), Evaluation settings (rule-group-level in AMP), Matched notification actions and the Notification routing guidance section (routing is Alertmanager's job, driven by labels) 

#### Condition model & payload -

The Metrics page flyout no longer sends `operator`/`threshold` — previously the server appended them to the expr, which would silently turn `rate(...)` into `rate(...) > 0.05` - YAML previews single-quote templated label values, matching the server's js-yaml serialization 

#### Severity —

Aligned with Prometheus conventions - Severity is a routing **label** (Alertmanager matches its literal value); both flyouts seed `severity: warning` by default so a new rule never pages anyone unless deliberately escalated (metrics flyout previously seeded `critical`; Alert Manager previously mis-flagged the static default as a dynamic template) - Dynamic (templated) label values round-trip: edit seeding infers the dynamic flag from `{{ }}` syntax 

#### Misc -

 Alert Manager gains a **Build query in metrics →** link (same round-trip pattern as the logs flyout) - Detail flyout: routing link renamed to **View notification routing →** (read-only surface) 

### Testing -

 311 unit tests across 42 alerting suites pass, including new coverage for: builder seeding/round-trip, Run preview toggle, rule group propagation, dup-name blocking, datasource-list defaulting, payload shape (asserts `operator`/`threshold` absent), and template quoting - TypeScript and lint clean; formatting verified against both prettier 2.x and 3.x 


https://github.com/user-attachments/assets/09177b28-0e92-4805-bfdc-72411d0aee26



 ### Check List

 - [x] New functionality includes testing. - [x] All tests pass, including unit test, integration test and doctest - [ ] New functionality has been documented. - [x] Commits are signed per the DCO using --signoff By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.