### PR TITLE
Improve Alerts Manager empty state

### DIFF
--- a/public/components/alerting/__tests__/alerts_dashboard.test.tsx
+++ b/public/components/alerting/__tests__/alerts_dashboard.test.tsx
@@ -97,6 +97,10 @@ const baseProps = {
   rulesTotal: 1,
   defaultDatasources: [],
   onGoToRules: jest.fn(),
+  onCreateLogsRule: jest.fn(),
+  onCreateMetricsRule: jest.fn(),
+  onCreateAnomalyDetection: jest.fn(),
+  onCreateForecasting: jest.fn(),
   startMs: NOW - HOUR_MS,
   endMs: NOW,
   pickerStart: 'now-24h',
@@ -113,16 +117,72 @@ describe('AlertsDashboard', () => {
   it('renders "no alerts in range" empty state when rules exist but no alerts', () => {
     const { getByText } = render(<AlertsDashboard {...baseProps} />);
     expect(getByText('No alerts in the selected time range')).toBeInTheDocument();
+    expect(
+      getByText('No alerts or anomalies were detected in the selected time range.')
+    ).toBeInTheDocument();
   });
 
   it('renders "no datasource" empty state when selection is empty', () => {
     const { getByText } = render(<AlertsDashboard {...baseProps} selectedDsIds={[]} />);
-    expect(getByText('No datasource selected')).toBeInTheDocument();
+    expect(
+      getByText('Define rules, detect anomalies, and forecast from one place')
+    ).toBeInTheDocument();
+    expect(getByText('Alerting')).toBeInTheDocument();
+    expect(getByText('Anomaly detection')).toBeInTheDocument();
+    expect(getByText('Forecasting')).toBeInTheDocument();
+    expect(
+      getByText('Select a datasource to view alerts and detected anomalies.')
+    ).toBeInTheDocument();
+  });
+
+  it('offers logs and metrics creation from the Alerting capability card', () => {
+    const onCreateLogsRule = jest.fn();
+    const onCreateMetricsRule = jest.fn();
+    const onCreateAnomalyDetection = jest.fn();
+    const onCreateForecasting = jest.fn();
+    const { getByText } = render(
+      <AlertsDashboard
+        {...baseProps}
+        selectedDsIds={[]}
+        onCreateLogsRule={onCreateLogsRule}
+        onCreateMetricsRule={onCreateMetricsRule}
+        onCreateAnomalyDetection={onCreateAnomalyDetection}
+        onCreateForecasting={onCreateForecasting}
+      />
+    );
+
+    fireEvent.click(getByText('Alerting'));
+    expect(screen.getByTestId('alertsEmptyAlertingRuleTypeModal')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('alertsEmptyCreateLogsRule'));
+    expect(onCreateLogsRule).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(getByText('Alerting'));
+    fireEvent.click(screen.getByTestId('alertsEmptyCreateMetricsRule'));
+    expect(onCreateMetricsRule).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(getByText('Anomaly detection'));
+    expect(onCreateAnomalyDetection).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(getByText('Forecasting'));
+    expect(onCreateForecasting).toHaveBeenCalledTimes(1);
   });
 
   it('renders "no rules or detectors" empty state when rulesTotal is 0', () => {
     const { getByText } = render(<AlertsDashboard {...baseProps} rulesTotal={0} />);
-    expect(getByText('No rules or detectors have been created')).toBeInTheDocument();
+    expect(
+      getByText('Define rules, detect anomalies, and forecast from one place')
+    ).toBeInTheDocument();
+    expect(
+      getByText(
+        'Create an alerting, anomaly detection, or forecasting rule for the selected datasource.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      getByText(
+        'Create a rule to get started. Triggered alerts and detected anomalies will appear here.'
+      )
+    ).toBeInTheDocument();
+    expect(getByText('Go to Rules')).toBeInTheDocument();
   });
 
   it('renders alert table when alerts provided', () => {

--- a/public/components/alerting/__tests__/alerts_dashboard.test.tsx
+++ b/public/components/alerting/__tests__/alerts_dashboard.test.tsx
@@ -153,6 +153,7 @@ describe('AlertsDashboard', () => {
 
     fireEvent.click(getByText('Alerting'));
     expect(screen.getByTestId('alertsEmptyAlertingRuleTypeModal')).toBeInTheDocument();
+    expect(document.querySelectorAll('.euiOverlayMask, .ouiOverlayMask')).toHaveLength(1);
     fireEvent.click(screen.getByTestId('alertsEmptyCreateLogsRule'));
     expect(onCreateLogsRule).toHaveBeenCalledTimes(1);
 

--- a/public/components/alerting/__tests__/alerts_dashboard.test.tsx
+++ b/public/components/alerting/__tests__/alerts_dashboard.test.tsx
@@ -168,6 +168,54 @@ describe('AlertsDashboard', () => {
     expect(onCreateForecasting).toHaveBeenCalledTimes(1);
   });
 
+  it('disables AD and Forecasting cards when no standard OpenSearch datasource is available', () => {
+    const onCreateAnomalyDetection = jest.fn();
+    const onCreateForecasting = jest.fn();
+    const unavailableDatasources: Datasource[] = [
+      {
+        id: 'aoss-1',
+        name: 'OpenSearch Serverless',
+        type: 'opensearch',
+        url: '',
+        enabled: true,
+        engineType: 'OpenSearch Serverless',
+      },
+      {
+        id: 'prometheus-1',
+        name: 'Prometheus',
+        type: 'prometheus',
+        url: '',
+        enabled: true,
+      },
+    ];
+
+    render(
+      <AlertsDashboard
+        {...baseProps}
+        datasources={unavailableDatasources}
+        selectedDsIds={[]}
+        onCreateAnomalyDetection={onCreateAnomalyDetection}
+        onCreateForecasting={onCreateForecasting}
+      />
+    );
+
+    const anomalyCard = screen.getByTestId('alertsEmptyCreateAnomalyDetection');
+    const forecastingCard = screen.getByTestId('alertsEmptyCreateForecasting');
+    expect(anomalyCard).toBeDisabled();
+    expect(forecastingCard).toBeDisabled();
+    expect(
+      screen.getByText('An OpenSearch datasource is required to create an anomaly detection rule.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('An OpenSearch datasource is required to create a forecasting rule.')
+    ).toBeInTheDocument();
+
+    fireEvent.click(anomalyCard);
+    fireEvent.click(forecastingCard);
+    expect(onCreateAnomalyDetection).not.toHaveBeenCalled();
+    expect(onCreateForecasting).not.toHaveBeenCalled();
+  });
+
   it('renders "no rules or detectors" empty state when rulesTotal is 0', () => {
     const { getByText } = render(<AlertsDashboard {...baseProps} rulesTotal={0} />);
     expect(

--- a/public/components/alerting/__tests__/alerts_dashboard.test.tsx
+++ b/public/components/alerting/__tests__/alerts_dashboard.test.tsx
@@ -190,7 +190,7 @@ describe('AlertsDashboard', () => {
     fireEvent.click(screen.getByText('Alerting'));
 
     const metricsCard = screen.getByTestId('alertsEmptyCreateMetricsRule');
-    expect(metricsCard).toBeDisabled();
+    expect(metricsCard).toHaveClass('euiCard-isDisabled');
     expect(
       screen.getByText('A Prometheus datasource is required to create a metrics alert rule.')
     ).toBeInTheDocument();
@@ -232,8 +232,8 @@ describe('AlertsDashboard', () => {
 
     const anomalyCard = screen.getByTestId('alertsEmptyCreateAnomalyDetection');
     const forecastingCard = screen.getByTestId('alertsEmptyCreateForecasting');
-    expect(anomalyCard).toBeDisabled();
-    expect(forecastingCard).toBeDisabled();
+    expect(anomalyCard).toHaveClass('euiCard-isDisabled');
+    expect(forecastingCard).toHaveClass('euiCard-isDisabled');
     expect(
       screen.getByText('An OpenSearch datasource is required to create an anomaly detection rule.')
     ).toBeInTheDocument();

--- a/public/components/alerting/__tests__/alerts_dashboard.test.tsx
+++ b/public/components/alerting/__tests__/alerts_dashboard.test.tsx
@@ -81,6 +81,14 @@ const sampleDs: Datasource = {
   enabled: true,
 };
 
+const samplePrometheusDs: Datasource = {
+  id: 'prometheus-1',
+  name: 'Prometheus',
+  type: 'prometheus',
+  url: '',
+  enabled: true,
+};
+
 const HOUR_MS = 60 * 60 * 1000;
 const NOW = Date.now();
 
@@ -143,6 +151,7 @@ describe('AlertsDashboard', () => {
     const { getByText } = render(
       <AlertsDashboard
         {...baseProps}
+        datasources={[sampleDs, samplePrometheusDs]}
         selectedDsIds={[]}
         onCreateLogsRule={onCreateLogsRule}
         onCreateMetricsRule={onCreateMetricsRule}
@@ -166,6 +175,28 @@ describe('AlertsDashboard', () => {
 
     fireEvent.click(getByText('Forecasting'));
     expect(onCreateForecasting).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Metrics creation when no Prometheus datasource is available', () => {
+    const onCreateMetricsRule = jest.fn();
+    render(
+      <AlertsDashboard
+        {...baseProps}
+        selectedDsIds={[]}
+        onCreateMetricsRule={onCreateMetricsRule}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Alerting'));
+
+    const metricsCard = screen.getByTestId('alertsEmptyCreateMetricsRule');
+    expect(metricsCard).toBeDisabled();
+    expect(
+      screen.getByText('A Prometheus datasource is required to create a metrics alert rule.')
+    ).toBeInTheDocument();
+
+    fireEvent.click(metricsCard);
+    expect(onCreateMetricsRule).not.toHaveBeenCalled();
   });
 
   it('disables AD and Forecasting cards when no standard OpenSearch datasource is available', () => {

--- a/public/components/alerting/__tests__/create_ad_rule_payload.test.ts
+++ b/public/components/alerting/__tests__/create_ad_rule_payload.test.ts
@@ -8,6 +8,7 @@ import {
   buildRulePayload,
   formFromAdResource,
   getCreateAdRuleDatasources,
+  getInitialDatasourceId,
   shouldAutoStartCreatedRule,
   validateForm,
 } from '../create_ad_rule_flyout';
@@ -163,6 +164,9 @@ describe('AD rule payload serialization', () => {
       'aos-1',
       'local-cluster',
     ]);
+    expect(getInitialDatasourceId(datasources)).toBe('');
+    expect(getInitialDatasourceId(datasources, ['aoss-1'])).toBe('');
+    expect(getInitialDatasourceId(datasources, ['aos-1'])).toBe('aos-1');
   });
 
   it('preserves unmodeled settings while emitting only canonical configuration keys', () => {

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -25,7 +25,7 @@
  *   - `AlertManagerEndTime`   — date-math string for picker end.
  */
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { EuiCallOut, EuiLink, EuiTab, EuiTabs } from '@elastic/eui';
+import { EuiLink, EuiTab, EuiTabs } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { toMountPoint } from '../../../../../src/plugins/opensearch_dashboards_react/public';
@@ -76,16 +76,6 @@ import {
   formStateToRule,
   resolveDatasourceTokens,
 } from './alarms_page_helpers';
-
-/**
- * App id of the legacy (pre-unified) alerting experience, served by the
- * standalone `alerts` plugin. The "old experience" link in the new-experience
- * callout deep-links to its `#/dashboard` route.
- */
-const OLD_ALERTING_APP_ID = 'alerts';
-
-/** localStorage key persisting dismissal of the new-experience intro callout. */
-const NEW_EXPERIENCE_CALLOUT_DISMISSED_KEY = 'observability.alerting.newExperienceCalloutDismissed';
 
 // ============================================================================
 // Main Page Component
@@ -476,18 +466,12 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   // datasource happens to be Prometheus.
   const [createBackendType, setCreateBackendType] = useState<MonitorBackendType | null>(null);
   const [createAdRuleType, setCreateAdRuleType] = useState<CreateAdRuleType | null>(null);
-  const [editTarget, setEditTarget] = useState<{ dsId: string; ruleId: string } | null>(null);
+  const [editTarget, setEditTarget] = useState<{
+    dsId: string;
+    ruleId: string;
+  } | null>(null);
   const [editAdTarget, setEditAdTarget] = useState<AdEditTarget | null>(null);
   const [selectedAlert, setSelectedAlert] = useState<UnifiedAlertSummary | null>(null);
-  // Whether the "new alerting experience" intro callout has been dismissed.
-  // Persisted in localStorage so it stays hidden across reloads once closed.
-  const [newExperienceCalloutDismissed, setNewExperienceCalloutDismissed] = useState<boolean>(
-    () => window.localStorage.getItem(NEW_EXPERIENCE_CALLOUT_DISMISSED_KEY) === 'true'
-  );
-  const dismissNewExperienceCallout = useCallback(() => {
-    window.localStorage.setItem(NEW_EXPERIENCE_CALLOUT_DISMISSED_KEY, 'true');
-    setNewExperienceCalloutDismissed(true);
-  }, []);
   const { setToast: addToast } = useToast();
 
   const handleNavigateToDetectorResults = useCallback((href: string) => {
@@ -1146,7 +1130,12 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       datasourceId: form.datasourceId,
       datasourceType: 'prometheus',
       query: form.query,
-      threshold: { operator: '>', value: 0, unit: '', forDuration: form.forDuration },
+      threshold: {
+        operator: '>',
+        value: 0,
+        unit: '',
+        forDuration: form.forDuration,
+      },
       evaluationInterval: form.evalInterval,
       pendingPeriod: form.forDuration,
       firingPeriod: form.forDuration,
@@ -1323,6 +1312,16 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
               maxDatasources
             )}
             onGoToRules={() => handleTabClick('rules')}
+            onCreateLogsRule={() => {
+              setCreateBackendType('opensearch');
+              setShowCreateMonitor(true);
+            }}
+            onCreateMetricsRule={() => {
+              setCreateBackendType('prometheus');
+              setShowCreateMonitor(true);
+            }}
+            onCreateAnomalyDetection={() => setCreateAdRuleType('detector')}
+            onCreateForecasting={() => setCreateAdRuleType('forecaster')}
             startMs={startMs}
             endMs={endMs}
             pickerStart={startTime}
@@ -1396,7 +1395,12 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       // if the datasource list hasn't hydrated yet.
       const ds = datasources.find((d) => d.name === dsName);
       const id = ds?.id ?? dsName;
-      if (!byId.has(id)) byId.set(id, { datasourceId: id, datasourceName: dsName, error: message });
+      if (!byId.has(id))
+        byId.set(id, {
+          datasourceId: id,
+          datasourceName: dsName,
+          error: message,
+        });
     };
     for (const w of alertsWarnings) addOnce(w.datasourceName, w.error);
     for (const w of rulesWarnings) addOnce(w.datasourceName, w.error);
@@ -1421,7 +1425,11 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         const ds = datasources.find((d) => d.id === id);
         if (!ds) continue;
         if (!byId.has(id)) {
-          byId.set(id, { datasourceId: id, datasourceName: ds.name, error: probeFailedText });
+          byId.set(id, {
+            datasourceId: id,
+            datasourceName: ds.name,
+            error: probeFailedText,
+          });
         }
       }
     }
@@ -1461,16 +1469,6 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     fallbackHints: alertsFallbackHints,
   });
 
-  // Link back to the legacy alerting dashboard (the standalone `alerts` app's
-  // `#/dashboard` route). Built from `basePath.get()` (which carries any
-  // workspace prefix) + the app path — same URL-building recipe as the
-  // Advanced Settings link above. Rendered as a plain anchor since this crosses
-  // into a different app, so browser navigation (open-in-new-tab / right-click)
-  // is preferable to an `onClick` SPA hop.
-  const oldExperienceHref = `${
-    coreRefs.http?.basePath.get() ?? ''
-  }/app/${OLD_ALERTING_APP_ID}#/dashboard`;
-
   return (
     <div data-test-subj="alertManagerPage" className="altPageRoot">
       {/* Page-top banner callouts (errors, alerting-plugin missing,           */}
@@ -1478,32 +1476,6 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       {/* have been migrated to toasts — see `useAlertingPageToasts`. Per-DS   */}
       {/* connection errors are ALSO surfaced next to the affected row in the  */}
       {/* datasource facet via `datasourceErrorMapByName`.                     */}
-      {!newExperienceCalloutDismissed && (
-        <EuiCallOut
-          size="s"
-          iconType="cheer"
-          color="primary"
-          data-test-subj="alertManagerNewExperienceCallout"
-          onDismiss={dismissNewExperienceCallout}
-          dismissible
-          title={
-            <FormattedMessage
-              id="observability.alerting.alarmsPage.newExperienceCallout"
-              defaultMessage="Welcome to the new alerting experience. View your OpenSearch and Prometheus alerts together in one place. Prefer the previous view? {oldExperienceLink}."
-              values={{
-                oldExperienceLink: (
-                  <EuiLink data-test-subj="alertManagerOldExperienceLink" href={oldExperienceHref}>
-                    <FormattedMessage
-                      id="observability.alerting.alarmsPage.newExperienceCallout.oldExperienceLink"
-                      defaultMessage="Switch to the classic experience"
-                    />
-                  </EuiLink>
-                ),
-              }}
-            />
-          }
-        />
-      )}
       <EuiTabs data-test-subj="alertManagerTabs">
         {tabs.map((t) => (
           <EuiTab

--- a/public/components/alerting/alerting.scss
+++ b/public/components/alerting/alerting.scss
@@ -167,6 +167,24 @@
   overflow: hidden;
 }
 
+.altUnifiedSignalsEmptyState {
+  padding: 4px 20px 16px;
+}
+
+.altUnifiedSignalsPrompt {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.altUnifiedSignalsCards {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.altUnifiedSignalsCard {
+  height: 100%;
+}
+
 /*
  * Scope: checkbox rows inside a facet filter group. EuiCheckbox's internal
  * <label> is `display: inline-block`, which shrink-wraps to the intrinsic

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -32,7 +32,6 @@ import {
   EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
-  EuiOverlayMask,
   EuiResizableContainer,
   EuiHorizontalRule,
   EuiSuperDatePicker,
@@ -297,86 +296,84 @@ const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
       </EuiFlexGroup>
 
       {showAlertingRuleTypeModal && (
-        <EuiOverlayMask>
-          <EuiModal
-            onClose={() => setShowAlertingRuleTypeModal(false)}
-            aria-labelledby="alertingRuleTypeModalTitle"
-            maxWidth={640}
-            data-test-subj="alertsEmptyAlertingRuleTypeModal"
-          >
-            <EuiModalHeader>
-              <EuiModalHeaderTitle id="alertingRuleTypeModalTitle">
+        <EuiModal
+          onClose={() => setShowAlertingRuleTypeModal(false)}
+          aria-labelledby="alertingRuleTypeModalTitle"
+          maxWidth={640}
+          data-test-subj="alertsEmptyAlertingRuleTypeModal"
+        >
+          <EuiModalHeader>
+            <EuiModalHeaderTitle id="alertingRuleTypeModalTitle">
+              <FormattedMessage
+                id="observability.alerting.alertsDashboard.ruleTypeModal.title"
+                defaultMessage="Create an alerting rule"
+              />
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <EuiText color="subdued" size="s">
+              <p>
                 <FormattedMessage
-                  id="observability.alerting.alertsDashboard.ruleTypeModal.title"
-                  defaultMessage="Create an alerting rule"
+                  id="observability.alerting.alertsDashboard.ruleTypeModal.description"
+                  defaultMessage="Choose the signal source you want this rule to evaluate."
                 />
-              </EuiModalHeaderTitle>
-            </EuiModalHeader>
-            <EuiModalBody>
-              <EuiText color="subdued" size="s">
-                <p>
-                  <FormattedMessage
-                    id="observability.alerting.alertsDashboard.ruleTypeModal.description"
-                    defaultMessage="Choose the signal source you want this rule to evaluate."
-                  />
-                </p>
-              </EuiText>
-              <EuiSpacer size="m" />
-              <EuiFlexGroup gutterSize="m" responsive={true}>
-                <EuiFlexItem>
-                  <EuiCard
-                    layout="horizontal"
-                    icon={<EuiIcon type="logsApp" color="primary" size="l" />}
-                    title={i18n.translate(
-                      'observability.alerting.alertsDashboard.ruleTypeModal.logsTitle',
-                      { defaultMessage: 'Logs alert rule' }
-                    )}
-                    description={i18n.translate(
-                      'observability.alerting.alertsDashboard.ruleTypeModal.logsDescription',
-                      {
-                        defaultMessage: 'Evaluate OpenSearch logs with a PPL query.',
-                      }
-                    )}
-                    onClick={() => {
-                      setShowAlertingRuleTypeModal(false);
-                      onCreateLogsRule();
-                    }}
-                    data-test-subj="alertsEmptyCreateLogsRule"
-                  />
-                </EuiFlexItem>
-                <EuiFlexItem>
-                  <EuiCard
-                    layout="horizontal"
-                    icon={<EuiIcon type="visMetric" color="primary" size="l" />}
-                    title={i18n.translate(
-                      'observability.alerting.alertsDashboard.ruleTypeModal.metricsTitle',
-                      { defaultMessage: 'Metrics alert rule' }
-                    )}
-                    description={i18n.translate(
-                      'observability.alerting.alertsDashboard.ruleTypeModal.metricsDescription',
-                      {
-                        defaultMessage: 'Evaluate Prometheus metrics with a PromQL query.',
-                      }
-                    )}
-                    onClick={() => {
-                      setShowAlertingRuleTypeModal(false);
-                      onCreateMetricsRule();
-                    }}
-                    data-test-subj="alertsEmptyCreateMetricsRule"
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiModalBody>
-            <EuiModalFooter>
-              <EuiButtonEmpty onClick={() => setShowAlertingRuleTypeModal(false)}>
-                <FormattedMessage
-                  id="observability.alerting.alertsDashboard.ruleTypeModal.cancelButton"
-                  defaultMessage="Cancel"
+              </p>
+            </EuiText>
+            <EuiSpacer size="m" />
+            <EuiFlexGroup gutterSize="m" responsive={true}>
+              <EuiFlexItem>
+                <EuiCard
+                  layout="horizontal"
+                  icon={<EuiIcon type="logsApp" color="primary" size="l" />}
+                  title={i18n.translate(
+                    'observability.alerting.alertsDashboard.ruleTypeModal.logsTitle',
+                    { defaultMessage: 'Logs alert rule' }
+                  )}
+                  description={i18n.translate(
+                    'observability.alerting.alertsDashboard.ruleTypeModal.logsDescription',
+                    {
+                      defaultMessage: 'Evaluate OpenSearch logs with a PPL query.',
+                    }
+                  )}
+                  onClick={() => {
+                    setShowAlertingRuleTypeModal(false);
+                    onCreateLogsRule();
+                  }}
+                  data-test-subj="alertsEmptyCreateLogsRule"
                 />
-              </EuiButtonEmpty>
-            </EuiModalFooter>
-          </EuiModal>
-        </EuiOverlayMask>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiCard
+                  layout="horizontal"
+                  icon={<EuiIcon type="visMetric" color="primary" size="l" />}
+                  title={i18n.translate(
+                    'observability.alerting.alertsDashboard.ruleTypeModal.metricsTitle',
+                    { defaultMessage: 'Metrics alert rule' }
+                  )}
+                  description={i18n.translate(
+                    'observability.alerting.alertsDashboard.ruleTypeModal.metricsDescription',
+                    {
+                      defaultMessage: 'Evaluate Prometheus metrics with a PromQL query.',
+                    }
+                  )}
+                  onClick={() => {
+                    setShowAlertingRuleTypeModal(false);
+                    onCreateMetricsRule();
+                  }}
+                  data-test-subj="alertsEmptyCreateMetricsRule"
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiModalBody>
+          <EuiModalFooter>
+            <EuiButtonEmpty onClick={() => setShowAlertingRuleTypeModal(false)}>
+              <FormattedMessage
+                id="observability.alerting.alertsDashboard.ruleTypeModal.cancelButton"
+                defaultMessage="Cancel"
+              />
+            </EuiButtonEmpty>
+          </EuiModalFooter>
+        </EuiModal>
       )}
     </div>
   );

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -43,7 +43,7 @@ import { UnifiedAlertSummary, Datasource } from '../../../common/types/alerting'
 import { filterAlerts } from '../../../common/services/alerting/filter';
 import { AlertTimeline } from './alerts_charts';
 import { FacetFilterGroup, useFacetCollapse } from './facet_filter_panel';
-import { countBy } from './shared_constants';
+import { countBy, isStandardOpenSearchDatasource } from './shared_constants';
 import { INTERNAL_LABEL_KEYS } from './monitors_table/monitors_table_helpers';
 import './alerting.scss';
 
@@ -151,6 +151,7 @@ const emptyAlertFilters = (): AlertFilterState => ({
 
 interface UnifiedSignalsEmptyStateProps {
   mode: 'no-ds' | 'no-rules';
+  datasources: Datasource[];
   defaultDatasources: string[];
   onDatasourceChange: (ids: string[]) => void;
   onGoToRules: () => void;
@@ -162,6 +163,7 @@ interface UnifiedSignalsEmptyStateProps {
 
 const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
   mode,
+  datasources,
   defaultDatasources,
   onDatasourceChange,
   onGoToRules,
@@ -171,6 +173,7 @@ const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
   onCreateForecasting,
 }) => {
   const [showAlertingRuleTypeModal, setShowAlertingRuleTypeModal] = useState(false);
+  const hasCompatibleOpenSearchDatasource = datasources.some(isStandardOpenSearchDatasource);
   const capabilities = [
     {
       id: 'alerting',
@@ -187,6 +190,7 @@ const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
       ),
       onClick: () => setShowAlertingRuleTypeModal(true),
       dataTestSubj: 'alertsEmptyCreateAlertingRule',
+      isDisabled: false,
     },
     {
       id: 'anomalyDetection',
@@ -195,15 +199,24 @@ const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
         'observability.alerting.alertsDashboard.unifiedEmptyState.anomalyDetectionTitle',
         { defaultMessage: 'Anomaly detection' }
       ),
-      description: i18n.translate(
-        'observability.alerting.alertsDashboard.unifiedEmptyState.anomalyDetectionDescription',
-        {
-          defaultMessage:
-            'Detect unusual behavior automatically and inspect anomalies alongside alerts.',
-        }
-      ),
+      description: hasCompatibleOpenSearchDatasource
+        ? i18n.translate(
+            'observability.alerting.alertsDashboard.unifiedEmptyState.anomalyDetectionDescription',
+            {
+              defaultMessage:
+                'Detect unusual behavior automatically and inspect anomalies alongside alerts.',
+            }
+          )
+        : i18n.translate(
+            'observability.alerting.alertsDashboard.unifiedEmptyState.anomalyDetectionUnavailable',
+            {
+              defaultMessage:
+                'An OpenSearch datasource is required to create an anomaly detection rule.',
+            }
+          ),
       onClick: onCreateAnomalyDetection,
       dataTestSubj: 'alertsEmptyCreateAnomalyDetection',
+      isDisabled: !hasCompatibleOpenSearchDatasource,
     },
     {
       id: 'forecasting',
@@ -212,15 +225,23 @@ const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
         'observability.alerting.alertsDashboard.unifiedEmptyState.forecastingTitle',
         { defaultMessage: 'Forecasting' }
       ),
-      description: i18n.translate(
-        'observability.alerting.alertsDashboard.unifiedEmptyState.forecastingDescription',
-        {
-          defaultMessage:
-            'Create forecasters to predict future values and anticipate emerging trends.',
-        }
-      ),
+      description: hasCompatibleOpenSearchDatasource
+        ? i18n.translate(
+            'observability.alerting.alertsDashboard.unifiedEmptyState.forecastingDescription',
+            {
+              defaultMessage:
+                'Create forecasters to predict future values and anticipate emerging trends.',
+            }
+          )
+        : i18n.translate(
+            'observability.alerting.alertsDashboard.unifiedEmptyState.forecastingUnavailable',
+            {
+              defaultMessage: 'An OpenSearch datasource is required to create a forecasting rule.',
+            }
+          ),
       onClick: onCreateForecasting,
       dataTestSubj: 'alertsEmptyCreateForecasting',
+      isDisabled: !hasCompatibleOpenSearchDatasource,
     },
   ];
 
@@ -285,10 +306,17 @@ const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
             <EuiCard
               className="altUnifiedSignalsCard"
               layout="horizontal"
-              icon={<EuiIcon type={capability.iconType} color="primary" size="l" />}
+              icon={
+                <EuiIcon
+                  type={capability.iconType}
+                  color={capability.isDisabled ? 'subdued' : 'primary'}
+                  size="l"
+                />
+              }
               title={capability.title}
               description={capability.description}
               onClick={capability.onClick}
+              isDisabled={capability.isDisabled}
               data-test-subj={capability.dataTestSubj}
             />
           </EuiFlexItem>
@@ -1432,6 +1460,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                       {emptyMode === 'no-ds' || emptyMode === 'no-rules' ? (
                         <UnifiedSignalsEmptyState
                           mode={emptyMode}
+                          datasources={datasources}
                           defaultDatasources={defaultDatasources}
                           onDatasourceChange={onDatasourceChange}
                           onGoToRules={onGoToRules}

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -174,7 +174,9 @@ const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
 }) => {
   const [showAlertingRuleTypeModal, setShowAlertingRuleTypeModal] = useState(false);
   const hasCompatibleOpenSearchDatasource = datasources.some(isStandardOpenSearchDatasource);
-  const hasPrometheusDatasource = datasources.some((datasource) => datasource.type === 'prometheus');
+  const hasPrometheusDatasource = datasources.some(
+    (datasource) => datasource.type === 'prometheus'
+  );
   const capabilities = [
     {
       id: 'alerting',

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -11,6 +11,7 @@ import React, { useState, useMemo } from 'react';
 import {
   EuiBasicTableColumn,
   EuiButton,
+  EuiCard,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
@@ -25,6 +26,13 @@ import {
   EuiFieldSearch,
   EuiEmptyPrompt,
   EuiButtonEmpty,
+  EuiIcon,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiOverlayMask,
   EuiResizableContainer,
   EuiHorizontalRule,
   EuiSuperDatePicker,
@@ -141,6 +149,238 @@ const emptyAlertFilters = (): AlertFilterState => ({
   state: [],
   labels: {},
 });
+
+interface UnifiedSignalsEmptyStateProps {
+  mode: 'no-ds' | 'no-rules';
+  defaultDatasources: string[];
+  onDatasourceChange: (ids: string[]) => void;
+  onGoToRules: () => void;
+  onCreateLogsRule: () => void;
+  onCreateMetricsRule: () => void;
+  onCreateAnomalyDetection: () => void;
+  onCreateForecasting: () => void;
+}
+
+const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
+  mode,
+  defaultDatasources,
+  onDatasourceChange,
+  onGoToRules,
+  onCreateLogsRule,
+  onCreateMetricsRule,
+  onCreateAnomalyDetection,
+  onCreateForecasting,
+}) => {
+  const [showAlertingRuleTypeModal, setShowAlertingRuleTypeModal] = useState(false);
+  const capabilities = [
+    {
+      id: 'alerting',
+      iconType: 'bell' as const,
+      title: i18n.translate(
+        'observability.alerting.alertsDashboard.unifiedEmptyState.alertingTitle',
+        { defaultMessage: 'Alerting' }
+      ),
+      description: i18n.translate(
+        'observability.alerting.alertsDashboard.unifiedEmptyState.alertingDescription',
+        {
+          defaultMessage: 'Create log and metric rules, then investigate triggered alerts.',
+        }
+      ),
+      onClick: () => setShowAlertingRuleTypeModal(true),
+      dataTestSubj: 'alertsEmptyCreateAlertingRule',
+    },
+    {
+      id: 'anomalyDetection',
+      iconType: 'inspect' as const,
+      title: i18n.translate(
+        'observability.alerting.alertsDashboard.unifiedEmptyState.anomalyDetectionTitle',
+        { defaultMessage: 'Anomaly detection' }
+      ),
+      description: i18n.translate(
+        'observability.alerting.alertsDashboard.unifiedEmptyState.anomalyDetectionDescription',
+        {
+          defaultMessage:
+            'Detect unusual behavior automatically and inspect anomalies alongside alerts.',
+        }
+      ),
+      onClick: onCreateAnomalyDetection,
+      dataTestSubj: 'alertsEmptyCreateAnomalyDetection',
+    },
+    {
+      id: 'forecasting',
+      iconType: 'visLine' as const,
+      title: i18n.translate(
+        'observability.alerting.alertsDashboard.unifiedEmptyState.forecastingTitle',
+        { defaultMessage: 'Forecasting' }
+      ),
+      description: i18n.translate(
+        'observability.alerting.alertsDashboard.unifiedEmptyState.forecastingDescription',
+        {
+          defaultMessage:
+            'Create forecasters to predict future values and anticipate emerging trends.',
+        }
+      ),
+      onClick: onCreateForecasting,
+      dataTestSubj: 'alertsEmptyCreateForecasting',
+    },
+  ];
+
+  return (
+    <div className="altUnifiedSignalsEmptyState" data-test-subj="alertsUnifiedSignalsEmptyState">
+      <EuiEmptyPrompt
+        className="altUnifiedSignalsPrompt"
+        iconType={mode === 'no-ds' ? 'database' : 'bell'}
+        title={
+          <h3>
+            <FormattedMessage
+              id="observability.alerting.alertsDashboard.unifiedEmptyState.title"
+              defaultMessage="Define rules, detect anomalies, and forecast from one place"
+            />
+          </h3>
+        }
+        body={
+          mode === 'no-ds' ? (
+            <p>
+              <FormattedMessage
+                id="observability.alerting.alertsDashboard.unifiedEmptyState.noDatasourceBody"
+                defaultMessage="Select a datasource from the filter panel to view alerts and anomalies, then manage all of your rules in one experience."
+              />
+            </p>
+          ) : (
+            <p>
+              <FormattedMessage
+                id="observability.alerting.alertsDashboard.unifiedEmptyState.noRulesBody"
+                defaultMessage="Create an alerting, anomaly detection, or forecasting rule for the selected datasource."
+              />
+            </p>
+          )
+        }
+        actions={
+          mode === 'no-ds' ? (
+            defaultDatasources.length > 0 ? (
+              <EuiButtonEmpty
+                size="s"
+                onClick={() => onDatasourceChange(defaultDatasources)}
+                data-test-subj="alertsEmptyResetDefaults"
+              >
+                <FormattedMessage
+                  id="observability.alerting.alertsDashboard.resetToDefaultDatasources"
+                  defaultMessage="Reset to default datasources"
+                />
+              </EuiButtonEmpty>
+            ) : undefined
+          ) : (
+            <EuiButton size="s" fill onClick={onGoToRules} data-test-subj="alertsEmptyGoToRules">
+              <FormattedMessage
+                id="observability.alerting.alertsDashboard.goToRules"
+                defaultMessage="Go to Rules"
+              />
+            </EuiButton>
+          )
+        }
+      />
+
+      <EuiFlexGroup className="altUnifiedSignalsCards" gutterSize="m" responsive={true}>
+        {capabilities.map((capability) => (
+          <EuiFlexItem key={capability.id}>
+            <EuiCard
+              className="altUnifiedSignalsCard"
+              layout="horizontal"
+              icon={<EuiIcon type={capability.iconType} color="primary" size="l" />}
+              title={capability.title}
+              description={capability.description}
+              onClick={capability.onClick}
+              data-test-subj={capability.dataTestSubj}
+            />
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+
+      {showAlertingRuleTypeModal && (
+        <EuiOverlayMask>
+          <EuiModal
+            onClose={() => setShowAlertingRuleTypeModal(false)}
+            aria-labelledby="alertingRuleTypeModalTitle"
+            maxWidth={640}
+            data-test-subj="alertsEmptyAlertingRuleTypeModal"
+          >
+            <EuiModalHeader>
+              <EuiModalHeaderTitle id="alertingRuleTypeModalTitle">
+                <FormattedMessage
+                  id="observability.alerting.alertsDashboard.ruleTypeModal.title"
+                  defaultMessage="Create an alerting rule"
+                />
+              </EuiModalHeaderTitle>
+            </EuiModalHeader>
+            <EuiModalBody>
+              <EuiText color="subdued" size="s">
+                <p>
+                  <FormattedMessage
+                    id="observability.alerting.alertsDashboard.ruleTypeModal.description"
+                    defaultMessage="Choose the signal source you want this rule to evaluate."
+                  />
+                </p>
+              </EuiText>
+              <EuiSpacer size="m" />
+              <EuiFlexGroup gutterSize="m" responsive={true}>
+                <EuiFlexItem>
+                  <EuiCard
+                    layout="horizontal"
+                    icon={<EuiIcon type="logsApp" color="primary" size="l" />}
+                    title={i18n.translate(
+                      'observability.alerting.alertsDashboard.ruleTypeModal.logsTitle',
+                      { defaultMessage: 'Logs alert rule' }
+                    )}
+                    description={i18n.translate(
+                      'observability.alerting.alertsDashboard.ruleTypeModal.logsDescription',
+                      {
+                        defaultMessage: 'Evaluate OpenSearch logs with a PPL query.',
+                      }
+                    )}
+                    onClick={() => {
+                      setShowAlertingRuleTypeModal(false);
+                      onCreateLogsRule();
+                    }}
+                    data-test-subj="alertsEmptyCreateLogsRule"
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiCard
+                    layout="horizontal"
+                    icon={<EuiIcon type="visMetric" color="primary" size="l" />}
+                    title={i18n.translate(
+                      'observability.alerting.alertsDashboard.ruleTypeModal.metricsTitle',
+                      { defaultMessage: 'Metrics alert rule' }
+                    )}
+                    description={i18n.translate(
+                      'observability.alerting.alertsDashboard.ruleTypeModal.metricsDescription',
+                      {
+                        defaultMessage: 'Evaluate Prometheus metrics with a PromQL query.',
+                      }
+                    )}
+                    onClick={() => {
+                      setShowAlertingRuleTypeModal(false);
+                      onCreateMetricsRule();
+                    }}
+                    data-test-subj="alertsEmptyCreateMetricsRule"
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiModalBody>
+            <EuiModalFooter>
+              <EuiButtonEmpty onClick={() => setShowAlertingRuleTypeModal(false)}>
+                <FormattedMessage
+                  id="observability.alerting.alertsDashboard.ruleTypeModal.cancelButton"
+                  defaultMessage="Cancel"
+                />
+              </EuiButtonEmpty>
+            </EuiModalFooter>
+          </EuiModal>
+        </EuiOverlayMask>
+      )}
+    </div>
+  );
+};
 
 function getAlertKind(alert: UnifiedAlertSummary): string {
   return alert.alertKind || 'alert';
@@ -393,7 +633,9 @@ function renderGroupedAnomalyOccurrences(
                           <FormattedMessage
                             id="observability.alerting.alertsDashboard.groupedAnomalyStartedAgo"
                             defaultMessage="{duration} ago"
-                            values={{ duration: formatDuration(occurrence.startTime) }}
+                            values={{
+                              duration: formatDuration(occurrence.startTime),
+                            }}
                           />
                         </span>
                       </EuiToolTip>
@@ -440,6 +682,14 @@ export interface AlertsDashboardProps {
   defaultDatasources: string[];
   /** Switch to the Rules tab (used by the "No rules" empty state CTA). */
   onGoToRules: () => void;
+  /** Open the logs alert rule creation flyout. */
+  onCreateLogsRule: () => void;
+  /** Open the metrics alert rule creation flyout. */
+  onCreateMetricsRule: () => void;
+  /** Open the anomaly detection rule creation flyout. */
+  onCreateAnomalyDetection: () => void;
+  /** Open the forecasting rule creation flyout. */
+  onCreateForecasting: () => void;
   /** Picker start resolved to epoch ms (resolved once by the parent). */
   startMs: number;
   /** Picker end resolved to epoch ms (resolved once by the parent). */
@@ -476,6 +726,10 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
   rulesTotal,
   defaultDatasources,
   onGoToRules,
+  onCreateLogsRule,
+  onCreateMetricsRule,
+  onCreateAnomalyDetection,
+  onCreateForecasting,
   startMs,
   endMs,
   pickerStart,
@@ -604,7 +858,10 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
   };
 
   const updateLabelFilter = (key: string, values: string[]) => {
-    setFilters((prev) => ({ ...prev, labels: { ...prev.labels, [key]: values } }));
+    setFilters((prev) => ({
+      ...prev,
+      labels: { ...prev.labels, [key]: values },
+    }));
   };
 
   const renderFacetGroup = (
@@ -875,6 +1132,24 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
           : null
     : null;
 
+  const emptyTableMessage =
+    searchQuery || activeFilterCount > 0
+      ? i18n.translate('observability.alerting.alertsDashboard.noAlertsMatchFilters', {
+          defaultMessage: 'No alerts or detected anomalies match your filters.',
+        })
+      : emptyMode === 'no-ds'
+        ? i18n.translate('observability.alerting.alertsDashboard.noDatasourceTableMessage', {
+            defaultMessage: 'Select a datasource to view alerts and detected anomalies.',
+          })
+        : emptyMode === 'no-rules'
+          ? i18n.translate('observability.alerting.alertsDashboard.noRulesTableMessage', {
+              defaultMessage:
+                'Create a rule to get started. Triggered alerts and detected anomalies will appear here.',
+            })
+          : i18n.translate('observability.alerting.alertsDashboard.noAlertsTableMessage', {
+              defaultMessage: 'No alerts or anomalies were detected in the selected time range.',
+            });
+
   return (
     <EuiResizableContainer className="altResizableContainer">
       {(EuiResizablePanel, EuiResizableButton, { togglePanel }) => (
@@ -908,7 +1183,11 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                 <EuiFlexItem grow={false}>
                   <EuiButtonIcon
                     iconType="menuLeft"
-                    onClick={() => togglePanel?.('alerts-filters-panel', { direction: 'left' })}
+                    onClick={() =>
+                      togglePanel?.('alerts-filters-panel', {
+                        direction: 'left',
+                      })
+                    }
                     aria-label={i18n.translate(
                       'observability.alerting.alertsDashboard.collapseFiltersAriaLabel',
                       {
@@ -1153,72 +1432,16 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                         </EuiFlexItem>
                       </EuiFlexGroup>
                       <EuiSpacer size="s" />
-                      {emptyMode === 'no-ds' ? (
-                        <EuiEmptyPrompt
-                          iconType="database"
-                          title={
-                            <h4>
-                              <FormattedMessage
-                                id="observability.alerting.alertsDashboard.noDatasourceTitle"
-                                defaultMessage="No datasource selected"
-                              />
-                            </h4>
-                          }
-                          body={
-                            <p>
-                              <FormattedMessage
-                                id="observability.alerting.alertsDashboard.noDatasourceBody"
-                                defaultMessage="Select a datasource from the filter panel on the left to view alerts."
-                              />
-                            </p>
-                          }
-                          actions={
-                            defaultDatasources.length > 0 ? (
-                              <EuiButtonEmpty
-                                size="s"
-                                onClick={() => onDatasourceChange(defaultDatasources)}
-                                data-test-subj="alertsEmptyResetDefaults"
-                              >
-                                <FormattedMessage
-                                  id="observability.alerting.alertsDashboard.resetToDefaultDatasources"
-                                  defaultMessage="Reset to default datasources"
-                                />
-                              </EuiButtonEmpty>
-                            ) : undefined
-                          }
-                        />
-                      ) : emptyMode === 'no-rules' ? (
-                        <EuiEmptyPrompt
-                          iconType="bell"
-                          title={
-                            <h4>
-                              <FormattedMessage
-                                id="observability.alerting.alertsDashboard.noRulesTitle"
-                                defaultMessage="No rules or detectors have been created"
-                              />
-                            </h4>
-                          }
-                          body={
-                            <p>
-                              <FormattedMessage
-                                id="observability.alerting.alertsDashboard.noRulesBody"
-                                defaultMessage="The selected datasource has no monitors or anomaly detectors configured. Create one to start receiving alerts."
-                              />
-                            </p>
-                          }
-                          actions={
-                            <EuiButton
-                              size="s"
-                              fill
-                              onClick={onGoToRules}
-                              data-test-subj="alertsEmptyGoToRules"
-                            >
-                              <FormattedMessage
-                                id="observability.alerting.alertsDashboard.goToRules"
-                                defaultMessage="Go to Rules"
-                              />
-                            </EuiButton>
-                          }
+                      {emptyMode === 'no-ds' || emptyMode === 'no-rules' ? (
+                        <UnifiedSignalsEmptyState
+                          mode={emptyMode}
+                          defaultDatasources={defaultDatasources}
+                          onDatasourceChange={onDatasourceChange}
+                          onGoToRules={onGoToRules}
+                          onCreateLogsRule={onCreateLogsRule}
+                          onCreateMetricsRule={onCreateMetricsRule}
+                          onCreateAnomalyDetection={onCreateAnomalyDetection}
+                          onCreateForecasting={onCreateForecasting}
                         />
                       ) : emptyMode === 'no-alerts' ? (
                         <EuiEmptyPrompt
@@ -1315,18 +1538,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                     columns={columns}
                     loading={loading}
                     itemIdToExpandedRowMap={groupedOccurrenceRows}
-                    message={
-                      searchQuery || activeFilterCount > 0
-                        ? i18n.translate(
-                            'observability.alerting.alertsDashboard.noAlertsMatchFilters',
-                            {
-                              defaultMessage: 'No alerts match your filters',
-                            }
-                          )
-                        : i18n.translate('observability.alerting.alertsDashboard.noAlerts', {
-                            defaultMessage: 'No alerts',
-                          })
-                    }
+                    message={emptyTableMessage}
                   />
                 </EuiPanel>
               </>

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -174,6 +174,7 @@ const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
 }) => {
   const [showAlertingRuleTypeModal, setShowAlertingRuleTypeModal] = useState(false);
   const hasCompatibleOpenSearchDatasource = datasources.some(isStandardOpenSearchDatasource);
+  const hasPrometheusDatasource = datasources.some((datasource) => datasource.type === 'prometheus');
   const capabilities = [
     {
       id: 'alerting',
@@ -373,21 +374,38 @@ const UnifiedSignalsEmptyState: React.FC<UnifiedSignalsEmptyStateProps> = ({
               <EuiFlexItem>
                 <EuiCard
                   layout="horizontal"
-                  icon={<EuiIcon type="visMetric" color="primary" size="l" />}
+                  icon={
+                    <EuiIcon
+                      type="visMetric"
+                      color={hasPrometheusDatasource ? 'primary' : 'subdued'}
+                      size="l"
+                    />
+                  }
                   title={i18n.translate(
                     'observability.alerting.alertsDashboard.ruleTypeModal.metricsTitle',
                     { defaultMessage: 'Metrics alert rule' }
                   )}
-                  description={i18n.translate(
-                    'observability.alerting.alertsDashboard.ruleTypeModal.metricsDescription',
-                    {
-                      defaultMessage: 'Evaluate Prometheus metrics with a PromQL query.',
-                    }
-                  )}
+                  description={
+                    hasPrometheusDatasource
+                      ? i18n.translate(
+                          'observability.alerting.alertsDashboard.ruleTypeModal.metricsDescription',
+                          {
+                            defaultMessage: 'Evaluate Prometheus metrics with a PromQL query.',
+                          }
+                        )
+                      : i18n.translate(
+                          'observability.alerting.alertsDashboard.ruleTypeModal.metricsUnavailable',
+                          {
+                            defaultMessage:
+                              'A Prometheus datasource is required to create a metrics alert rule.',
+                          }
+                        )
+                  }
                   onClick={() => {
                     setShowAlertingRuleTypeModal(false);
                     onCreateMetricsRule();
                   }}
+                  isDisabled={!hasPrometheusDatasource}
                   data-test-subj="alertsEmptyCreateMetricsRule"
                 />
               </EuiFlexItem>

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -353,12 +353,15 @@ const parseFilterQuery = (value: string): Record<string, unknown> => {
 export const getCreateAdRuleDatasources = (datasources: Datasource[]): Datasource[] =>
   datasources.filter(isStandardOpenSearchDatasource);
 
-const getInitialDatasourceId = (datasources: Datasource[], selectedDsIds?: string[]): string => {
+export const getInitialDatasourceId = (
+  datasources: Datasource[],
+  selectedDsIds?: string[]
+): string => {
   const openSearchDatasources = getCreateAdRuleDatasources(datasources);
   const selected = selectedDsIds
     ?.map((id) => openSearchDatasources.find((datasource) => datasource.id === id))
     .find(Boolean);
-  return selected?.id ?? openSearchDatasources[0]?.id ?? '';
+  return selected?.id ?? '';
 };
 
 const DIRECTION_THRESHOLD_TYPES = new Set(['ACTUAL_IS_BELOW_EXPECTED', 'ACTUAL_IS_OVER_EXPECTED']);


### PR DESCRIPTION
## Description

Improves the Alerts Manager empty state so the unified Alerting, Anomaly Detection, and Forecasting capabilities are visible when no datasource or rules are available.

- Replaces the generic empty prompt with capability cards for Alerting, Anomaly Detection, and Forecasting.
- Opens the existing anomaly detector and forecaster creation flyouts from their cards.
- Adds a Logs versus Metrics choice before opening an alert rule creation flyout.
- Improves the All Alerts empty-table messages to mention alerts and detected anomalies.
- Removes the introductory banner and link to the classic alerting experience.

The primary Alerts Manager navigation remains Alerts, Rules, and Routing; this change does not add a Forecasts tab.

## Validation

- `alerts_dashboard.test.tsx`: 12 tests passed.
- Changed files pass `git diff --check`.
- Changed files pass Prettier 3.5.3 formatting checks using the OpenSearch Dashboards configuration.
- Verified the empty-state cards, Logs/Metrics chooser, existing creation flyouts, navigation tabs, and banner removal on a local dashboard.
