### PR TITLE
[Notebooks] Remove broken "Maximize panel" 

### DIFF
--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -52,6 +52,29 @@ import { ObservabilitySavedVisualization } from '../../../../services/saved_obje
 import { ParaInput } from './para_input';
 import { ParaOutput } from './para_output';
 
+// Id of core's dashboard "Maximize panel" action (ExpandPanelAction). Its in-place
+// expand is broken when a visualization is embedded in a notebook: the panel overflows
+// the window and is hidden behind the chrome header, so it cannot be closed. We disable
+// the action rather than offer a broken control. See
+// https://github.com/opensearch-project/dashboards-observability/issues/2529
+const EXPAND_PANEL_ACTION_ID = 'togglePanel';
+
+// Disables the "Maximize panel" action on every panel of a dashboard input,
+// covering visualizations saved before this behavior existed.
+const disableExpandPanelAction = (input: DashboardContainerInput): DashboardContainerInput => {
+  const panels = Object.entries(input.panels ?? {}).reduce(
+    (acc, [key, panel]) => {
+      const disabledActions = Array.from(
+        new Set([...(panel.explicitInput?.disabledActions ?? []), EXPAND_PANEL_ACTION_ID])
+      );
+      acc[key] = { ...panel, explicitInput: { ...panel.explicitInput, disabledActions } };
+      return acc;
+    },
+    {} as DashboardContainerInput['panels']
+  );
+  return { ...input, panels };
+};
+
 /*
  * "Paragraphs" component is used to render cells of the notebook open and "add para div" between paragraphs
  *
@@ -240,9 +263,13 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
 
   useEffect(() => {
     if (para.isVizualisation) {
-      if (para.visSavedObjId !== '') setVisInput(JSON.parse(para.vizObjectInput));
+      if (para.visSavedObjId !== '')
+        setVisInput(disableExpandPanelAction(JSON.parse(para.vizObjectInput)));
       fetchVisualizations();
     }
+    // Intentionally only re-runs on data source change; re-running on every `para`
+    // update would re-fetch visualizations and reset visInput unnecessarily.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataSourceMDSId]);
 
   const createDashboardVizObject = (objectId: string) => {
@@ -263,6 +290,9 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
           explicitInput: {
             id: '1',
             savedObjectId: objectId,
+            // Disable core's "Maximize panel"; it is broken when embedded in a
+            // notebook (see EXPAND_PANEL_ACTION_ID).
+            disabledActions: [EXPAND_PANEL_ACTION_ID],
           },
         },
       },

--- a/public/components/notebooks/components/paragraph_components/paragraphs.tsx
+++ b/public/components/notebooks/components/paragraph_components/paragraphs.tsx
@@ -52,11 +52,8 @@ import { ObservabilitySavedVisualization } from '../../../../services/saved_obje
 import { ParaInput } from './para_input';
 import { ParaOutput } from './para_output';
 
-// Id of core's dashboard "Maximize panel" action (ExpandPanelAction). Its in-place
-// expand is broken when a visualization is embedded in a notebook: the panel overflows
-// the window and is hidden behind the chrome header, so it cannot be closed. We disable
-// the action rather than offer a broken control. See
-// https://github.com/opensearch-project/dashboards-observability/issues/2529
+// Core dashboard "Maximize panel" action id, disabled for notebook-embedded
+// visualizations where the in-place expand does not render correctly.
 const EXPAND_PANEL_ACTION_ID = 'togglePanel';
 
 // Disables the "Maximize panel" action on every panel of a dashboard input,
@@ -290,8 +287,6 @@ export const Paragraphs = forwardRef((props: ParagraphProps, ref) => {
           explicitInput: {
             id: '1',
             savedObjectId: objectId,
-            // Disable core's "Maximize panel"; it is broken when embedded in a
-            // notebook (see EXPAND_PANEL_ACTION_ID).
             disabledActions: [EXPAND_PANEL_ACTION_ID],
           },
         },


### PR DESCRIPTION
## Description

Disables the **"Maximize panel"** action on visualizations embedded in notebooks.

Core's dashboard **"Maximize panel"** action performs an in-place expand (sets `expandedPanelId`, switching the grid to `position: absolute; width/height: 100%`). That works in the Dashboards app because the grid fills a dedicated, full-size app region. Inside a notebook the visualization is rendered in a small in-flow container, so maximizing causes the panel to overflow the window and drop out of the document flow — the panel extends past the right edge and following paragraphs overlay it, leaving no way to close it.

Since the maximize behavior can't be made to work correctly for a visualization embedded in the notebook layout, this change removes the option rather than shipping a broken control (the alternative called out in the issue).

**Implementation:** Set `disabledActions: ['togglePanel']` on the dashboard panel input. Applied both when a visualization paragraph is created and when an existing notebook is loaded (via a small helper), so visualizations saved before this change are also covered. The panel's other actions (e.g. **Inspect**) are unaffected.

## Issues Resolved

Closes #2529

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
