### PR TITLE
[Alerts] simplify routing tab header

### DIFF
--- a/public/components/alerting/notification_routing_panel.tsx
+++ b/public/components/alerting/notification_routing_panel.tsx
@@ -20,9 +20,7 @@ import {
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiHealth,
   EuiLoadingSpinner,
-  EuiPanel,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -123,17 +121,6 @@ function getMatchers(route: AlertmanagerRoute): string[] {
   return result;
 }
 
-function formatUptime(isoStr?: string): string {
-  if (!isoStr) return '—';
-  const start = new Date(isoStr).getTime();
-  const diff = Date.now() - start;
-  const hours = Math.floor(diff / 3600000);
-  const days = Math.floor(hours / 24);
-  if (days > 0) return `${days}d ${hours % 24}h`;
-  if (hours > 0) return `${hours}h`;
-  return `${Math.floor(diff / 60000)}m`;
-}
-
 const INTEGRATION_COLORS: Record<string, string> = {
   webhook: 'hollow',
   slack: '#4A154B',
@@ -190,7 +177,7 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
       const res = await adminService.getConfig(selectedDsId);
       // The API client types route/inhibitRules as `unknown` because it's
       // handed back raw from Alertmanager; narrow to our local shape here.
-      setConfig((res as unknown) as AlertmanagerConfig);
+      setConfig(res as unknown as AlertmanagerConfig);
     } catch (e: unknown) {
       setError(
         e instanceof Error
@@ -343,8 +330,6 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
   const routes = flattenRoutes(config.config?.route);
   const receivers = config.config?.receivers || [];
   const inhibitRules = config.config?.inhibitRules || [];
-  const cluster = config.cluster;
-  const version = config.versionInfo?.version || '—';
 
   // -----------------------------------------------------------------------
   // Route tree table
@@ -557,66 +542,27 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
       </EuiCallOut>
       <EuiSpacer size="s" />
 
-      {/* Cluster status bar */}
-      <EuiPanel paddingSize="s" hasBorder>
-        <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
-          <EuiFlexItem grow={false}>
-            <EuiHealth color={cluster?.status === 'ready' ? 'success' : 'danger'}>
-              {cluster?.status ||
-                i18n.translate(
-                  'observability.alerting.notificationRoutingPanel.clusterStatusUnknown',
-                  { defaultMessage: 'unknown' }
-                )}
-            </EuiHealth>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs">
-              <FormattedMessage
-                id="observability.alerting.notificationRoutingPanel.alertmanagerVersion"
-                defaultMessage="{label} v{version}"
-                values={{ label: <strong>Alertmanager</strong>, version }}
-              />
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs" color="subdued">
-              <FormattedMessage
-                id="observability.alerting.notificationRoutingPanel.uptime"
-                defaultMessage="Uptime: {uptime}"
-                values={{ uptime: formatUptime(config.uptime) }}
-              />
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="xs" color="subdued">
-              <FormattedMessage
-                id="observability.alerting.notificationRoutingPanel.peers"
-                defaultMessage="Peers: {count}"
-                values={{ count: cluster?.peerCount ?? 0 }}
-              />
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem grow />
-          {datasourceSelector && <EuiFlexItem grow={false}>{datasourceSelector}</EuiFlexItem>}
-          <EuiFlexItem grow={false}>
-            <EuiToolTip
-              content={i18n.translate(
-                'observability.alerting.notificationRoutingPanel.refreshTooltip',
+      {/* Datasource selector + refresh toolbar */}
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+        {datasourceSelector && <EuiFlexItem grow={false}>{datasourceSelector}</EuiFlexItem>}
+        <EuiFlexItem grow={false}>
+          <EuiToolTip
+            content={i18n.translate(
+              'observability.alerting.notificationRoutingPanel.refreshTooltip',
+              { defaultMessage: 'Refresh' }
+            )}
+          >
+            <EuiButtonIcon
+              iconType="refresh"
+              aria-label={i18n.translate(
+                'observability.alerting.notificationRoutingPanel.refreshAriaLabel',
                 { defaultMessage: 'Refresh' }
               )}
-            >
-              <EuiButtonIcon
-                iconType="refresh"
-                aria-label={i18n.translate(
-                  'observability.alerting.notificationRoutingPanel.refreshAriaLabel',
-                  { defaultMessage: 'Refresh' }
-                )}
-                onClick={fetchConfig}
-              />
-            </EuiToolTip>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiPanel>
+              onClick={fetchConfig}
+            />
+          </EuiToolTip>
+        </EuiFlexItem>
+      </EuiFlexGroup>
 
       <EuiSpacer size="s" />
 

--- a/public/components/alerting/notification_routing_panel.tsx
+++ b/public/components/alerting/notification_routing_panel.tsx
@@ -65,9 +65,6 @@ interface AlertmanagerConfig {
   available: boolean;
   error?: string;
   configParseError?: string;
-  cluster?: { status: string; peers: Array<{ name: string; address: string }>; peerCount: number };
-  uptime?: string;
-  versionInfo?: Record<string, string>;
   config?: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Alertmanager global config has dynamic shape
     global?: Record<string, any>;


### PR DESCRIPTION
### Description
On the Alerting **Routing** tab (`app/observability-alerting#/routing`), the top of the page showed a status bar with `ready` / Alertmanager version / `Uptime` / `Peers`.

This PR removes that status cluster and keeps the controls that matter, left-aligned:

- **Removed** the bordered status panel: the `ready`/`unavailable` health badge, `Alertmanager vX.Y.Z`, `Uptime`, and `Peers`. Connection failures are already surfaced by the existing "Alertmanager Not Available" empty prompt, so the badge was redundant — and its `unknown` fallback (shown for single-node clusters that report no status) is gone with it.
- **Kept** the **Source** datasource selector and the refresh button, now as a compact left-aligned toolbar directly below the read-only callout and above "Route Tree".
- **Cleanup:** removed the now-unused `formatUptime()` helper, the `cluster`/`version` locals, and the `EuiHealth` / `EuiPanel` imports.

All changes are contained to `notification_routing_panel.tsx` — the status bar was not shared with any other tab.

Before:
<img width="1278" height="450" alt="Before" src="https://github.com/user-attachments/assets/5ddc19bc-d837-4b3b-9c96-0d5f3efa1103" />

After:
<img width="1282" height="420" alt="After" src="https://github.com/user-attachments/assets/e7689296-575d-41a4-aba1-e82ce5f53b97" />


### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/issues/2812

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
