### PR TITLE
feat(observability): SLO onboarding + Suggest toolbar + tidier rows; fix older monitor types in Alerts Rules tab

### DIFF
--- a/common/types/alerting/opensearch_types.ts
+++ b/common/types/alerting/opensearch_types.ts
@@ -82,13 +82,25 @@ export type OSMonitorInput =
         queries: Array<{ id: string; name: string; query: string; tags: string[] }>;
       };
     }
+  | {
+      // Composite (workflow) monitors sequence other monitors. Their documents
+      // are returned by the monitors search alongside regular monitors, so the
+      // UI must recognize this input shape to label + render them correctly
+      // rather than mis-detecting them as query-level monitors.
+      composite_input: {
+        sequence: {
+          delegates: Array<{
+            order: number;
+            monitor_id: string;
+            chained_monitor_findings?: { monitor_id?: string } | null;
+          }>;
+        };
+      };
+    }
   | OSPPLInput;
 
 export type OSMonitorType =
-  | 'query_level_monitor'
-  | 'bucket_level_monitor'
-  | 'doc_level_monitor'
-  | 'ppl_monitor';
+  'query_level_monitor' | 'bucket_level_monitor' | 'doc_level_monitor' | 'ppl_monitor';
 
 export interface OSMonitor {
   id: string;

--- a/public/components/alerting/__tests__/monitor_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/monitor_detail_flyout.test.tsx
@@ -22,18 +22,20 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
 
 // MonitorDetailFlyout instantiates AlertingOpenSearchService internally
 // via `useMemo(() => new AlertingOpenSearchService(), [])` and calls
-// `getRuleDetail(dsId, ruleId)` on mount. Mock the class so the
-// constructor returns a stubbed instance with `getRuleDetail` resolving
-// to `null` — the flyout falls back to the monitor summary in that
-// case, which is what these render tests exercise.
+// `getRuleDetail(dsId, ruleId)` on mount. Mock the class so every instance
+// shares one `getRuleDetail` spy the tests can drive per-case: resolve `null`
+// (the default — flyout falls back to the summary), resolve a full detail
+// (exercises the structured bucket view), or reject (exercises the
+// detail-unavailable / suppressed-error-banner branches).
+const mockGetRuleDetail = jest.fn();
 jest.mock('../query_services/alerting_opensearch_service', () => ({
   AlertingOpenSearchService: jest.fn().mockImplementation(() => ({
-    getRuleDetail: jest.fn().mockResolvedValue(null),
+    getRuleDetail: mockGetRuleDetail,
   })),
 }));
 
 import { MonitorDetailFlyout } from '../monitor_detail_flyout';
-import type { UnifiedRuleSummary } from '../../../../common/types/alerting';
+import type { UnifiedRule, UnifiedRuleSummary } from '../../../../common/types/alerting';
 
 const mockMonitor: UnifiedRuleSummary = {
   id: 'mon-1',
@@ -58,6 +60,21 @@ const mockMonitor: UnifiedRuleSummary = {
 };
 
 describe('MonitorDetailFlyout', () => {
+  beforeEach(() => {
+    // Default: detail fetch resolves null so the flyout renders from the
+    // summary props (what the base render tests expect). Structured-view and
+    // error-path tests override this with mockResolvedValue / mockRejectedValue.
+    mockGetRuleDetail.mockReset();
+    mockGetRuleDetail.mockResolvedValue(null);
+    // The hook's catch path logs via console.error; silence it so the
+    // rejection tests don't spam the runner output.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (console.error as jest.Mock).mockRestore?.();
+  });
+
   it('renders flyout with monitor name', () => {
     const { getByText } = render(
       <MonitorDetailFlyout
@@ -118,5 +135,151 @@ describe('MonitorDetailFlyout', () => {
       await Promise.resolve();
     });
     expect(queryByText('Condition Preview')).toBeNull();
+  });
+
+  // ==========================================================================
+  // Composite (workflow) monitors — the safety-relevant branches. A composite
+  // can't be safely cloned/deleted or edited through the monitor APIs used
+  // here, so those actions MUST stay gated; a regression here risks workflow
+  // corruption.
+  // ==========================================================================
+  const compositeMonitor: UnifiedRuleSummary = {
+    ...mockMonitor,
+    id: 'composite-1',
+    name: 'Composite Monitor',
+    monitorType: 'composite',
+    labels: { monitor_kind: 'composite', composite_delegates: 'mon-a,mon-b' },
+  };
+
+  it('renders composite monitors with the member list and gates Clone/Delete', async () => {
+    // Composite detail 404s on the monitors endpoint by design — reject so we
+    // also assert the error banner is suppressed for composites.
+    mockGetRuleDetail.mockRejectedValue(new Error('workflow not found on monitors endpoint'));
+    const onClone = jest.fn();
+    const onDelete = jest.fn();
+    const { getByText, queryByText, queryByTestId } = render(
+      <MonitorDetailFlyout
+        monitor={compositeMonitor}
+        onClose={jest.fn()}
+        onDelete={onDelete}
+        onClone={onClone}
+        onEdit={jest.fn()}
+      />
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // "Associated monitors" section titled + member ids listed in order.
+    expect(getByText('Associated monitors')).toBeInTheDocument();
+    expect(getByText('mon-a')).toBeInTheDocument();
+    expect(getByText('mon-b')).toBeInTheDocument();
+
+    // Clone/Delete are disabled and inert — the gating that protects the
+    // workflow. `.closest('button')` reaches the actual control behind the
+    // button label span.
+    const cloneBtn = getByText('Clone').closest('button');
+    const deleteBtn = getByText('Delete').closest('button');
+    expect(cloneBtn).toBeDisabled();
+    expect(deleteBtn).toBeDisabled();
+    fireEvent.click(cloneBtn!);
+    fireEvent.click(deleteBtn!);
+    expect(onClone).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
+
+    // Edit is gated too (only ppl/metric are editable).
+    expect(getByText('Edit').closest('button')).toBeDisabled();
+
+    // The detail 404 is expected for composites, so no error banner and no
+    // threshold/pending/preview noise.
+    expect(queryByTestId('alertManagerMonitorDetailLoadError')).toBeNull();
+    expect(queryByText('Condition Preview')).toBeNull();
+    expect(queryByText('Pending Period')).toBeNull();
+    expect(queryByText('Threshold')).toBeNull();
+  });
+
+  // ==========================================================================
+  // Bucket-level monitors — structured view derived from the raw monitor body.
+  // ==========================================================================
+  it('renders a bucket-level monitor as a structured view (indices, group-by, condition, query toggle)', async () => {
+    const bucketMonitor: UnifiedRuleSummary = {
+      ...mockMonitor,
+      id: 'bucket-1',
+      name: 'Bucket Monitor',
+      monitorType: 'metric',
+      condition: 'params._count > 5',
+      query: JSON.stringify({ aggregations: {} }),
+      labels: { monitor_kind: 'bucket' },
+    };
+    const rawDetail = {
+      ...bucketMonitor,
+      alertHistory: [],
+      conditionPreviewData: [],
+      raw: {
+        id: 'bucket-1',
+        type: 'monitor',
+        monitor_type: 'bucket_level_monitor',
+        inputs: [
+          {
+            search: {
+              indices: ['logs-app-*'],
+              query: {
+                aggregations: {
+                  by_service: { terms: { field: 'service.name' } },
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as UnifiedRule;
+    mockGetRuleDetail.mockResolvedValue(rawDetail);
+
+    const { getByText } = render(
+      <MonitorDetailFlyout
+        monitor={bucketMonitor}
+        onClose={jest.fn()}
+        onDelete={jest.fn()}
+        onClone={jest.fn()}
+      />
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getByText('Target indices:')).toBeInTheDocument();
+    expect(getByText('logs-app-*')).toBeInTheDocument();
+    // Group-by field extracted from the aggregation's terms.field, shown as a badge.
+    expect(getByText('service.name')).toBeInTheDocument();
+    expect(getByText('Per-bucket condition')).toBeInTheDocument();
+    // Raw aggregation query is tucked behind a toggle rather than dumped inline.
+    expect(getByText('Show aggregation query')).toBeInTheDocument();
+  });
+
+  // ==========================================================================
+  // Structured kinds whose detail fetch fails: show a plain "unavailable" note
+  // instead of rendering the abbreviated summary string as malformed JSON.
+  // ==========================================================================
+  it('shows a plain unavailable note when a structured kind fails to load detail', async () => {
+    mockGetRuleDetail.mockRejectedValue(new Error('detail fetch failed'));
+    const clusterMonitor: UnifiedRuleSummary = {
+      ...mockMonitor,
+      id: 'cluster-1',
+      name: 'Cluster Metrics Monitor',
+      query: 'GET _cluster/health', // abbreviated, non-JSON summary string
+      labels: { monitor_kind: 'cluster_metrics' },
+    };
+    const { getByText } = render(
+      <MonitorDetailFlyout
+        monitor={clusterMonitor}
+        onClose={jest.fn()}
+        onDelete={jest.fn()}
+        onClone={jest.fn()}
+      />
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getByText('Detailed configuration is unavailable for this rule.')).toBeInTheDocument();
   });
 });

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -29,6 +29,7 @@ import {
   EuiAccordion,
   EuiToolTip,
   EuiCallOut,
+  EuiCode,
   EuiCodeBlock,
   EuiLink,
   EuiLoadingContent,
@@ -134,6 +135,20 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
 
   // Detect monitor kind from raw data for type-specific rendering
   const monitorKind = monitor.labels?.monitor_kind as string | undefined;
+  const isComposite = monitorKind === 'composite';
+  // Ordered member-monitor ids for composite (workflow) monitors, carried on
+  // the summary because the workflow detail can't be fetched via the monitors
+  // endpoint.
+  const compositeDelegates = (monitor.labels?.composite_delegates ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  // Composite (workflow) monitors can't be safely cloned/deleted through the
+  // monitor APIs used here, so those actions are gated with this explanation.
+  const compositeActionTooltip = i18n.translate(
+    'observability.alerting.monitorDetailFlyout.compositeActionTooltip',
+    { defaultMessage: 'Composite monitors are managed in the classic Alerting app.' }
+  );
   const rawMonitor = detail?.raw as OSMonitor | undefined;
   const rawInput: OSMonitorInput | undefined =
     rawMonitor && 'inputs' in rawMonitor ? rawMonitor.inputs?.[0] : undefined;
@@ -151,6 +166,11 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
     queryDefTitle = i18n.translate('observability.alerting.monitorDetailFlyout.queryDef.docLevel', {
       defaultMessage: 'Document-Level Queries',
     });
+  } else if (monitorKind === 'composite') {
+    queryDefTitle = i18n.translate(
+      'observability.alerting.monitorDetailFlyout.queryDef.composite',
+      { defaultMessage: 'Associated monitors' }
+    );
   } else {
     queryDefTitle = i18n.translate(
       'observability.alerting.monitorDetailFlyout.queryDef.queryDefinition',
@@ -252,25 +272,47 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
               )}
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty size="s" iconType="copy" onClick={() => onClone(monitor)}>
-                <FormattedMessage
-                  id="observability.alerting.monitorDetailFlyout.cloneButton"
-                  defaultMessage="Clone"
-                />
-              </EuiButtonEmpty>
+              {isComposite ? (
+                <EuiToolTip content={compositeActionTooltip}>
+                  <EuiButtonEmpty size="s" iconType="copy" isDisabled>
+                    <FormattedMessage
+                      id="observability.alerting.monitorDetailFlyout.cloneButton"
+                      defaultMessage="Clone"
+                    />
+                  </EuiButtonEmpty>
+                </EuiToolTip>
+              ) : (
+                <EuiButtonEmpty size="s" iconType="copy" onClick={() => onClone(monitor)}>
+                  <FormattedMessage
+                    id="observability.alerting.monitorDetailFlyout.cloneButton"
+                    defaultMessage="Clone"
+                  />
+                </EuiButtonEmpty>
+              )}
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                size="s"
-                iconType="trash"
-                color="danger"
-                onClick={() => setShowDeleteConfirm(true)}
-              >
-                <FormattedMessage
-                  id="observability.alerting.monitorDetailFlyout.deleteButton"
-                  defaultMessage="Delete"
-                />
-              </EuiButtonEmpty>
+              {isComposite ? (
+                <EuiToolTip content={compositeActionTooltip}>
+                  <EuiButtonEmpty size="s" iconType="trash" color="danger" isDisabled>
+                    <FormattedMessage
+                      id="observability.alerting.monitorDetailFlyout.deleteButton"
+                      defaultMessage="Delete"
+                    />
+                  </EuiButtonEmpty>
+                </EuiToolTip>
+              ) : (
+                <EuiButtonEmpty
+                  size="s"
+                  iconType="trash"
+                  color="danger"
+                  onClick={() => setShowDeleteConfirm(true)}
+                >
+                  <FormattedMessage
+                    id="observability.alerting.monitorDetailFlyout.deleteButton"
+                    defaultMessage="Delete"
+                  />
+                </EuiButtonEmpty>
+              )}
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlyoutHeader>
@@ -407,6 +449,32 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                         )}
                       </EuiPanel>
                     ))}
+                  </>
+                ) : isComposite ? (
+                  <>
+                    <EuiText size="s">
+                      <FormattedMessage
+                        id="observability.alerting.monitorDetailFlyout.composite.description"
+                        defaultMessage="This composite monitor triggers based on the alerts of its member monitors, evaluated in order:"
+                      />
+                    </EuiText>
+                    <EuiSpacer size="s" />
+                    {compositeDelegates.length > 0 ? (
+                      <ol style={{ paddingLeft: 20, margin: 0 }}>
+                        {compositeDelegates.map((mid, idx) => (
+                          <li key={mid || idx} style={{ marginBottom: 4 }}>
+                            <EuiCode>{mid}</EuiCode>
+                          </li>
+                        ))}
+                      </ol>
+                    ) : (
+                      <EuiText size="s" color="subdued">
+                        <FormattedMessage
+                          id="observability.alerting.monitorDetailFlyout.composite.noMembers"
+                          defaultMessage="No member monitors are configured."
+                        />
+                      </EuiText>
+                    )}
                   </>
                 ) : (
                   <>

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -83,6 +83,28 @@ export interface MonitorDetailFlyoutProps {
   onToggleEnabled?: (monitor: UnifiedRuleSummary) => Promise<void> | void;
 }
 
+/**
+ * Collect the `terms.field` values from a bucket-level monitor's aggregation
+ * tree — both `composite.sources[].<name>.terms.field` and plain `terms` aggs —
+ * so the flyout can show the group-by dimensions. Best-effort + defensive: any
+ * unexpected shape simply yields fewer fields, never a throw.
+ */
+function extractGroupByFields(aggregations: unknown): string[] {
+  const fields: string[] = [];
+  const walk = (node: unknown) => {
+    if (!node || typeof node !== 'object') return;
+    const obj = node as Record<string, unknown>;
+    const terms = obj.terms as { field?: unknown } | undefined;
+    if (terms && typeof terms.field === 'string') fields.push(terms.field);
+    Object.values(obj).forEach((v) => {
+      if (Array.isArray(v)) v.forEach(walk);
+      else if (v && typeof v === 'object') walk(v);
+    });
+  };
+  walk(aggregations);
+  return Array.from(new Set(fields));
+}
+
 // ============================================================================
 // Main Component
 // ============================================================================
@@ -152,6 +174,19 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
   const rawMonitor = detail?.raw as OSMonitor | undefined;
   const rawInput: OSMonitorInput | undefined =
     rawMonitor && 'inputs' in rawMonitor ? rawMonitor.inputs?.[0] : undefined;
+  const isBucket = monitorKind === 'bucket';
+  // Group-by fields for a bucket-level monitor — pulled from the aggregation's
+  // `terms.field`s (composite sources or plain terms aggs) so the flyout can
+  // show what the buckets are grouped on rather than only the raw query JSON.
+  const bucketGroupByFields =
+    isBucket && rawInput && 'search' in rawInput
+      ? extractGroupByFields((rawInput.search.query as Record<string, unknown>)?.aggregations)
+      : [];
+  // When the detail fetch fails for a structured kind (cluster-metrics / doc /
+  // bucket), the summary `query` is an abbreviated non-JSON string; show a
+  // plain "unavailable" note instead of rendering it as malformed JSON.
+  const detailUnavailableForStructuredKind =
+    !!detailError && (monitorKind === 'cluster_metrics' || monitorKind === 'doc' || isBucket);
 
   // Query definition accordion title, type-aware
   let queryDefTitle: string;
@@ -339,7 +374,7 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                     <p>
                       <FormattedMessage
                         id="observability.alerting.monitorDetailFlyout.detailLoadError.body"
-                        defaultMessage="Showing summary information only. Try reopening the flyout to retry."
+                        defaultMessage="Showing summary information only — the full configuration is unavailable for this rule."
                       />
                     </p>
                   </EuiCallOut>
@@ -476,22 +511,84 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                       </EuiText>
                     )}
                   </>
-                ) : (
+                ) : isBucket && rawInput && 'search' in rawInput ? (
                   <>
-                    <EuiCodeBlock language={queryLang} fontSize="s" paddingSize="m" isCopyable>
-                      {queryDisplay}
-                    </EuiCodeBlock>
-                    {monitorKind === 'bucket' && (
-                      <EuiText size="xs" color="subdued">
-                        <em>
-                          <FormattedMessage
-                            id="observability.alerting.monitorDetailFlyout.bucketLevelDescription"
-                            defaultMessage="Bucket-level rule — triggers evaluate per aggregation bucket"
-                          />
-                        </em>
+                    <EuiText size="s">
+                      <strong>
+                        <FormattedMessage
+                          id="observability.alerting.monitorDetailFlyout.targetIndices"
+                          defaultMessage="Target indices:"
+                        />
+                      </strong>{' '}
+                      {rawInput.search.indices?.join(', ') || '—'}
+                    </EuiText>
+                    <EuiSpacer size="s" />
+                    <EuiText size="s">
+                      <strong>
+                        <FormattedMessage
+                          id="observability.alerting.monitorDetailFlyout.bucket.groupBy"
+                          defaultMessage="Group by"
+                        />
+                      </strong>
+                    </EuiText>
+                    {bucketGroupByFields.length > 0 ? (
+                      <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
+                        {bucketGroupByFields.map((f) => (
+                          <EuiFlexItem grow={false} key={f}>
+                            <EuiBadge color="hollow">{f}</EuiBadge>
+                          </EuiFlexItem>
+                        ))}
+                      </EuiFlexGroup>
+                    ) : (
+                      <EuiText size="s" color="subdued">
+                        —
                       </EuiText>
                     )}
+                    {monitor.condition && (
+                      <>
+                        <EuiSpacer size="s" />
+                        <EuiText size="s">
+                          <strong>
+                            <FormattedMessage
+                              id="observability.alerting.monitorDetailFlyout.bucket.condition"
+                              defaultMessage="Per-bucket condition"
+                            />
+                          </strong>
+                        </EuiText>
+                        <EuiCodeBlock fontSize="s" paddingSize="s" isCopyable>
+                          {monitor.condition}
+                        </EuiCodeBlock>
+                      </>
+                    )}
+                    <EuiSpacer size="s" />
+                    <EuiAccordion
+                      id={`bucketQuery-${monitor.id}`}
+                      buttonContent={
+                        <EuiText size="xs">
+                          <FormattedMessage
+                            id="observability.alerting.monitorDetailFlyout.bucket.showQuery"
+                            defaultMessage="Show aggregation query"
+                          />
+                        </EuiText>
+                      }
+                      paddingSize="s"
+                    >
+                      <EuiCodeBlock language="json" fontSize="s" paddingSize="m" isCopyable>
+                        {queryDisplay}
+                      </EuiCodeBlock>
+                    </EuiAccordion>
                   </>
+                ) : detailUnavailableForStructuredKind ? (
+                  <EuiText size="s" color="subdued">
+                    <FormattedMessage
+                      id="observability.alerting.monitorDetailFlyout.detailUnavailable"
+                      defaultMessage="Detailed configuration is unavailable for this rule."
+                    />
+                  </EuiText>
+                ) : (
+                  <EuiCodeBlock language={queryLang} fontSize="s" paddingSize="m" isCopyable>
+                    {queryDisplay}
+                  </EuiCodeBlock>
                 )}
                 {/* Prometheus rules: the expr above IS the condition — the
                     summary `condition` field is a canned template, so hide it */}

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -357,7 +357,10 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
             <EuiLoadingContent lines={10} />
           ) : (
             <>
-              {detailError && (
+              {/* Composite (workflow) detail always 404s on the monitors
+                  endpoint — that's expected, not an error — so skip the banner
+                  and just render the summary-derived details cleanly. */}
+              {detailError && !isComposite && (
                 <>
                   <EuiCallOut
                     size="s"
@@ -635,13 +638,20 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                             ),
                             description: evaluationInterval,
                           },
-                          {
-                            title: i18n.translate(
-                              'observability.alerting.monitorDetailFlyout.pendingPeriod',
-                              { defaultMessage: 'Pending Period' }
-                            ),
-                            description: pendingPeriod,
-                          },
+                          // Pending period isn't a meaningful concept for a
+                          // composite (it fires off member alerts, not a
+                          // sustained threshold), so omit it there.
+                          ...(!isComposite
+                            ? [
+                                {
+                                  title: i18n.translate(
+                                    'observability.alerting.monitorDetailFlyout.pendingPeriod',
+                                    { defaultMessage: 'Pending Period' }
+                                  ),
+                                  description: pendingPeriod,
+                                },
+                              ]
+                            : []),
                         ]
                       : []),
                     ...(detail?.firingPeriod
@@ -666,7 +676,7 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                           },
                         ]
                       : []),
-                    ...(monitor.threshold && monitor.datasourceType !== 'prometheus'
+                    ...(monitor.threshold && monitor.datasourceType !== 'prometheus' && !isComposite
                       ? [
                           {
                             title: i18n.translate(
@@ -720,6 +730,7 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                     'monitor_type',
                     'monitor_kind',
                     'datasource_id',
+                    'composite_delegates',
                     '_workspace',
                   ];
                   const visibleLabels = Object.entries(monitor.labels).filter(
@@ -755,8 +766,9 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                   monitors carry a `ppl_input` that isn't covered, so the
                   data array would always be empty and the accordion would
                   permanently render the "No recent evaluation data" copy.
-                  Skip rendering until a PPL preview pipeline ships. */}
-              {monitor.monitorType !== 'ppl' && (
+                  Skip rendering until a PPL preview pipeline ships. Also skip
+                  for composites — a workflow has no single series to plot. */}
+              {monitor.monitorType !== 'ppl' && !isComposite && (
                 <>
                   <EuiAccordion
                     id={`preview-${monitor.id}`}

--- a/public/components/apm/pages/slos/__tests__/slo_listing_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_listing_page.test.tsx
@@ -30,7 +30,7 @@ jest.mock('../../../shared/hooks/use_services', () => ({
 const mockUseServices = useServices as jest.Mock;
 const setDiscoveredServices = (names: string[]) =>
   mockUseServices.mockReturnValue({
-    data: names.map((name) => ({ name })),
+    data: names.map((name) => ({ serviceName: name })),
     isLoading: false,
     error: null,
     availableGroupByAttributes: {},
@@ -139,7 +139,11 @@ describe('SloListingPage — filter integration', () => {
     await act(async () => {
       fireEvent.click(suggestCta);
     });
+    // The CTA must hand the discovered service names to the Suggest page as its
+    // scope — otherwise it lands unscoped and drafts nothing, contradicting the
+    // "we discovered services and can draft SLOs" onboarding copy.
     expect(navigateToSloSuggest).toHaveBeenCalledTimes(1);
+    expect(navigateToSloSuggest).toHaveBeenCalledWith(['payments-api', 'checkout']);
   });
 
   it('guides the user to set up services when none are discovered', async () => {

--- a/public/components/apm/pages/slos/__tests__/slo_listing_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_listing_page.test.tsx
@@ -9,11 +9,33 @@ import { MemoryRouter, Route } from 'react-router-dom';
 import { SloListingPage } from '../slo_listing_page';
 import type { SloApiClient } from '../slo_api_client';
 import type { SloListFilters, SloSummary } from '../../../../../../common/slo/slo_types';
-import { navigateToServicesList } from '../../../shared/utils/navigation_utils';
+import {
+  navigateToServicesList,
+  navigateToSloSuggest,
+} from '../../../shared/utils/navigation_utils';
+import { useServices } from '../../../shared/hooks/use_services';
 
 jest.mock('../../../shared/utils/navigation_utils', () => ({
   navigateToServicesList: jest.fn(),
+  navigateToSloSuggest: jest.fn(),
 }));
+
+// The onboarding empty state discovers APM services to decide whether to pitch
+// "Suggest SLOs" (services exist) or "Set up services" (none yet). Mock the hook
+// so each test drives the branch it wants without a live PPL backend.
+jest.mock('../../../shared/hooks/use_services', () => ({
+  useServices: jest.fn(),
+}));
+
+const mockUseServices = useServices as jest.Mock;
+const setDiscoveredServices = (names: string[]) =>
+  mockUseServices.mockReturnValue({
+    data: names.map((name) => ({ name })),
+    isLoading: false,
+    error: null,
+    availableGroupByAttributes: {},
+    refetch: jest.fn(),
+  });
 
 // Overview panel + header wrapper reach into chrome/portals that aren't
 // wired in this jsdom setup. Inline them so the rest of the page mounts.
@@ -57,19 +79,19 @@ function makeSummary(overrides: Partial<SloSummary> = {}): SloSummary {
 }
 
 function renderPage(listImpl: SloApiClient['list'], initialSearch = '') {
-  const apiClient = ({ list: listImpl } as unknown) as SloApiClient;
-  const chrome = ({ setBreadcrumbs: jest.fn() } as unknown) as Parameters<
+  const apiClient = { list: listImpl } as unknown as SloApiClient;
+  const chrome = { setBreadcrumbs: jest.fn() } as unknown as Parameters<
     typeof SloListingPage
   >[0]['chrome'];
-  const notifications = ({
+  const notifications = {
     toasts: { addDanger: jest.fn(), addWarning: jest.fn(), addSuccess: jest.fn() },
-  } as unknown) as Parameters<typeof SloListingPage>[0]['notifications'];
+  } as unknown as Parameters<typeof SloListingPage>[0]['notifications'];
   // The listing page fires one GET to /api/alerting/datasources on mount.
   // Resolve it to an empty list so the facet renders the "no datasources
   // registered" text and the rest of the page doesn't wait on a real fetch.
-  const http = ({
+  const http = {
     get: jest.fn().mockResolvedValue({ datasources: [] }),
-  } as unknown) as Parameters<typeof SloListingPage>[0]['http'];
+  } as unknown as Parameters<typeof SloListingPage>[0]['http'];
   return render(
     <MemoryRouter initialEntries={[`/slos${initialSearch}`]}>
       <Route path="/slos">
@@ -88,9 +110,14 @@ function renderPage(listImpl: SloApiClient['list'], initialSearch = '') {
 describe('SloListingPage — filter integration', () => {
   beforeEach(() => {
     (navigateToServicesList as jest.Mock).mockReset();
+    (navigateToSloSuggest as jest.Mock).mockReset();
+    // Default the onboarding empty state to the "services discovered" branch so
+    // it leads with Suggest SLOs. Tests that need the "no services" branch
+    // override this with setDiscoveredServices([]).
+    setDiscoveredServices(['payments-api', 'checkout']);
   });
 
-  it('shows the "no SLOs yet" empty state when list returns zero unfiltered', async () => {
+  it('leads with the "Suggest SLOs" onboarding when services are discovered', async () => {
     const list = jest.fn().mockResolvedValue({
       results: [],
       total: 0,
@@ -104,15 +131,21 @@ describe('SloListingPage — filter integration', () => {
     });
     expect(await screen.findByTestId('slosEmptyNoSlos')).toBeInTheDocument();
     expect(screen.queryByTestId('slosEmptyFilteredZero')).not.toBeInTheDocument();
-    // Empty state pitches Services as the primary discovery path (M4: the
-    // listing page no longer hosts a Suggest SLOs button).
-    expect(screen.queryByTestId('slosSuggestEmpty')).not.toBeInTheDocument();
-    const servicesCta = screen.getByTestId('slosEmptyGoToServices');
-    expect(servicesCta).toHaveTextContent('Go to Services');
+    // Services exist → fastest path to a first SLO is the Suggest batch flow,
+    // so it leads as the primary CTA with "Create manually" as the fallback.
+    const suggestCta = screen.getByTestId('slosEmptySuggest');
+    expect(suggestCta).toHaveTextContent('Suggest SLOs');
     expect(screen.getByTestId('slosCreateEmpty')).toHaveTextContent('Create manually');
+    await act(async () => {
+      fireEvent.click(suggestCta);
+    });
+    expect(navigateToSloSuggest).toHaveBeenCalledTimes(1);
   });
 
-  it('cross-navigates to Services Home when the empty-state CTA is clicked', async () => {
+  it('guides the user to set up services when none are discovered', async () => {
+    // No services → Suggest SLOs has nothing to draft against, so the empty
+    // state steers the user to set up services first.
+    setDiscoveredServices([]);
     const list = jest.fn().mockResolvedValue({
       results: [],
       total: 0,
@@ -124,13 +157,16 @@ describe('SloListingPage — filter integration', () => {
     await act(async () => {
       renderPage(list);
     });
+    const servicesCta = await screen.findByTestId('slosEmptyGoToServices');
+    expect(servicesCta).toHaveTextContent('Set up services');
+    expect(screen.getByTestId('slosCreateEmpty')).toHaveTextContent('Create manually');
     await act(async () => {
-      fireEvent.click(await screen.findByTestId('slosEmptyGoToServices'));
+      fireEvent.click(servicesCta);
     });
     expect(navigateToServicesList).toHaveBeenCalledTimes(1);
   });
 
-  it('does not render a header-toolbar Suggest SLOs button (M4)', async () => {
+  it('surfaces an enabled Suggest SLOs toolbar button when SLOs and services exist', async () => {
     const list = jest.fn().mockResolvedValue({
       results: [makeSummary()],
       total: 1,
@@ -143,7 +179,35 @@ describe('SloListingPage — filter integration', () => {
       renderPage(list);
     });
     await screen.findByTestId('slosTable');
-    expect(screen.queryByTestId('slosSuggest')).not.toBeInTheDocument();
+    const suggest = screen.getByTestId('slosSuggest');
+    expect(suggest).toHaveTextContent('Suggest SLOs');
+    expect(suggest).not.toBeDisabled();
+    await act(async () => {
+      fireEvent.click(suggest);
+    });
+    expect(navigateToSloSuggest).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the Suggest SLOs toolbar button when no services are discovered', async () => {
+    // SLOs can exist without APM services (e.g. custom PromQL SLOs); with no
+    // services, Suggest has nothing to draft against, so the button is disabled.
+    setDiscoveredServices([]);
+    const list = jest.fn().mockResolvedValue({
+      results: [makeSummary()],
+      total: 1,
+      pageSize: 20,
+      hasMore: false,
+      nextCursor: null,
+      prevCursor: null,
+    });
+    await act(async () => {
+      renderPage(list);
+    });
+    await screen.findByTestId('slosTable');
+    const suggest = screen.getByTestId('slosSuggest');
+    expect(suggest).toBeDisabled();
+    fireEvent.click(suggest);
+    expect(navigateToSloSuggest).not.toHaveBeenCalled();
   });
 
   it('shows the "no matches" empty state with Clear-filters CTA when filtered to zero', async () => {

--- a/public/components/apm/pages/slos/__tests__/slo_listing_page_datasource_scope.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_listing_page_datasource_scope.test.tsx
@@ -20,6 +20,19 @@ import { datasourceScopeCacheKey } from '../slo_datasource_scope_cache';
 
 jest.mock('../../../shared/utils/navigation_utils', () => ({
   navigateToServicesList: jest.fn(),
+  navigateToSloSuggest: jest.fn(),
+}));
+// The toolbar Suggest button + onboarding empty state call useServices; this
+// suite doesn't exercise them, so stub an empty result so they render without a
+// live PPL backend (an unmocked useServices returns undefined and throws).
+jest.mock('../../../shared/hooks/use_services', () => ({
+  useServices: jest.fn(() => ({
+    data: [],
+    isLoading: false,
+    error: null,
+    availableGroupByAttributes: {},
+    refetch: jest.fn(),
+  })),
 }));
 jest.mock('../../../../../plugin_helpers/plugin_headerControl', () => ({
   HeaderControlledComponentsWrapper: ({ components }: { components: React.ReactNode[] }) => (

--- a/public/components/apm/pages/slos/__tests__/slo_listing_page_pagination.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_listing_page_pagination.test.tsx
@@ -19,6 +19,19 @@ import type { SloSummary } from '../../../../../../common/slo/slo_types';
 
 jest.mock('../../../shared/utils/navigation_utils', () => ({
   navigateToServicesList: jest.fn(),
+  navigateToSloSuggest: jest.fn(),
+}));
+// The toolbar Suggest button + onboarding empty state call useServices; this
+// suite doesn't exercise them, so stub an empty result so they render without a
+// live PPL backend (an unmocked useServices returns undefined and throws).
+jest.mock('../../../shared/hooks/use_services', () => ({
+  useServices: jest.fn(() => ({
+    data: [],
+    isLoading: false,
+    error: null,
+    availableGroupByAttributes: {},
+    refetch: jest.fn(),
+  })),
 }));
 jest.mock('../../../../../plugin_helpers/plugin_headerControl', () => ({
   HeaderControlledComponentsWrapper: ({ components }: { components: React.ReactNode[] }) => (
@@ -58,16 +71,16 @@ function summary(id: string): SloSummary {
 }
 
 function renderPage(list: SloApiClient['list'], initialSearch = '') {
-  const apiClient = ({ list } as unknown) as SloApiClient;
-  const chrome = ({ setBreadcrumbs: jest.fn() } as unknown) as Parameters<
+  const apiClient = { list } as unknown as SloApiClient;
+  const chrome = { setBreadcrumbs: jest.fn() } as unknown as Parameters<
     typeof SloListingPage
   >[0]['chrome'];
-  const notifications = ({
+  const notifications = {
     toasts: { addDanger: jest.fn(), addWarning: jest.fn(), addSuccess: jest.fn() },
-  } as unknown) as Parameters<typeof SloListingPage>[0]['notifications'];
-  const http = ({
+  } as unknown as Parameters<typeof SloListingPage>[0]['notifications'];
+  const http = {
     get: jest.fn().mockResolvedValue({ datasources: [] }),
-  } as unknown) as Parameters<typeof SloListingPage>[0]['http'];
+  } as unknown as Parameters<typeof SloListingPage>[0]['http'];
   return render(
     <MemoryRouter initialEntries={[`/slos${initialSearch}`]}>
       <Route path="/slos">

--- a/public/components/apm/pages/slos/slo_listing_page.tsx
+++ b/public/components/apm/pages/slos/slo_listing_page.tsx
@@ -35,8 +35,9 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { ChromeStart, HttpStart, NotificationsStart } from '../../../../../../../src/core/public';
 import { HeaderControlledComponentsWrapper } from '../../../../plugin_helpers/plugin_headerControl';
 import { ActiveFilterBadges, FilterBadge } from '../../shared/components/active_filter_badges';
-import { navigateToServicesList } from '../../shared/utils/navigation_utils';
 import { SloOverviewPanel } from './slo_overview_panel';
+import { SloNoSlosEmptyState } from './slo_no_slos_empty_state';
+import { SloSuggestHeaderButton } from './slo_suggest_header_button';
 import { DATASOURCE_SELECTION_CAP, SloListFilterPanel } from './slo_list_filter_panel';
 import { usePrometheusDatasources } from './use_prometheus_datasources';
 import {
@@ -923,49 +924,91 @@ export const SloListingPage: React.FC<SloListingPageProps> = ({
         name: i18n.translate('observability.apm.slo.listing.column.name', {
           defaultMessage: 'Name',
         }),
+        // Give Name a real share of the table so it isn't the squeeze victim of
+        // auto-layout, and truncate to a single line (full name on hover +
+        // detail link) so long names don't word-break into 3-4 line rows on
+        // narrower screens.
+        width: '30%',
+        truncateText: true,
         render: (row: SloSummary) => (
-          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-            <EuiFlexItem grow={false}>
-              <EuiIcon
-                type={templateIconFor(row)}
-                size="m"
-                color="subdued"
-                data-test-subj={`slosNameIcon-${row.id}`}
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiLink
-                href={`#/slos/${encodeURIComponent(row.id)}`}
-                data-test-subj={`slosLink-${row.id}`}
-              >
-                <EuiText size="s">
-                  <strong>{row.name}</strong>
-                </EuiText>
-              </EuiLink>
-            </EuiFlexItem>
-          </EuiFlexGroup>
+          // Plain flex + explicit ellipsis styles (rather than EUI flex + the
+          // eui-textTruncate class alone): in a fixed-layout table the tooltip
+          // anchor otherwise grows to its nowrap min-content width and overflows
+          // into the next column. `overflow:hidden` + `minWidth:0` on the text
+          // wrapper forces it to shrink to the cell and clip with an ellipsis.
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+            <EuiIcon
+              type={templateIconFor(row)}
+              size="m"
+              color="subdued"
+              style={{ flexShrink: 0 }}
+              data-test-subj={`slosNameIcon-${row.id}`}
+            />
+            <div style={{ flex: '1 1 auto', minWidth: 0, overflow: 'hidden' }}>
+              <EuiToolTip content={row.name} anchorClassName="eui-textTruncate" display="block">
+                <EuiLink
+                  href={`#/slos/${encodeURIComponent(row.id)}`}
+                  data-test-subj={`slosLink-${row.id}`}
+                >
+                  <span
+                    style={{
+                      display: 'block',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      fontWeight: 700,
+                      fontSize: '0.875rem',
+                    }}
+                  >
+                    {row.name}
+                  </span>
+                </EuiLink>
+              </EuiToolTip>
+            </div>
+          </div>
         ),
       },
       {
         name: i18n.translate('observability.apm.slo.listing.column.service', {
           defaultMessage: 'Service',
         }),
-        render: (row: SloSummary) => <EuiText size="s">{row.service}</EuiText>,
+        // Deterministic widths + single-line truncation on the secondary text
+        // columns so the extra room Name gives up doesn't just move the wrapping
+        // problem onto Service/Owner/Objectives.
+        width: '15%',
+        truncateText: true,
+        render: (row: SloSummary) => (
+          <EuiToolTip content={row.service} anchorClassName="eui-textTruncate" display="block">
+            <EuiText size="s" className="eui-textTruncate">
+              {row.service}
+            </EuiText>
+          </EuiToolTip>
+        ),
       },
       {
         name: i18n.translate('observability.apm.slo.listing.column.owner', {
           defaultMessage: 'Owner',
         }),
-        render: (row: SloSummary) => (
-          <EuiText size="s">{row.owner.teams.join(', ') || '—'}</EuiText>
-        ),
+        width: '13%',
+        truncateText: true,
+        render: (row: SloSummary) => {
+          const owner = row.owner.teams.join(', ') || '—';
+          return (
+            <EuiToolTip content={owner} anchorClassName="eui-textTruncate" display="block">
+              <EuiText size="s" className="eui-textTruncate">
+                {owner}
+              </EuiText>
+            </EuiToolTip>
+          );
+        },
       },
       {
         name: i18n.translate('observability.apm.slo.listing.column.objectives', {
           defaultMessage: 'Objectives',
         }),
+        width: '120px',
         render: (row: SloSummary) => (
-          <EuiText size="s">
+          <EuiText size="s" style={{ whiteSpace: 'nowrap' }}>
             {row.objectiveCount} • {formatTargetPct(row.worstTarget)}
           </EuiText>
         ),
@@ -1338,7 +1381,18 @@ export const SloListingPage: React.FC<SloListingPageProps> = ({
   return (
     <EuiPage data-test-subj="slosPage">
       <EuiPageBody component="main">
-        <HeaderControlledComponentsWrapper components={[refreshButton, createButton]} />
+        <HeaderControlledComponentsWrapper
+          components={
+            // Surface Suggest SLOs in the toolbar (left of Create) once the
+            // workspace already has SLOs — it's the easier path than the manual
+            // create wizard. Hidden only in the zero-SLO onboarding state (where
+            // the empty state already leads with Suggest) and during first load /
+            // error, so it still shows when the user arrives with a filter active.
+            !isFirstLoad && !error && !noSlosExist
+              ? [refreshButton, <SloSuggestHeaderButton key="suggest" />, createButton]
+              : [refreshButton, createButton]
+          }
+        />
         <EuiPageContent color="transparent" hasBorder={false} paddingSize="none">
           <EuiPageContentBody>
             {isFirstLoad ? (
@@ -1370,47 +1424,7 @@ export const SloListingPage: React.FC<SloListingPageProps> = ({
                 />
               </EuiPanel>
             ) : noSlosExist ? (
-              <EuiPanel style={{ marginTop: '8px' }} data-test-subj="slosEmptyNoSlos">
-                <EuiEmptyPrompt
-                  iconType="visualizeApp"
-                  title={
-                    <h2>
-                      {i18n.translate('observability.apm.slo.listing.emptyState.title', {
-                        defaultMessage: 'No SLOs yet',
-                      })}
-                    </h2>
-                  }
-                  body={
-                    <p>
-                      {i18n.translate('observability.apm.slo.listing.emptyState.body', {
-                        defaultMessage:
-                          'Track reliability objectives for your APM services. Visit the Services view to see which services are missing SLOs and create them directly from there.',
-                      })}
-                    </p>
-                  }
-                  actions={[
-                    <EuiButton
-                      key="services"
-                      fill
-                      onClick={navigateToServicesList}
-                      data-test-subj="slosEmptyGoToServices"
-                    >
-                      {i18n.translate('observability.apm.slo.listing.emptyState.goToServices', {
-                        defaultMessage: 'Go to Services',
-                      })}
-                    </EuiButton>,
-                    <EuiButtonEmpty
-                      key="create"
-                      href="#/slos/create"
-                      data-test-subj="slosCreateEmpty"
-                    >
-                      {i18n.translate('observability.apm.slo.listing.emptyState.createManually', {
-                        defaultMessage: 'Create manually',
-                      })}
-                    </EuiButtonEmpty>,
-                  ]}
-                />
-              </EuiPanel>
+              <SloNoSlosEmptyState />
             ) : (
               <EuiResizableContainer style={{ marginTop: '8px' }}>
                 {(EuiResizablePanel, EuiResizableButton) => (

--- a/public/components/apm/pages/slos/slo_no_slos_empty_state.tsx
+++ b/public/components/apm/pages/slos/slo_no_slos_empty_state.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useMemo } from 'react';
+import { EuiButton, EuiButtonEmpty, EuiEmptyPrompt, EuiPanel } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { useServices } from '../../shared/hooks/use_services';
+import { parseTimeRange } from '../../shared/utils/time_utils';
+import { DEFAULT_APM_TIME_RANGE } from '../../common/constants';
+import { navigateToServicesList, navigateToSloSuggest } from '../../shared/utils/navigation_utils';
+
+/**
+ * Onboarding empty state shown on the SLO listing when the workspace has no
+ * SLOs at all (the `noSlosExist` branch).
+ *
+ * It is a separate component — mounted only in that branch — so the
+ * `useServices` discovery query runs *only* when there is genuinely nothing to
+ * list, never on the hot path where SLOs already exist.
+ *
+ * The state steers the user down the fastest path to their first SLO rather
+ * than leaving them at a blank page:
+ *   - Services discovered → lead with **Suggest SLOs**, which auto-drafts
+ *     availability + latency objectives for each service so the user reviews
+ *     and creates a whole batch in one step.
+ *   - No services yet → Suggest SLOs has nothing to draft against, so guide the
+ *     user to **set up services** first (send trace data), then come back.
+ *
+ * "Create manually" stays available as the secondary path in both cases.
+ */
+export const SloNoSlosEmptyState: React.FC = () => {
+  // Discovery window: SLO onboarding has no time picker of its own, so use the
+  // shared APM default. Memoized once at mount — `parseTimeRange` resolves the
+  // relative bounds to concrete Dates, and we don't want the window drifting
+  // (and re-firing the query) on every render.
+  const parsedTimeRange = useMemo(() => parseTimeRange(DEFAULT_APM_TIME_RANGE), []);
+
+  const {
+    data: services,
+    isLoading: servicesLoading,
+    error: servicesError,
+  } = useServices({
+    startTime: parsedTimeRange.startTime,
+    endTime: parsedTimeRange.endTime,
+  });
+
+  const serviceCount = services?.length ?? 0;
+  // While discovery is in flight, optimistically show the Suggest path: the
+  // Suggest page has its own no-services / no-datasource handling, so landing
+  // there early is harmless and avoids a spinner-then-swap flicker.
+  const hasServices = servicesLoading || serviceCount > 0;
+
+  if (hasServices) {
+    return (
+      <EuiPanel style={{ marginTop: '8px' }} data-test-subj="slosEmptyNoSlos">
+        <EuiEmptyPrompt
+          iconType="visualizeApp"
+          title={
+            <h2>
+              {i18n.translate('observability.apm.slo.listing.emptyState.title', {
+                defaultMessage: 'No SLOs yet',
+              })}
+            </h2>
+          }
+          body={
+            <p>
+              {serviceCount > 0
+                ? i18n.translate('observability.apm.slo.listing.emptyState.bodyWithServices', {
+                    defaultMessage:
+                      'Suggest SLOs reads your {count, plural, one {# discovered service} other {# discovered services}} and drafts availability and latency objectives for each one — review and create them in a single step.',
+                    values: { count: serviceCount },
+                  })
+                : i18n.translate('observability.apm.slo.listing.emptyState.body', {
+                    defaultMessage:
+                      'Suggest SLOs drafts availability and latency objectives for your APM services automatically — review and create them in a single step.',
+                  })}
+            </p>
+          }
+          actions={[
+            <EuiButton
+              key="suggest"
+              fill
+              iconType="inspect"
+              onClick={() => navigateToSloSuggest([])}
+              data-test-subj="slosEmptySuggest"
+            >
+              {i18n.translate('observability.apm.slo.listing.emptyState.suggest', {
+                defaultMessage: 'Suggest SLOs',
+              })}
+            </EuiButton>,
+            <EuiButtonEmpty key="create" href="#/slos/create" data-test-subj="slosCreateEmpty">
+              {i18n.translate('observability.apm.slo.listing.emptyState.createManually', {
+                defaultMessage: 'Create manually',
+              })}
+            </EuiButtonEmpty>,
+          ]}
+        />
+      </EuiPanel>
+    );
+  }
+
+  // No services discovered (or discovery failed). SLOs describe the reliability
+  // of APM services and Suggest SLOs needs services to draft against, so the
+  // best next step is to get services reporting first.
+  return (
+    <EuiPanel style={{ marginTop: '8px' }} data-test-subj="slosEmptyNoServices">
+      <EuiEmptyPrompt
+        iconType="wrench"
+        title={
+          <h2>
+            {i18n.translate('observability.apm.slo.listing.emptyNoServices.title', {
+              defaultMessage: 'Set up services to get started',
+            })}
+          </h2>
+        }
+        body={
+          <p>
+            {servicesError
+              ? i18n.translate('observability.apm.slo.listing.emptyNoServices.errorBody', {
+                  defaultMessage:
+                    'SLOs track the reliability of your APM services. We could not load your services just now — open Services to check your APM setup, then come back to auto-draft SLOs with Suggest SLOs.',
+                })
+              : i18n.translate('observability.apm.slo.listing.emptyNoServices.body', {
+                  defaultMessage:
+                    'SLOs track the reliability of your APM services. Set up service monitoring and send trace data first — then Suggest SLOs can auto-draft availability and latency objectives for each service.',
+                })}
+          </p>
+        }
+        actions={[
+          <EuiButton
+            key="services"
+            fill
+            onClick={navigateToServicesList}
+            data-test-subj="slosEmptyGoToServices"
+          >
+            {i18n.translate('observability.apm.slo.listing.emptyNoServices.goToServices', {
+              defaultMessage: 'Set up services',
+            })}
+          </EuiButton>,
+          <EuiButtonEmpty key="create" href="#/slos/create" data-test-subj="slosCreateEmpty">
+            {i18n.translate('observability.apm.slo.listing.emptyState.createManually', {
+              defaultMessage: 'Create manually',
+            })}
+          </EuiButtonEmpty>,
+        ]}
+      />
+    </EuiPanel>
+  );
+};

--- a/public/components/apm/pages/slos/slo_no_slos_empty_state.tsx
+++ b/public/components/apm/pages/slos/slo_no_slos_empty_state.tsx
@@ -51,6 +51,15 @@ export const SloNoSlosEmptyState: React.FC = () => {
   // there early is harmless and avoids a spinner-then-swap flicker.
   const hasServices = servicesLoading || serviceCount > 0;
 
+  // Names of the services discovery found, passed to the Suggest page as its
+  // URL scope so it lands pre-scoped and auto-drafts objectives for each one —
+  // matching the empty-state promise. Without this, an unscoped Suggest deep
+  // link drafts nothing and drops the user on the "pick services" prompt.
+  const discoveredServiceNames = useMemo(
+    () => (services ?? []).map((s) => s.serviceName).filter(Boolean),
+    [services]
+  );
+
   if (hasServices) {
     return (
       <EuiPanel style={{ marginTop: '8px' }} data-test-subj="slosEmptyNoSlos">
@@ -82,7 +91,7 @@ export const SloNoSlosEmptyState: React.FC = () => {
               key="suggest"
               fill
               iconType="inspect"
-              onClick={() => navigateToSloSuggest([])}
+              onClick={() => navigateToSloSuggest(discoveredServiceNames)}
               data-test-subj="slosEmptySuggest"
             >
               {i18n.translate('observability.apm.slo.listing.emptyState.suggest', {

--- a/public/components/apm/pages/slos/slo_suggest_header_button.tsx
+++ b/public/components/apm/pages/slos/slo_suggest_header_button.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useMemo } from 'react';
+import { EuiButton, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { useServices } from '../../shared/hooks/use_services';
+import { parseTimeRange } from '../../shared/utils/time_utils';
+import { DEFAULT_APM_TIME_RANGE } from '../../common/constants';
+import { navigateToSloSuggest } from '../../shared/utils/navigation_utils';
+
+/**
+ * Toolbar CTA that steers users to the Suggest SLOs batch flow (the fastest way
+ * to a first SLO) rather than the manual create wizard. Rendered next to
+ * "Create SLO" once the workspace already has SLOs.
+ *
+ * Suggest only makes sense when there are APM services to draft objectives
+ * against, so the button is disabled when discovery finds none — with a tooltip
+ * that points the user at the Services page to set them up first.
+ */
+export const SloSuggestHeaderButton: React.FC = () => {
+  // Discovery window: reuse the shared APM default and resolve it once so the
+  // query doesn't re-fire on every render.
+  const parsedTimeRange = useMemo(() => parseTimeRange(DEFAULT_APM_TIME_RANGE), []);
+
+  const { data: services, isLoading: servicesLoading } = useServices({
+    startTime: parsedTimeRange.startTime,
+    endTime: parsedTimeRange.endTime,
+  });
+
+  const serviceCount = services?.length ?? 0;
+  // Stay enabled while discovery is in flight — the Suggest page has its own
+  // no-services handling, so an early click is harmless and avoids a flicker.
+  const hasServices = servicesLoading || serviceCount > 0;
+
+  const button = (
+    <EuiButton
+      fill
+      size="s"
+      iconType="inspect"
+      isDisabled={!hasServices}
+      onClick={hasServices ? () => navigateToSloSuggest([]) : undefined}
+      data-test-subj="slosSuggest"
+    >
+      {i18n.translate('observability.apm.slo.listing.suggestButton', {
+        defaultMessage: 'Suggest SLOs',
+      })}
+    </EuiButton>
+  );
+
+  if (hasServices) {
+    return button;
+  }
+
+  return (
+    <EuiToolTip
+      position="bottom"
+      content={i18n.translate('observability.apm.slo.listing.suggestButton.noServicesTooltip', {
+        defaultMessage:
+          'No services detected. Set up services on the Services page first — then Suggest SLOs can draft objectives for them.',
+      })}
+    >
+      {/* A disabled button doesn't emit the pointer events EuiToolTip needs, so
+          wrap it in a span that acts as the (enabled) hover target. */}
+      <span>{button}</span>
+    </EuiToolTip>
+  );
+};

--- a/server/services/alerting/__tests__/alert_utils.test.ts
+++ b/server/services/alerting/__tests__/alert_utils.test.ts
@@ -212,14 +212,14 @@ describe('osAlertToUnified', () => {
 });
 
 // ============================================================================
-// osMonitorToUnifiedRuleSummary — monitorType derivation from index prefixes
+// osMonitorToUnifiedRuleSummary — monitorType derivation
 // ============================================================================
 //
-// Regression coverage for the L5 cleanup that hoisted the previously-inline
-// prefix list into named `LOG_INDEX_PREFIXES` / `APM_INDEX_PREFIXES`
-// constants. Encodes the schema list so adding a new well-known schema
-// (e.g. SS4O metrics) is a one-line constant change with a single test
-// case to follow.
+// The Rules-tab "Type" is derived from the detected monitor kind: composite,
+// cluster-metrics, and anomaly-detector monitors keep their own types; every
+// other OpenSearch monitor — per-query, per-bucket, per-document — is surfaced
+// under a single "Log" type (the old apm/log/metric index-name heuristic was
+// removed because it guessed a data domain rather than the monitor mechanism).
 
 describe('osMonitorToUnifiedRuleSummary — monitorType derivation', () => {
   function buildMonitor(indices: string[]): OSMonitor {
@@ -250,23 +250,17 @@ describe('osMonitorToUnifiedRuleSummary — monitorType derivation', () => {
     }
   );
 
-  it.each([
-    ['otel-v1-apm-span'],
-    ['otel-v1-apm-service-map'],
-    ['ss4o_traces-myapp'],
-    ['ss4o_traces'],
-  ])('classifies %s as an apm monitor', (idx) => {
-    expect(osMonitorToUnifiedRuleSummary(buildMonitor([idx]), 'ds').monitorType).toBe('apm');
-  });
+  // Per-query monitors are surfaced as "log" regardless of the index they
+  // target — the index-name domain heuristic (apm/metric) was removed.
+  it.each([['otel-v1-apm-span'], ['ss4o_traces-myapp'], ['my-custom-index'], ['foo-*']])(
+    'classifies a query monitor over %s as a log monitor',
+    (idx) => {
+      expect(osMonitorToUnifiedRuleSummary(buildMonitor([idx]), 'ds').monitorType).toBe('log');
+    }
+  );
 
-  it('falls back to "metric" for indices that match no schema prefix', () => {
-    const r = osMonitorToUnifiedRuleSummary(buildMonitor(['my-custom-index', 'foo-*']), 'ds');
-    expect(r.monitorType).toBe('metric');
-  });
-
-  it('falls back to "metric" when no input indices are present', () => {
-    const r = osMonitorToUnifiedRuleSummary(buildMonitor([]), 'ds');
-    expect(r.monitorType).toBe('metric');
+  it('classifies a query monitor with no indices as a log monitor', () => {
+    expect(osMonitorToUnifiedRuleSummary(buildMonitor([]), 'ds').monitorType).toBe('log');
   });
 
   it.each([['.opendistro-anomaly-results*'], ['opensearch-ad-plugin-result-test-history-*']])(
@@ -315,9 +309,39 @@ describe('osMonitorToUnifiedRuleSummary — monitorType derivation', () => {
     expect(extractADAnomalyResultIdsFromMonitor(monitor)).toEqual(['anomaly-1', 'anomaly-2']);
   });
 
-  it('treats the first matching prefix as authoritative — log wins over apm when both are present', () => {
-    const r = osMonitorToUnifiedRuleSummary(buildMonitor(['logs-app', 'otel-v1-apm-span']), 'ds');
-    expect(r.monitorType).toBe('log');
+  it('classifies bucket-level monitors as a log monitor', () => {
+    const m = {
+      ...buildMonitor(['logs-x']),
+      monitor_type: 'bucket_level_monitor',
+    } as unknown as OSMonitor;
+    expect(osMonitorToUnifiedRuleSummary(m, 'ds').monitorType).toBe('log');
+  });
+
+  it('classifies doc-level monitors as a log monitor', () => {
+    const m = {
+      ...buildMonitor([]),
+      monitor_type: 'doc_level_monitor',
+      inputs: [{ doc_level_input: { description: '', indices: ['logs-x'], queries: [] } }],
+    } as unknown as OSMonitor;
+    expect(osMonitorToUnifiedRuleSummary(m, 'ds').monitorType).toBe('log');
+  });
+
+  it('keeps cluster-metrics monitors classified as cluster_metrics', () => {
+    const m = {
+      ...buildMonitor([]),
+      inputs: [
+        {
+          uri: {
+            api_type: 'CLUSTER_HEALTH',
+            path: '/_cluster/health',
+            path_params: '',
+            url: '',
+            clusters: [],
+          },
+        },
+      ],
+    } as unknown as OSMonitor;
+    expect(osMonitorToUnifiedRuleSummary(m, 'ds').monitorType).toBe('cluster_metrics');
   });
 
   it('classifies composite (workflow) monitors as "composite" and surfaces member monitor ids', () => {

--- a/server/services/alerting/__tests__/alert_utils.test.ts
+++ b/server/services/alerting/__tests__/alert_utils.test.ts
@@ -319,6 +319,41 @@ describe('osMonitorToUnifiedRuleSummary — monitorType derivation', () => {
     const r = osMonitorToUnifiedRuleSummary(buildMonitor(['logs-app', 'otel-v1-apm-span']), 'ds');
     expect(r.monitorType).toBe('log');
   });
+
+  it('classifies composite (workflow) monitors as "composite" and surfaces member monitor ids', () => {
+    // Workflows are returned by the monitors search with no monitor_type (so
+    // mapMonitor coerces to query_level_monitor); the composite_input is the
+    // authoritative signal.
+    const composite = {
+      id: 'wf-1',
+      type: 'monitor',
+      monitor_type: 'query_level_monitor',
+      name: 'composite-wf',
+      enabled: true,
+      schedule: { period: { interval: 1, unit: 'MINUTES' } },
+      inputs: [
+        {
+          composite_input: {
+            sequence: {
+              delegates: [
+                { order: 2, monitor_id: 'mon-b' },
+                { order: 1, monitor_id: 'mon-a' },
+              ],
+            },
+          },
+        },
+      ],
+      triggers: [],
+      last_update_time: 1700000000000,
+    } as unknown as OSMonitor;
+
+    const r = osMonitorToUnifiedRuleSummary(composite, 'ds');
+    expect(r.monitorType).toBe('composite');
+    expect(r.labels?.monitor_kind).toBe('composite');
+    // Ordered by `order`, so mon-a (order 1) precedes mon-b (order 2).
+    expect(r.labels?.composite_delegates).toBe('mon-a,mon-b');
+    expect(r.query).toBe('mon-a, mon-b');
+  });
 });
 
 describe('adForecasterToUnifiedRuleSummary', () => {

--- a/server/services/alerting/alert_utils.ts
+++ b/server/services/alerting/alert_utils.ts
@@ -583,46 +583,14 @@ function hashLabels(labels: Record<string, string>): string {
  */
 const RULE_IDENTITY_STRIP_LABELS = new Set(['__name__', 'alertstate']);
 
-/**
- * Index-name prefixes used to derive a `MonitorType` for query-level OS
- * monitors that don't carry an explicit `kind` hint. These mirror the
- * well-known OSD schemas:
- *
- *   - `logs-*`, `ss4o_logs*` — Simple Schema for Observability (SS4O) logs
- *     and the legacy `logs-*` convention used by the Logs app.
- *   - `otel-v1-apm-*`, `ss4o_traces*` — OTel-derived APM/trace indices
- *     (legacy `otel-v1-apm-*` data prepper output and SS4O traces).
- *
- * Anything that doesn't match either family falls through to `'metric'` —
- * the catch-all bucket for Prometheus / cluster-metrics-style monitors.
- *
- * Hoisted to module scope (rather than inlined in the derivation site) so
- * the schema list is greppable, testable, and obvious. Adding a new schema
- * means adding one row; previously the convention was buried in a
- * 60-line function.
- *
- * Callers that have access to a request-scoped `uiSettings` client should
- * prefer the user-configurable `observability:traceAnalyticsSpanIndices` /
- * `observability:traceAnalyticsCorrelatedLogsIndices` settings when
- * classifying. `osMonitorToUnifiedRuleSummary` runs in code paths that
- * don't yet plumb the request, so it falls back to the static defaults
- * below.
- */
-const LOG_INDEX_PREFIXES = ['logs-', 'ss4o_logs'] as const;
-const APM_INDEX_PREFIXES = ['otel-v1-apm', 'ss4o_traces'] as const;
+// Anomaly-detector result index patterns — used to flag query monitors that
+// alert on AD results so they surface as "Anomaly detector monitor" rather
+// than a generic monitor.
 const AD_RESULT_INDEX_PATTERNS = [
   '.opendistro-anomaly-results',
   '.opensearch-ad-plugin-result',
   'opensearch-ad-plugin-result',
 ] as const;
-
-function inferMonitorTypeFromIndices(indices: string[]): MonitorType {
-  const startsWithAny = (prefixes: readonly string[]): boolean =>
-    indices.some((idx) => prefixes.some((p) => idx.startsWith(p)));
-  if (startsWithAny(LOG_INDEX_PREFIXES)) return 'log';
-  if (startsWithAny(APM_INDEX_PREFIXES)) return 'apm';
-  return 'metric';
-}
 
 export function isAnomalyDetectorMonitor(input: OSMonitor['inputs'][number] | undefined): boolean {
   if (!input || !('search' in input)) return false;
@@ -870,7 +838,13 @@ export function osMonitorToUnifiedRuleSummary(m: OSMonitor, dsId: string): Unifi
     query = '{}';
   }
 
-  // Derive monitor type from kind and index patterns
+  // Derive the displayed monitor type from the detected kind. Composite and
+  // cluster-metrics keep their own types; anomaly-detector-backed monitors are
+  // flagged separately. Everything else — per-query, per-bucket, and
+  // per-document monitors — is surfaced under a single "Log" type. (The type
+  // column previously split query monitors into apm/log/metric by index-name
+  // heuristics, which guessed a data domain rather than the monitor mechanism
+  // and confused users; the flyout still renders the kind-specific detail.)
   let monitorType: MonitorType;
   if (kind === 'composite') {
     monitorType = 'composite';
@@ -878,17 +852,10 @@ export function osMonitorToUnifiedRuleSummary(m: OSMonitor, dsId: string): Unifi
     monitorType = 'ppl';
   } else if (kind === 'cluster_metrics') {
     monitorType = 'cluster_metrics';
-  } else if (kind === 'doc') {
-    monitorType = 'log';
-  } else if (kind === 'bucket') {
-    monitorType = 'infrastructure';
   } else if (isAnomalyDetectorMonitor(input)) {
     monitorType = 'anomaly_detector_monitor';
   } else {
-    // query-level: derive from index patterns. See LOG_INDEX_PREFIXES /
-    // APM_INDEX_PREFIXES at module scope for the schema list.
-    const indices = input && 'search' in input ? (input.search.indices ?? []) : [];
-    monitorType = inferMonitorTypeFromIndices(indices);
+    monitorType = 'log';
   }
 
   const destNames = triggerActions.map((a) => a.name);

--- a/server/services/alerting/alert_utils.ts
+++ b/server/services/alerting/alert_utils.ts
@@ -749,7 +749,12 @@ export function hashRuleIdentity(labels: Record<string, string>): string {
  */
 export function detectMonitorKind(
   m: OSMonitor
-): 'query' | 'bucket' | 'doc' | 'cluster_metrics' | 'ppl' {
+): 'query' | 'bucket' | 'doc' | 'cluster_metrics' | 'ppl' | 'composite' {
+  // Composite (workflow) monitors carry a `composite_input` and no
+  // `monitor_type` on the wire, so mapMonitor coerces them to
+  // `query_level_monitor`. Detect them structurally, before the query default,
+  // so they are labeled + rendered as composites rather than metric monitors.
+  if (m.inputs[0] && 'composite_input' in m.inputs[0]) return 'composite';
   if (m.monitor_type === 'ppl_monitor') return 'ppl';
   if (m.monitor_type === 'bucket_level_monitor') return 'bucket';
   if (m.monitor_type === 'doc_level_monitor') return 'doc';
@@ -789,6 +794,17 @@ export function osMonitorToUnifiedRuleSummary(m: OSMonitor, dsId: string): Unifi
     labels.doc_queries = String(input.doc_level_input.queries?.length ?? 0);
   } else if (input && 'ppl_input' in input) {
     labels.query_language = input.ppl_input.query_language;
+  } else if (input && 'composite_input' in input) {
+    const delegates = input.composite_input.sequence?.delegates ?? [];
+    if (delegates.length > 0) {
+      // Ordered member monitor ids — the detail fetch can't resolve a workflow
+      // via the monitors endpoint, so surface the sequence from the summary.
+      labels.composite_delegates = delegates
+        .slice()
+        .sort((a, b) => a.order - b.order)
+        .map((d) => d.monitor_id)
+        .join(',');
+    }
   }
   labels.monitor_type = m.monitor_type;
   labels.monitor_kind = kind;
@@ -841,13 +857,24 @@ export function osMonitorToUnifiedRuleSummary(m: OSMonitor, dsId: string): Unifi
     query = JSON.stringify(input.search.query ?? {});
   } else if (input && 'ppl_input' in input) {
     query = input.ppl_input.query;
+  } else if (input && 'composite_input' in input) {
+    const delegates = input.composite_input.sequence?.delegates ?? [];
+    query = delegates.length
+      ? delegates
+          .slice()
+          .sort((a, b) => a.order - b.order)
+          .map((d) => d.monitor_id)
+          .join(', ')
+      : '(no member monitors)';
   } else {
     query = '{}';
   }
 
   // Derive monitor type from kind and index patterns
   let monitorType: MonitorType;
-  if (kind === 'ppl') {
+  if (kind === 'composite') {
+    monitorType = 'composite';
+  } else if (kind === 'ppl') {
     monitorType = 'ppl';
   } else if (kind === 'cluster_metrics') {
     monitorType = 'cluster_metrics';


### PR DESCRIPTION
## Description

Improves the **SLO listing** onboarding/empty state, adds a **"Suggest SLOs" toolbar button**, tidies up the **SLO catalog table rows**, and fixes how the **unified Alerts Rules tab** handles the older OpenSearch monitor types (composite/workflow support, simplified type labels, and a richer bucket-level flyout).

### SLO listing
- Replaced the generic *"No SLOs yet"* onboarding with a **services-aware empty state** (`SloNoSlosEmptyState`):
  - **Services discovered → leads with "Suggest SLOs"**, which auto-drafts availability + latency objectives for each service (the body shows the discovered-service count).
  - **No services yet → "Set up services to get started"**, guiding the user to set up service monitoring first.
  - "Create manually" remains the secondary path in both cases. The discovery query is mount-gated so it runs only when there are zero SLOs.
- Added a **"Suggest SLOs" toolbar button** (left of "Create SLO") once the workspace already has SLOs, to steer users to the easier batch flow. It is **disabled with an explanatory tooltip** when no APM services are discovered.
- **Tidied the catalog rows:** the Name column now truncates to a single line (full name on hover + via the detail link) and the text columns have deterministic widths, so long SLO names no longer word-break into cramped multi-line rows on narrower screens.

## Before / After

### SLO listing — empty state (no services configured)

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/before-slo-empty.png" width="460"> | <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/after-slo-empty-no-services.png" width="460"> |

### SLO listing — empty state (services discovered)
Leads with the **Suggest SLOs** batch-onboarding flow.

<img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/uav-after-slo-suggest.png" width="620">

### SLO listing — "Suggest SLOs" toolbar button
Added left of "Create SLO" once SLOs exist. **Enabled** when services are set up; **disabled with a tooltip** when they aren't.

| Before (toolbar) | Disabled — no services (tooltip) | Enabled — services set up |
|---|---|---|
| <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/before-slo-toolbar.png" width="300"> | <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/after-slo-toolbar-suggest-tooltip.png" width="300"> | <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/after-slo-name-fixed-v3.png" width="300"> |

### SLO catalog — Name column no longer scrunched
Long names used to word-break across ~4 lines on narrower widths; now they stay on one line and elide with an ellipsis.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/after-slo-toolbar-suggest-enabled.png" width="460"> | <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/after-slo-name-fixed-v3.png" width="460"> |

The full name is available on hover via a tooltip (and on the detail page):

<img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/after-slo-name-tooltip.png" width="620">

## Unified Alerts — Rules tab & monitor flyout
Tested creating all five older OpenSearch monitor types (per-query, per-bucket, per-document, cluster-metrics, composite) and viewing each in the Rules tab + flyout.

**Composite (workflow) monitors** were returned by the monitors search with no `monitor_type`, so they were coerced to query-level and shown as **"Metric"**, with a broken flyout: an empty `{}` query, a nonsensical `Threshold > 0`, and **Edit/Clone/Delete/Disable enabled** (acting on them would corrupt the workflow). Now recognized structurally (`composite_input`) → labeled **"Composite"** (which also auto-gates Edit/Enable-Disable), with an **"Associated monitors"** list of member monitors and Clone/Delete disabled. Because a composite is a workflow (its detail can't be fetched from the monitors endpoint), the flyout drops the "could not load details" banner and the fields that don't apply (threshold, pending period, condition-preview chart), showing only the member monitors + evaluation interval.

| Composite flyout — before (broken) | After (clean) |
|---|---|
| <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/flyout-composite.png" width="460"> | <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/flyout-composite-final.png" width="460"> |

**Type labels** were guessed from index names (per-document → "Log", per-bucket → "Infrastructure", per-query → "APM"/"Metric"), which described a data domain rather than the monitor mechanism. Consolidated so per-query / per-bucket / per-document all surface as **"Log"**, with **"Cluster Metrics"** and **"Composite"** kept distinct.

| Type column — before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/alerts-rules-tab-types.png" width="460"> | <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/alerts-rules-types-after2.png" width="460"> |

**Bucket-level flyout** previously showed only the raw query JSON; it now renders a structured view — target indices, group-by fields, and the per-bucket condition — with the full aggregation query behind a toggle. Detail-load failures on cluster-metrics/doc/bucket monitors now show a plain "configuration unavailable" note instead of a malformed query block.

| Bucket flyout — before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/flyout-bucket.png" width="460"> | <img src="https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-assets-empty-states/flyout-bucket-fixed.png" width="460"> |

## Testing
Verified against a live observability stack (OTel demo data) via a dev server:
- SLO empty state shows the "Set up services" branch with no services, and the "Suggest SLOs" branch when services are discovered.
- With real SLOs present, the toolbar shows "Suggest SLOs" left of "Create SLO" — enabled when services are configured, disabled + tooltip otherwise.
- Long SLO names stay on a single line and truncate with a tooltip.

Automated:
- `slo_listing_page.test.tsx` — covers both empty-state branches and the enabled/disabled toolbar button.
- `slo_listing_page_datasource_scope.test.tsx` + `slo_listing_page_pagination.test.tsx` — updated to stub `useServices` for the new toolbar button.
- Full plugin Jest suite (512 tests) + ESLint pass locally.

## Check List
- [x] All tests pass
- [x] New functionality has been documented / covered by tests
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
