### PR TITLE
Alerts: classic-experience escape hatches for unsupported monitor types

### DIFF
--- a/public/components/alerting/__tests__/monitor_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/monitor_detail_flyout.test.tsx
@@ -32,8 +32,19 @@ jest.mock('../query_services/alerting_opensearch_service', () => ({
   })),
 }));
 
+// Stub the shared core refs so the Edit-redirect path can assert on
+// `navigateToApp` without a real Core start contract.
+jest.mock('../../../framework/core_refs', () => ({
+  coreRefs: {
+    application: { navigateToApp: jest.fn() },
+  },
+}));
+
 import { MonitorDetailFlyout } from '../monitor_detail_flyout';
+import { coreRefs } from '../../../framework/core_refs';
 import type { UnifiedRuleSummary } from '../../../../common/types/alerting';
+
+const navigateToApp = coreRefs.application!.navigateToApp as jest.Mock;
 
 const mockMonitor: UnifiedRuleSummary = {
   id: 'mon-1',
@@ -118,5 +129,100 @@ describe('MonitorDetailFlyout', () => {
       await Promise.resolve();
     });
     expect(queryByText('Condition Preview')).toBeNull();
+  });
+
+  describe('Edit redirect to the classic experience', () => {
+    // Non-PPL / non-metric OpenSearch monitor types can't be edited in this
+    // flyout yet, so Edit deep-links to the classic alerting app instead of
+    // being disabled.
+    const logMonitor: UnifiedRuleSummary = {
+      ...mockMonitor,
+      monitorType: 'log',
+      datasourceId: 'ds-1',
+      labels: { monitor_type: 'query_level_monitor' },
+    };
+
+    beforeEach(() => {
+      navigateToApp.mockClear();
+    });
+
+    it('confirms, then deep-links to the classic edit route with id, type, and MDS dataSourceId', () => {
+      const { getByTestId, getByText } = render(
+        <MonitorDetailFlyout
+          monitor={logMonitor}
+          onClose={jest.fn()}
+          onDelete={jest.fn()}
+          onClone={jest.fn()}
+        />
+      );
+
+      // The redirect variant of Edit is clickable (not disabled) and opens a
+      // heads-up confirmation before navigating.
+      fireEvent.click(getByTestId('alertManagerMonitorDetailEditRedirect'));
+      expect(navigateToApp).not.toHaveBeenCalled();
+
+      fireEvent.click(getByText('Continue to classic experience'));
+      expect(navigateToApp).toHaveBeenCalledWith('monitors', {
+        path: '#/monitors/mon-1?action=edit-monitor&monitorType=query_level_monitor&dataSourceId=ds-1',
+      });
+    });
+
+    it('does not navigate when the confirmation is cancelled', () => {
+      const { getByTestId, getByText } = render(
+        <MonitorDetailFlyout
+          monitor={logMonitor}
+          onClose={jest.fn()}
+          onDelete={jest.fn()}
+          onClone={jest.fn()}
+        />
+      );
+      fireEvent.click(getByTestId('alertManagerMonitorDetailEditRedirect'));
+      fireEvent.click(getByText('Cancel'));
+      expect(navigateToApp).not.toHaveBeenCalled();
+    });
+
+    it('maps cluster-metrics monitors to the cluster_metrics_monitor type', () => {
+      const clusterMonitor: UnifiedRuleSummary = {
+        ...logMonitor,
+        monitorType: 'cluster_metrics',
+        // Cluster-metrics monitors are stored as query_level_monitor; only
+        // monitor_kind distinguishes them.
+        labels: { monitor_kind: 'cluster_metrics', monitor_type: 'query_level_monitor' },
+      };
+      const { getByTestId, getByText } = render(
+        <MonitorDetailFlyout
+          monitor={clusterMonitor}
+          onClose={jest.fn()}
+          onDelete={jest.fn()}
+          onClone={jest.fn()}
+        />
+      );
+      fireEvent.click(getByTestId('alertManagerMonitorDetailEditRedirect'));
+      fireEvent.click(getByText('Continue to classic experience'));
+      expect(navigateToApp).toHaveBeenCalledWith('monitors', {
+        path: '#/monitors/mon-1?action=edit-monitor&monitorType=cluster_metrics_monitor&dataSourceId=ds-1',
+      });
+    });
+
+    it('sends an empty dataSourceId for local-cluster monitors', () => {
+      const localMonitor: UnifiedRuleSummary = {
+        ...logMonitor,
+        datasourceId: 'local-cluster',
+        labels: { monitor_type: 'doc_level_monitor' },
+      };
+      const { getByTestId, getByText } = render(
+        <MonitorDetailFlyout
+          monitor={localMonitor}
+          onClose={jest.fn()}
+          onDelete={jest.fn()}
+          onClone={jest.fn()}
+        />
+      );
+      fireEvent.click(getByTestId('alertManagerMonitorDetailEditRedirect'));
+      fireEvent.click(getByText('Continue to classic experience'));
+      expect(navigateToApp).toHaveBeenCalledWith('monitors', {
+        path: '#/monitors/mon-1?action=edit-monitor&monitorType=doc_level_monitor&dataSourceId=',
+      });
+    });
   });
 });

--- a/public/components/alerting/create_monitor/index.tsx
+++ b/public/components/alerting/create_monitor/index.tsx
@@ -31,7 +31,6 @@ import {
   EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiFormRow,
-  EuiIconTip,
   EuiLink,
   EuiPanel,
   EuiSpacer,
@@ -40,6 +39,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
 import { coreRefs } from '../../../framework/core_refs';
 import { Datasource } from '../../../../common/types/alerting';
 import {
@@ -510,26 +510,24 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
             <>
               <EuiSpacer size="xs" />
               <EuiText size="xs" color="subdued">
-                <EuiLink
-                  data-test-subj="createMonitorClassicExperienceLink"
-                  href={`${
-                    coreRefs.http?.basePath?.get() ?? ''
-                  }/app/${OLD_ALERTING_APP_ID}#/create-monitor`}
-                >
-                  {i18n.translate('observability.alerting.createMonitor.classicExperienceLink', {
-                    defaultMessage: 'Need another rule (monitor) type? Open the classic experience',
-                  })}
-                </EuiLink>{' '}
-                <EuiIconTip
-                  type="iInCircle"
-                  position="right"
-                  content={i18n.translate(
-                    'observability.alerting.createMonitor.classicExperienceTooltip',
-                    {
-                      defaultMessage:
-                        'This flow creates per-query logs rules only. For per-bucket, per-cluster metrics, per-document, or composite rule (monitor) types, use the classic alerting experience.',
-                    }
-                  )}
+                <FormattedMessage
+                  id="observability.alerting.createMonitor.classicExperiencePrompt"
+                  defaultMessage="Want to create another rule type (e.g. per query, per bucket), {link}."
+                  values={{
+                    link: (
+                      <EuiLink
+                        data-test-subj="createMonitorClassicExperienceLink"
+                        href={`${
+                          coreRefs.http?.basePath?.get() ?? ''
+                        }/app/${OLD_ALERTING_APP_ID}#/create-monitor`}
+                      >
+                        {i18n.translate(
+                          'observability.alerting.createMonitor.classicExperienceLink',
+                          { defaultMessage: 'open the classic experience' }
+                        )}
+                      </EuiLink>
+                    ),
+                  }}
                 />
               </EuiText>
             </>

--- a/public/components/alerting/create_monitor/index.tsx
+++ b/public/components/alerting/create_monitor/index.tsx
@@ -513,7 +513,7 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
                 <EuiLink
                   data-test-subj="createMonitorClassicExperienceLink"
                   href={`${
-                    coreRefs.http?.basePath.get() ?? ''
+                    coreRefs.http?.basePath?.get() ?? ''
                   }/app/${OLD_ALERTING_APP_ID}#/create-monitor`}
                 >
                   {i18n.translate('observability.alerting.createMonitor.classicExperienceLink', {

--- a/public/components/alerting/create_monitor/index.tsx
+++ b/public/components/alerting/create_monitor/index.tsx
@@ -31,7 +31,8 @@ import {
   EuiFlyoutFooter,
   EuiFlyoutHeader,
   EuiFormRow,
-  EuiOverlayMask,
+  EuiIconTip,
+  EuiLink,
   EuiPanel,
   EuiSpacer,
   EuiSwitch,
@@ -39,6 +40,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
+import { coreRefs } from '../../../framework/core_refs';
 import { Datasource } from '../../../../common/types/alerting';
 import {
   MonitorFormState as ValidatorFormState,
@@ -61,6 +63,14 @@ import { OpenSearchFormSection } from './opensearch_form_section';
 // Re-export the shared form-state type so existing consumers that import
 // `MonitorFormState` from `'./create_monitor'` keep working unchanged.
 export type { MonitorFormState } from './create_monitor_types';
+
+// Legacy standalone alerting app. The new flyout only supports per-query
+// monitors, so we surface an escape hatch to the classic monitor-creation
+// flow for the monitor types we don't yet cover (per bucket, per cluster
+// metrics, per document, composite). Same app id as the Alert Manager
+// page's "classic experience" callout; here we deep-link to its
+// create-monitor route instead of the dashboard.
+const OLD_ALERTING_APP_ID = 'alerts';
 
 // ============================================================================
 // Main Component — Flyout
@@ -487,6 +497,43 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
                   defaultMessage: 'PPL-based alerting rule',
                 })}
           </EuiText>
+          {/* Escape hatch to the classic monitor-creation flow. This flyout
+              only builds per-query logs monitors; users who need per-bucket,
+              per-cluster-metrics, per-document, or composite monitors go to
+              the legacy `alerts` app. Rendered only when creating a logs rule
+              (not in edit mode, not for the Prometheus/metrics variant) — it's
+              a decision about which creation flow to use, made up front. A
+              full `href` (not `navigateToApp`) is deliberate so right-click /
+              open-in-new-tab work across apps, mirroring the Alert Manager
+              page's classic-experience link. */}
+          {backendType !== 'prometheus' && !isEdit && (
+            <>
+              <EuiSpacer size="xs" />
+              <EuiText size="xs" color="subdued">
+                <EuiLink
+                  data-test-subj="createMonitorClassicExperienceLink"
+                  href={`${
+                    coreRefs.http?.basePath.get() ?? ''
+                  }/app/${OLD_ALERTING_APP_ID}#/create-monitor`}
+                >
+                  {i18n.translate('observability.alerting.createMonitor.classicExperienceLink', {
+                    defaultMessage: 'Need another rule (monitor) type? Open the classic experience',
+                  })}
+                </EuiLink>{' '}
+                <EuiIconTip
+                  type="iInCircle"
+                  position="right"
+                  content={i18n.translate(
+                    'observability.alerting.createMonitor.classicExperienceTooltip',
+                    {
+                      defaultMessage:
+                        'This flow creates per-query logs rules only. For per-bucket, per-cluster metrics, per-document, or composite rule (monitor) types, use the classic alerting experience.',
+                    }
+                  )}
+                />
+              </EuiText>
+            </>
+          )}
         </EuiFlyoutHeader>
 
         <EuiFlyoutBody>
@@ -664,36 +711,36 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
         </EuiFlyoutFooter>
       </EuiFlyout>
       {showDiscardConfirm && (
-        <EuiOverlayMask>
-          <EuiConfirmModal
-            title={i18n.translate('observability.alerting.createMonitor.discardConfirmTitle', {
-              defaultMessage: 'Discard unsaved changes?',
+        // EuiConfirmModal renders its own EuiOverlayMask, so no wrapping mask
+        // (wrapping double-dims the backdrop).
+        <EuiConfirmModal
+          title={i18n.translate('observability.alerting.createMonitor.discardConfirmTitle', {
+            defaultMessage: 'Discard unsaved changes?',
+          })}
+          onCancel={() => setShowDiscardConfirm(false)}
+          onConfirm={() => {
+            setShowDiscardConfirm(false);
+            onCancel();
+          }}
+          cancelButtonText={i18n.translate(
+            'observability.alerting.createMonitor.discardConfirmCancel',
+            { defaultMessage: 'Keep editing' }
+          )}
+          confirmButtonText={i18n.translate(
+            'observability.alerting.createMonitor.discardConfirmConfirm',
+            { defaultMessage: 'Discard changes' }
+          )}
+          buttonColor="danger"
+          defaultFocusedButton="cancel"
+          data-test-subj="alertManagerDiscardChangesConfirm"
+        >
+          <p>
+            {i18n.translate('observability.alerting.createMonitor.discardConfirmBody', {
+              defaultMessage:
+                "You've made changes to this rule that haven't been saved. Discarding will lose them.",
             })}
-            onCancel={() => setShowDiscardConfirm(false)}
-            onConfirm={() => {
-              setShowDiscardConfirm(false);
-              onCancel();
-            }}
-            cancelButtonText={i18n.translate(
-              'observability.alerting.createMonitor.discardConfirmCancel',
-              { defaultMessage: 'Keep editing' }
-            )}
-            confirmButtonText={i18n.translate(
-              'observability.alerting.createMonitor.discardConfirmConfirm',
-              { defaultMessage: 'Discard changes' }
-            )}
-            buttonColor="danger"
-            defaultFocusedButton="cancel"
-            data-test-subj="alertManagerDiscardChangesConfirm"
-          >
-            <p>
-              {i18n.translate('observability.alerting.createMonitor.discardConfirmBody', {
-                defaultMessage:
-                  "You've made changes to this rule that haven't been saved. Discarding will lose them.",
-              })}
-            </p>
-          </EuiConfirmModal>
-        </EuiOverlayMask>
+          </p>
+        </EuiConfirmModal>
       )}
     </>
   );

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -30,6 +30,7 @@ import {
   EuiToolTip,
   EuiCallOut,
   EuiCodeBlock,
+  EuiConfirmModal,
   EuiLink,
   EuiLoadingContent,
 } from '@elastic/eui';
@@ -56,6 +57,13 @@ import { SEVERITY_COLORS, STATE_COLORS, STATUS_COLORS, HEALTH_COLORS } from './s
 // thousands of historical alerts would render every row, freezing the
 // flyout. The Alerts tab is the right place to drill into the full history.
 const MAX_ALERT_HISTORY_ROWS = 50;
+
+// Classic alerting app that hosts the full monitor editor. Its `monitors`
+// browser app mounts the `/monitors` hash route, so a deep link of the form
+// `#/monitors/{id}?action=edit-monitor&monitorType={type}` opens the classic
+// edit form directly. Used as the escape hatch for OpenSearch monitor types
+// this flyout can't yet edit in place.
+const CLASSIC_MONITORS_APP_ID = 'monitors';
 
 // ============================================================================
 // Props
@@ -95,6 +103,7 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
   onToggleEnabled,
 }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showEditRedirectConfirm, setShowEditRedirectConfirm] = useState(false);
   const [isTogglingEnabled, setIsTogglingEnabled] = useState(false);
   // Mirror the Edit-button gate (PPL only). Non-PPL types stay read-only;
   // the existing tooltip surfaces explains the limitation.
@@ -137,6 +146,50 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
   const rawMonitor = detail?.raw as OSMonitor | undefined;
   const rawInput: OSMonitorInput | undefined =
     rawMonitor && 'inputs' in rawMonitor ? rawMonitor.inputs?.[0] : undefined;
+
+  // Edit affordance routing. PPL and Prometheus ('metric') rules edit in
+  // place via `onEdit`. Every other OpenSearch monitor type (bucket / doc /
+  // cluster-metrics / query-level log & apm) isn't yet editable in this
+  // flyout, so rather than disable Edit we send the user to the classic
+  // alerting app after a heads-up confirmation.
+  const canEditInPlace =
+    !!onEdit && (monitor.monitorType === 'ppl' || monitor.monitorType === 'metric');
+  // Only OpenSearch monitors have a real `_id` + monitor_type the classic
+  // editor understands; detectors/forecasters/Prometheus rules do not.
+  const isOpenSearchMonitor =
+    (monitor.definitionType ?? 'monitor') === 'monitor' && monitor.datasourceType === 'opensearch';
+  const canRedirectToClassicEdit = !canEditInPlace && isOpenSearchMonitor;
+  // The classic `monitorType` param is advisory (the classic app re-derives
+  // the form from the fetched monitor body), but we send the best value we
+  // have. Cluster-metrics monitors are stored as `query_level_monitor` and
+  // are only distinguishable via `monitor_kind`, so special-case them.
+  const classicMonitorType =
+    monitorKind === 'cluster_metrics'
+      ? 'cluster_metrics_monitor'
+      : ((monitor.labels?.monitor_type as string | undefined) ??
+        rawMonitor?.monitor_type ??
+        'query_level_monitor');
+
+  const goToClassicEdit = () => {
+    // The classic app resolves its data source from the URL's `dataSourceId`
+    // param when multi-data-source is enabled. If the param is ABSENT it never
+    // sets the data source (cold deep-link → "DataSource was not set" +
+    // DataSourceView crash), so we always include it. For MDS OpenSearch
+    // monitors the registry `datasourceId` IS the data-source saved-object id
+    // (id === mdsId), so it maps straight through; the local-cluster sentinel
+    // maps to an empty value, which the classic app treats as the local
+    // cluster. When MDS is disabled the classic app ignores the param.
+    const localSentinels = ['local-cluster', 'local', ''];
+    const dataSourceIdParam = localSentinels.includes(monitor.datasourceId)
+      ? ''
+      : monitor.datasourceId;
+    // navigateToApp resolves the basepath/workspace prefix (bare hash hrefs
+    // don't) — matches the routing deep-link pattern used elsewhere here.
+    coreRefs?.application?.navigateToApp(CLASSIC_MONITORS_APP_ID, {
+      path: `#/monitors/${monitor.id}?action=edit-monitor&monitorType=${classicMonitorType}&dataSourceId=${dataSourceIdParam}`,
+    });
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+  };
 
   // Query definition accordion title, type-aware
   let queryDefTitle: string;
@@ -221,11 +274,11 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
           {/* Quick actions */}
           <EuiFlexGroup gutterSize="s" responsive={false}>
             <EuiFlexItem grow={false}>
-              {onEdit && (monitor.monitorType === 'ppl' || monitor.monitorType === 'metric') ? (
+              {canEditInPlace ? (
                 <EuiButtonEmpty
                   size="s"
                   iconType="pencil"
-                  onClick={() => onEdit(monitor)}
+                  onClick={() => onEdit?.(monitor)}
                   data-test-subj="alertManagerMonitorDetailEdit"
                 >
                   <FormattedMessage
@@ -233,6 +286,28 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                     defaultMessage="Edit"
                   />
                 </EuiButtonEmpty>
+              ) : canRedirectToClassicEdit ? (
+                <EuiToolTip
+                  content={i18n.translate(
+                    'observability.alerting.monitorDetailFlyout.editRedirectTooltip',
+                    {
+                      defaultMessage:
+                        'This rule type is edited in the classic experience. You’ll be redirected there.',
+                    }
+                  )}
+                >
+                  <EuiButtonEmpty
+                    size="s"
+                    iconType="pencil"
+                    onClick={() => setShowEditRedirectConfirm(true)}
+                    data-test-subj="alertManagerMonitorDetailEditRedirect"
+                  >
+                    <FormattedMessage
+                      id="observability.alerting.monitorDetailFlyout.editButton"
+                      defaultMessage="Edit"
+                    />
+                  </EuiButtonEmpty>
+                </EuiToolTip>
               ) : (
                 <EuiToolTip
                   content={i18n.translate(
@@ -873,6 +948,48 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
             onClose();
           }}
         />
+      )}
+
+      {/* Redirect-to-classic-editor confirmation. Non-PPL/non-metric
+          OpenSearch monitor types aren't editable in this flyout yet, so we
+          warn the user before navigating them to the classic alerting app. */}
+      {showEditRedirectConfirm && (
+        // EuiConfirmModal renders its own EuiOverlayMask, so no wrapping mask
+        // (wrapping double-dims the backdrop).
+        <EuiConfirmModal
+          title={i18n.translate(
+            'observability.alerting.monitorDetailFlyout.editRedirectModalTitle',
+            {
+              defaultMessage: 'Edit in the classic experience?',
+            }
+          )}
+          onCancel={() => setShowEditRedirectConfirm(false)}
+          onConfirm={() => {
+            setShowEditRedirectConfirm(false);
+            goToClassicEdit();
+          }}
+          cancelButtonText={i18n.translate(
+            'observability.alerting.monitorDetailFlyout.editRedirectModalCancel',
+            { defaultMessage: 'Cancel' }
+          )}
+          confirmButtonText={i18n.translate(
+            'observability.alerting.monitorDetailFlyout.editRedirectModalConfirm',
+            { defaultMessage: 'Continue to classic experience' }
+          )}
+          buttonColor="primary"
+          defaultFocusedButton="confirm"
+          data-test-subj="alertManagerMonitorDetailEditRedirectModal"
+        >
+          <EuiText size="s">
+            <p>
+              <FormattedMessage
+                id="observability.alerting.monitorDetailFlyout.editRedirectModalBody"
+                defaultMessage="This rule type can’t be edited in the new experience yet. You’ll be taken to the classic alerting app to edit {name}."
+                values={{ name: <strong>{monitor.name}</strong> }}
+              />
+            </p>
+          </EuiText>
+        </EuiConfirmModal>
       )}
     </>
   );

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -185,8 +185,15 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
       : monitor.datasourceId;
     // navigateToApp resolves the basepath/workspace prefix (bare hash hrefs
     // don't) — matches the routing deep-link pattern used elsewhere here.
+    // Encode the interpolated values so a reserved char (&, #, =, space) in any
+    // of them can't be parsed as URL structure. In practice all three are
+    // URL-safe (system `_id`, backend enum, saved-object id), so this is
+    // defensive hardening rather than a behavior change.
+    const id = encodeURIComponent(monitor.id);
+    const monitorTypeParam = encodeURIComponent(classicMonitorType);
+    const dsParam = encodeURIComponent(dataSourceIdParam);
     coreRefs?.application?.navigateToApp(CLASSIC_MONITORS_APP_ID, {
-      path: `#/monitors/${monitor.id}?action=edit-monitor&monitorType=${classicMonitorType}&dataSourceId=${dataSourceIdParam}`,
+      path: `#/monitors/${id}?action=edit-monitor&monitorType=${monitorTypeParam}&dataSourceId=${dsParam}`,
     });
     window.dispatchEvent(new HashChangeEvent('hashchange'));
   };


### PR DESCRIPTION
### Description

The new alerting experience doesn't yet support every monitor type (per-bucket, per-cluster-metrics, per-document, composite) or edit them. This PR adds two escape hatches to the classic alerting app so users aren't blocked, plus a backdrop fix for the confirmation modals.

**1. "Open the classic experience" link in the Create logs rule flyout**

The Create logs rule flyout only builds per-query PPL rules. Added a link in the flyout header (under the subtitle, create-mode logs only) to the classic create-monitor flow for the types we don't cover yet, with a tooltip explaining why. Placed at the flow level in the header — deliberately separated from the query-scoped "Build query in logs" link so the two don't compete.

Wording leads with the new term and keeps the old one in parentheses ("Need another rule (monitor) type?") since existing users know these as monitors while we transition to "rule".

**2. Edit redirect for non-PPL rule types in the monitor detail flyout**

Previously the Edit button was disabled for every non-PPL/non-metric rule with a "only supported for PPL" tooltip. Now those OpenSearch monitor types show a clickable Edit that opens a confirmation and then deep-links to the classic alerting app's edit form:

`/app/monitors#/monitors/{id}?action=edit-monitor&monitorType={type}&dataSourceId={id}`

- `{id}` is the monitor's OpenSearch document `_id`, carried through unchanged from the backend (`mapMonitor` → `osMonitorToUnifiedRuleSummary`).
- `{type}` is derived from the preserved backend `monitor_type`/`monitor_kind` labels (cluster-metrics is special-cased since it's stored as `query_level_monitor`).
- `{dataSourceId}` is always included so the classic app can resolve its data source on a cold deep link (omitting it caused "DataSource was not set" + a `DataSourceView` crash when MDS is enabled). MDS monitors use their data-source saved-object id; the local-cluster sentinel maps to an empty value.

PPL/Prometheus-metric rules still edit in place; detectors/forecasters and non-OpenSearch rules keep the disabled tooltip.

**3. Remove redundant overlay masks**

`EuiConfirmModal` renders its own `EuiOverlayMask`; the edit-redirect and discard-changes modals were each wrapped in a second one, double-dimming the backdrop. Removed the redundant wrappers so the modals use the standard single backdrop.

### Testing

- Added unit tests for the edit-redirect: URL construction (`id`, `type`, `dataSourceId`), cluster-metrics type mapping, local-cluster empty `dataSourceId`, and that Cancel doesn't navigate.
- [ ] Manually verify the classic edit redirect against both a local-cluster and an MDS-data-source rule.
- [ ] Verify the "Open the classic experience" link from the Create logs rule flyout.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
