### PR TITLE
feat(observability): generic error classification & surfacing layer

### DIFF
--- a/common/error/README.md
+++ b/common/error/README.md
@@ -1,0 +1,143 @@
+# Error classification & surfacing (`common/error`)
+
+A small, **framework-agnostic** layer that turns opaque failures (the classic
+`HTTP 500 {"message":"An internal error occurred"}`) into a **classified,
+sanitized** result with a stable category, code, user-facing title/message,
+remediation, retryability, and a correlation id — so both features (SLOs and
+the unified alerts view) surface a clear cause instead of a generic wall.
+
+The core is pure TypeScript: **no** imports from OpenSearch Dashboards, Kibana,
+React, or EUI. Rendering (toasts/callouts) and i18n resolution live in
+framework-specific adapters. This is what lets the whole `common/error/`
+directory drop into a downstream fork unchanged; the fork only re-implements
+the thin adapters and registers its own extras.
+
+## Taxonomy
+
+Provider-neutral categories (`ErrorCategory`):
+
+| Category | Meaning |
+|---|---|
+| `VALIDATION` | The request was rejected as invalid (bad input, invalid query). |
+| `NOT_FOUND` | The target resource does not exist. |
+| `CONFLICT` | The request conflicts with current state (e.g. "already exists"). |
+| `PERMISSION_DENIED` | Not authenticated (`AUTH_REQUIRED`) or not allowed (`PERMISSION_DENIED`). |
+| `UPSTREAM_UNAVAILABLE` | A backend could not be reached / did not complete. |
+| `TIMEOUT` | The request did not finish in time / was aborted. |
+| `RATE_LIMITED` | The backend is throttling requests. |
+| `PRECONDITION_FAILED` | The resource changed since it was loaded. |
+| `PARTIAL_STATE` | A successful response in an unusable state (missing rule groups, unknown routing status). |
+| `UNKNOWN` | Unmatched — surfaced with a **redacted** message, never a raw one. |
+
+`code` narrows a category to a specific, actionable situation (e.g.
+`RULE_GROUP_CONFLICT`, `RULE_BACKEND_UNAVAILABLE`, `RULE_CONFIG_INVALID`,
+`RULES_MISSING`). Wording for each code lives in `messages.ts`.
+
+## Pipeline
+
+```
+RawErrorContext ──▶ classifyError() ──▶ ClassifiedError ──▶ toClientPayload() ──▶ wire
+                     (highest-priority        (resolved,        (exposure policy)
+                      matching classifier)     localized)
+```
+
+- `classifyError(ctx)` picks the highest-`priority` classifier whose `match`
+  returns true (else the `UNKNOWN` fallback), resolves wording from the catalog
+  (or the classifier's inline overrides) through the registered `Translator`,
+  runs any enrichers, and echoes the correlation id.
+- `toClientPayload(err, { exposeSensitive })` enforces the exposure policy
+  before anything reaches the browser.
+
+## The three-tier exposure guarantee
+
+Raw upstream text can leak deployment topology, so exposure is tiered:
+
+1. **Server logs** — the full, un-redacted detail is always logged with the
+   correlation id at the server boundary. Never dropped.
+2. **`safe` details** — a **redacted** excerpt (`redactForDisplay`) is attached
+   and shown by default (toast text / "View details" callout).
+3. **`sensitive` details** — verbatim upstream text. **Stripped from client
+   payloads by default.** Revealed only when opted in:
+   - an operator sets `observability.errors.exposeSensitiveErrorDetail: true`, or
+   - a downstream `ErrorDetailEnricher` opts in.
+
+**Invariant:** the browser never receives raw upstream text unless explicitly
+opted in. Even `UNKNOWN` surfaces only a redacted message.
+
+`redactForDisplay` scrubs URLs, hostnames, IPs, ARNs, UUIDs, long opaque ids,
+account-number-like runs, and long mixed tokens. It is best-effort
+defense-in-depth, not a security boundary — the exposure gate above is. Known
+gaps: a **single-label** hostname with no port and no dotted TLD (e.g. a bare
+`cortex-ruler`) can pass through; a forker that needs stricter scrubbing should
+add rules via its own enricher rather than editing core.
+
+## Extension model — registration only, no core edits
+
+A downstream fork extends behavior **at startup**, touching no file in
+`common/error/`:
+
+```ts
+import {
+  registerDefaultClassifiers,
+  registerErrorClassifier,
+  registerErrorDetailEnricher,
+  setTranslator,
+} from 'common/error';
+
+registerDefaultClassifiers();               // core defaults
+setTranslator(myFrameworkTranslate);        // @osd/i18n here, @kbn/i18n in the fork
+
+// (a) higher-priority classifier overrides a default and can inline its own wording
+registerErrorClassifier({
+  name: 'myenv.ruleBackendUnavailable',
+  priority: 200,                            // > any core priority (max 100)
+  match: (ctx) => ctx.operation === 'rule.create.metric' && ctx.upstreamCode === 'RULER_UNREACHABLE',
+  classify: () => ({
+    category: 'UPSTREAM_UNAVAILABLE',
+    code: 'MYENV_RULE_BACKEND_UNAVAILABLE',
+    retryable: true,
+    messages: { title: { id: '…', defaultMessage: '…' }, message: { id: '…', defaultMessage: '…' } },
+  }),
+});
+
+// (b) enricher adds environment-specific detail (safe values are re-redacted;
+//     it cannot remove safety guarantees)
+registerErrorDetailEnricher({
+  name: 'myenv.supportHint',
+  enrich: (err) => ({ ...err, details: [...(err.details ?? []), /* … */] }),
+});
+```
+
+A complete, provider-neutral example lives in
+`examples/example_downstream_registration.ts` (exercised by
+`__tests__/downstream_registration.test.ts`). Provider-specific names,
+endpoints, ids, and phrasing belong **only** in a fork's registered
+classifiers/enrichers — never in this open-source tree.
+
+## Adapters in this repo
+
+- **Server** — `server/routes/alerting/classified_error.ts`:
+  `classifyToHandlerResult(e, { operation, logger })` builds the neutral
+  context, classifies, logs full detail with a correlation id, applies the
+  exposure policy, and returns a body that keeps the legacy `error` string and
+  adds a structured `errorDetail` + `correlationId` (backward compatible).
+- **Client** — `public/components/common/error/`:
+  `extractClassifiedError(httpError)`, `showClassifiedErrorToast(...)`, and
+  `<ClassifiedErrorCallout />`. These localize the wording via `@osd/i18n` and
+  render safe/sensitive details appropriately.
+
+## Portability checklist (Kibana fork)
+
+- **Imports unchanged:** copy `common/error/` verbatim.
+- **Register at startup:** `setTranslator(kbnTranslate)`, `registerDefaultClassifiers()`,
+  plus the fork's own classifiers/enrichers.
+- **Re-implement only the adapters:** the toast/callout components and the
+  `contextFromError` boundary mapping, against the fork's HTTP/i18n APIs.
+- **Do not change:** the core, the taxonomy, or the redaction defaults.
+- **Priority scale:** core classifiers occupy **0–100** (state 90, ruler 80,
+  timeout 60, http-status 40; upstream-wrapped 100). Downstream classifiers
+  should use **200+** so they always outrank core and never collide with it.
+- **Shared test harnesses:** `registerDefaultClassifiers()` is idempotent via a
+  module `defaultsRegistered` flag. A harness that registers into the same
+  process more than once (or wants to re-register after a reset) must call
+  `__resetRegistryForTests()` + `__resetDefaultsFlagForTests()` first.

--- a/common/error/__tests__/classifiers.test.ts
+++ b/common/error/__tests__/classifiers.test.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Coverage tests for the default classifiers, one per observed failure shape.
+ * Fixtures mirror the shapes captured on a live devstack, with all
+ * provider-specific strings replaced by redacted placeholders.
+ */
+
+import { __resetDefaultsFlagForTests, registerDefaultClassifiers } from '../index';
+import { __resetRegistryForTests, classifyError } from '../registry';
+import { classifyRoutingStatus, classifyRuleHealthState } from '../classifiers/state';
+
+beforeEach(() => {
+  __resetRegistryForTests();
+  __resetDefaultsFlagForTests();
+  registerDefaultClassifiers();
+});
+
+describe('default classifiers — coverage table', () => {
+  it('#1 ruler unreachable → UPSTREAM_UNAVAILABLE / RULE_BACKEND_UNAVAILABLE (retryable)', () => {
+    const out = classifyError({
+      operation: 'rule.create.metric',
+      upstreamCode: 'RULER_UNREACHABLE',
+      httpStatus: 503,
+      message: 'Ruler RULER_UNREACHABLE (HTTP 503): <upstream body>',
+    });
+    expect(out.category).toBe('UPSTREAM_UNAVAILABLE');
+    expect(out.code).toBe('RULE_BACKEND_UNAVAILABLE');
+    expect(out.retryable).toBe(true);
+    expect(out.title).toBe('Rule service unavailable');
+  });
+
+  it('#2 wrapped 503 hiding a 409 "already exists" → CONFLICT / RULE_GROUP_CONFLICT', () => {
+    const out = classifyError({
+      operation: 'slo.repair',
+      upstreamCode: 'RULER_UNREACHABLE',
+      httpStatus: 503,
+      rawBody:
+        'POST Rule Groups Namespace: error: 409 - { "message": "A namespace with name <namespace> already exists in this workspace." }',
+    });
+    // Must NOT trust the outer 503 — inner cause is a conflict.
+    expect(out.category).toBe('CONFLICT');
+    expect(out.code).toBe('RULE_GROUP_CONFLICT');
+    expect(out.httpStatus).toBe(409);
+    expect(out.retryable).toBe(false);
+  });
+
+  it('#3 abort/timeout → TIMEOUT / REQUEST_TIMEOUT (retryable)', () => {
+    const out = classifyError({
+      operation: 'alert.acknowledge',
+      errorName: 'AbortError',
+      message: 'Acknowledge request timed out after 30000ms',
+    });
+    expect(out.category).toBe('TIMEOUT');
+    expect(out.code).toBe('REQUEST_TIMEOUT');
+    expect(out.retryable).toBe(true);
+  });
+
+  it('#4 routing status "unknown" → PARTIAL_STATE / ROUTING_STATE_UNKNOWN', () => {
+    const out = classifyRoutingStatus('unknown');
+    expect(out).not.toBeNull();
+    expect(out!.category).toBe('PARTIAL_STATE');
+    expect(out!.code).toBe('ROUTING_STATE_UNKNOWN');
+    // 'ready' is healthy — nothing to surface.
+    expect(classifyRoutingStatus('ready')).toBeNull();
+    // 'settling' is a valid transient state — also non-error.
+    expect(classifyRoutingStatus('settling')).toBeNull();
+  });
+
+  it('#5 rule_health states map to shared language', () => {
+    expect(classifyRuleHealthState('rules_missing')!.code).toBe('RULES_MISSING');
+    expect(classifyRuleHealthState('rules_partial')!.code).toBe('RULES_PARTIAL');
+    expect(classifyRuleHealthState('ruler_unreachable')!.code).toBe('RULE_HEALTH_UNAVAILABLE');
+    expect(classifyRuleHealthState('rules_partial')!.category).toBe('PARTIAL_STATE');
+    expect(classifyRuleHealthState('ruler_unreachable')!.retryable).toBe(true);
+    // 'ok' surfaces nothing.
+    expect(classifyRuleHealthState('ok')).toBeNull();
+  });
+
+  it('#6 invalid rule config → VALIDATION / RULE_CONFIG_INVALID with redacted safe detail', () => {
+    const out = classifyError({
+      operation: 'rule.create.metric',
+      upstreamCode: 'RULER_VALIDATION_FAILED',
+      httpStatus: 400,
+      rawBody: 'invalid PromQL: parse error; source https://host.internal:9090/rules',
+    });
+    expect(out.category).toBe('VALIDATION');
+    expect(out.code).toBe('RULE_CONFIG_INVALID');
+    expect(out.retryable).toBe(false);
+    const safe = out.details?.find((d) => d.sensitivity === 'safe');
+    expect(safe?.value).toContain('invalid PromQL: parse error');
+    expect(safe?.value).not.toContain('host.internal');
+    expect(safe?.value).toContain('<redacted-url>');
+  });
+
+  it('#7 401 → AUTH_REQUIRED, 403 → PERMISSION_DENIED (both PERMISSION_DENIED, non-retryable)', () => {
+    const unauthorized = classifyError({
+      operation: 'rule.create.metric',
+      upstreamCode: 'RULER_AUTH_FAILED',
+      httpStatus: 401,
+    });
+    expect(unauthorized.category).toBe('PERMISSION_DENIED');
+    expect(unauthorized.code).toBe('AUTH_REQUIRED');
+    expect(unauthorized.retryable).toBe(false);
+
+    const forbidden = classifyError({
+      operation: 'rule.create.metric',
+      upstreamCode: 'RULER_AUTH_FAILED',
+      httpStatus: 403,
+    });
+    expect(forbidden.code).toBe('PERMISSION_DENIED');
+
+    // Auth failures carry no raw upstream detail.
+    expect(unauthorized.details).toBeUndefined();
+  });
+
+  it('UNKNOWN: unmatched error still surfaces a redacted message + keeps raw sensitive', () => {
+    const out = classifyError({
+      operation: 'slo.create',
+      message: 'unexpected token in response from https://host.cloud/api at id 123456789012',
+    });
+    expect(out.category).toBe('UNKNOWN');
+    expect(out.code).toBe('UNKNOWN_ERROR');
+    const safe = out.details?.find((d) => d.sensitivity === 'safe');
+    expect(safe?.value).toBe(
+      'unexpected token in response from <redacted-url> at id <redacted-id>'
+    );
+    const sensitive = out.details?.find((d) => d.sensitivity === 'sensitive');
+    expect(sensitive?.value).toContain('host.cloud');
+  });
+});
+
+describe('classifier robustness', () => {
+  it('timeoutClassifier does not hijack a 4xx that merely mentions "timeout"', () => {
+    // A 400 whose upstream message happens to include the word "timeout" (e.g.
+    // an OpenSearch parse error on a `timeout` field) must fall through to the
+    // http-status classifier (VALIDATION) instead of being flagged retryable.
+    const out = classifyError({
+      operation: 'op',
+      httpStatus: 400,
+      message: 'parse_exception: unknown timeout field "search_timeout_ms"',
+    });
+    expect(out.category).toBe('VALIDATION');
+    expect(out.retryable).toBe(false);
+  });
+
+  it('timeoutClassifier still catches 5xx timeouts and message-only cases', () => {
+    // 504 status is a definitive timeout.
+    expect(
+      classifyError({ operation: 'op', httpStatus: 504, message: 'gateway timeout' }).category
+    ).toBe('TIMEOUT');
+    // Message-only (no status) still counts as a timeout (e.g. a client abort).
+    expect(
+      classifyError({ operation: 'op', errorName: 'AbortError', message: 'request timed out' })
+        .category
+    ).toBe('TIMEOUT');
+  });
+
+  it('upstreamWrapped treats a 4xx "already exists" as validation, not a conflict', () => {
+    // A client error that merely uses "already exists" as a noun is a genuine
+    // validation failure — leave it to the http-status classifier.
+    const ambiguous = classifyError({
+      operation: 'op',
+      httpStatus: 400,
+      rawBody: "'name' field already exists in the schema",
+    });
+    expect(ambiguous.category).toBe('VALIDATION');
+  });
+
+  it('upstreamWrapped catches a conflict masked by a 5xx even without a literal "409"', () => {
+    // The upstream 409 is often not echoed as a number in the body. A 5xx
+    // envelope carrying "already exists" is a masked conflict.
+    const masked = classifyError({
+      operation: 'slo.repair',
+      httpStatus: 500,
+      rawBody: 'namespace already exists in this workspace',
+    });
+    expect(masked.category).toBe('CONFLICT');
+    expect(masked.code).toBe('RULE_GROUP_CONFLICT');
+    expect(masked.httpStatus).toBe(409);
+    expect(masked.retryable).toBe(false);
+  });
+
+  it('upstreamWrapped honors an explicit inner 409 marker regardless of outer status', () => {
+    const wrapped = classifyError({
+      operation: 'op',
+      httpStatus: 503,
+      rawBody: 'error: 409 - resource already exists',
+    });
+    expect(wrapped.category).toBe('CONFLICT');
+    expect(wrapped.httpStatus).toBe(409);
+  });
+});
+
+describe('generic http-status classifier', () => {
+  it('maps standard statuses to the taxonomy', () => {
+    expect(classifyError({ operation: 'op', httpStatus: 404 }).code).toBe('RESOURCE_NOT_FOUND');
+    expect(classifyError({ operation: 'op', httpStatus: 409 }).code).toBe('RESOURCE_CONFLICT');
+    expect(classifyError({ operation: 'op', httpStatus: 429 }).category).toBe('RATE_LIMITED');
+    expect(classifyError({ operation: 'op', httpStatus: 412 }).category).toBe(
+      'PRECONDITION_FAILED'
+    );
+    expect(classifyError({ operation: 'op', httpStatus: 502 }).category).toBe(
+      'UPSTREAM_UNAVAILABLE'
+    );
+  });
+});

--- a/common/error/__tests__/downstream_registration.test.ts
+++ b/common/error/__tests__/downstream_registration.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Proves the registration-only extension model: a downstream-style
+ * registration overrides a default classifier and adds `safe` detail, using
+ * only generic placeholder content — touching no core file.
+ */
+
+import { __resetDefaultsFlagForTests, registerDefaultClassifiers } from '../index';
+import { __resetRegistryForTests, classifyError, toClientPayload } from '../registry';
+import { registerExampleDownstreamExtensions } from '../examples/example_downstream_registration';
+
+const ctx = {
+  operation: 'rule.create.metric',
+  upstreamCode: 'RULER_UNREACHABLE',
+  httpStatus: 503,
+};
+
+describe('downstream registration', () => {
+  beforeEach(() => {
+    __resetRegistryForTests();
+    __resetDefaultsFlagForTests();
+    registerDefaultClassifiers();
+  });
+
+  it('default (no downstream) classifies with core wording', () => {
+    const out = classifyError(ctx);
+    expect(out.code).toBe('RULE_BACKEND_UNAVAILABLE');
+    expect(out.title).toBe('Rule service unavailable');
+  });
+
+  it('downstream override wins and supplies its own wording + safe detail', () => {
+    registerExampleDownstreamExtensions();
+    const out = classifyError(ctx);
+
+    // The higher-priority classifier overrides the default code + wording.
+    expect(out.code).toBe('EXAMPLE_RULE_BACKEND_UNAVAILABLE');
+    expect(out.title).toBe('Rule service is temporarily unavailable');
+    expect(out.message).toContain('<namespace>');
+
+    // Its safe detail is present...
+    const hint = out.details?.find((d) => d.key === 'upstreamStatus');
+    expect(hint?.value).toContain('<namespace>');
+
+    // ...and the enricher appended a further safe breadcrumb.
+    const support = out.details?.find((d) => d.key === 'exampleSupportHint');
+    expect(support?.value).toContain('<namespace>');
+
+    // Safe details survive the default (sensitive-stripping) client payload.
+    const payload = toClientPayload(out);
+    expect(payload.details?.some((d) => d.key === 'exampleSupportHint')).toBe(true);
+  });
+});

--- a/common/error/__tests__/redact.test.ts
+++ b/common/error/__tests__/redact.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { redactForDisplay } from '../redact';
+
+describe('redactForDisplay', () => {
+  it('returns empty string for empty/undefined input', () => {
+    expect(redactForDisplay('')).toBe('');
+    expect(redactForDisplay(undefined)).toBe('');
+    expect(redactForDisplay(null)).toBe('');
+  });
+
+  it('preserves ordinary actionable text', () => {
+    expect(redactForDisplay('invalid PromQL: parse error at position 12')).toBe(
+      'invalid PromQL: parse error at position 12'
+    );
+  });
+
+  it('redacts URLs', () => {
+    expect(redactForDisplay('failed to reach https://host.internal:9090/api/v1/rules now')).toBe(
+      'failed to reach <redacted-url> now'
+    );
+  });
+
+  it('redacts ARNs', () => {
+    const out = redactForDisplay('denied for arn:partition:svc:region:acct:resource/name');
+    expect(out).toContain('<redacted-arn>');
+    expect(out).not.toContain('resource/name');
+  });
+
+  it('redacts bare IPv4 with port', () => {
+    expect(redactForDisplay('connection refused 10.1.2.3:9200')).toBe(
+      'connection refused <redacted-ip>'
+    );
+  });
+
+  it('redacts FQDN-like hosts with generic infra suffixes', () => {
+    expect(redactForDisplay('lookup failed for cortex.svc.cluster.local')).toContain(
+      '<redacted-host>'
+    );
+  });
+
+  it('redacts network-ish single-label hosts with a port but preserves prose', () => {
+    // A single-label host that looks network-ish (contains a hyphen/digit, e.g.
+    // Kubernetes pod DNS) followed by a port is redacted even without a TLD.
+    expect(redactForDisplay('dial tcp alertmanager-0:9093: connect: refused')).toContain(
+      '<redacted-host>'
+    );
+    // Ordinary "word:NN" prose (a parse-error line/column, not a host) is left
+    // intact — the host must contain a hyphen or digit to be treated as an
+    // endpoint.
+    expect(redactForDisplay('invalid PromQL: parse error at line:42')).toBe(
+      'invalid PromQL: parse error at line:42'
+    );
+    expect(redactForDisplay('bad token at column:15')).toBe('bad token at column:15');
+    // A word with no port must NOT match either.
+    expect(redactForDisplay('this rulesmissing message stays intact')).toBe(
+      'this rulesmissing message stays intact'
+    );
+  });
+
+  it('redacts UUIDs and long opaque ids', () => {
+    expect(redactForDisplay('request 123e4567-e89b-12d3-a456-426614174000 failed')).toBe(
+      'request <redacted-id> failed'
+    );
+    expect(redactForDisplay('account 123456789012 blocked')).toBe('account <redacted-id> blocked');
+  });
+
+  it('redacts long mixed-alphanumeric tokens but leaves plain words', () => {
+    expect(redactForDisplay('token aB3xY7kLm9QpZ2wR5tN8vD1c present')).toContain(
+      '<redacted-token>'
+    );
+    expect(redactForDisplay('rulesmissingfromnamespace')).toBe('rulesmissingfromnamespace');
+  });
+
+  it('is idempotent', () => {
+    const once = redactForDisplay('see https://host.cloud/x and 10.0.0.1');
+    expect(redactForDisplay(once)).toBe(once);
+  });
+});

--- a/common/error/__tests__/registry.test.ts
+++ b/common/error/__tests__/registry.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  __resetRegistryForTests,
+  classifyError,
+  registerErrorClassifier,
+  registerErrorDetailEnricher,
+  setTranslator,
+  toClientPayload,
+} from '../registry';
+import { DetailKey } from '../messages';
+import type { ClassifiedError, ErrorClassifier } from '../types';
+
+function classifier(name: string, priority: number, code: string): ErrorClassifier {
+  return {
+    name,
+    priority,
+    match: () => true,
+    classify: () => ({ category: 'UNKNOWN', code, retryable: false }),
+  };
+}
+
+describe('registry', () => {
+  beforeEach(() => __resetRegistryForTests());
+
+  it('picks the highest-priority matching classifier', () => {
+    registerErrorClassifier(classifier('low', 10, 'LOW_CODE'));
+    registerErrorClassifier(classifier('high', 100, 'HIGH_CODE'));
+    expect(classifyError({ operation: 'op' }).code).toBe('HIGH_CODE');
+  });
+
+  it('falls back to UNKNOWN when no classifier matches', () => {
+    const result = classifyError({
+      operation: 'op',
+      message: 'boom at https://host.internal/x',
+    });
+    expect(result.category).toBe('UNKNOWN');
+    expect(result.code).toBe('UNKNOWN_ERROR');
+    // Surfaces a redacted safe excerpt and keeps the raw as a sensitive detail.
+    const safe = result.details?.find((d) => d.sensitivity === 'safe');
+    const sensitive = result.details?.find((d) => d.sensitivity === 'sensitive');
+    expect(safe?.value).toBe('boom at <redacted-url>');
+    expect(sensitive?.value).toBe('boom at https://host.internal/x');
+  });
+
+  it('echoes the correlation id onto the classified error', () => {
+    expect(classifyError({ operation: 'op', correlationId: 'abc-123' }).correlationId).toBe(
+      'abc-123'
+    );
+  });
+
+  it('uses the registered translator to resolve wording', () => {
+    setTranslator((d) => `T:${d.id}`);
+    registerErrorClassifier(classifier('only', 1, 'RULE_GROUP_CONFLICT'));
+    expect(classifyError({ operation: 'op' }).title).toBe(
+      'T:observability.error.RULE_GROUP_CONFLICT.title'
+    );
+  });
+
+  describe('toClientPayload exposure policy', () => {
+    const withDetails: ClassifiedError = {
+      category: 'UNKNOWN',
+      code: 'UNKNOWN_ERROR',
+      title: 'Something went wrong',
+      message: 'An unexpected error occurred.',
+      retryable: false,
+      details: [
+        {
+          key: DetailKey.REDACTED,
+          label: 'Details',
+          value: 'boom',
+          sensitivity: 'safe',
+        },
+        {
+          key: DetailKey.RAW,
+          label: 'Raw',
+          value: 'boom at https://host.internal/x',
+          sensitivity: 'sensitive',
+        },
+      ],
+    };
+
+    it('strips sensitive details by default', () => {
+      const out = toClientPayload(withDetails);
+      expect(out.details).toHaveLength(1);
+      expect(out.details?.[0].sensitivity).toBe('safe');
+    });
+
+    it('keeps sensitive details when exposeSensitive is set', () => {
+      const out = toClientPayload(withDetails, { exposeSensitive: true });
+      expect(out.details).toHaveLength(2);
+      expect(out.details?.some((d) => d.sensitivity === 'sensitive')).toBe(true);
+    });
+
+    it('re-redacts safe detail values as defense in depth', () => {
+      const out = toClientPayload({
+        ...withDetails,
+        details: [
+          {
+            key: 'x',
+            label: 'l',
+            value: 'see https://host.cloud/y',
+            sensitivity: 'safe',
+          },
+        ],
+      });
+      expect(out.details?.[0].value).toBe('see <redacted-url>');
+    });
+  });
+
+  describe('enrichers', () => {
+    it('adds detail but cannot bypass redaction of safe values', () => {
+      registerErrorClassifier(classifier('only', 1, 'UNKNOWN_ERROR'));
+      registerErrorDetailEnricher({
+        name: 'leaky',
+        enrich: (err) => ({
+          ...err,
+          details: [
+            ...(err.details ?? []),
+            {
+              key: 'hint',
+              label: 'Hint',
+              value: 'call https://host.internal/api',
+              sensitivity: 'safe',
+            },
+          ],
+        }),
+      });
+      const out = classifyError({ operation: 'op' });
+      const hint = out.details?.find((d) => d.key === 'hint');
+      expect(hint?.value).toBe('call <redacted-url>');
+    });
+
+    it('a throwing enricher never breaks classification', () => {
+      registerErrorClassifier(classifier('only', 1, 'UNKNOWN_ERROR'));
+      registerErrorDetailEnricher({
+        name: 'bad',
+        enrich: () => {
+          throw new Error('enricher blew up');
+        },
+      });
+      expect(() => classifyError({ operation: 'op' })).not.toThrow();
+      expect(classifyError({ operation: 'op' }).code).toBe('UNKNOWN_ERROR');
+    });
+  });
+});

--- a/common/error/classifiers/http_status.ts
+++ b/common/error/classifiers/http_status.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Generic HTTP-status classifier — the broad fallback for any error that
+ * carries a status but wasn't matched by a more specific classifier. Maps the
+ * standard status families onto the taxonomy.
+ */
+
+import { ErrorCode } from '../messages';
+import type { ClassifierResult, ErrorClassifier } from '../types';
+import { rawDetails } from './util';
+
+export const httpStatusClassifier: ErrorClassifier = {
+  name: 'core.httpStatus',
+  priority: 40,
+  match: (ctx) => typeof ctx.httpStatus === 'number' && ctx.httpStatus >= 400,
+  classify: (ctx): ClassifierResult => {
+    const status = ctx.httpStatus as number;
+    switch (status) {
+      case 401:
+        return {
+          category: 'PERMISSION_DENIED',
+          code: ErrorCode.AUTH_REQUIRED,
+          retryable: false,
+          httpStatus: status,
+        };
+      case 403:
+        return {
+          category: 'PERMISSION_DENIED',
+          code: ErrorCode.PERMISSION_DENIED,
+          retryable: false,
+          httpStatus: status,
+        };
+      case 404:
+        return {
+          category: 'NOT_FOUND',
+          code: ErrorCode.RESOURCE_NOT_FOUND,
+          retryable: false,
+          httpStatus: status,
+        };
+      case 408:
+        return {
+          category: 'TIMEOUT',
+          code: ErrorCode.REQUEST_TIMEOUT,
+          retryable: true,
+          httpStatus: status,
+        };
+      case 409:
+        return {
+          category: 'CONFLICT',
+          code: ErrorCode.RESOURCE_CONFLICT,
+          retryable: false,
+          httpStatus: status,
+        };
+      case 412:
+        return {
+          category: 'PRECONDITION_FAILED',
+          code: ErrorCode.PRECONDITION_FAILED,
+          retryable: false,
+          httpStatus: status,
+        };
+      case 429:
+        return {
+          category: 'RATE_LIMITED',
+          code: ErrorCode.RATE_LIMITED,
+          retryable: true,
+          httpStatus: status,
+        };
+      default:
+        if (status >= 500) {
+          return {
+            category: 'UPSTREAM_UNAVAILABLE',
+            code: ErrorCode.UPSTREAM_UNAVAILABLE,
+            retryable: true,
+            httpStatus: status,
+          };
+        }
+        // Any other 4xx — treat as a validation-style rejection and surface the
+        // (redacted) upstream detail so the user can correct the request.
+        return {
+          category: 'VALIDATION',
+          code: ErrorCode.VALIDATION_FAILED,
+          retryable: false,
+          httpStatus: status,
+          details: rawDetails(ctx.rawBody),
+        };
+    }
+  },
+};

--- a/common/error/classifiers/ruler.ts
+++ b/common/error/classifiers/ruler.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Classifies provider-neutral ruler dual-write failures, keyed off the stable
+ * `upstreamCode` (RULER_*) captured at the transport boundary rather than off
+ * message text. This is what turns the create-rule / SLO-write generic 500
+ * into a specific, actionable category.
+ */
+
+import { ErrorCode } from '../messages';
+import type { ClassifierResult, ErrorClassifier } from '../types';
+import { rawDetails } from './util';
+
+export const rulerClassifier: ErrorClassifier = {
+  name: 'core.ruler',
+  priority: 80,
+  match: (ctx) => typeof ctx.upstreamCode === 'string' && ctx.upstreamCode.startsWith('RULER_'),
+  classify: (ctx): ClassifierResult => {
+    switch (ctx.upstreamCode) {
+      case 'RULER_VALIDATION_FAILED':
+        // The upstream diagnostic is genuinely actionable — attach it (redacted
+        // safe excerpt + sensitive raw) so the form can self-serve.
+        return {
+          category: 'VALIDATION',
+          code: ErrorCode.RULE_CONFIG_INVALID,
+          retryable: false,
+          httpStatus: ctx.httpStatus,
+          details: rawDetails(ctx.rawBody),
+        };
+      case 'RULER_AUTH_FAILED':
+        // No raw details for auth failures — upstream auth errors can echo
+        // tokens/headers. Split 401 (re-auth) from 403 (lacks permission).
+        return ctx.httpStatus === 401
+          ? {
+              category: 'PERMISSION_DENIED',
+              code: ErrorCode.AUTH_REQUIRED,
+              retryable: false,
+              httpStatus: ctx.httpStatus,
+            }
+          : {
+              category: 'PERMISSION_DENIED',
+              code: ErrorCode.PERMISSION_DENIED,
+              retryable: false,
+              httpStatus: ctx.httpStatus,
+            };
+      case 'RULER_UNREACHABLE':
+      default:
+        return {
+          category: 'UPSTREAM_UNAVAILABLE',
+          code: ErrorCode.RULE_BACKEND_UNAVAILABLE,
+          retryable: true,
+          httpStatus: ctx.httpStatus,
+        };
+    }
+  },
+};

--- a/common/error/classifiers/state.ts
+++ b/common/error/classifiers/state.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * "Successful response, unusable state" cases. Some surfaces return HTTP 200
+ * with a state enum that still means something is wrong for the user — a
+ * missing rule group, or a routing backend that reported no usable status.
+ * These aren't thrown errors, but they should speak the same user-facing
+ * language as the error layer.
+ *
+ * We model them as synthetic `upstreamCode`s ('STATE_*') routed through the
+ * same `classifyError` pipeline, so wording, categories, and adapters are
+ * shared. Callers use the thin helpers below rather than constructing contexts
+ * by hand.
+ */
+
+import { classifyError } from '../registry';
+import { ErrorCode } from '../messages';
+import type { ClassifiedError, ClassifierResult, ErrorClassifier, RawErrorContext } from '../types';
+
+const STATE_CODE_MAP: Record<
+  string,
+  { category: ClassifierResult['category']; code: string; retryable: boolean }
+> = {
+  STATE_RULES_MISSING: {
+    category: 'PARTIAL_STATE',
+    code: ErrorCode.RULES_MISSING,
+    retryable: false,
+  },
+  STATE_RULES_PARTIAL: {
+    category: 'PARTIAL_STATE',
+    code: ErrorCode.RULES_PARTIAL,
+    retryable: false,
+  },
+  STATE_RULER_UNREACHABLE: {
+    category: 'UPSTREAM_UNAVAILABLE',
+    code: ErrorCode.RULE_HEALTH_UNAVAILABLE,
+    retryable: true,
+  },
+  STATE_ROUTING_UNKNOWN: {
+    category: 'PARTIAL_STATE',
+    code: ErrorCode.ROUTING_STATE_UNKNOWN,
+    retryable: false,
+  },
+};
+
+export const stateClassifier: ErrorClassifier = {
+  name: 'core.state',
+  priority: 90,
+  match: (ctx) => typeof ctx.upstreamCode === 'string' && ctx.upstreamCode in STATE_CODE_MAP,
+  classify: (ctx): ClassifierResult => {
+    const mapped = STATE_CODE_MAP[ctx.upstreamCode as string];
+    return {
+      category: mapped.category,
+      code: mapped.code,
+      retryable: mapped.retryable,
+    };
+  },
+};
+
+const RULE_HEALTH_STATE_TO_CODE: Record<string, string> = {
+  rules_missing: 'STATE_RULES_MISSING',
+  rules_partial: 'STATE_RULES_PARTIAL',
+  ruler_unreachable: 'STATE_RULER_UNREACHABLE',
+};
+
+/**
+ * Classify a rule-health `state` enum. Returns null for healthy/unknown states
+ * ('ok' or anything not recognized as a problem) so callers can skip surfacing.
+ */
+export function classifyRuleHealthState(
+  state: string,
+  ctx: Partial<RawErrorContext> = {}
+): ClassifiedError | null {
+  const upstreamCode = RULE_HEALTH_STATE_TO_CODE[state];
+  if (!upstreamCode) return null;
+  return classifyError({ operation: 'slo.rule_health', ...ctx, upstreamCode });
+}
+
+/**
+ * Recognized routing/alertmanager cluster states that are NOT errors: 'ready'
+ * (healthy) and 'settling' (valid transient — starting up / gossip in
+ * progress). Callers surface these as their literal status rather than a
+ * partial-state error.
+ */
+const NON_ERROR_ROUTING_STATES: ReadonlySet<string> = new Set(['ready', 'settling']);
+
+/**
+ * Classify a routing/alertmanager cluster status string. Returns null for a
+ * recognized non-error state (so the caller shows the literal status); anything
+ * else — including 'unknown' or '' — surfaces as a partial/unknown routing
+ * state instead of the literal word.
+ */
+export function classifyRoutingStatus(
+  status: string | undefined,
+  ctx: Partial<RawErrorContext> = {}
+): ClassifiedError | null {
+  if (status && NON_ERROR_ROUTING_STATES.has(status)) return null;
+  return classifyError({
+    operation: 'routing.config',
+    ...ctx,
+    upstreamCode: 'STATE_ROUTING_UNKNOWN',
+  });
+}

--- a/common/error/classifiers/timeout.ts
+++ b/common/error/classifiers/timeout.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Classifies client- or server-side timeouts. Matches an aborted request
+ * (`AbortController` → `AbortError`), an HTTP 408, or a "timed out" message,
+ * so both the acknowledge abort path and upstream request-timeouts land in the
+ * TIMEOUT category consistently.
+ */
+
+import { ErrorCode } from '../messages';
+import type { ErrorClassifier, RawErrorContext } from '../types';
+
+function looksLikeTimeout(ctx: RawErrorContext): boolean {
+  // Explicit signals: an aborted / timed-out request, or a timeout status.
+  if (ctx.errorName === 'AbortError' || ctx.errorName === 'TimeoutError') return true;
+  if (ctx.httpStatus === 408 || ctx.httpStatus === 504) return true;
+  // Message-based match is only trusted when it can't be a more specific 4xx:
+  // a client-error response (e.g. an upstream parse error naming a "timeout"
+  // field) that merely contains the word is a validation failure, not a
+  // timeout, and retrying it would fail identically. Defer those to
+  // httpStatusClassifier by requiring no client-error status here.
+  const messageMatch = typeof ctx.message === 'string' && /timed out|timeout/i.test(ctx.message);
+  if (!messageMatch) return false;
+  return ctx.httpStatus === undefined || ctx.httpStatus >= 500;
+}
+
+export const timeoutClassifier: ErrorClassifier = {
+  name: 'core.timeout',
+  priority: 60,
+  match: looksLikeTimeout,
+  classify: (ctx) => ({
+    category: 'TIMEOUT',
+    code: ErrorCode.REQUEST_TIMEOUT,
+    retryable: true,
+    httpStatus: ctx.httpStatus,
+  }),
+};

--- a/common/error/classifiers/upstream_wrapped.ts
+++ b/common/error/classifiers/upstream_wrapped.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Highest-priority classifier: inspect the *inner* upstream cause rather than
+ * trusting the outer status. Upstream layers routinely wrap a specific failure
+ * (e.g. a 409 "already exists" conflict) inside a generic 5xx envelope. When
+ * the raw body / message reveals a more specific cause, we classify on that.
+ *
+ * Kept deliberately conservative — it only overrides when the inner signal is
+ * unambiguous, so it never mis-promotes a generic 5xx into a conflict.
+ */
+
+import { ErrorCode } from '../messages';
+import type { ErrorClassifier, RawErrorContext } from '../types';
+import { rawDetails, stringifyRaw } from './util';
+
+function haystack(ctx: RawErrorContext): string {
+  return `${stringifyRaw(ctx.rawBody)}\n${ctx.message ?? ''}`;
+}
+
+/** A conflict wrapped inside another (usually 5xx) status envelope. */
+function hasInnerConflict(ctx: RawErrorContext): boolean {
+  const text = haystack(ctx);
+  // Explicit inner 409 markers in the body are conclusive on their own (a
+  // wrapped conflict whose envelope echoes the real status).
+  if (/\bHTTP 409\b/i.test(text) || /\b409\b\s*-/.test(text)) return true;
+  // "already exists" on its own is ambiguous — a validation message can use it
+  // as a noun ("'name' field already exists in the schema"). Treat it as a
+  // conflict only when the outer status is a 409 (the real conflict — claim it
+  // here for the rule-group-specific wording) or a 5xx/unknown envelope masking
+  // one. A plain 4xx that merely mentions "already exists" is a genuine
+  // validation error and is left to the http-status classifier; a bare 409 with
+  // no such body also falls through to the generic RESOURCE_CONFLICT there.
+  if (!/already exists/i.test(text)) return false;
+  return ctx.httpStatus === undefined || ctx.httpStatus === 409 || ctx.httpStatus >= 500;
+}
+
+export const upstreamWrappedClassifier: ErrorClassifier = {
+  name: 'core.upstreamWrapped',
+  priority: 100,
+  match: (ctx) => hasInnerConflict(ctx),
+  classify: (ctx) => ({
+    category: 'CONFLICT',
+    code: ErrorCode.RULE_GROUP_CONFLICT,
+    retryable: false,
+    // Normalize to the true inner status — the outer 5xx was misleading.
+    httpStatus: 409,
+    details: rawDetails(ctx.rawBody),
+  }),
+};

--- a/common/error/classifiers/util.ts
+++ b/common/error/classifiers/util.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DETAIL_LABELS, DetailKey } from '../messages';
+import { redactForDisplay } from '../redact';
+import type { ErrorDetail } from '../types';
+
+/** Best-effort stringify of an arbitrary upstream body. */
+export function stringifyRaw(rawBody: unknown): string {
+  if (rawBody == null) return '';
+  if (typeof rawBody === 'string') return rawBody;
+  try {
+    return JSON.stringify(rawBody);
+  } catch {
+    return String(rawBody);
+  }
+}
+
+/**
+ * Build the standard pair of details from an upstream body: a `safe`
+ * redacted excerpt (shown by default) and the `sensitive` verbatim text
+ * (stripped from client payloads unless exposure is opted in).
+ */
+export function rawDetails(rawBody: unknown): ErrorDetail[] {
+  const raw = stringifyRaw(rawBody);
+  if (!raw) return [];
+  const details: ErrorDetail[] = [];
+  const redacted = redactForDisplay(raw);
+  if (redacted) {
+    details.push({
+      key: DetailKey.REDACTED,
+      label: DETAIL_LABELS[DetailKey.REDACTED],
+      value: redacted,
+      sensitivity: 'safe',
+    });
+  }
+  details.push({
+    key: DetailKey.RAW,
+    label: DETAIL_LABELS[DetailKey.RAW],
+    value: raw,
+    sensitivity: 'sensitive',
+  });
+  return details;
+}

--- a/common/error/examples/example_downstream_registration.ts
+++ b/common/error/examples/example_downstream_registration.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Generic, in-repo demonstration of the registration-only extension model.
+ *
+ * This is what a downstream fork does at startup to add richer, environment-
+ * specific behavior WITHOUT editing any core file:
+ *   1. register a higher-priority classifier that overrides a default, and
+ *   2. register a detail enricher that adds environment-specific detail.
+ *
+ * Everything here is provider-neutral and uses only placeholders (e.g.
+ * `<namespace>`). A real fork would substitute its own (non-open-source)
+ * wording and detail in exactly this shape — never by forking core.
+ */
+
+import { registerErrorClassifier, registerErrorDetailEnricher } from '../registry';
+import { DetailKey } from '../messages';
+import type {
+  ClassifiedError,
+  ErrorClassifier,
+  ErrorDetailEnricher,
+  RawErrorContext,
+} from '../types';
+
+/**
+ * A higher-priority classifier that overrides the default UPSTREAM_UNAVAILABLE
+ * wording for a specific operation, supplying inline messages and an extra
+ * `safe` hint. Priority 200 beats every core classifier (max core priority is
+ * 100), so it wins whenever it matches.
+ */
+export const exampleOverrideClassifier: ErrorClassifier = {
+  name: 'example.ruleBackendUnavailable',
+  priority: 200,
+  match: (ctx: RawErrorContext) =>
+    ctx.operation === 'rule.create.metric' && ctx.upstreamCode === 'RULER_UNREACHABLE',
+  classify: () => ({
+    category: 'UPSTREAM_UNAVAILABLE',
+    code: 'EXAMPLE_RULE_BACKEND_UNAVAILABLE',
+    retryable: true,
+    messages: {
+      title: {
+        id: 'example.error.ruleBackendUnavailable.title',
+        defaultMessage: 'Rule service is temporarily unavailable',
+      },
+      message: {
+        id: 'example.error.ruleBackendUnavailable.message',
+        defaultMessage:
+          'The rule service in namespace <namespace> did not respond. Your rule was not created.',
+      },
+      remediation: {
+        id: 'example.error.ruleBackendUnavailable.remediation',
+        defaultMessage: 'Retry in a few minutes; the service usually recovers on its own.',
+      },
+    },
+    details: [
+      {
+        key: DetailKey.UPSTREAM_STATUS,
+        label: { id: 'example.error.detail.hint', defaultMessage: 'Hint' },
+        value: 'Namespace <namespace> is provisioned but the ruler is not reachable.',
+        sensitivity: 'safe',
+      },
+    ],
+  }),
+};
+
+/**
+ * An enricher that appends an environment-specific `safe` breadcrumb to every
+ * classified error. Enrichers add detail; they cannot remove the core's safety
+ * guarantees (any `safe` value they add is re-redacted by the registry).
+ */
+export const exampleEnricher: ErrorDetailEnricher = {
+  name: 'example.correlationHint',
+  enrich: (err: ClassifiedError): ClassifiedError => ({
+    ...err,
+    details: [
+      ...(err.details ?? []),
+      {
+        key: 'exampleSupportHint',
+        label: 'Support',
+        value: 'Reference <namespace> when contacting support.',
+        sensitivity: 'safe',
+      },
+    ],
+  }),
+};
+
+/** Call once at downstream startup — mirrors what a fork's plugin setup does. */
+export function registerExampleDownstreamExtensions(): void {
+  registerErrorClassifier(exampleOverrideClassifier);
+  registerErrorDetailEnricher(exampleEnricher);
+}

--- a/common/error/index.ts
+++ b/common/error/index.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Framework-agnostic error-classification core. See ./README.md for the
+ * taxonomy and the registration-only extension model.
+ *
+ * Consumers (server routes, client adapters, downstream forks) import from
+ * here. The core has no framework dependencies; rendering and i18n live in
+ * adapters that call `setTranslator` and the `register*` seams.
+ */
+
+export * from './types';
+export { redactForDisplay } from './redact';
+export { ErrorCode, MESSAGE_CATALOG, DETAIL_LABELS, DetailKey, fallbackEntry } from './messages';
+export type { CatalogEntry, ErrorCodeValue } from './messages';
+export {
+  classifyError,
+  toClientPayload,
+  localizeClassified,
+  registerErrorClassifier,
+  registerErrorDetailEnricher,
+  setTranslator,
+  __resetRegistryForTests,
+} from './registry';
+export type { ClientPayloadOptions } from './registry';
+export {
+  classifyRuleHealthState,
+  classifyRoutingStatus,
+  stateClassifier,
+} from './classifiers/state';
+export { rulerClassifier } from './classifiers/ruler';
+export { upstreamWrappedClassifier } from './classifiers/upstream_wrapped';
+export { httpStatusClassifier } from './classifiers/http_status';
+export { timeoutClassifier } from './classifiers/timeout';
+export { rawDetails, stringifyRaw } from './classifiers/util';
+
+import { registerErrorClassifier } from './registry';
+import { upstreamWrappedClassifier } from './classifiers/upstream_wrapped';
+import { stateClassifier } from './classifiers/state';
+import { rulerClassifier } from './classifiers/ruler';
+import { timeoutClassifier } from './classifiers/timeout';
+import { httpStatusClassifier } from './classifiers/http_status';
+
+let defaultsRegistered = false;
+
+/**
+ * Register the built-in classifiers. Idempotent — safe to call from both the
+ * server and public plugin `setup()`. Downstream forks call this too, then add
+ * their own higher-priority classifiers/enrichers on top.
+ */
+export function registerDefaultClassifiers(): void {
+  if (defaultsRegistered) return;
+  defaultsRegistered = true;
+  registerErrorClassifier(upstreamWrappedClassifier);
+  registerErrorClassifier(stateClassifier);
+  registerErrorClassifier(rulerClassifier);
+  registerErrorClassifier(timeoutClassifier);
+  registerErrorClassifier(httpStatusClassifier);
+}
+
+/** Test-only: allow re-registration of defaults after a registry reset. */
+export function __resetDefaultsFlagForTests(): void {
+  defaultsRegistered = false;
+}

--- a/common/error/messages.ts
+++ b/common/error/messages.ts
@@ -1,0 +1,228 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Stable error codes and their provider-neutral wording.
+ *
+ * The catalog is the single source of user-facing text for the default
+ * classifiers. Wording here is deliberately generic — no vendor, product,
+ * host, or endpoint names. A downstream fork adds environment-specific
+ * phrasing by registering classifiers that inline their own `messages`, never
+ * by editing this file.
+ *
+ * Each code maps to a `title` (short), `message` (plain-language cause), and
+ * optional `remediation` (what to do next), as `MessageDescriptor`s so
+ * adapters can localize them. Dynamic specifics (counts, redacted excerpts)
+ * ride in `details`, not interpolated here, so every message localizes from
+ * its `code` alone.
+ */
+
+import type { ErrorCategory, MessageDescriptor } from './types';
+
+/** Stable machine codes. Values are intentionally provider-neutral. */
+export const ErrorCode = {
+  RULE_BACKEND_UNAVAILABLE: 'RULE_BACKEND_UNAVAILABLE',
+  RULE_GROUP_CONFLICT: 'RULE_GROUP_CONFLICT',
+  RESOURCE_CONFLICT: 'RESOURCE_CONFLICT',
+  RULE_CONFIG_INVALID: 'RULE_CONFIG_INVALID',
+  REQUEST_TIMEOUT: 'REQUEST_TIMEOUT',
+  ROUTING_STATE_UNKNOWN: 'ROUTING_STATE_UNKNOWN',
+  RULES_MISSING: 'RULES_MISSING',
+  RULES_PARTIAL: 'RULES_PARTIAL',
+  RULE_HEALTH_UNAVAILABLE: 'RULE_HEALTH_UNAVAILABLE',
+  AUTH_REQUIRED: 'AUTH_REQUIRED',
+  PERMISSION_DENIED: 'PERMISSION_DENIED',
+  RESOURCE_NOT_FOUND: 'RESOURCE_NOT_FOUND',
+  RATE_LIMITED: 'RATE_LIMITED',
+  PRECONDITION_FAILED: 'PRECONDITION_FAILED',
+  UPSTREAM_UNAVAILABLE: 'UPSTREAM_UNAVAILABLE',
+  VALIDATION_FAILED: 'VALIDATION_FAILED',
+  UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+} as const;
+
+export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+export interface CatalogEntry {
+  category: ErrorCategory;
+  title: MessageDescriptor;
+  message: MessageDescriptor;
+  remediation?: MessageDescriptor;
+}
+
+const ID_PREFIX = 'observability.error';
+
+function entry(
+  code: string,
+  category: ErrorCategory,
+  title: string,
+  message: string,
+  remediation?: string
+): CatalogEntry {
+  return {
+    category,
+    title: { id: `${ID_PREFIX}.${code}.title`, defaultMessage: title },
+    message: { id: `${ID_PREFIX}.${code}.message`, defaultMessage: message },
+    remediation: remediation
+      ? { id: `${ID_PREFIX}.${code}.remediation`, defaultMessage: remediation }
+      : undefined,
+  };
+}
+
+/** Code → wording. Consumed by `classifyError`; keyed by stable code. */
+export const MESSAGE_CATALOG: Record<string, CatalogEntry> = {
+  [ErrorCode.RULE_BACKEND_UNAVAILABLE]: entry(
+    ErrorCode.RULE_BACKEND_UNAVAILABLE,
+    'UPSTREAM_UNAVAILABLE',
+    'Rule service unavailable',
+    'The rule backend could not be reached, so the request did not complete.',
+    'Retry shortly; if it persists, check that the rule backend is healthy.'
+  ),
+  [ErrorCode.RULE_GROUP_CONFLICT]: entry(
+    ErrorCode.RULE_GROUP_CONFLICT,
+    'CONFLICT',
+    'Rule group already exists',
+    'A rule group with this name already exists.',
+    'Open the existing rule group, or choose a different name and retry.'
+  ),
+  [ErrorCode.RESOURCE_CONFLICT]: entry(
+    ErrorCode.RESOURCE_CONFLICT,
+    'CONFLICT',
+    'Conflict',
+    'The request conflicts with the current state of the resource.',
+    'Reload the latest state and retry.'
+  ),
+  [ErrorCode.RULE_CONFIG_INVALID]: entry(
+    ErrorCode.RULE_CONFIG_INVALID,
+    'VALIDATION',
+    'Alert rule is invalid',
+    'The alert rule was rejected because its configuration is invalid.',
+    'Correct the highlighted fields (for example, the query expression) and resubmit.'
+  ),
+  [ErrorCode.REQUEST_TIMEOUT]: entry(
+    ErrorCode.REQUEST_TIMEOUT,
+    'TIMEOUT',
+    'Request timed out',
+    'The request did not complete in the allowed time.',
+    'Retry; the operation may already have taken effect.'
+  ),
+  [ErrorCode.ROUTING_STATE_UNKNOWN]: entry(
+    ErrorCode.ROUTING_STATE_UNKNOWN,
+    'PARTIAL_STATE',
+    'Routing status unavailable',
+    'The routing backend responded but did not report a usable status.',
+    'Verify that routing is configured and reachable, then refresh.'
+  ),
+  [ErrorCode.RULES_MISSING]: entry(
+    ErrorCode.RULES_MISSING,
+    'PARTIAL_STATE',
+    'Rule groups missing',
+    'One or more expected rule groups are missing from the rule backend.',
+    'Use Restore to recreate the missing rule groups.'
+  ),
+  [ErrorCode.RULES_PARTIAL]: entry(
+    ErrorCode.RULES_PARTIAL,
+    'PARTIAL_STATE',
+    'Rule groups incomplete',
+    'Some of the expected rule groups are present and some are missing.',
+    'Use Restore to recreate the missing rule groups.'
+  ),
+  [ErrorCode.RULE_HEALTH_UNAVAILABLE]: entry(
+    ErrorCode.RULE_HEALTH_UNAVAILABLE,
+    'UPSTREAM_UNAVAILABLE',
+    'Rule health unavailable',
+    'Rule health could not be determined because the rule backend was unreachable.',
+    'Retry once the rule backend is reachable.'
+  ),
+  [ErrorCode.AUTH_REQUIRED]: entry(
+    ErrorCode.AUTH_REQUIRED,
+    'PERMISSION_DENIED',
+    'Authentication required',
+    'The request was not authenticated with the backend.',
+    'Sign in again or refresh your session, then retry.'
+  ),
+  [ErrorCode.PERMISSION_DENIED]: entry(
+    ErrorCode.PERMISSION_DENIED,
+    'PERMISSION_DENIED',
+    'Permission denied',
+    "You don't have permission to perform this action on the backend.",
+    'Ask an administrator to grant the required access, then retry.'
+  ),
+  [ErrorCode.RESOURCE_NOT_FOUND]: entry(
+    ErrorCode.RESOURCE_NOT_FOUND,
+    'NOT_FOUND',
+    'Not found',
+    'The requested resource could not be found.',
+    'Refresh and confirm the resource still exists.'
+  ),
+  [ErrorCode.RATE_LIMITED]: entry(
+    ErrorCode.RATE_LIMITED,
+    'RATE_LIMITED',
+    'Too many requests',
+    'The backend is rate-limiting requests.',
+    'Wait a moment and retry.'
+  ),
+  [ErrorCode.PRECONDITION_FAILED]: entry(
+    ErrorCode.PRECONDITION_FAILED,
+    'PRECONDITION_FAILED',
+    'Precondition failed',
+    'The resource changed since it was last loaded.',
+    'Reload the latest version and reapply your change.'
+  ),
+  [ErrorCode.UPSTREAM_UNAVAILABLE]: entry(
+    ErrorCode.UPSTREAM_UNAVAILABLE,
+    'UPSTREAM_UNAVAILABLE',
+    'Service unavailable',
+    'A backend service could not be reached, so the request did not complete.',
+    'Retry shortly; if it persists, check the backend service health.'
+  ),
+  [ErrorCode.VALIDATION_FAILED]: entry(
+    ErrorCode.VALIDATION_FAILED,
+    'VALIDATION',
+    'Invalid request',
+    'The request was rejected because it is invalid.',
+    'Correct the highlighted fields and resubmit.'
+  ),
+  [ErrorCode.UNKNOWN_ERROR]: entry(
+    ErrorCode.UNKNOWN_ERROR,
+    'UNKNOWN',
+    'Something went wrong',
+    'An unexpected error occurred while completing the request.',
+    'Retry; if it persists, share the correlation id with an administrator.'
+  ),
+};
+
+/** Fallback wording per category when a code isn't in the catalog. */
+export function fallbackEntry(category: ErrorCategory): CatalogEntry {
+  const byCategory = Object.values(MESSAGE_CATALOG).find((e) => e.category === category);
+  return byCategory ?? MESSAGE_CATALOG[ErrorCode.UNKNOWN_ERROR];
+}
+
+/** Stable detail keys used by default classifiers. */
+export const DetailKey = {
+  RAW: 'rawDetail',
+  REDACTED: 'redactedDetail',
+  RULE_GROUP_COUNTS: 'ruleGroupCounts',
+  UPSTREAM_STATUS: 'upstreamStatus',
+} as const;
+
+/** Localizable labels for the default detail keys. */
+export const DETAIL_LABELS: Record<string, MessageDescriptor> = {
+  [DetailKey.RAW]: {
+    id: `${ID_PREFIX}.detail.raw`,
+    defaultMessage: 'Raw error details',
+  },
+  [DetailKey.REDACTED]: {
+    id: `${ID_PREFIX}.detail.redacted`,
+    defaultMessage: 'Details',
+  },
+  [DetailKey.RULE_GROUP_COUNTS]: {
+    id: `${ID_PREFIX}.detail.ruleGroupCounts`,
+    defaultMessage: 'Rule groups',
+  },
+  [DetailKey.UPSTREAM_STATUS]: {
+    id: `${ID_PREFIX}.detail.upstreamStatus`,
+    defaultMessage: 'Reported status',
+  },
+};

--- a/common/error/redact.ts
+++ b/common/error/redact.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Default redaction used before any upstream-derived text reaches the browser.
+ *
+ * Goal: scrub content that could leak deployment topology or identifiers —
+ * URLs, hostnames, IPs, ARNs, long opaque IDs, and account-number-like token
+ * runs — while preserving the human-actionable substance of a message
+ * (e.g. "invalid PromQL: parse error"). This is best-effort defense-in-depth,
+ * not a security boundary: verbatim upstream text is only ever exposed through
+ * an explicit opt-in (a registered enricher or the server's default-off
+ * `exposeSensitiveErrorDetail` flag). Everything shown by default goes through
+ * here first.
+ *
+ * The rules are provider-neutral: they match generic network/identifier
+ * shapes, never any specific vendor, product, host, or account.
+ */
+
+interface RedactionRule {
+  pattern: RegExp;
+  replacement: string;
+}
+
+// Order matters: URL/ARN rules run before bare host/IP rules so the
+// surrounding structure is consumed as one unit.
+const RULES: RedactionRule[] = [
+  // Full URLs (http/https and generic scheme://).
+  {
+    pattern: /\b[a-z][a-z0-9+.-]*:\/\/[^\s"'<>)]+/gi,
+    replacement: '<redacted-url>',
+  },
+  // ARN-style resource identifiers (generic "arn:...:..." shape).
+  { pattern: /\barn:[^\s"'<>)]+/gi, replacement: '<redacted-arn>' },
+  // UUIDs.
+  {
+    pattern: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+    replacement: '<redacted-id>',
+  },
+  // IPv4 with optional :port.
+  {
+    pattern: /\b\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?\b/g,
+    replacement: '<redacted-ip>',
+  },
+  // IPv6 (rough — 3+ hextet groups).
+  {
+    pattern: /\b(?:[0-9a-f]{1,4}:){3,}[0-9a-f]{1,4}\b/gi,
+    replacement: '<redacted-ip>',
+  },
+  // FQDN-like hosts ending in a generic infra/TLD suffix, optional :port.
+  {
+    pattern:
+      /\b(?:[a-z0-9-]+\.)+(?:com|net|org|io|dev|internal|local|svc|cluster|cloud|corp)\b(?::\d+)?/gi,
+    replacement: '<redacted-host>',
+  },
+  // Single-label host WITH an explicit port (e.g. Kubernetes pod DNS
+  // "alertmanager-0:9093"). The host must itself look network-ish — contain a
+  // hyphen or digit — so ordinary prose like "at line:42" or "column:15" is
+  // left intact. A single-label host that is a plain word (no hyphen/digit) and
+  // has no dotted TLD still passes through — see the README ("best-effort").
+  {
+    pattern: /\b(?=[a-z0-9-]*[-0-9])[a-z][a-z0-9-]{1,}:\d{2,5}\b/gi,
+    replacement: '<redacted-host>',
+  },
+  // Long hex blobs (hashes / tokens).
+  { pattern: /\b[0-9a-f]{16,}\b/gi, replacement: '<redacted-id>' },
+  // Account-number-like runs of digits.
+  { pattern: /\b\d{10,}\b/g, replacement: '<redacted-id>' },
+];
+
+// Long mixed-alphanumeric tokens (bearer tokens, base64-ish secrets): require
+// both a letter and a digit and a minimum length, so ordinary long words are
+// left intact.
+const TOKEN_PATTERN =
+  /\b(?=[A-Za-z0-9+/_-]*[A-Za-z])(?=[A-Za-z0-9+/_-]*\d)[A-Za-z0-9+/_-]{24,}={0,2}\b/g;
+
+/**
+ * Scrub `text` of network/identifier content for safe display. Idempotent:
+ * running it twice yields the same result. Returns '' for empty/undefined
+ * input so callers can treat "nothing safe to show" uniformly.
+ */
+export function redactForDisplay(text: string | undefined | null): string {
+  if (!text) return '';
+  let out = String(text);
+  for (const { pattern, replacement } of RULES) {
+    out = out.replace(pattern, replacement);
+  }
+  out = out.replace(TOKEN_PATTERN, '<redacted-token>');
+  return out.trim();
+}

--- a/common/error/registry.ts
+++ b/common/error/registry.ts
@@ -1,0 +1,220 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The classification registry and pipeline.
+ *
+ * Core registers default classifiers at startup; a downstream fork registers
+ * additional classifiers (higher priority) and optional detail enrichers —
+ * purely by calling the `register*` functions, touching no core file.
+ *
+ * `classifyError` picks the highest-priority matching classifier, resolves
+ * wording from the shared catalog (or the classifier's inline overrides)
+ * through the registered `Translator`, applies enrichers, and returns a
+ * fully-resolved `ClassifiedError`. `toClientPayload` then enforces the
+ * exposure policy that keeps raw upstream text out of the browser by default.
+ */
+
+import { DETAIL_LABELS, DetailKey, ErrorCode, MESSAGE_CATALOG, fallbackEntry } from './messages';
+import type { CatalogEntry } from './messages';
+import { redactForDisplay } from './redact';
+import type {
+  ClassifiedError,
+  ClassifierResult,
+  ErrorClassifier,
+  ErrorDetail,
+  ErrorDetailEnricher,
+  MessageDescriptor,
+  RawErrorContext,
+  ResolvedErrorDetail,
+  Translator,
+} from './types';
+
+/** Interpolate `{placeholder}` tokens — the identity translator's behavior. */
+function interpolate(message: string, values?: Record<string, string | number>): string {
+  if (!values) return message;
+  return message.replace(/\{(\w+)\}/g, (match, key: string) =>
+    key in values ? String(values[key]) : match
+  );
+}
+
+const identityTranslator: Translator = (descriptor) =>
+  interpolate(descriptor.defaultMessage, descriptor.values);
+
+// Module-level mutable registry state. Reset in tests via
+// __resetRegistryForTests(). Classifiers are kept sorted by descending
+// priority; ties preserve registration order (stable sort).
+let classifiers: ErrorClassifier[] = [];
+let enrichers: ErrorDetailEnricher[] = [];
+let translator: Translator = identityTranslator;
+
+/** Install the framework translator (e.g. `@osd/i18n` / `@kbn/i18n`). */
+export function setTranslator(next: Translator): void {
+  translator = next;
+}
+
+/** Register a classifier. Higher `priority` wins during `classifyError`. */
+export function registerErrorClassifier(classifier: ErrorClassifier): void {
+  classifiers = [...classifiers, classifier].sort((a, b) => b.priority - a.priority);
+}
+
+/** Register a detail enricher. Enrichers run in registration order. */
+export function registerErrorDetailEnricher(enricher: ErrorDetailEnricher): void {
+  enrichers = [...enrichers, enricher];
+}
+
+/** Test-only: clear all registered classifiers/enrichers and the translator. */
+export function __resetRegistryForTests(): void {
+  classifiers = [];
+  enrichers = [];
+  translator = identityTranslator;
+}
+
+/**
+ * Built-in UNKNOWN result. Surfaces a redacted excerpt of the underlying
+ * message as a `safe` detail (so users get *something* actionable) and keeps
+ * the verbatim message as a `sensitive` detail for opt-in exposure.
+ */
+function unknownResult(ctx: RawErrorContext): ClassifierResult {
+  const details: ErrorDetail[] = [];
+  if (ctx.message) {
+    const redacted = redactForDisplay(ctx.message);
+    if (redacted) {
+      details.push({
+        key: DetailKey.REDACTED,
+        label: DETAIL_LABELS[DetailKey.REDACTED],
+        value: redacted,
+        sensitivity: 'safe',
+      });
+    }
+    details.push({
+      key: DetailKey.RAW,
+      label: DETAIL_LABELS[DetailKey.RAW],
+      value: String(ctx.message),
+      sensitivity: 'sensitive',
+    });
+  }
+  return {
+    category: 'UNKNOWN',
+    code: ErrorCode.UNKNOWN_ERROR,
+    retryable: false,
+    httpStatus: ctx.httpStatus,
+    details: details.length ? details : undefined,
+  };
+}
+
+function resolveDetail(detail: ErrorDetail): ResolvedErrorDetail {
+  return {
+    key: detail.key,
+    label: translator(detail.label),
+    // Re-redact safe values defensively; sensitive values pass through here and
+    // are gated later by toClientPayload.
+    value: detail.sensitivity === 'safe' ? redactForDisplay(detail.value) : detail.value,
+    sensitivity: detail.sensitivity,
+  };
+}
+
+/**
+ * Classify a raw error context into a fully-resolved `ClassifiedError`.
+ * Never throws: an unmatched context yields the UNKNOWN fallback.
+ */
+export function classifyError(ctx: RawErrorContext): ClassifiedError {
+  const classifier = classifiers.find((c) => {
+    try {
+      return c.match(ctx);
+    } catch {
+      return false;
+    }
+  });
+
+  const result = classifier ? classifier.classify(ctx) : unknownResult(ctx);
+
+  const catalog = MESSAGE_CATALOG[result.code] ?? fallbackEntry(result.category);
+  const pick = (
+    override: MessageDescriptor | undefined,
+    base: MessageDescriptor | undefined
+  ): string | undefined => {
+    const descriptor = override ?? base;
+    return descriptor ? translator(descriptor) : undefined;
+  };
+
+  let classified: ClassifiedError = {
+    category: result.category,
+    code: result.code,
+    title: pick(result.messages?.title, catalog.title) ?? result.code,
+    message: pick(result.messages?.message, catalog.message) ?? '',
+    remediation: pick(result.messages?.remediation, catalog.remediation),
+    retryable: result.retryable,
+    httpStatus: result.httpStatus ?? ctx.httpStatus,
+    correlationId: ctx.correlationId,
+    details: result.details?.map(resolveDetail),
+  };
+
+  for (const enricher of enrichers) {
+    try {
+      const enriched = enricher.enrich(classified, ctx);
+      // Re-apply redaction to any safe details the enricher introduced —
+      // enrichers add detail, they cannot bypass the safety guarantee.
+      classified = {
+        ...enriched,
+        details: enriched.details?.map((d) =>
+          d.sensitivity === 'safe' ? { ...d, value: redactForDisplay(d.value) } : d
+        ),
+      };
+    } catch {
+      // A misbehaving enricher must never break classification.
+    }
+  }
+
+  return classified;
+}
+
+/**
+ * Re-localize a classified error's wording using the currently-registered
+ * translator, keyed by its stable `code` and detail `key`s. Used on the client
+ * to localize a server-produced payload (which arrived resolved in English)
+ * through `@osd/i18n`. Codes not in the shared catalog (e.g. a downstream
+ * classifier's inline messages) are left as the server provided them.
+ */
+export function localizeClassified(err: ClassifiedError): ClassifiedError {
+  const catalog: CatalogEntry | undefined = MESSAGE_CATALOG[err.code];
+  if (!catalog) return err;
+  return {
+    ...err,
+    title: translator(catalog.title),
+    message: translator(catalog.message),
+    remediation: catalog.remediation ? translator(catalog.remediation) : err.remediation,
+    // Re-translate the label (a fixed catalog string) but never the value —
+    // detail values are data (a redacted excerpt, a count, an upstream status),
+    // not localizable text. A downstream classifier that wants localized detail
+    // text should localize it before attaching, not store a message key here.
+    details: err.details?.map((d) => {
+      const label = DETAIL_LABELS[d.key];
+      return label ? { ...d, label: translator(label) } : d;
+    }),
+  };
+}
+
+export interface ClientPayloadOptions {
+  /** When true, `sensitive` details survive to the client. Default false. */
+  exposeSensitive?: boolean;
+}
+
+/**
+ * Produce the client-facing payload. Strips `sensitive` details unless
+ * `exposeSensitive` is set, and re-redacts `safe` detail values as
+ * defense-in-depth. This is the one gate that enforces "no raw upstream text
+ * in the browser unless explicitly opted in".
+ */
+export function toClientPayload(
+  err: ClassifiedError,
+  options: ClientPayloadOptions = {}
+): ClassifiedError {
+  const exposeSensitive = options.exposeSensitive ?? false;
+  const details = (err.details ?? [])
+    .filter((d) => exposeSensitive || d.sensitivity === 'safe')
+    .map((d) => (d.sensitivity === 'safe' ? { ...d, value: redactForDisplay(d.value) } : d));
+  return { ...err, details: details.length ? details : undefined };
+}

--- a/common/error/types.ts
+++ b/common/error/types.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Framework-agnostic error-classification types.
+ *
+ * This module is pure TypeScript: it imports nothing from OpenSearch
+ * Dashboards, Kibana, React, or EUI, so the whole `common/error/` core drops
+ * into a downstream fork unchanged. Rendering (toasts/callouts) and i18n
+ * resolution live in framework-specific adapters that consume these types.
+ *
+ * The design intentionally separates three concerns:
+ *   1. Classification — deciding a stable `category` + `code` from a raw error
+ *      (the `ErrorClassifier`s). Provider-neutral by contract.
+ *   2. Wording — mapping a `code` to user-facing text (the message catalog),
+ *      resolved through a pluggable `Translator` so `@osd/i18n` (here) or
+ *      `@kbn/i18n` (fork) can localize without touching core.
+ *   3. Exposure — how much of the raw upstream detail reaches the browser
+ *      (the `sensitivity` flag on `ErrorDetail`, enforced at serialization).
+ */
+
+/**
+ * Provider-agnostic taxonomy. Every classified error lands in exactly one
+ * category; the `code` narrows it to a specific, actionable situation.
+ */
+export type ErrorCategory =
+  | 'VALIDATION'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'PERMISSION_DENIED'
+  | 'UPSTREAM_UNAVAILABLE'
+  | 'TIMEOUT'
+  | 'RATE_LIMITED'
+  | 'PRECONDITION_FAILED'
+  | 'PARTIAL_STATE'
+  | 'UNKNOWN';
+
+/**
+ * A localizable message. Carries a stable i18n `id` plus an English
+ * `defaultMessage`; adapters translate via a `Translator`. The default
+ * (identity) translator returns `defaultMessage` with `{placeholders}`
+ * interpolated, so the core is usable with no i18n framework at all.
+ */
+export interface MessageDescriptor {
+  id: string;
+  defaultMessage: string;
+  values?: Record<string, string | number>;
+}
+
+/** Resolves a descriptor to a display string. Registered per framework. */
+export type Translator = (descriptor: MessageDescriptor) => string;
+
+/**
+ * Whether a piece of detail is safe to show in the browser by default.
+ * `safe` values are redacted and always renderable; `sensitive` values hold
+ * verbatim upstream text and are stripped before reaching the client unless
+ * an operator/enricher explicitly opts in.
+ */
+export type DetailSensitivity = 'safe' | 'sensitive';
+
+/** Classifier-produced detail (label is still a descriptor, pre-resolution). */
+export interface ErrorDetail {
+  /** Stable key so adapters can re-localize the label, e.g. 'rawDetail'. */
+  key: string;
+  label: MessageDescriptor;
+  value: string;
+  sensitivity: DetailSensitivity;
+}
+
+/** Detail after label resolution — the shape carried on a ClassifiedError. */
+export interface ResolvedErrorDetail {
+  key: string;
+  label: string;
+  value: string;
+  sensitivity: DetailSensitivity;
+}
+
+/**
+ * Everything a classifier gets to look at. Deliberately neutral: it never
+ * carries framework objects, only primitives extracted at the boundary.
+ */
+export interface RawErrorContext {
+  /** Stable operation id, e.g. 'rule.create.metric' | 'slo.repair'. */
+  operation: string;
+  /** Outer HTTP status, if the failure came from an HTTP call. */
+  httpStatus?: number;
+  /** Provider-neutral upstream code if one was extracted, e.g. 'RULER_UNREACHABLE'. */
+  upstreamCode?: string;
+  /** `Error.name` of the thrown value, if any. */
+  errorName?: string;
+  /** The underlying error message — used for UNKNOWN redaction, never shown verbatim. */
+  message?: string;
+  /** Original upstream payload. Never surfaced verbatim by default. */
+  rawBody?: unknown;
+  /** Neutral source hint, e.g. 'prometheus' | 'opensearch'. */
+  sourceType?: string;
+  /** Correlation id minted at the server boundary; echoed to the client. */
+  correlationId?: string;
+}
+
+/**
+ * What a classifier returns. It decides category/code/retryable and may attach
+ * structured details; wording is normally looked up from the shared catalog by
+ * `code`, but a classifier (e.g. a downstream one) may inline its own
+ * `messages` for codes the catalog doesn't know.
+ */
+export interface ClassifierResult {
+  category: ErrorCategory;
+  code: string;
+  retryable: boolean;
+  httpStatus?: number;
+  details?: ErrorDetail[];
+  messages?: Partial<Record<'title' | 'message' | 'remediation', MessageDescriptor>>;
+}
+
+/** Fully-resolved, client-facing classified error. All text is display-ready. */
+export interface ClassifiedError {
+  category: ErrorCategory;
+  code: string;
+  title: string;
+  message: string;
+  remediation?: string;
+  retryable: boolean;
+  httpStatus?: number;
+  correlationId?: string;
+  details?: ResolvedErrorDetail[];
+}
+
+/**
+ * A classifier. Higher `priority` wins. `match` is a cheap predicate;
+ * `classify` runs only for the winning classifier. Downstream forks register
+ * additional classifiers at a higher priority to override defaults — without
+ * editing any core file.
+ */
+export interface ErrorClassifier {
+  readonly name: string;
+  readonly priority: number;
+  match(ctx: RawErrorContext): boolean;
+  classify(ctx: RawErrorContext): ClassifierResult;
+}
+
+/**
+ * Optional enrichment seam. Runs after classification+resolution. May add
+ * details (safe or sensitive) or refine wording; it cannot remove the safety
+ * guarantees — any `safe` detail it returns is re-redacted, and `sensitive`
+ * details still obey the client-exposure policy.
+ */
+export interface ErrorDetailEnricher {
+  readonly name: string;
+  enrich(err: ClassifiedError, ctx: RawErrorContext): ClassifiedError;
+}

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -31,6 +31,11 @@ import { FormattedMessage } from '@osd/i18n/react';
 import { toMountPoint } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { useToast } from '../common/toast';
 import {
+  ClassifiedErrorToastBody,
+  classifiedToastColor,
+  extractClassifiedError,
+} from '../common/error';
+import {
   Datasource,
   UnifiedAlertSummary,
   UnifiedRule,
@@ -120,7 +125,11 @@ type AdResourceLifecycleAction = 'start' | 'stop';
  * live on a Prometheus datasource the user just unchecked silently
  * shows zero matches.
  */
-export function parseAlarmsHashRoute(hash: string): { tab?: TabId; q?: string; ds?: string } {
+export function parseAlarmsHashRoute(hash: string): {
+  tab?: TabId;
+  q?: string;
+  ds?: string;
+} {
   if (!hash) return {};
   // Strip leading `#` then `/`. The hash router's URLs are
   // `#/rules?q=…` or `#/routing` etc.
@@ -382,7 +391,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     () =>
       (alertsData?.datasourceStatus || [])
         .filter((s) => s.fallback)
-        .map((s) => ({ datasourceName: s.datasourceName, fallback: s.fallback! })),
+        .map((s) => ({
+          datasourceName: s.datasourceName,
+          fallback: s.fallback!,
+        })),
     [alertsData]
   );
   const alertsErrorMessage =
@@ -582,7 +594,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       // immediately. The override is dropped once the refetch's response
       // either confirms the ack or removes the row.
       const lastUpdated = new Date().toISOString();
-      setAckOverrides((prev) => ({ ...prev, [alertId]: { state: 'acknowledged', lastUpdated } }));
+      setAckOverrides((prev) => ({
+        ...prev,
+        [alertId]: { state: 'acknowledged', lastUpdated },
+      }));
       // Bump the refresh token so the hook refetches and the override can
       // be reconciled / cleared once the backend agrees.
       bumpRefreshToken();
@@ -777,7 +792,11 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       setRules((prev) =>
         prev.map((r) =>
           r.id === monitor.id
-            ? { ...r, enabled: nextEnabled, status: nextEnabled ? 'active' : 'disabled' }
+            ? {
+                ...r,
+                enabled: nextEnabled,
+                status: nextEnabled ? 'active' : 'disabled',
+              }
             : r
         )
       );
@@ -1079,13 +1098,25 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       const message = extractServerErrorMessage(e);
       const pplError = extractPplValidationError(message);
       if (pplError) setPplSubmitError(pplError);
-      addToast(
-        i18n.translate('observability.alerting.alarmsPage.toast.createMonitorFailed', {
-          defaultMessage: 'Failed to create alert rule',
-        }),
-        'danger',
-        message
-      );
+      // Prefer the server's classified error: show its title plus a "See full
+      // error" expander carrying the exact, fully-unwrapped upstream diagnostic.
+      // Fall back to the raw message.
+      const classified = extractClassifiedError(e);
+      if (classified) {
+        addToast(
+          classified.title,
+          classifiedToastColor(classified),
+          toMountPoint(<ClassifiedErrorToastBody error={classified} />)
+        );
+      } else {
+        addToast(
+          i18n.translate('observability.alerting.alarmsPage.toast.createMonitorFailed', {
+            defaultMessage: 'Failed to create alert rule',
+          }),
+          'danger',
+          message
+        );
+      }
     }
   };
 
@@ -1365,7 +1396,9 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         <FormattedMessage
           id="observability.alerting.alarmsPage.ariaLive.showingTab"
           defaultMessage="Showing {tabName} tab"
-          values={{ tabName: tabs.find((t) => t.id === activeTab)?.name ?? activeTab }}
+          values={{
+            tabName: tabs.find((t) => t.id === activeTab)?.name ?? activeTab,
+          }}
         />
       </div>
       {renderTable()}

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -44,6 +44,7 @@ import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { EchartsRender } from './echarts_render';
 import { PromQLEditor } from './promql_editor';
+import { classifiedToastColor, classifiedToastText, extractClassifiedError } from '../common/error';
 import { MetricBrowser } from './metric_browser';
 
 // ============================================================================
@@ -97,8 +98,12 @@ export interface CreateMetricsMonitorProps {
   http?: {
     post: (path: string, options: { body: string }) => Promise<unknown>;
   };
-  /** Toast notification callback */
-  addToast?: (title: string, color?: 'success' | 'danger') => void;
+  /**
+   * Toast notification callback. `text` carries the classified error body
+   * (message + remediation + safe details); mount adapters must forward it and
+   * honor 'warning' so the detailed cause reaches the toast.
+   */
+  addToast?: (title: string, color?: 'success' | 'warning' | 'danger', text?: string) => void;
 }
 
 // ============================================================================
@@ -350,7 +355,10 @@ function buildThresholdChartOption(thresholdValue: number): Record<string, unkno
           symbol: 'none',
           lineStyle: { type: 'dashed', color: '#BD271E', width: 2 },
           data: [{ yAxis: thresholdValue }],
-          label: { formatter: `Threshold: ${thresholdValue}`, position: 'insideEndTop' },
+          label: {
+            formatter: `Threshold: ${thresholdValue}`,
+            position: 'insideEndTop',
+          },
         },
       },
     ],
@@ -407,7 +415,12 @@ const MonitorDetailsSection = React.memo<{
             defaultMessage: 'Description',
           })}{' '}
           <span
-            style={{ fontSize: 12, color: '#98A2B3', fontStyle: 'italic', fontWeight: 'normal' }}
+            style={{
+              fontSize: 12,
+              color: '#98A2B3',
+              fontStyle: 'italic',
+              fontWeight: 'normal',
+            }}
           >
             {i18n.translate('observability.alerting.createMetricsMonitor.descriptionOptional', {
               defaultMessage: '— optional',
@@ -452,7 +465,12 @@ const QuerySection = React.memo<{
   // datasource is provided (e.g. standalone usage), show a placeholder.
   const datasourceOptions = useMemo(() => {
     if (form.datasourceId) {
-      return [{ id: form.datasourceId, name: contextDatasourceName || form.datasourceId }];
+      return [
+        {
+          id: form.datasourceId,
+          name: contextDatasourceName || form.datasourceId,
+        },
+      ];
     }
     return [];
   }, [form.datasourceId, contextDatasourceName]);
@@ -654,7 +672,14 @@ const QuerySection = React.memo<{
             hideToolbar
           />
           <div
-            style={{ position: 'absolute', top: 4, right: 4, zIndex: 2, display: 'flex', gap: 2 }}
+            style={{
+              position: 'absolute',
+              top: 4,
+              right: 4,
+              zIndex: 2,
+              display: 'flex',
+              gap: 2,
+            }}
           >
             <EuiToolTip
               content={i18n.translate(
@@ -754,7 +779,9 @@ const TriggerConditionSection = React.memo<{
             options={OPERATOR_OPTIONS}
             value={form.operator}
             onChange={(e) =>
-              onUpdate({ operator: e.target.value as MetricsMonitorFormState['operator'] })
+              onUpdate({
+                operator: e.target.value as MetricsMonitorFormState['operator'],
+              })
             }
             compressed
             aria-label={i18n.translate(
@@ -991,7 +1018,10 @@ const LabelsSection = React.memo<{
               compressed
               aria-label={i18n.translate(
                 'observability.alerting.createMetricsMonitor.labelKeyAriaLabel',
-                { defaultMessage: 'Label key {index}', values: { index: i + 1 } }
+                {
+                  defaultMessage: 'Label key {index}',
+                  values: { index: i + 1 },
+                }
               )}
             />
           </EuiFlexItem>
@@ -1010,7 +1040,10 @@ const LabelsSection = React.memo<{
               compressed
               aria-label={i18n.translate(
                 'observability.alerting.createMetricsMonitor.labelValueAriaLabel',
-                { defaultMessage: 'Label value {index}', values: { index: i + 1 } }
+                {
+                  defaultMessage: 'Label value {index}',
+                  values: { index: i + 1 },
+                }
               )}
             />
           </EuiFlexItem>
@@ -1129,7 +1162,10 @@ const AnnotationsSection = React.memo<{
               compressed
               aria-label={i18n.translate(
                 'observability.alerting.createMetricsMonitor.annotationKeyAriaLabel',
-                { defaultMessage: 'Annotation key {index}', values: { index: i + 1 } }
+                {
+                  defaultMessage: 'Annotation key {index}',
+                  values: { index: i + 1 },
+                }
               )}
             />
           </EuiFlexItem>
@@ -1144,7 +1180,10 @@ const AnnotationsSection = React.memo<{
               compressed
               aria-label={i18n.translate(
                 'observability.alerting.createMetricsMonitor.annotationValueAriaLabel',
-                { defaultMessage: 'Annotation value {index}', values: { index: i + 1 } }
+                {
+                  defaultMessage: 'Annotation value {index}',
+                  values: { index: i + 1 },
+                }
               )}
             />
           </EuiFlexItem>
@@ -1220,7 +1259,10 @@ const ActionsSection = React.memo<{
                 onClick={() => onDeleteAction(action.id)}
                 aria-label={i18n.translate(
                   'observability.alerting.createMetricsMonitor.deleteActionAriaLabel',
-                  { defaultMessage: 'Delete action {name}', values: { name: action.name } }
+                  {
+                    defaultMessage: 'Delete action {name}',
+                    values: { name: action.name },
+                  }
                 )}
               >
                 {i18n.translate('observability.alerting.createMetricsMonitor.deleteActionButton', {
@@ -1402,9 +1444,10 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
     setForm((prev) => ({ ...prev, ...patch }));
   }, []);
 
-  const handleLabelsUpdate = useCallback((labels: LabelEntry[]) => updateForm({ labels }), [
-    updateForm,
-  ]);
+  const handleLabelsUpdate = useCallback(
+    (labels: LabelEntry[]) => updateForm({ labels }),
+    [updateForm]
+  );
 
   const handleAnnotationsUpdate = useCallback(
     (annotations: AnnotationEntry[]) => updateForm({ annotations }),
@@ -1479,12 +1522,25 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
       onSave(form);
     } catch (err) {
       console.error('CreateMetricsMonitor: rule creation failed', err);
-      addToast?.(
-        i18n.translate('observability.alerting.createMetricsMonitor.toast.failed', {
-          defaultMessage: 'Failed to create alert rule.',
-        }),
-        'danger'
-      );
+      // Surface the server's classified error (specific cause + remediation +
+      // correlation id) instead of a static "Failed to create alert rule."
+      // toast. Falls back to the generic message when no structured error is
+      // present (older server, network error, etc.).
+      const classified = extractClassifiedError(err);
+      if (classified) {
+        addToast?.(
+          classified.title,
+          classifiedToastColor(classified) === 'warning' ? 'warning' : 'danger',
+          classifiedToastText(classified)
+        );
+      } else {
+        addToast?.(
+          i18n.translate('observability.alerting.createMetricsMonitor.toast.failed', {
+            defaultMessage: 'Failed to create alert rule.',
+          }),
+          'danger'
+        );
+      }
     } finally {
       setIsSaving(false);
     }

--- a/public/components/alerting/explore_create_monitor.tsx
+++ b/public/components/alerting/explore_create_monitor.tsx
@@ -37,6 +37,7 @@ import { useDatasources } from './hooks/use_datasources';
 import { useMonitorMutations } from './hooks/use_monitor_mutations';
 import { useRulesData } from './hooks/use_rules_data';
 import { useToast } from '../common/toast';
+import { extractClassifiedError, classifiedToastColor, classifiedToastText } from '../common/error';
 import { transformPplFormToPayload } from '../../../common/services/alerting/form_transforms';
 import { Datasource } from '../../../common/types/alerting';
 import { showMonitorCreatedToast } from './toast_helpers';
@@ -177,7 +178,7 @@ export const ExploreCreateMonitor: React.FC<ExploreCreateMonitorProps> = ({
     }
     // Explore-launched flyout is OS-only; this branch is unreachable in
     // practice (we force `initialBackendType='opensearch'`).
-    return (form as unknown) as Record<string, unknown>;
+    return form as unknown as Record<string, unknown>;
   };
 
   const handleSave = async (formState: MonitorFormState) => {
@@ -202,13 +203,24 @@ export const ExploreCreateMonitor: React.FC<ExploreCreateMonitorProps> = ({
       // them inline under the editor so the user can fix without losing context.
       const match = message.match(/PPL Query validation failed:[^"}]+/i);
       if (match) setPplSubmitError(match[0]);
-      setToast(
-        i18n.translate('observability.alerting.exploreCreateMonitor.toast.createFailed', {
-          defaultMessage: 'Failed to create alert rule',
-        }),
-        'danger',
-        message
-      );
+      // Prefer the server's classified error (specific cause + remediation +
+      // safe details) when present; fall back to the raw message otherwise.
+      const classified = extractClassifiedError(e);
+      if (classified) {
+        setToast(
+          classified.title,
+          classifiedToastColor(classified),
+          classifiedToastText(classified)
+        );
+      } else {
+        setToast(
+          i18n.translate('observability.alerting.exploreCreateMonitor.toast.createFailed', {
+            defaultMessage: 'Failed to create alert rule',
+          }),
+          'danger',
+          message
+        );
+      }
     }
   };
 

--- a/public/components/alerting/notification_routing_panel.tsx
+++ b/public/components/alerting/notification_routing_panel.tsx
@@ -30,6 +30,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
+import { classifyRoutingStatus } from '../../../common/error';
 import { Datasource } from '../../../common/types/alerting';
 import { AlertmanagerAdminService } from './query_services/alertmanager_admin_service';
 
@@ -67,7 +68,11 @@ interface AlertmanagerConfig {
   available: boolean;
   error?: string;
   configParseError?: string;
-  cluster?: { status: string; peers: Array<{ name: string; address: string }>; peerCount: number };
+  cluster?: {
+    status: string;
+    peers: Array<{ name: string; address: string }>;
+    peerCount: number;
+  };
   uptime?: string;
   versionInfo?: Record<string, string>;
   config?: {
@@ -190,7 +195,7 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
       const res = await adminService.getConfig(selectedDsId);
       // The API client types route/inhibitRules as `unknown` because it's
       // handed back raw from Alertmanager; narrow to our local shape here.
-      setConfig((res as unknown) as AlertmanagerConfig);
+      setConfig(res as unknown as AlertmanagerConfig);
     } catch (e: unknown) {
       setError(
         e instanceof Error
@@ -345,6 +350,10 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
   const inhibitRules = config.config?.inhibitRules || [];
   const cluster = config.cluster;
   const version = config.versionInfo?.version || '—';
+  // Map the raw cluster status through the shared error layer. Null when the
+  // backend reports a healthy 'ready'; otherwise a PARTIAL_STATE classification
+  // whose title replaces the previously-literal "unknown".
+  const routingStatus = classifyRoutingStatus(cluster?.status);
 
   // -----------------------------------------------------------------------
   // Route tree table
@@ -357,7 +366,12 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
         defaultMessage: 'Receiver',
       }),
       render: (val: string, item: FlatRoute) => (
-        <span style={{ paddingLeft: item.depth * 20, fontWeight: item.depth === 0 ? 600 : 400 }}>
+        <span
+          style={{
+            paddingLeft: item.depth * 20,
+            fontWeight: item.depth === 0 ? 600 : 400,
+          }}
+        >
           {item.depth > 0 && <span style={{ color: '#98A2B3', marginRight: 6 }}>{'└'}</span>}
           {val || (
             <EuiText size="xs" color="subdued">
@@ -561,12 +575,11 @@ export const NotificationRoutingPanel: React.FC<NotificationRoutingPanelProps> =
       <EuiPanel paddingSize="s" hasBorder>
         <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
           <EuiFlexItem grow={false}>
-            <EuiHealth color={cluster?.status === 'ready' ? 'success' : 'danger'}>
-              {cluster?.status ||
-                i18n.translate(
-                  'observability.alerting.notificationRoutingPanel.clusterStatusUnknown',
-                  { defaultMessage: 'unknown' }
-                )}
+            <EuiHealth color={cluster?.status === 'ready' ? 'success' : 'warning'}>
+              {/* 'ready' is healthy; any other/empty/unknown status is surfaced
+                  through the shared error layer as a partial-state label
+                  ("Routing status unavailable") instead of the literal word. */}
+              {routingStatus ? routingStatus.title : cluster?.status}
             </EuiHealth>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -41,6 +41,7 @@ import { useHistory, useParams } from 'react-router-dom';
 import { ChromeStart, NotificationsStart } from '../../../../../../../src/core/public';
 import { HeaderControlledComponentsWrapper } from '../../../../plugin_helpers/plugin_headerControl';
 import { extractRulerErrorEnvelope } from './slo_api_client';
+import { redactForDisplay } from '../../../../../common/error';
 import type { SloApiClient, SloRulerErrorEnvelope } from './slo_api_client';
 import { GeneratedRulesPreview } from './generated_rules_preview';
 import { DatasourceSelect } from './datasource_select';
@@ -188,9 +189,10 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
     ]);
   }, [chrome]);
 
-  const template = useMemo(() => SLO_TEMPLATES.find((t) => t.id === state.templateId) ?? null, [
-    state.templateId,
-  ]);
+  const template = useMemo(
+    () => SLO_TEMPLATES.find((t) => t.id === state.templateId) ?? null,
+    [state.templateId]
+  );
 
   // Reset scroll to the top whenever a template is (re)selected, so picking a
   // card lower on the picker grid lands the user at the start of the creation
@@ -232,7 +234,10 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   // (matches the shortest recording window). The probe's lookback is a
   // horizontal-axis concern applied server-side by queryRange(); these
   // PromQL strings are what the ruler would otherwise evaluate.
-  const probeQueries = useMemo<{ good: string | null; total: string | null }>(() => {
+  const probeQueries = useMemo<{
+    good: string | null;
+    total: string | null;
+  }>(() => {
     if (!liveInput) return { good: null, total: null };
     const firstObjective = liveInput.spec.objectives[0];
     if (!firstObjective) return { good: null, total: null };
@@ -497,7 +502,9 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
                               <EuiText size="xs" color="subdued" component="span">
                                 {i18n.translate(
                                   'observability.apm.slo.wizard.sli.dimensionsAccordionHint',
-                                  { defaultMessage: '— scoped to the selected service by default' }
+                                  {
+                                    defaultMessage: '— scoped to the selected service by default',
+                                  }
                                 )}
                               </EuiText>
                             </EuiText>
@@ -575,7 +582,13 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
                           data-test-subj="slosWizardRulerError"
                         >
                           <EuiText size="s">
-                            <p data-test-subj="slosWizardRulerErrorBody">{rulerError.rawBody}</p>
+                            {/* Redact before display — the upstream body can
+                                embed hostnames / URLs / ids. The un-redacted
+                                body remains available server-side by
+                                correlation id. */}
+                            <p data-test-subj="slosWizardRulerErrorBody">
+                              {redactForDisplay(rulerError.rawBody)}
+                            </p>
                             <p>
                               <small>
                                 {i18n.translate(
@@ -692,6 +705,7 @@ const IdentityPanel: React.FC<PanelProps & { template: string }> = ({
       error={errors['spec.name']}
     >
       <EuiFieldText
+        isInvalid={!!errors['spec.name']}
         value={state.name}
         onChange={(e) => dispatch({ kind: 'setField', field: 'name', value: e.target.value })}
         data-test-subj="slosWizardName"
@@ -706,7 +720,11 @@ const IdentityPanel: React.FC<PanelProps & { template: string }> = ({
         rows={2}
         value={state.description}
         onChange={(e) =>
-          dispatch({ kind: 'setField', field: 'description', value: e.target.value })
+          dispatch({
+            kind: 'setField',
+            field: 'description',
+            value: e.target.value,
+          })
         }
         data-test-subj="slosWizardDescription"
       />
@@ -773,7 +791,11 @@ const OwnerPanel: React.FC<
         <EuiFieldText
           value={state.ownerPrimaryUser}
           onChange={(e) =>
-            dispatch({ kind: 'setField', field: 'ownerPrimaryUser', value: e.target.value })
+            dispatch({
+              kind: 'setField',
+              field: 'ownerPrimaryUser',
+              value: e.target.value,
+            })
           }
           data-test-subj="slosWizardOwnerPrimaryUser"
         />
@@ -797,7 +819,9 @@ const OwnerPanel: React.FC<
 // into the type-specific SLI editors (CustomPromqlEditor / StructuredSliEditor);
 // this panel now owns only the dimension rows, which apply to every SLI type.
 const SliPanel: React.FC<
-  PanelProps & { template: import('../../../../../common/slo/slo_templates').SloTemplate }
+  PanelProps & {
+    template: import('../../../../../common/slo/slo_templates').SloTemplate;
+  }
 > = ({ state, errors, dispatch, template }) => (
   <>
     <EuiText size="xs" color="subdued">

--- a/public/components/common/error/__tests__/classified_error_callout.test.tsx
+++ b/public/components/common/error/__tests__/classified_error_callout.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ClassifiedErrorCallout } from '../classified_error_callout';
+import type { ClassifiedError } from '../../../../../common/error';
+
+function classified(overrides: Partial<ClassifiedError> = {}): ClassifiedError {
+  return {
+    category: 'VALIDATION',
+    code: 'RULE_CONFIG_INVALID',
+    title: 'Alert rule is invalid',
+    message: 'The alert rule was rejected because its configuration is invalid.',
+    remediation: 'Correct the highlighted fields and resubmit.',
+    retryable: false,
+    correlationId: 'cid-42',
+    ...overrides,
+  };
+}
+
+describe('ClassifiedErrorCallout', () => {
+  it('renders title, message, remediation and (for escalation categories) the correlation id', () => {
+    render(
+      <ClassifiedErrorCallout
+        error={classified({
+          category: 'UPSTREAM_UNAVAILABLE',
+          code: 'RULE_BACKEND_UNAVAILABLE',
+        })}
+      />
+    );
+    expect(screen.getByText('Alert rule is invalid')).toBeInTheDocument();
+    expect(
+      screen.getByText('The alert rule was rejected because its configuration is invalid.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Correct the highlighted fields and resubmit.')).toBeInTheDocument();
+    expect(screen.getByTestId('classifiedErrorCorrelationId')).toHaveTextContent('cid-42');
+  });
+
+  it('omits the correlation id for self-serviceable categories (e.g. VALIDATION)', () => {
+    render(<ClassifiedErrorCallout error={classified({ category: 'VALIDATION' })} />);
+    expect(screen.queryByTestId('classifiedErrorCorrelationId')).not.toBeInTheDocument();
+  });
+
+  it('shows a safe-details accordion and omits raw details when none are exposed', () => {
+    render(
+      <ClassifiedErrorCallout
+        error={classified({
+          details: [
+            {
+              key: 'redactedDetail',
+              label: 'Details',
+              value: 'invalid PromQL: parse error',
+              sensitivity: 'safe',
+            },
+          ],
+        })}
+      />
+    );
+    expect(screen.getByTestId('classifiedErrorSafeDetails')).toBeInTheDocument();
+    expect(screen.queryByTestId('classifiedErrorRawDetails')).not.toBeInTheDocument();
+  });
+
+  it('shows a raw-details accordion when sensitive details are exposed', () => {
+    render(
+      <ClassifiedErrorCallout
+        error={classified({
+          details: [
+            {
+              key: 'rawDetail',
+              label: 'Raw error details',
+              value: 'verbatim upstream body',
+              sensitivity: 'sensitive',
+            },
+          ],
+        })}
+      />
+    );
+    expect(screen.getByTestId('classifiedErrorRawDetails')).toBeInTheDocument();
+  });
+});

--- a/public/components/common/error/__tests__/extract.test.ts
+++ b/public/components/common/error/__tests__/extract.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  classifiedToastColor,
+  classifiedToastText,
+  extractClassifiedError,
+  showClassifiedErrorToast,
+} from '../extract';
+import type { ClassifiedError } from '../../../../../common/error';
+
+function classified(overrides: Partial<ClassifiedError> = {}): ClassifiedError {
+  return {
+    category: 'UPSTREAM_UNAVAILABLE',
+    code: 'RULE_BACKEND_UNAVAILABLE',
+    title: 'Rule service unavailable',
+    message: 'The rule backend could not be reached.',
+    remediation: 'Retry shortly.',
+    retryable: true,
+    correlationId: 'cid-1',
+    ...overrides,
+  };
+}
+
+describe('extractClassifiedError', () => {
+  it('reads the structured error from an OSD http error body', () => {
+    const err = {
+      body: { message: 'x', attributes: { errorDetail: classified() } },
+    };
+    const out = extractClassifiedError(err);
+    expect(out?.code).toBe('RULE_BACKEND_UNAVAILABLE');
+  });
+
+  it('also reads a top-level body.errorDetail (no attributes wrapper)', () => {
+    // Some routes may return the classified body directly rather than the
+    // OSD `{ message, attributes }` wrap. Both shapes should work.
+    const err = { body: { errorDetail: classified() } };
+    const out = extractClassifiedError(err);
+    expect(out?.code).toBe('RULE_BACKEND_UNAVAILABLE');
+  });
+
+  it('returns null when no structured error is present', () => {
+    expect(extractClassifiedError({ body: { message: 'x' } })).toBeNull();
+    expect(extractClassifiedError('nope')).toBeNull();
+    expect(extractClassifiedError(null)).toBeNull();
+  });
+});
+
+describe('toast presentation', () => {
+  it('maps partial/timeout/rate-limited to warning, others to danger', () => {
+    expect(classifiedToastColor(classified({ category: 'PARTIAL_STATE' }))).toBe('warning');
+    expect(classifiedToastColor(classified({ category: 'TIMEOUT' }))).toBe('warning');
+    expect(classifiedToastColor(classified({ category: 'CONFLICT' }))).toBe('danger');
+  });
+
+  it('composes text with message, remediation, safe details and reference', () => {
+    const text = classifiedToastText(
+      classified({
+        details: [
+          {
+            key: 'redactedDetail',
+            label: 'Details',
+            value: 'invalid PromQL',
+            sensitivity: 'safe',
+          },
+          {
+            key: 'rawDetail',
+            label: 'Raw',
+            value: 'secret',
+            sensitivity: 'sensitive',
+          },
+        ],
+      })
+    );
+    expect(text).toContain('The rule backend could not be reached.');
+    expect(text).toContain('Retry shortly.');
+    expect(text).toContain('Details: invalid PromQL');
+    expect(text).toContain('Reference: cid-1');
+    // Sensitive details never appear in toast text.
+    expect(text).not.toContain('secret');
+  });
+
+  it('omits the reference for self-serviceable categories, keeps it for escalation ones', () => {
+    // VALIDATION / CONFLICT are self-serviceable — no reference noise.
+    expect(classifiedToastText(classified({ category: 'VALIDATION' }))).not.toContain('Reference:');
+    expect(classifiedToastText(classified({ category: 'CONFLICT' }))).not.toContain('Reference:');
+    // Escalation categories keep the reference so it can be quoted in a ticket.
+    expect(classifiedToastText(classified({ category: 'UPSTREAM_UNAVAILABLE' }))).toContain(
+      'Reference: cid-1'
+    );
+    expect(classifiedToastText(classified({ category: 'PERMISSION_DENIED' }))).toContain(
+      'Reference: cid-1'
+    );
+  });
+
+  it('dispatches to addWarning/addDanger by category', () => {
+    const toasts = { addDanger: jest.fn(), addWarning: jest.fn() };
+    showClassifiedErrorToast(toasts, classified({ category: 'CONFLICT' }));
+    expect(toasts.addDanger).toHaveBeenCalledTimes(1);
+    expect(toasts.addWarning).not.toHaveBeenCalled();
+
+    showClassifiedErrorToast(toasts, classified({ category: 'TIMEOUT' }));
+    expect(toasts.addWarning).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/components/common/error/classified_error_callout.tsx
+++ b/public/components/common/error/classified_error_callout.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Inline callout variant of a classified error, for form/detail pages. Mirrors
+ * the existing alerting callout patterns (danger/warning `EuiCallOut`, small
+ * size, data-test-subj). Safe details are shown behind a "View details"
+ * accordion; raw (`sensitive`) details — present only when an operator/fork
+ * opted into exposure — get their own clearly-labeled accordion.
+ */
+
+import React from 'react';
+import { EuiAccordion, EuiCallOut, EuiCodeBlock, EuiSpacer, EuiText } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import type { ClassifiedError } from '../../../../common/error';
+import { classifiedToastColor, shouldShowCorrelationReference } from './extract';
+
+export interface ClassifiedErrorCalloutProps {
+  error: ClassifiedError;
+  dataTestSubj?: string;
+}
+
+export const ClassifiedErrorCallout: React.FC<ClassifiedErrorCalloutProps> = ({
+  error,
+  dataTestSubj = 'classifiedErrorCallout',
+}) => {
+  const color = classifiedToastColor(error);
+  const safe = (error.details ?? []).filter((d) => d.sensitivity === 'safe' && d.value);
+  const sensitive = (error.details ?? []).filter((d) => d.sensitivity === 'sensitive' && d.value);
+
+  return (
+    <EuiCallOut
+      title={error.title}
+      color={color}
+      iconType="alert"
+      size="s"
+      data-test-subj={dataTestSubj}
+    >
+      <EuiText size="s">
+        <p>{error.message}</p>
+      </EuiText>
+      {error.remediation && (
+        <EuiText size="s">
+          <p>{error.remediation}</p>
+        </EuiText>
+      )}
+
+      {safe.length > 0 && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiAccordion
+            id={`classifiedError-details-${error.code}`}
+            buttonContent={i18n.translate('observability.error.callout.viewDetails', {
+              defaultMessage: 'View details',
+            })}
+            data-test-subj="classifiedErrorSafeDetails"
+          >
+            {safe.map((detail, idx) => (
+              <EuiCodeBlock key={idx} paddingSize="s" fontSize="s" isCopyable>
+                {`${detail.label}: ${detail.value}`}
+              </EuiCodeBlock>
+            ))}
+          </EuiAccordion>
+        </>
+      )}
+
+      {sensitive.length > 0 && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiAccordion
+            id={`classifiedError-raw-${error.code}`}
+            buttonContent={i18n.translate('observability.error.callout.rawDetails', {
+              defaultMessage: 'Raw error details (may contain internal detail)',
+            })}
+            data-test-subj="classifiedErrorRawDetails"
+          >
+            {sensitive.map((detail, idx) => (
+              <EuiCodeBlock key={idx} paddingSize="s" fontSize="s" isCopyable>
+                {detail.value}
+              </EuiCodeBlock>
+            ))}
+          </EuiAccordion>
+        </>
+      )}
+
+      {shouldShowCorrelationReference(error) && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiText size="xs" color="subdued">
+            <p data-test-subj="classifiedErrorCorrelationId">
+              {i18n.translate('observability.error.callout.reference', {
+                defaultMessage: 'Reference: {id}',
+                values: { id: error.correlationId },
+              })}
+            </p>
+          </EuiText>
+        </>
+      )}
+    </EuiCallOut>
+  );
+};

--- a/public/components/common/error/classified_error_toast.tsx
+++ b/public/components/common/error/classified_error_toast.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Toast body for a classified error, plus the modal it opens.
+ *
+ * The toast shows the plain-language message and a "See the full error" link.
+ * Clicking it opens a modal (via the overlays service) with the exact, fully
+ * unwrapped upstream diagnostic (e.g. an upstream query parse error) in a
+ * scrollable, copyable code block — matching the Discover "Search Error"
+ * pattern. Render the body into an OSD toast via
+ * `toMountPoint(<ClassifiedErrorToastBody .../>)`.
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiCodeBlock,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { toMountPoint } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
+import { coreRefs } from '../../../framework/core_refs';
+import type { ClassifiedError } from '../../../../common/error';
+import { shouldShowCorrelationReference } from './extract';
+
+/** The full, copyable error body: the unwrapped `safe` diagnostic(s) + reference. */
+export function fullErrorText(error: ClassifiedError): string {
+  const parts: string[] = [];
+  for (const d of error.details ?? []) {
+    if (d.sensitivity === 'safe' && d.value) parts.push(d.value);
+  }
+  if (shouldShowCorrelationReference(error) && error.correlationId) {
+    parts.push(`Reference: ${error.correlationId}`);
+  }
+  return parts.join('\n\n');
+}
+
+export interface ClassifiedErrorModalProps {
+  error: ClassifiedError;
+  onClose: () => void;
+}
+
+/** Modal showing the summary callout + the full, unwrapped error (copyable). */
+export const ClassifiedErrorModal: React.FC<ClassifiedErrorModalProps> = ({ error, onClose }) => {
+  const full = fullErrorText(error);
+  return (
+    <EuiModal onClose={onClose} maxWidth={900} data-test-subj="classifiedErrorModal">
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <h1>{error.title}</h1>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiCallOut title={error.message} color="danger" iconType="alert" size="s" />
+        {error.remediation && (
+          <>
+            <EuiSpacer size="s" />
+            <EuiText size="s">
+              <p>{error.remediation}</p>
+            </EuiText>
+          </>
+        )}
+        {full && (
+          <>
+            <EuiSpacer size="s" />
+            <EuiCodeBlock
+              language="text"
+              paddingSize="m"
+              fontSize="s"
+              isCopyable
+              overflowHeight={400}
+              whiteSpace="pre-wrap"
+              data-test-subj="classifiedErrorModalBody"
+            >
+              {full}
+            </EuiCodeBlock>
+          </>
+        )}
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButton onClick={onClose} fill data-test-subj="classifiedErrorModalClose">
+          {i18n.translate('observability.error.modal.close', {
+            defaultMessage: 'Close',
+          })}
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};
+
+export interface ClassifiedErrorToastBodyProps {
+  error: ClassifiedError;
+}
+
+export const ClassifiedErrorToastBody: React.FC<ClassifiedErrorToastBodyProps> = ({ error }) => {
+  const hasFull = Boolean(fullErrorText(error));
+
+  const openFullError = () => {
+    const overlays = coreRefs.overlays;
+    if (!overlays) return;
+    const ref = overlays.openModal(
+      toMountPoint(<ClassifiedErrorModal error={error} onClose={() => ref.close()} />)
+    );
+  };
+
+  return (
+    <EuiText size="s" data-test-subj="classifiedErrorToastBody">
+      <p>{error.message}</p>
+      {hasFull && (
+        <>
+          <EuiSpacer size="s" />
+          <div style={{ textAlign: 'right' }}>
+            <EuiButton
+              size="s"
+              color="danger"
+              onClick={openFullError}
+              data-test-subj="classifiedErrorToastSeeFullError"
+            >
+              {i18n.translate('observability.error.toast.seeFullError', {
+                defaultMessage: 'See the full error',
+              })}
+            </EuiButton>
+          </div>
+        </>
+      )}
+    </EuiText>
+  );
+};

--- a/public/components/common/error/extract.ts
+++ b/public/components/common/error/extract.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Client-side helpers that turn a `ClassifiedError` into presentation inputs.
+ * Framework-facing (toasts), but kept free of React so they're unit-testable
+ * without a DOM. The callout component lives alongside in
+ * ./classified_error_callout.tsx.
+ */
+
+import type { ToastInputFields } from '../../../../../../src/core/public';
+import { localizeClassified } from '../../../../common/error';
+import type { ClassifiedError } from '../../../../common/error';
+
+export type ClassifiedToastColor = 'danger' | 'warning';
+
+/**
+ * Pull a structured `ClassifiedError` out of an OSD http error, if the server
+ * attached one. OSD wraps `res.customError({ body: { message, attributes } })`
+ * into an error whose `.body` is `{ message, attributes }`; our server adapter
+ * places the structured error at `attributes.errorDetail` (the shape produced
+ * by `toErrorBody` / the SLO route's `{ message, attributes }` wrap). We also
+ * accept a top-level `body.errorDetail` so a future route that returns the
+ * classified body directly still surfaces the rich toast. Re-localizes the
+ * wording through the client translator. Returns null when absent so callers
+ * can fall back to their existing generic handling.
+ */
+export function extractClassifiedError(err: unknown): ClassifiedError | null {
+  if (!err || typeof err !== 'object') return null;
+  const body = (err as { body?: unknown }).body;
+  if (!body || typeof body !== 'object') return null;
+  const attrs = (body as { attributes?: unknown }).attributes;
+  const fromAttrs =
+    attrs && typeof attrs === 'object'
+      ? (attrs as { errorDetail?: unknown }).errorDetail
+      : undefined;
+  const detail = fromAttrs ?? (body as { errorDetail?: unknown }).errorDetail;
+  if (
+    !detail ||
+    typeof detail !== 'object' ||
+    typeof (detail as ClassifiedError).code !== 'string' ||
+    typeof (detail as ClassifiedError).category !== 'string'
+  ) {
+    return null;
+  }
+  return localizeClassified(detail as ClassifiedError);
+}
+
+/** Warning for soft/partial/transient states; danger otherwise. */
+export function classifiedToastColor(error: ClassifiedError): ClassifiedToastColor {
+  switch (error.category) {
+    case 'PARTIAL_STATE':
+    case 'TIMEOUT':
+    case 'RATE_LIMITED':
+      return 'warning';
+    default:
+      return 'danger';
+  }
+}
+
+/**
+ * Categories whose next step is escalation (contact an admin / ops), where the
+ * correlation id is worth quoting in a ticket so support can find the full,
+ * un-redacted detail in the server logs. Self-serviceable categories
+ * (VALIDATION, CONFLICT, NOT_FOUND, PRECONDITION_FAILED) surface an actionable
+ * message on their own, so the reference is omitted there to avoid noise.
+ */
+const REFERENCE_CATEGORIES: ReadonlySet<ClassifiedError['category']> = new Set([
+  'UPSTREAM_UNAVAILABLE',
+  'TIMEOUT',
+  'PERMISSION_DENIED',
+  'RATE_LIMITED',
+  'PARTIAL_STATE',
+  'UNKNOWN',
+]);
+
+/**
+ * Whether to surface the correlation id ("Reference: …") to the user. True only
+ * when a correlation id exists and the category is one the user would escalate.
+ */
+export function shouldShowCorrelationReference(error: ClassifiedError): boolean {
+  return Boolean(error.correlationId) && REFERENCE_CATEGORIES.has(error.category);
+}
+
+/** Compose the toast body text: message, remediation, safe details, reference. */
+export function classifiedToastText(error: ClassifiedError): string {
+  const parts: string[] = [error.message];
+  if (error.remediation) parts.push(error.remediation);
+  for (const detail of error.details ?? []) {
+    if (detail.sensitivity === 'safe' && detail.value)
+      parts.push(`${detail.label}: ${detail.value}`);
+  }
+  if (shouldShowCorrelationReference(error)) parts.push(`Reference: ${error.correlationId}`);
+  return parts.join('\n');
+}
+
+/** Minimal shape of the OSD toasts service used by the adapter. */
+export interface ToastsLike {
+  addDanger: (toast: ToastInputFields) => void;
+  addWarning: (toast: ToastInputFields) => void;
+}
+
+/**
+ * Surface a classified error as an EUI toast (danger or warning by category).
+ * The title/message are already localized; safe details and the correlation id
+ * ride in the text. Raw (`sensitive`) details are shown only in the inline
+ * callout, never in a toast.
+ */
+export function showClassifiedErrorToast(toasts: ToastsLike, error: ClassifiedError): void {
+  const toast: ToastInputFields = {
+    title: error.title,
+    text: classifiedToastText(error),
+  };
+  if (classifiedToastColor(error) === 'warning') {
+    toasts.addWarning(toast);
+  } else {
+    toasts.addDanger(toast);
+  }
+}

--- a/public/components/common/error/index.ts
+++ b/public/components/common/error/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  extractClassifiedError,
+  classifiedToastColor,
+  classifiedToastText,
+  showClassifiedErrorToast,
+} from './extract';
+export type { ToastsLike, ClassifiedToastColor } from './extract';
+export { shouldShowCorrelationReference } from './extract';
+export { ClassifiedErrorCallout } from './classified_error_callout';
+export type { ClassifiedErrorCalloutProps } from './classified_error_callout';
+export {
+  ClassifiedErrorToastBody,
+  ClassifiedErrorModal,
+  fullErrorText,
+} from './classified_error_toast';
+export type {
+  ClassifiedErrorToastBodyProps,
+  ClassifiedErrorModalProps,
+} from './classified_error_toast';

--- a/public/components/common/toast/index.tsx
+++ b/public/components/common/toast/index.tsx
@@ -3,17 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ToastInputFields } from '../../../../../../src/core/public';
+import { MountPoint, ToastInputFields } from '../../../../../../src/core/public';
 import { coreRefs } from '../../../framework/core_refs';
 
 type Color = 'success' | 'primary' | 'warning' | 'danger' | undefined;
 
+// Monotonic counter so two toasts raised in the same millisecond get distinct
+// ids. A bare `new Date().toISOString()` collides when, e.g., a single submit
+// raises two failure toasts, and EUI dedupes same-id toasts into one entry.
+let toastSeq = 0;
+
 export const useToast = () => {
   const toasts = coreRefs.toasts!;
 
-  const setToast = (title: string, color: Color = 'success', text?: string) => {
+  // `text` accepts a MountPoint (e.g. toMountPoint(<ClassifiedErrorToastBody/>))
+  // in addition to a plain string, so callers can render a rich toast body such
+  // as the "See full error" expander.
+  const setToast = (title: string, color: Color = 'success', text?: string | MountPoint) => {
     const newToast: ToastInputFields = {
-      id: new Date().toISOString(),
+      id: `${new Date().toISOString()}-${(toastSeq += 1)}`,
       title,
       text,
     };

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -8,6 +8,7 @@ import { i18n } from '@osd/i18n';
 import React from 'react';
 import { BehaviorSubject, combineLatest } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { registerDefaultClassifiers, setTranslator } from '../common/error';
 import {
   App,
   AppCategory,
@@ -156,46 +157,43 @@ interface PublicConfig {
   };
 }
 
-export const [
-  getRenderAccelerationDetailsFlyout,
-  setRenderAccelerationDetailsFlyout,
-] = createGetterSetter<
-  ({
-    acceleration,
-    dataSourceName,
-    handleRefresh,
-    dataSourceMDSId,
-  }: RenderAccelerationDetailsFlyoutParams) => void
->('renderAccelerationDetailsFlyout');
+export const [getRenderAccelerationDetailsFlyout, setRenderAccelerationDetailsFlyout] =
+  createGetterSetter<
+    ({
+      acceleration,
+      dataSourceName,
+      handleRefresh,
+      dataSourceMDSId,
+    }: RenderAccelerationDetailsFlyoutParams) => void
+  >('renderAccelerationDetailsFlyout');
 
-export const [
-  getRenderAssociatedObjectsDetailsFlyout,
-  setRenderAssociatedObjectsDetailsFlyout,
-] = createGetterSetter<
-  ({
-    tableDetail,
-    dataSourceName,
-    handleRefresh,
-    dataSourceMDSId,
-  }: RenderAssociatedObjectsDetailsFlyoutParams) => void
->('renderAssociatedObjectsDetailsFlyout');
+export const [getRenderAssociatedObjectsDetailsFlyout, setRenderAssociatedObjectsDetailsFlyout] =
+  createGetterSetter<
+    ({
+      tableDetail,
+      dataSourceName,
+      handleRefresh,
+      dataSourceMDSId,
+    }: RenderAssociatedObjectsDetailsFlyoutParams) => void
+  >('renderAssociatedObjectsDetailsFlyout');
 
-export const [
-  getRenderCreateAccelerationFlyout,
-  setRenderCreateAccelerationFlyout,
-] = createGetterSetter<
-  ({
-    dataSource,
-    dataSourceMDSId,
-    databaseName,
-    tableName,
-    handleRefresh,
-  }: RenderAccelerationFlyoutParams) => void
->('renderCreateAccelerationFlyout');
+export const [getRenderCreateAccelerationFlyout, setRenderCreateAccelerationFlyout] =
+  createGetterSetter<
+    ({
+      dataSource,
+      dataSourceMDSId,
+      databaseName,
+      tableName,
+      handleRefresh,
+    }: RenderAccelerationFlyoutParams) => void
+  >('renderCreateAccelerationFlyout');
 
-export class ObservabilityPlugin
-  implements
-    Plugin<ObservabilitySetup, ObservabilityStart, SetupDependencies, AppPluginStartDependencies> {
+export class ObservabilityPlugin implements Plugin<
+  ObservabilitySetup,
+  ObservabilityStart,
+  SetupDependencies,
+  AppPluginStartDependencies
+> {
   private config: PublicConfig;
   constructor(initializerContext: PluginInitializerContext) {
     this.config = initializerContext.config.get<PublicConfig>();
@@ -216,6 +214,20 @@ export class ObservabilityPlugin
     setupDeps: SetupDependencies
   ): Promise<ObservabilitySetup> {
     uiSettingsService.init(core.uiSettings, core.notifications);
+
+    // Stand up the shared error-classification layer for the browser: register
+    // the default classifiers and route wording through @osd/i18n. Server
+    // responses carry a structured `errorDetail`; the render adapters localize
+    // it here. Downstream forks add higher-priority classifiers/enrichers on
+    // top (registration only). See common/error/README.md.
+    registerDefaultClassifiers();
+    setTranslator((descriptor) =>
+      i18n.translate(descriptor.id, {
+        defaultMessage: descriptor.defaultMessage,
+        values: descriptor.values,
+      })
+    );
+
     const pplService = new PPLService(core.http);
     const qm = new QueryManager();
     setPPLService(pplService);
@@ -358,35 +370,34 @@ export class ObservabilityPlugin
       // prometheus: openSearchLocalDataSourcePluggable
     };
 
-    const appMountWithStartPage = (startPage: string, defaultRoute?: string) => async (
-      params: AppMountParameters
-    ) => {
-      const { Observability } = await import('./components/index');
-      const [coreStart, depsStart] = await core.getStartServices();
-      const dslService = new DSLService(coreStart.http);
-      const savedObjects = new SavedObjects(coreStart.http);
-      const timestampUtils = new TimestampUtils(dslService, pplService);
-      const { dataSourceManagement } = setupDeps;
+    const appMountWithStartPage =
+      (startPage: string, defaultRoute?: string) => async (params: AppMountParameters) => {
+        const { Observability } = await import('./components/index');
+        const [coreStart, depsStart] = await core.getStartServices();
+        const dslService = new DSLService(coreStart.http);
+        const savedObjects = new SavedObjects(coreStart.http);
+        const timestampUtils = new TimestampUtils(dslService, pplService);
+        const { dataSourceManagement } = setupDeps;
 
-      const mlCommonsRCFService = new MLCommonsRCFService(coreStart.http);
+        const mlCommonsRCFService = new MLCommonsRCFService(coreStart.http);
 
-      return Observability(
-        coreStart,
-        depsStart,
-        params,
-        pplService,
-        dslService,
-        mlCommonsRCFService,
-        savedObjects,
-        timestampUtils,
-        qm,
-        startPage,
-        dataSourcePluggables, // just pass down for now due to time constraint, later may better expose this as context
-        dataSourceManagement,
-        coreStart.savedObjects,
-        defaultRoute
-      );
-    };
+        return Observability(
+          coreStart,
+          depsStart,
+          params,
+          pplService,
+          dslService,
+          mlCommonsRCFService,
+          savedObjects,
+          timestampUtils,
+          qm,
+          startPage,
+          dataSourcePluggables, // just pass down for now due to time constraint, later may better expose this as context
+          dataSourceManagement,
+          coreStart.savedObjects,
+          defaultRoute
+        );
+      };
 
     core.application.register({
       id: observabilityMetricsID,
@@ -483,7 +494,7 @@ export class ObservabilityPlugin
                 ...sloUpdate,
                 navLinkStatus: eitherHidden
                   ? AppNavLinkStatus.hidden
-                  : sloUpdate.navLinkStatus ?? apmUpdate.navLinkStatus,
+                  : (sloUpdate.navLinkStatus ?? apmUpdate.navLinkStatus),
               };
             })
           ),
@@ -615,8 +626,7 @@ export class ObservabilityPlugin
         .getStartServices()
         .then(([coreStart]) => {
           const capabilities = coreStart.application.capabilities as
-            | { observability?: { alertManagerEnabled?: boolean } }
-            | undefined;
+            { observability?: { alertManagerEnabled?: boolean } } | undefined;
           if (!capabilities?.observability?.alertManagerEnabled) {
             return;
           }
@@ -634,8 +644,7 @@ export class ObservabilityPlugin
               // agent config + cluster gate; we just light up alongside
               // theirs so users see this option when PPL alerting is on.
               const liveCapabilities = coreRefs.application?.capabilities as
-                | { alertingDashboards?: { pplV2?: boolean } }
-                | undefined;
+                { alertingDashboards?: { pplV2?: boolean } } | undefined;
               if (!liveCapabilities?.alertingDashboards?.pplV2) return false;
               // This is a Logs (PPL) rule action — disable on Metrics
               // (PromQL) pages so users don't get the wrong flyout.
@@ -648,13 +657,15 @@ export class ObservabilityPlugin
               return !isAOSS;
             },
             component: (props) => {
-              const dataset = (props.dependencies.query as {
-                dataset?: {
-                  dataSource?: { id?: string; title?: string; name?: string };
-                  title?: string;
-                  timeFieldName?: string;
-                };
-              }).dataset;
+              const dataset = (
+                props.dependencies.query as {
+                  dataset?: {
+                    dataSource?: { id?: string; title?: string; name?: string };
+                    title?: string;
+                    timeFieldName?: string;
+                  };
+                }
+              ).dataset;
               const exploreContext = {
                 dataSourceId: dataset?.dataSource?.id,
                 dataSourceName: dataset?.dataSource?.title ?? dataset?.dataSource?.name,
@@ -699,8 +710,7 @@ export class ObservabilityPlugin
         .getStartServices()
         .then(([coreStart]) => {
           const capabilities = coreStart.application.capabilities as
-            | { observability?: { alertManagerEnabled?: boolean } }
-            | undefined;
+            { observability?: { alertManagerEnabled?: boolean } } | undefined;
           if (!capabilities?.observability?.alertManagerEnabled) {
             return;
           }
@@ -724,13 +734,15 @@ export class ObservabilityPlugin
               return !isAOSS;
             },
             component: (props) => {
-              const dataset = (props.dependencies.query as {
-                dataset?: {
-                  id?: string;
-                  title?: string;
-                  dataSource?: { id?: string; title?: string; name?: string };
-                };
-              }).dataset;
+              const dataset = (
+                props.dependencies.query as {
+                  dataset?: {
+                    id?: string;
+                    title?: string;
+                    dataSource?: { id?: string; title?: string; name?: string };
+                  };
+                }
+              ).dataset;
               // On the Metrics page the Prometheus connection is the dataset
               // itself (dataset.id), not a nested dataSource. Fall back to
               // dataset.dataSource.id for compatibility with other layouts.
@@ -747,11 +759,16 @@ export class ObservabilityPlugin
                     datasourceId={dsId}
                     datasourceName={dsName}
                     http={props.services.http}
-                    addToast={(title, color) =>
-                      props.services.notifications.toasts[
-                        color === 'danger' ? 'addDanger' : 'addSuccess'
-                      ](title)
-                    }
+                    addToast={(title, color, text) => {
+                      // Forward the classified error body (`text`) and honor
+                      // 'warning' so the detailed cause — not just the title —
+                      // reaches the toast on create failure.
+                      const toast = text ? { title, text } : { title };
+                      const svc = props.services.notifications.toasts;
+                      if (color === 'danger') svc.addDanger(toast);
+                      else if (color === 'warning') svc.addWarning(toast);
+                      else svc.addSuccess(toast);
+                    }}
                   />
                 </React.Suspense>
               );
@@ -787,8 +804,7 @@ export class ObservabilityPlugin
     // take effect on the next page load. Components
     // (`apm/pages/services_home`, `apm/pages/service_details`) read this ref.
     const observabilityCapabilities = core.application.capabilities.observability as
-      | { alertManagerEnabled?: boolean; sloEnabled?: boolean }
-      | undefined;
+      { alertManagerEnabled?: boolean; sloEnabled?: boolean } | undefined;
     const sloEnabledFromCapability = !!observabilityCapabilities?.sloEnabled;
     const alertManagerEnabledFromCapability = !!observabilityCapabilities?.alertManagerEnabled;
     coreRefs.sloEnabled = sloEnabledFromCapability;

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,6 +24,14 @@ const observabilityConfig = {
     alertManager: schema.object({
       enabled: schema.boolean({ defaultValue: false }),
     }),
+    errors: schema.object({
+      // When true, verbatim upstream error detail (classified as `sensitive`)
+      // is included in API error responses. Defaults off so open-source /
+      // multi-tenant deployments never leak raw upstream text to the browser;
+      // operators and downstream forks opt in per environment. The full detail
+      // is always logged server-side with a correlation id regardless.
+      exposeSensitiveErrorDetail: schema.boolean({ defaultValue: false }),
+    }),
     slo: schema.object({
       // Top-level SLO feature gate. Ships dark — operators opt in via
       // `observability.slo.enabled: true` in `opensearch_dashboards.yml`.

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -26,6 +26,8 @@ import { PPLParsers } from './parsers/ppl_parser';
 import { registerObservabilityUISettings } from './plugin_helper/register_settings';
 import { setupRoutes } from './routes/index';
 import { registerSloRoutes } from './routes/slo';
+import { registerDefaultClassifiers } from '../common/error';
+import { configureErrorExposure } from './routes/alerting/classified_error';
 import {
   getSearchSavedObject,
   getVisualizationSavedObject,
@@ -68,7 +70,11 @@ export class ObservabilityPlugin implements Plugin<
    * `first()` and replays don't refresh on reload.
    */
   private sloRulerClient?: DirectQueryRulerClient;
-  private sloReconcilerOpts?: { enabled: boolean; intervalMs: number; graceMs: number };
+  private sloReconcilerOpts?: {
+    enabled: boolean;
+    intervalMs: number;
+    graceMs: number;
+  };
   private sloReconciler?: SloReconciler;
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
@@ -317,7 +323,10 @@ export class ObservabilityPlugin implements Plugin<
           };
         },
         getTitle(obj) {
-          const attrs = obj.attributes as { name?: string; spec?: { name?: string } };
+          const attrs = obj.attributes as {
+            name?: string;
+            spec?: { name?: string };
+          };
           return String(attrs.name ?? attrs.spec?.name ?? obj.id);
         },
       },
@@ -339,14 +348,26 @@ export class ObservabilityPlugin implements Plugin<
     const observabilityConfig = await this.initializerContext.config
       .create<{
         alertManager?: { enabled?: boolean };
+        errors?: { exposeSensitiveErrorDetail?: boolean };
         slo?: {
           enabled?: boolean;
           ruleDedup?: { enabled: boolean };
-          reconciler?: { enabled?: boolean; intervalMs?: number; graceMs?: number };
+          reconciler?: {
+            enabled?: boolean;
+            intervalMs?: number;
+            graceMs?: number;
+          };
         };
       }>()
       .pipe(first())
       .toPromise();
+
+    // Stand up the shared error-classification layer: register the default
+    // provider-neutral classifiers and apply the client-exposure policy. A
+    // downstream fork adds higher-priority classifiers / enrichers on top
+    // (registration only, no core edits). See common/error/README.md.
+    registerDefaultClassifiers();
+    configureErrorExposure(observabilityConfig.errors?.exposeSensitiveErrorDetail ?? false);
     // yml-derived defaults for the two UI-visibility flags. When the
     // dynamic-config layer is absent (open-source / GitHub OSD) these
     // values flow straight through to the registered capability defaults
@@ -614,7 +635,10 @@ export class ObservabilityPlugin implements Plugin<
           core.savedObjects,
           core.opensearch,
           this.sloRulerClient,
-          { intervalMs: reconcilerOpts.intervalMs, graceMs: reconcilerOpts.graceMs }
+          {
+            intervalMs: reconcilerOpts.intervalMs,
+            graceMs: reconcilerOpts.graceMs,
+          }
         );
         this.sloReconciler.start();
       }

--- a/server/routes/alerting/__tests__/classified_error.test.ts
+++ b/server/routes/alerting/__tests__/classified_error.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  __resetDefaultsFlagForTests,
+  __resetRegistryForTests,
+  registerDefaultClassifiers,
+} from '../../../../common/error';
+import type { ClassifiedError } from '../../../../common/error';
+import type { Logger } from '../../../../common/types/alerting';
+import { SloRulerError } from '../../../../common/slo/slo_errors';
+import { createInternalError } from '../../../services/alerting/errors';
+import {
+  classifyToHandlerResult,
+  configureErrorExposure,
+  contextFromError,
+} from '../classified_error';
+
+const logger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+} as unknown as Logger;
+
+beforeEach(() => {
+  __resetRegistryForTests();
+  __resetDefaultsFlagForTests();
+  registerDefaultClassifiers();
+  configureErrorExposure(false);
+  jest.clearAllMocks();
+});
+
+describe('contextFromError', () => {
+  it('extracts a neutral context from a SloRulerError, dropping httpStatus 0', () => {
+    const ctx = contextFromError(new SloRulerError('RULER_UNREACHABLE', 0, 'body'), 'op', 'cid');
+    expect(ctx.upstreamCode).toBe('RULER_UNREACHABLE');
+    expect(ctx.httpStatus).toBeUndefined();
+    expect(ctx.correlationId).toBe('cid');
+  });
+
+  it('maps an AlertManagerError to its status', () => {
+    const ctx = contextFromError(createInternalError('boom'), 'op', 'cid');
+    expect(ctx.httpStatus).toBe(500);
+    expect(ctx.message).toBe('boom');
+  });
+
+  it('reads opensearch-js style statusCode off a plain Error', () => {
+    const e = Object.assign(new Error('nope'), { statusCode: 404 });
+    expect(contextFromError(e, 'op', 'cid').httpStatus).toBe(404);
+  });
+});
+
+describe('classifyToHandlerResult', () => {
+  it('turns a ruler-unreachable failure into a specific classified error, not a generic 500', () => {
+    const result = classifyToHandlerResult(
+      new SloRulerError('RULER_UNREACHABLE', 503, 'upstream body'),
+      { operation: 'rule.create.metric', logger }
+    );
+    const detail = result.body.errorDetail as ClassifiedError;
+    expect(detail.category).toBe('UPSTREAM_UNAVAILABLE');
+    expect(detail.code).toBe('RULE_BACKEND_UNAVAILABLE');
+    expect(detail.title).toBe('Rule service unavailable');
+    // The legacy `error` field carries the plain-language message (→ HTTP `message`).
+    expect(result.body.error).toBe(detail.message);
+    expect(result.body.correlationId).toEqual(expect.any(String));
+    // Full detail logged server-side with the correlation id.
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect((logger.error as jest.Mock).mock.calls[0][0]).toContain(result.body.correlationId);
+  });
+
+  it('reclassifies a wrapped inner 409 conflict and trusts its 409 over the outer 503', () => {
+    const result = classifyToHandlerResult(
+      new SloRulerError(
+        'RULER_UNREACHABLE',
+        503,
+        'error: 409 - { "message": "A namespace with name <namespace> already exists in this workspace." }'
+      ),
+      { operation: 'slo.repair', logger }
+    );
+    const detail = result.body.errorDetail as ClassifiedError;
+    expect(detail.category).toBe('CONFLICT');
+    expect(detail.code).toBe('RULE_GROUP_CONFLICT');
+    expect(result.status).toBe(409);
+  });
+
+  it('strips sensitive detail by default but keeps it when exposure is enabled', () => {
+    const err = new SloRulerError(
+      'RULER_VALIDATION_FAILED',
+      400,
+      'invalid PromQL at https://host.internal/x'
+    );
+
+    const stripped = classifyToHandlerResult(err, {
+      operation: 'rule.create.metric',
+      logger,
+    });
+    const strippedDetail = stripped.body.errorDetail as ClassifiedError;
+    expect(strippedDetail.details?.some((d) => d.sensitivity === 'sensitive')).toBeFalsy();
+    // Safe (redacted) detail still present.
+    const safe = strippedDetail.details?.find((d) => d.sensitivity === 'safe');
+    expect(safe?.value).toContain('<redacted-url>');
+
+    configureErrorExposure(true);
+    const exposed = classifyToHandlerResult(err, {
+      operation: 'rule.create.metric',
+      logger,
+    });
+    const exposedDetail = exposed.body.errorDetail as ClassifiedError;
+    expect(exposedDetail.details?.some((d) => d.sensitivity === 'sensitive')).toBe(true);
+  });
+});

--- a/server/routes/alerting/classified_error.ts
+++ b/server/routes/alerting/classified_error.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Server boundary adapter for the framework-agnostic error-classification core
+ * (`common/error`). It turns a caught error into a `HandlerResult` whose body
+ * keeps the legacy `error` string (so existing clients keep working) and adds
+ * a structured `errorDetail` object plus a `correlationId`.
+ *
+ * Responsibilities that belong at the boundary (not in the pure core):
+ *   - mint a correlation id,
+ *   - build a neutral `RawErrorContext` from framework/domain error shapes,
+ *   - log the FULL upstream detail server-side (with the correlation id) so the
+ *     true cause is never lost, and
+ *   - apply the client-exposure policy (strip `sensitive` details unless the
+ *     operator opted in via config).
+ */
+
+import { randomUUID } from 'crypto';
+import {
+  classifyError,
+  toClientPayload,
+  type ClassifiedError,
+  type RawErrorContext,
+} from '../../../common/error';
+import type { Logger } from '../../../common/types/alerting';
+import { SloRulerError } from '../../../common/slo/slo_errors';
+import { errorToStatus, isAlertManagerError } from '../../services/alerting/errors';
+import type { HandlerResult } from './route_utils';
+
+// Whether verbatim upstream detail (`sensitive` details) may reach the client.
+// Default off — set once at plugin setup from
+// `observability.errors.exposeSensitiveErrorDetail`.
+let exposeSensitive = false;
+
+/** Configure client exposure of sensitive detail. Called at plugin setup. */
+export function configureErrorExposure(next: boolean): void {
+  exposeSensitive = next;
+}
+
+/** Build a provider-neutral context from an arbitrary caught error. */
+export function contextFromError(
+  e: unknown,
+  operation: string,
+  correlationId: string
+): RawErrorContext {
+  const base: RawErrorContext = { operation, correlationId };
+  if (e instanceof SloRulerError) {
+    return {
+      ...base,
+      upstreamCode: e.code,
+      // httpStatus 0 means "transport failure, no response" — leave undefined
+      // so classifiers key off upstreamCode instead of a bogus status.
+      httpStatus: e.httpStatus > 0 ? e.httpStatus : undefined,
+      rawBody: e.rawBody,
+      message: e.message,
+      errorName: e.name,
+    };
+  }
+  if (isAlertManagerError(e)) {
+    return {
+      ...base,
+      httpStatus: errorToStatus(e),
+      message: e.message,
+      errorName: e.kind,
+    };
+  }
+  if (e instanceof Error) {
+    const statusCode = (e as { statusCode?: unknown }).statusCode;
+    return {
+      ...base,
+      httpStatus: typeof statusCode === 'number' ? statusCode : undefined,
+      message: e.message,
+      errorName: e.name,
+    };
+  }
+  return { ...base, message: e == null ? undefined : String(e) };
+}
+
+// Cap on the raw upstream body written to the server log line, so a large
+// upstream object can't balloon log output. The full body is still available
+// upstream of this layer; this only bounds the diagnostic log.
+const LOG_RAW_MAX_LEN = 4096;
+
+function stringifyRaw(rawBody: unknown): string {
+  if (rawBody == null) return '';
+  if (typeof rawBody === 'string') return rawBody;
+  try {
+    return JSON.stringify(rawBody);
+  } catch {
+    return String(rawBody);
+  }
+}
+
+export interface ClassifyOptions {
+  operation: string;
+  logger?: Logger;
+}
+
+/**
+ * Classify a caught error into a `HandlerResult`. The body is backward
+ * compatible: `error` (string) still maps to the response `message`, and the
+ * added `code` / `correlationId` / `errorDetail` fields ride along in
+ * `attributes` through the existing route adapters.
+ */
+export function classifyToHandlerResult(e: unknown, opts: ClassifyOptions): HandlerResult {
+  const correlationId = randomUUID();
+  const ctx = contextFromError(e, opts.operation, correlationId);
+  const classified: ClassifiedError = { ...classifyError(ctx), correlationId };
+
+  if (opts.logger) {
+    // Full detail, server-side only, keyed by correlation id — this is where
+    // the true upstream cause is preserved regardless of what the client sees.
+    // Cap the raw body so a large upstream object can't balloon a log line.
+    const raw = stringifyRaw(ctx.rawBody);
+    const rawForLog = raw.length > LOG_RAW_MAX_LEN ? `${raw.slice(0, LOG_RAW_MAX_LEN)}…` : raw;
+    opts.logger.error(
+      `[${opts.operation}] correlationId=${correlationId} ` +
+        `${classified.category}/${classified.code} ` +
+        `(HTTP ${classified.httpStatus ?? '-'}): ${ctx.message ?? ''} ${rawForLog}`.trim()
+    );
+  }
+
+  const clientErr = toClientPayload(classified, { exposeSensitive });
+  return {
+    status: clientErr.httpStatus ?? 500,
+    body: {
+      error: clientErr.message,
+      code: clientErr.code,
+      correlationId,
+      errorDetail: clientErr,
+    },
+  };
+}

--- a/server/routes/alerting/mutations/prometheus_routes.ts
+++ b/server/routes/alerting/mutations/prometheus_routes.ts
@@ -16,7 +16,8 @@ import { schema } from '@osd/config-schema';
 import { IRouter, RequestHandlerContext } from '../../../../../../src/core/server';
 import type { AlertingOSClient, Datasource, Logger } from '../../../../common/types/alerting';
 import type { RulerClient } from '../../../services/slo/ruler_client';
-import { toErrorBody, toHandlerResult } from '../route_utils';
+import { toErrorBody } from '../route_utils';
+import { classifyToHandlerResult } from '../classified_error';
 import { alertingIdSchema } from '../schema_helpers';
 import {
   handleCreatePrometheusRule,
@@ -47,8 +48,12 @@ const prometheusRuleBodySchema = schema.object({
   threshold: schema.maybe(schema.number()),
   forDuration: schema.string({ defaultValue: '5m' }),
   evaluationInterval: schema.string({ defaultValue: '1m' }),
-  labels: schema.recordOf(schema.string(), schema.string(), { defaultValue: {} }),
-  annotations: schema.recordOf(schema.string(), schema.string(), { defaultValue: {} }),
+  labels: schema.recordOf(schema.string(), schema.string(), {
+    defaultValue: {},
+  }),
+  annotations: schema.recordOf(schema.string(), schema.string(), {
+    defaultValue: {},
+  }),
   enabled: schema.boolean({ defaultValue: true }),
   groupName: schema.maybe(schema.string()),
 });
@@ -81,7 +86,13 @@ export function registerPrometheusRuleRoutes(
         );
         return res.ok({ body: result });
       } catch (e: unknown) {
-        const result = toHandlerResult(e, logger);
+        // Classify: a ruler dual-write failure (unreachable / invalid PromQL /
+        // auth / wrapped conflict) becomes a specific, actionable error instead
+        // of the old generic "An internal error occurred" 500.
+        const result = classifyToHandlerResult(e, {
+          operation: 'rule.create.metric',
+          logger,
+        });
         return res.customError({
           statusCode: result.status,
           body: toErrorBody(result.body),
@@ -118,7 +129,10 @@ export function registerPrometheusRuleRoutes(
         );
         return res.ok({ body: result });
       } catch (e: unknown) {
-        const result = toHandlerResult(e, logger);
+        const result = classifyToHandlerResult(e, {
+          operation: 'rule.delete.metric',
+          logger,
+        });
         return res.customError({
           statusCode: result.status,
           body: toErrorBody(result.body),

--- a/server/routes/slo/__tests__/handlers_repair_and_health.test.ts
+++ b/server/routes/slo/__tests__/handlers_repair_and_health.test.ts
@@ -112,13 +112,11 @@ function makeDeploy(ruler: SloRulerClient): SloDeployContext {
     enabled: true,
     directQueryName: 'prom-connection',
   };
-  const client = ({ transport: { request: jest.fn() } } as unknown) as AlertingOSClient;
+  const client = { transport: { request: jest.fn() } } as unknown as AlertingOSClient;
   return { ruler, client, datasource, workspaceId: 'ws-unit' };
 }
 
-function makeHealth(
-  reports: RuleHealthReportLite[]
-): SloRuleHealthProbe & {
+function makeHealth(reports: RuleHealthReportLite[]): SloRuleHealthProbe & {
   check: jest.Mock;
   invalidate: jest.Mock;
 } {
@@ -286,6 +284,33 @@ describe('handleRepairSLO', () => {
 
     expect(result.status).toBe(400);
     expect(result.body).toMatchObject({ code: 'RULER_VALIDATION_FAILED' });
+  });
+
+  it('redacts the legacy rawBody server-side so consumers other than the wizard get scrubbed text', async () => {
+    const { store } = makeStore();
+    const ruler = makeRuler();
+    ruler.upsertRuleGroup.mockRejectedValueOnce(
+      new SloRulerError(
+        'RULER_VALIDATION_FAILED',
+        400,
+        'invalid PromQL at https://host.internal:9090/rules'
+      )
+    );
+    const deploy = makeDeploy(ruler);
+    const svc = new SloService(noopLogger(), store);
+    const doc = await svc.create({ spec: validSpec() }, 'alice', makeDeploy(makeRuler()));
+    const groups =
+      doc.status.provisioning.backend === 'prometheus'
+        ? [doc.status.provisioning.alertGroupName ?? '']
+        : [];
+    const health = makeHealth([missingReport(groups)]);
+
+    const result = await handleRepairSLO(svc, doc.id, noopLogger(), { health, deploy });
+
+    const body = result.body as { rawBody: string };
+    expect(body.rawBody).toContain('invalid PromQL');
+    expect(body.rawBody).toContain('<redacted-url>');
+    expect(body.rawBody).not.toContain('host.internal');
   });
 });
 

--- a/server/routes/slo/handlers.ts
+++ b/server/routes/slo/handlers.ts
@@ -25,7 +25,9 @@ import {
 } from '../../../common/slo/slo_service';
 import type { SloCreateInput, SloListFilters, SloUpdateInput } from '../../../common/slo/slo_types';
 import type { HandlerResult } from '../alerting/route_utils';
-import { toHandlerResult } from '../alerting/route_utils';
+import { classifyToHandlerResult } from '../alerting/classified_error';
+import type { ClassifiedError } from '../../../common/error';
+import { redactForDisplay } from '../../../common/error';
 
 /**
  * Cap on the upstream ruler diagnostic surfaced to the client. Cortex's
@@ -52,7 +54,10 @@ function sanitizeRulerRawBody(body: string): string {
 function toSloError(e: unknown, logger?: Logger): HandlerResult {
   if (e instanceof SloValidationError) {
     if (logger) logger.warn(e.message);
-    return { status: 400, body: { error: 'Validation failed', errors: e.errors } };
+    return {
+      status: 400,
+      body: { error: 'Validation failed', errors: e.errors },
+    };
   }
   if (e instanceof SloNotFoundError) {
     return { status: 404, body: { error: e.message } };
@@ -68,25 +73,38 @@ function toSloError(e: unknown, logger?: Logger): HandlerResult {
     };
   }
   if (e instanceof SloRulerError) {
-    if (logger) {
-      // Log the full upstream body server-side so ops still has the raw
-      // diagnostic; the client gets a sanitized excerpt instead.
-      logger.warn(
-        `Ruler dual-write failed: ${e.code} (HTTP ${e.httpStatus}). Upstream body: ${e.rawBody}`
-      );
-    }
+    // Classify (this logs the full upstream detail with a correlation id) so
+    // we get a structured, provider-neutral errorDetail alongside the legacy
+    // ruler envelope. The classifier also inspects the inner cause: a wrapped
+    // conflict (e.g. an inner 409 "already exists" carried in a 503) is
+    // reclassified to CONFLICT, and we trust its 409 over the misleading outer
+    // status.
+    const classified = classifyToHandlerResult(e, {
+      operation: 'slo.ruler',
+      logger,
+    });
+    const errorDetail = classified.body.errorDetail as ClassifiedError | undefined;
     // Surface upstream status verbatim when available (4xx) so the wizard can
-    // show Cortex's own diagnostic. 0 (transport / network failure with no
+    // show the upstream diagnostic. 0 (transport / network failure with no
     // response) maps to 503 — semantically "upstream unavailable" rather
     // than 502 "bad gateway response".
-    const status = e.httpStatus >= 400 && e.httpStatus < 600 ? e.httpStatus : 503;
+    const legacyStatus = e.httpStatus >= 400 && e.httpStatus < 600 ? e.httpStatus : 503;
+    const status = errorDetail?.category === 'CONFLICT' ? classified.status : legacyStatus;
     return {
       status,
       body: {
+        // Legacy fields the SLO wizard already consumes — kept verbatim.
         error: e.message,
         code: e.code,
         httpStatus: e.httpStatus,
-        rawBody: sanitizeRulerRawBody(e.rawBody),
+        // Redact before truncating so any consumer of this legacy field (not
+        // just the wizard, which also redacts at render) gets scrubbed text.
+        // The full, un-redacted body is still logged server-side by the
+        // classifier under the correlation id.
+        rawBody: sanitizeRulerRawBody(redactForDisplay(e.rawBody)),
+        // Additive structured classification + correlation id.
+        correlationId: classified.body.correlationId,
+        errorDetail,
       },
     };
   }
@@ -105,7 +123,10 @@ function toSloError(e: unknown, logger?: Logger): HandlerResult {
       },
     };
   }
-  return toHandlerResult(e, logger);
+  // Anything else: classify instead of collapsing to a bare generic 500. The
+  // classifier surfaces a redacted, provider-neutral message (and keeps the
+  // raw detail server-side under the correlation id).
+  return classifyToHandlerResult(e, { operation: 'slo', logger });
 }
 
 export async function handleListSLOs(
@@ -317,7 +338,9 @@ export async function handleRepairSLO(
     if (!ctx?.health) {
       return {
         status: 501,
-        body: { error: 'Rule health checker not configured in this environment' },
+        body: {
+          error: 'Rule health checker not configured in this environment',
+        },
       };
     }
     if (!ctx.deploy) {
@@ -329,7 +352,10 @@ export async function handleRepairSLO(
         },
       };
     }
-    const repairCtx: SloRepairContext = { health: ctx.health, deploy: ctx.deploy };
+    const repairCtx: SloRepairContext = {
+      health: ctx.health,
+      deploy: ctx.deploy,
+    };
     const result = await svc.repair(id, repairCtx, request);
     return { status: 200, body: result };
   } catch (e) {
@@ -353,7 +379,9 @@ export async function handleGetRuleHealth(
     if (!ctx?.health) {
       return {
         status: 501,
-        body: { error: 'Rule health checker not configured in this environment' },
+        body: {
+          error: 'Rule health checker not configured in this environment',
+        },
       };
     }
     const doc = await svc.get(id, request);


### PR DESCRIPTION
## Description

Adds a framework-agnostic **error-classification and surfacing layer** so opaque failures in the SLO and unified-alerts features stop collapsing to `HTTP 500 {"message":"An internal error occurred"}` and instead show a clear **category, cause, remediation, and correlation id**.

### Core — `common/error/` (pure TS; no OSD/React/EUI imports)
- Provider-neutral taxonomy + message catalog, redaction, and a priority-ordered classifier registry with a translator seam and a detail-enricher seam.
- Default classifiers: upstream-wrapped (inspects the **inner** cause), ruler, state (rule_health / routing), timeout, and generic HTTP-status. The `UNKNOWN` fallback surfaces a **redacted** message rather than a bare generic string.
- **Registration-only extension model** — downstream consumers add higher-priority classifiers/enrichers with zero core edits (in-repo generic example + README).

### Server
- Boundary adapter mints a correlation id, logs full detail server-side, and applies a client-exposure policy (`observability.errors.exposeSensitiveErrorDetail`, default **off**).
- Prometheus rule create/delete and SLO handler paths classify instead of collapsing to a generic 500; a wrapped inner 409 conflict is reclassified from 503.
- **Backward compatible**: legacy `message`, `error`, `code`, `httpStatus`, and `rawBody` fields are preserved; `errorDetail` + `correlationId` are added alongside them.
- **Response-status behavior change (worth calling out):** on the Prometheus rule create/delete route, a `RULER_UNREACHABLE` failure previously produced HTTP 500 (via the generic `toHandlerResult` fallback). It now returns the classified status — for a real upstream unreachable, that's **503** — which is semantically more accurate. A client asserting `=== 500` on that specific failure needs updating; body shape is unchanged and legacy fields still populate. The SLO route preserves its existing status via the `legacyStatus` guard, so its wire status is unaffected.

### Client
- Toast + inline callout render adapter (localized via `@osd/i18n`, redacted by default); a "See the full error" toast opens a modal with the copyable safe diagnostic.
- Correlation id shown only for escalation categories.
- Wired into rule creation (metrics + explore), the alerts page, routing status, and the SLO wizard (verbatim raw body now redacted).

### Safety
Sensitive raw upstream text never reaches the browser unless explicitly opted in (a registered enricher or the default-off config flag). The full detail is always retrievable server-side via the correlation id.

## Testing
Unit tests for classifiers, redaction, the registry, a downstream-override example, the server adapter, and the client extract/callout helpers.

## Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.