### PR TITLE
[Alerting] Alert flyout: labeled enums, tz-aware timestamps, named source, linkified runbooks (SRE2/OBS1)

### DIFF
--- a/public/components/alerting/__tests__/alert_colors.test.ts
+++ b/public/components/alerting/__tests__/alert_colors.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ALERT_KIND_HEX,
+  SEVERITY_HEX,
+  STATE_HEX,
+  UNKNOWN_HEX,
+  getSeverityHex,
+  getStateHex,
+} from '../alert_colors';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../../common/types/alerting';
+
+const ALL_SEVERITIES: UnifiedAlertSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
+const ALL_STATES: UnifiedAlertState[] = [
+  'active',
+  'pending',
+  'acknowledged',
+  'silenced',
+  'resolved',
+  'error',
+];
+
+describe('alert_colors', () => {
+  it('resolves every severity to a real theme color', () => {
+    ALL_SEVERITIES.forEach((severity) => {
+      // A typo in a euiThemeVars key yields `undefined`, which silently renders
+      // as "no color" — assert we got an actual CSS color back.
+      expect(SEVERITY_HEX[severity]).toMatch(/^#[0-9a-f]{3,8}$/i);
+    });
+  });
+
+  it('resolves every state to a real theme color', () => {
+    ALL_STATES.forEach((state) => {
+      expect(STATE_HEX[state]).toMatch(/^#[0-9a-f]{3,8}$/i);
+    });
+  });
+
+  it('resolves both row kinds and keeps anomaly distinct from a high-severity alert', () => {
+    expect(ALERT_KIND_HEX.alert).toMatch(/^#[0-9a-f]{3,8}$/i);
+    expect(ALERT_KIND_HEX.anomaly).toMatch(/^#[0-9a-f]{3,8}$/i);
+    expect(ALERT_KIND_HEX.anomaly).not.toBe(SEVERITY_HEX.high);
+  });
+
+  it('gives critical and active the danger tone', () => {
+    expect(getSeverityHex('critical')).toBe(SEVERITY_HEX.critical);
+    expect(getStateHex('active')).toBe(STATE_HEX.active);
+    expect(getStateHex('error')).toBe(STATE_HEX.active);
+  });
+
+  it('resolves the anomaly row kind through the state getter', () => {
+    expect(getStateHex('anomaly')).toBe(ALERT_KIND_HEX.anomaly);
+  });
+
+  it('falls back to a subdued tone for missing or unknown values', () => {
+    expect(getSeverityHex(undefined)).toBe(UNKNOWN_HEX);
+    expect(getSeverityHex('sev0')).toBe(UNKNOWN_HEX);
+    expect(getStateHex(null)).toBe(UNKNOWN_HEX);
+    expect(getStateHex('quiesced')).toBe(UNKNOWN_HEX);
+  });
+});

--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -439,6 +439,7 @@ describe('AlertDetailFlyout', () => {
       // The action is labelled "Open SLO" whenever `slo_id` is present, and the
       // source row names the SLO instead of repeating the action label.
       expect(getByText('Source SLO')).toBeInTheDocument();
+      expect(getByTestId('alertDetailOpenSource')).toHaveTextContent('Open SLO');
       expect(getByTestId('alertDetailSourceRuleLink')).toHaveTextContent('API availability');
       fireEvent.click(getByTestId('alertDetailOpenSource'));
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -463,6 +464,7 @@ describe('AlertDetailFlyout', () => {
         />
       );
       expect(getByText('Source rule')).toBeInTheDocument();
+      expect(getByTestId('alertDetailOpenSource')).toHaveTextContent('Open rule');
       expect(getByTestId('alertDetailSourceRuleLink')).toHaveTextContent('High latency');
       fireEvent.click(getByTestId('alertDetailOpenSource'));
       // Rule deep-links stay inside the alerting app (hash-only), so

--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -492,6 +492,56 @@ describe('AlertDetailFlyout', () => {
     });
   });
 
+  describe('detail-list formatting parity with the alerts table', () => {
+    it('title-cases the State and Severity values instead of showing raw enums', () => {
+      const { getAllByText, queryByText } = render(
+        <AlertDetailFlyout
+          alert={baseAlert}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      // The alerts table renders "Active"/"Critical"; the flyout used to show
+      // the raw backend enums, so the same alert read two different ways on
+      // the same screen. Each value appears twice — once as a header chip, once
+      // in the detail list — and no lowercase rendering may survive anywhere.
+      expect(getAllByText('Active')).toHaveLength(2);
+      expect(getAllByText('Critical')).toHaveLength(2);
+      expect(queryByText('active')).toBeNull();
+      expect(queryByText('critical')).toBeNull();
+    });
+
+    it('names the timezone on the Started and Last Updated timestamps', () => {
+      const { getAllByText } = render(
+        <AlertDetailFlyout
+          alert={{ ...baseAlert, startTime: '2026-06-04T20:00:00.000Z' }}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      // `toLocaleString()` never says which zone it rendered in. Assert the
+      // zone-labelled shape rather than a fixed string, so the test doesn't
+      // depend on the machine's timezone. Both Started and Last Updated match.
+      expect(getAllByText(/^\w{3} \d{1,2}, 20\d{2} @ \d{2}:\d{2}:\d{2} \S+$/)).toHaveLength(2);
+    });
+
+    it('renders the shared em-dash placeholder when a timestamp is missing', () => {
+      const { getAllByText } = render(
+        <AlertDetailFlyout
+          alert={{ ...baseAlert, lastUpdated: '' }}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      // Not "Invalid date", and not the flyout's old "Not available" wording —
+      // the same glyph the table uses for an empty cell.
+      expect(getAllByText('—').length).toBeGreaterThan(0);
+    });
+  });
+
   describe('annotation runbook links (SRE2)', () => {
     it('renders a runbook URL annotation as a clickable external link', () => {
       const alertWithRunbook: UnifiedAlertSummary = {

--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -63,8 +63,20 @@ jest.mock('../query_services/alerting_opensearch_service', () => ({
   })),
 }));
 
+// Stub the shared core refs so the cross-app SLO deep-link can assert on
+// `navigateToApp` without a real Core start contract.
+jest.mock('../../../framework/core_refs', () => ({
+  coreRefs: {
+    application: { navigateToApp: jest.fn() },
+  },
+}));
+
 import { AlertDetailFlyout } from '../alert_detail_flyout';
+import { coreRefs } from '../../../framework/core_refs';
+import { observabilityApmSloID } from '../../../../common/constants/apm';
 import type { Datasource, UnifiedAlertSummary } from '../../../../common/types/alerting';
+
+const navigateToApp = coreRefs.application!.navigateToApp as jest.Mock;
 
 const baseAlert: UnifiedAlertSummary = {
   id: 'alert-42',
@@ -401,6 +413,77 @@ describe('AlertDetailFlyout', () => {
       );
       fireEvent.click(getByText('Raw Alert Data'));
       expect(mockGetAlertDetail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('source deep-link (OBS1)', () => {
+    beforeEach(() => {
+      navigateToApp.mockClear();
+    });
+
+    it('pivots an SLO burn-rate alert to the SLO detail page in the SLO app', () => {
+      const onClose = jest.fn();
+      const sloAlert: UnifiedAlertSummary = {
+        ...baseAlert,
+        datasourceType: 'prometheus',
+        labels: { slo_id: 'slo/api ok', alertname: 'BurnRate' },
+      };
+      const { getByText } = render(
+        <AlertDetailFlyout
+          alert={sloAlert}
+          datasources={datasources}
+          onClose={onClose}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      // The action is labelled "Open SLO" whenever `slo_id` is present.
+      fireEvent.click(getByText('Open SLO'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+      // Cross-app navigation to the SLO detail route, with the id encoded.
+      expect(navigateToApp).toHaveBeenCalledWith(observabilityApmSloID, {
+        path: `#/slos/${encodeURIComponent('slo/api ok')}`,
+      });
+    });
+
+    it('does not cross apps for a monitor rule deep-link', () => {
+      const monitorAlert: UnifiedAlertSummary = {
+        ...baseAlert,
+        datasourceType: 'opensearch',
+        labels: { monitor_id: 'mon-7' },
+      };
+      const { getByText } = render(
+        <AlertDetailFlyout
+          alert={monitorAlert}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      fireEvent.click(getByText('Open rule'));
+      // Rule deep-links stay inside the alerting app (hash-only), so
+      // navigateToApp must not fire.
+      expect(navigateToApp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('annotation runbook links (SRE2)', () => {
+    it('renders a runbook URL annotation as a clickable external link', () => {
+      const alertWithRunbook: UnifiedAlertSummary = {
+        ...baseAlert,
+        annotations: { runbook: 'https://runbooks.example/api' },
+      };
+      const { getByText } = render(
+        <AlertDetailFlyout
+          alert={alertWithRunbook}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      const link = getByText('https://runbooks.example/api');
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('href', 'https://runbooks.example/api');
+      expect(link).toHaveAttribute('target', '_blank');
     });
   });
 

--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -426,9 +426,9 @@ describe('AlertDetailFlyout', () => {
       const sloAlert: UnifiedAlertSummary = {
         ...baseAlert,
         datasourceType: 'prometheus',
-        labels: { slo_id: 'slo/api ok', alertname: 'BurnRate' },
+        labels: { slo_id: 'slo/api ok', slo_name: 'API availability', alertname: 'BurnRate' },
       };
-      const { getByText } = render(
+      const { getByText, getByTestId } = render(
         <AlertDetailFlyout
           alert={sloAlert}
           datasources={datasources}
@@ -436,8 +436,11 @@ describe('AlertDetailFlyout', () => {
           onAcknowledge={jest.fn()}
         />
       );
-      // The action is labelled "Open SLO" whenever `slo_id` is present.
-      fireEvent.click(getByText('Open SLO'));
+      // The action is labelled "Open SLO" whenever `slo_id` is present, and the
+      // source row names the SLO instead of repeating the action label.
+      expect(getByText('Source SLO')).toBeInTheDocument();
+      expect(getByTestId('alertDetailSourceRuleLink')).toHaveTextContent('API availability');
+      fireEvent.click(getByTestId('alertDetailOpenSource'));
       expect(onClose).toHaveBeenCalledTimes(1);
       // Cross-app navigation to the SLO detail route, with the id encoded.
       expect(navigateToApp).toHaveBeenCalledWith(observabilityApmSloID, {
@@ -449,9 +452,9 @@ describe('AlertDetailFlyout', () => {
       const monitorAlert: UnifiedAlertSummary = {
         ...baseAlert,
         datasourceType: 'opensearch',
-        labels: { monitor_id: 'mon-7' },
+        labels: { monitor_id: 'mon-7', monitor_name: 'High latency' },
       };
-      const { getByText } = render(
+      const { getByText, getByTestId } = render(
         <AlertDetailFlyout
           alert={monitorAlert}
           datasources={datasources}
@@ -459,10 +462,31 @@ describe('AlertDetailFlyout', () => {
           onAcknowledge={jest.fn()}
         />
       );
-      fireEvent.click(getByText('Open rule'));
+      expect(getByText('Source rule')).toBeInTheDocument();
+      expect(getByTestId('alertDetailSourceRuleLink')).toHaveTextContent('High latency');
+      fireEvent.click(getByTestId('alertDetailOpenSource'));
       // Rule deep-links stay inside the alerting app (hash-only), so
       // navigateToApp must not fire.
       expect(navigateToApp).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the source id, never the action label, when no name label exists', () => {
+      const namelessAlert: UnifiedAlertSummary = {
+        ...baseAlert,
+        datasourceType: 'opensearch',
+        labels: { monitor_id: 'mon-7' },
+      };
+      const { getByTestId } = render(
+        <AlertDetailFlyout
+          alert={namelessAlert}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      const sourceRow = getByTestId('alertDetailSourceRuleLink');
+      expect(sourceRow).toHaveTextContent('mon-7');
+      expect(sourceRow).not.toHaveTextContent('Open rule');
     });
   });
 

--- a/public/components/alerting/__tests__/enum_labels.test.ts
+++ b/public/components/alerting/__tests__/enum_labels.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EMPTY_VALUE,
+  SEVERITY_LABELS,
+  STATE_LABELS,
+  getSeverityLabel,
+  getStateLabel,
+} from '../enum_labels';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../../common/types/alerting';
+
+const ALL_SEVERITIES: UnifiedAlertSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
+const ALL_STATES: UnifiedAlertState[] = [
+  'active',
+  'pending',
+  'acknowledged',
+  'silenced',
+  'resolved',
+  'error',
+];
+
+describe('enum_labels', () => {
+  it('covers every severity in the union with a non-empty, non-raw label', () => {
+    ALL_SEVERITIES.forEach((severity) => {
+      const label = SEVERITY_LABELS[severity];
+      expect(label).toBeTruthy();
+      // The whole point is not to render the raw lowercase machine value.
+      expect(label).not.toBe(severity);
+    });
+  });
+
+  it('covers every state in the union with a non-empty, non-raw label', () => {
+    ALL_STATES.forEach((state) => {
+      const label = STATE_LABELS[state];
+      expect(label).toBeTruthy();
+      expect(label).not.toBe(state);
+    });
+  });
+
+  it('returns the empty placeholder for missing values', () => {
+    expect(getSeverityLabel(undefined)).toBe(EMPTY_VALUE);
+    expect(getSeverityLabel(null)).toBe(EMPTY_VALUE);
+    expect(getSeverityLabel('')).toBe(EMPTY_VALUE);
+    expect(getStateLabel(undefined)).toBe(EMPTY_VALUE);
+    expect(getStateLabel('')).toBe(EMPTY_VALUE);
+  });
+
+  it('humanizes values the UI does not know about instead of dropping them', () => {
+    expect(getStateLabel('awaiting_data')).toBe('Awaiting data');
+    expect(getSeverityLabel('sev-one')).toBe('Sev one');
+  });
+
+  it('falls back to the placeholder when an unknown value is only separators', () => {
+    expect(getStateLabel('__')).toBe(EMPTY_VALUE);
+  });
+
+  it('maps known values through the label tables', () => {
+    expect(getSeverityLabel('critical')).toBe(SEVERITY_LABELS.critical);
+    expect(getStateLabel('acknowledged')).toBe(STATE_LABELS.acknowledged);
+  });
+});

--- a/public/components/alerting/__tests__/enum_labels.test.ts
+++ b/public/components/alerting/__tests__/enum_labels.test.ts
@@ -7,10 +7,15 @@ import {
   EMPTY_VALUE,
   SEVERITY_LABELS,
   STATE_LABELS,
+  getMonitorStateLabel,
   getSeverityLabel,
   getStateLabel,
 } from '../enum_labels';
-import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../../common/types/alerting';
+import type {
+  MonitorHealthStatus,
+  UnifiedAlertSeverity,
+  UnifiedAlertState,
+} from '../../../../common/types/alerting';
 
 const ALL_SEVERITIES: UnifiedAlertSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
 const ALL_STATES: UnifiedAlertState[] = [
@@ -60,5 +65,39 @@ describe('enum_labels', () => {
   it('maps known values through the label tables', () => {
     expect(getSeverityLabel('critical')).toBe(SEVERITY_LABELS.critical);
     expect(getStateLabel('acknowledged')).toBe(STATE_LABELS.acknowledged);
+  });
+
+  describe('getMonitorStateLabel', () => {
+    it('title-cases the lowercase rule-status tokens', () => {
+      expect(getMonitorStateLabel('active')).toBe('Active');
+      expect(getMonitorStateLabel('pending')).toBe('Pending');
+      expect(getMonitorStateLabel('muted')).toBe('Muted');
+      expect(getMonitorStateLabel('disabled')).toBe('Disabled');
+    });
+
+    it('covers every health status with a non-raw label', () => {
+      const ALL_HEALTH: MonitorHealthStatus[] = ['healthy', 'failing', 'no_data'];
+      ALL_HEALTH.forEach((health) => {
+        const label = getMonitorStateLabel(health);
+        expect(label).toBeTruthy();
+        expect(label).not.toBe(health);
+      });
+      // `no_data` in particular must not leak the underscore into the UI.
+      expect(getMonitorStateLabel('no_data')).toBe('No data');
+    });
+
+    it('passes through the AD/forecaster statuses, which already read as prose', () => {
+      // These arrive from the anomaly-detection plugin already display-ready;
+      // re-casing them would corrupt wording like "Awaiting data to init".
+      expect(getMonitorStateLabel('Running')).toBe('Running');
+      expect(getMonitorStateLabel('Awaiting data to init')).toBe('Awaiting data to init');
+      expect(getMonitorStateLabel('Initialization failure')).toBe('Initialization failure');
+    });
+
+    it('returns the empty placeholder for missing values', () => {
+      expect(getMonitorStateLabel(undefined)).toBe(EMPTY_VALUE);
+      expect(getMonitorStateLabel(null)).toBe(EMPTY_VALUE);
+      expect(getMonitorStateLabel('')).toBe(EMPTY_VALUE);
+    });
   });
 });

--- a/public/components/alerting/__tests__/linkify_annotation.test.tsx
+++ b/public/components/alerting/__tests__/linkify_annotation.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { LinkifyAnnotation, isSafeHttpUrl } from '../linkify_annotation';
+
+describe('isSafeHttpUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(isSafeHttpUrl('http://runbooks.example/api')).toBe(true);
+    expect(isSafeHttpUrl('https://runbooks.example/api?x=1#frag')).toBe(true);
+  });
+
+  it('rejects non-URL plain text', () => {
+    expect(isSafeHttpUrl('see the wiki')).toBe(false);
+    expect(isSafeHttpUrl('www.example.com')).toBe(false);
+    expect(isSafeHttpUrl('')).toBe(false);
+  });
+
+  it('rejects unsafe / non-http schemes', () => {
+    // eslint-disable-next-line no-script-url
+    expect(isSafeHttpUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isSafeHttpUrl('file:///etc/passwd')).toBe(false);
+    expect(isSafeHttpUrl('ftp://host/file')).toBe(false);
+  });
+});
+
+describe('LinkifyAnnotation', () => {
+  it('renders a safe URL as an external link', () => {
+    const { getByText } = render(
+      <LinkifyAnnotation value="https://runbooks.example/api" data-test-subj="v" />
+    );
+    const link = getByText('https://runbooks.example/api');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', 'https://runbooks.example/api');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'));
+  });
+
+  it('renders plain text (not a link) for non-URL values', () => {
+    const { getByText } = render(<LinkifyAnnotation value="oncall handbook" data-test-subj="v" />);
+    const node = getByText('oncall handbook');
+    expect(node.tagName).not.toBe('A');
+  });
+
+  it('does not linkify unsafe schemes', () => {
+    // eslint-disable-next-line no-script-url
+    const value = 'javascript:alert(1)';
+    const { getByText } = render(<LinkifyAnnotation value={value} data-test-subj="v" />);
+    const node = getByText(value);
+    expect(node.tagName).not.toBe('A');
+  });
+
+  it('renders the fallback for empty values', () => {
+    const { getByText } = render(<LinkifyAnnotation value="" fallback="—" data-test-subj="v" />);
+    expect(getByText('—')).toBeInTheDocument();
+  });
+});

--- a/public/components/alerting/__tests__/time_format.test.ts
+++ b/public/components/alerting/__tests__/time_format.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { uiSettingsService } from '../../../../common/utils';
+import { EMPTY_VALUE } from '../enum_labels';
+import { formatTimestamp, getTimezoneLabel, resolveDisplayTz } from '../time_format';
+
+// 2026-08-25T18:04:05Z — a fixed instant so assertions don't depend on "now".
+const INSTANT = '2026-08-25T18:04:05.000Z';
+
+describe('time_format', () => {
+  let getSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getSpy = jest.spyOn(uiSettingsService, 'get');
+  });
+
+  afterEach(() => {
+    getSpy.mockRestore();
+  });
+
+  describe('resolveDisplayTz', () => {
+    it('uses the configured dateFormat:tz', () => {
+      getSpy.mockReturnValue('America/Los_Angeles');
+      expect(resolveDisplayTz()).toBe('America/Los_Angeles');
+    });
+
+    it('falls back to the browser zone when unset or left at Browser', () => {
+      const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      getSpy.mockReturnValue(undefined);
+      expect(resolveDisplayTz()).toBe(browserTz);
+      getSpy.mockReturnValue('Browser');
+      expect(resolveDisplayTz()).toBe(browserTz);
+    });
+  });
+
+  describe('formatTimestamp', () => {
+    it('renders in the configured zone and names that zone', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(INSTANT)).toBe('Aug 25, 2026 @ 18:04:05 UTC');
+    });
+
+    it('shifts the wall-clock time to the configured zone', () => {
+      getSpy.mockReturnValue('America/Los_Angeles');
+      // 18:04 UTC is 11:04 PDT on this date.
+      expect(formatTimestamp(INSTANT)).toBe('Aug 25, 2026 @ 11:04:05 PDT');
+    });
+
+    it('omits the zone label when asked', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(INSTANT, { withZone: false })).toBe('Aug 25, 2026 @ 18:04:05');
+    });
+
+    it('honors a custom format', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(INSTANT, { format: 'YYYY-MM-DD', withZone: false })).toBe('2026-08-25');
+    });
+
+    it('accepts epoch millis and Date instances', () => {
+      getSpy.mockReturnValue('UTC');
+      const ms = new Date(INSTANT).getTime();
+      expect(formatTimestamp(ms)).toBe('Aug 25, 2026 @ 18:04:05 UTC');
+      expect(formatTimestamp(new Date(INSTANT))).toBe('Aug 25, 2026 @ 18:04:05 UTC');
+    });
+
+    it('returns the placeholder rather than "Invalid date" for bad input', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(undefined)).toBe(EMPTY_VALUE);
+      expect(formatTimestamp(null)).toBe(EMPTY_VALUE);
+      expect(formatTimestamp('')).toBe(EMPTY_VALUE);
+      expect(formatTimestamp('not a timestamp')).toBe(EMPTY_VALUE);
+    });
+
+    it('honors a caller-supplied fallback', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(null, { fallback: 'Never' })).toBe('Never');
+    });
+  });
+
+  describe('getTimezoneLabel', () => {
+    it('labels a zone with an abbreviation where one exists', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(getTimezoneLabel(INSTANT)).toBe('UTC');
+    });
+
+    it('uses the zone abbreviation when the zone has one', () => {
+      getSpy.mockReturnValue('Asia/Kolkata');
+      expect(getTimezoneLabel(INSTANT)).toBe('IST');
+    });
+
+    it('falls back to a numeric offset for zones without an abbreviation', () => {
+      getSpy.mockReturnValue('Asia/Kathmandu');
+      expect(getTimezoneLabel(INSTANT)).toBe('+0545');
+    });
+  });
+});

--- a/public/components/alerting/__tests__/time_format.test.ts
+++ b/public/components/alerting/__tests__/time_format.test.ts
@@ -55,7 +55,9 @@ describe('time_format', () => {
 
     it('honors a custom format', () => {
       getSpy.mockReturnValue('UTC');
-      expect(formatTimestamp(INSTANT, { format: 'YYYY-MM-DD', withZone: false })).toBe('2026-08-25');
+      expect(formatTimestamp(INSTANT, { format: 'YYYY-MM-DD', withZone: false })).toBe(
+        '2026-08-25'
+      );
     });
 
     it('accepts epoch millis and Date instances', () => {

--- a/public/components/alerting/alert_colors.ts
+++ b/public/components/alerting/alert_colors.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { euiThemeVars } from '@osd/ui-shared-deps/theme';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../common/types/alerting';
+
+/**
+ * Theme-derived colors for alert severity, state, and row kind.
+ *
+ * Alert surfaces previously hand-rolled these as literal hex — which pinned them
+ * to the light theme (so dark mode rendered near-invisible swatches) and let each
+ * component drift from the next. `euiThemeVars` resolves against whichever theme
+ * is active, so consumers get the right value in both.
+ *
+ * Use these where a raw CSS color is unavoidable (chart series, custom swatches).
+ * Where an OUI component takes a semantic color name — `EuiHealth`, `EuiBadge` —
+ * prefer the semantic maps in `shared_constants.ts` instead.
+ */
+
+/** Severity → theme color. Ramps danger → warning → primary → subdued. */
+export const SEVERITY_HEX: Record<UnifiedAlertSeverity, string> = {
+  critical: euiThemeVars.euiColorDanger,
+  high: euiThemeVars.euiColorWarning,
+  medium: euiThemeVars.euiColorPrimary,
+  low: euiThemeVars.euiColorMediumShade,
+  info: euiThemeVars.euiColorLightShade,
+};
+
+/** Alert state → theme color. */
+export const STATE_HEX: Record<UnifiedAlertState, string> = {
+  active: euiThemeVars.euiColorDanger,
+  pending: euiThemeVars.euiColorWarning,
+  acknowledged: euiThemeVars.euiColorPrimary,
+  silenced: euiThemeVars.euiColorMediumShade,
+  resolved: euiThemeVars.euiColorSuccess,
+  error: euiThemeVars.euiColorDanger,
+};
+
+/**
+ * Row kind → theme color. Anomaly rows use the darker warning tone so they read
+ * as distinct from a `high`-severity alert rather than merely similar.
+ */
+export const ALERT_KIND_HEX: Record<string, string> = {
+  alert: euiThemeVars.euiColorPrimary,
+  anomaly: euiThemeVars.euiColorWarningText,
+};
+
+/** Fallback for a value the UI doesn't recognise — subdued rather than alarming. */
+export const UNKNOWN_HEX = euiThemeVars.euiColorMediumShade;
+
+/** Severity color, falling back to a subdued tone for unrecognised values. */
+export function getSeverityHex(severity?: string | null): string {
+  if (!severity) return UNKNOWN_HEX;
+  return SEVERITY_HEX[severity as UnifiedAlertSeverity] ?? UNKNOWN_HEX;
+}
+
+/**
+ * State color. `anomaly` is not an alert state but appears in the same column of
+ * the alerts table, so it is resolved here too.
+ */
+export function getStateHex(state?: string | null): string {
+  if (!state) return UNKNOWN_HEX;
+  return STATE_HEX[state as UnifiedAlertState] ?? ALERT_KIND_HEX[state] ?? UNKNOWN_HEX;
+}

--- a/public/components/alerting/alert_colors.ts
+++ b/public/components/alerting/alert_colors.ts
@@ -4,7 +4,11 @@
  */
 
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
-import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../common/types/alerting';
+import type {
+  UnifiedAlertKind,
+  UnifiedAlertSeverity,
+  UnifiedAlertState,
+} from '../../../common/types/alerting';
 
 /**
  * Theme-derived colors for alert severity, state, and row kind.
@@ -42,7 +46,7 @@ export const STATE_HEX: Record<UnifiedAlertState, string> = {
  * Row kind → theme color. Anomaly rows use the darker warning tone so they read
  * as distinct from a `high`-severity alert rather than merely similar.
  */
-export const ALERT_KIND_HEX: Record<string, string> = {
+export const ALERT_KIND_HEX: Record<UnifiedAlertKind, string> = {
   alert: euiThemeVars.euiColorPrimary,
   anomaly: euiThemeVars.euiColorWarningText,
 };
@@ -62,5 +66,6 @@ export function getSeverityHex(severity?: string | null): string {
  */
 export function getStateHex(state?: string | null): string {
   if (!state) return UNKNOWN_HEX;
-  return STATE_HEX[state as UnifiedAlertState] ?? ALERT_KIND_HEX[state] ?? UNKNOWN_HEX;
+  const kindHex = ALERT_KIND_HEX[state as UnifiedAlertKind];
+  return STATE_HEX[state as UnifiedAlertState] ?? kindHex ?? UNKNOWN_HEX;
 }

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -31,8 +31,11 @@ import {
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { UnifiedAlert, UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
+import { observabilityApmSloID } from '../../../common/constants/apm';
+import { coreRefs } from '../../framework/core_refs';
 import { AnomalyDetailContent } from './anomaly_detail_flyout';
 import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
+import { LinkifyAnnotation } from './linkify_annotation';
 import { SEVERITY_COLORS, STATE_COLORS } from './shared_constants';
 
 /** Internal label keys filtered from the Labels accordion display. */
@@ -143,48 +146,52 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
   const dsName =
     datasources.find((d) => d.id === alert.datasourceId)?.name || alert.datasourceId || '\u2014';
   // Memoize so `allLabels` keeps a stable reference between renders when
-  // `alertData.labels` is unchanged \u2014 the `useMemo` for `sourceLinkPath`
+  // `alertData.labels` is unchanged \u2014 the `useMemo` for `sourceLink`
   // below depends on it, and a fresh `{}` from the `||` fallback would
   // otherwise re-run the dep-list check every render.
   const allLabels = useMemo(() => alertData.labels || {}, [alertData.labels]);
 
-  // Source-rule deep-link computation (BUG-14). The unified alert shape
-  // doesn't carry a typed pointer to the originating monitor; we derive
-  // one from the labels available per-backend:
-  //   - OpenSearch alerts: `labels.monitor_id` is reliably populated.
-  //     Match on `monitor_id:<id>` so the Rules tab's `matchesSearch`
-  //     narrows to the originating monitor (rules carry the same id).
-  //   - Prometheus alerts: no `monitor_*` label exists; the closest
-  //     stable handle is `labels.alertname` (Prom convention) which
-  //     equals the rule's `name`. Match by name.
-  // SLO burn-rate alerts (Prometheus side) carry `slo_id` \u2014 match on
-  // that label so the Rules tab narrows to the burn-rate group rather
-  // than just the single firing tier.
-  // Falls back to undefined when no usable handle exists, in which case
-  // the source-link surfaces are simply not rendered. Includes the
-  // backing datasource id (`ds=\u2026`) so the Rules tab DS filter
-  // auto-selects the right cluster on landing \u2014 same mechanism as the
-  // SLO detail "View alert rules" deep-link (BUG-12).
-  const sourceLinkPath = useMemo(() => {
+  // Source deep-link computation (BUG-14 / OBS1). The unified alert shape
+  // doesn't carry a typed pointer to its origin; we derive a navigation
+  // target from the labels available per-backend. The target is an object so
+  // each surface knows whether it must cross an OSD app boundary (`appId`)
+  // or can stay within the alerting app (hash-only):
+  //   - SLO burn-rate alerts (either backend) carry `slo_id`. These open the
+  //     SLO *detail* page, which lives in the separate SLO app
+  //     (`observabilityApmSloID`) \u2014 so carry that app id and point at
+  //     `#/slos/<id>` (matches the SLO listing/detail deep-link convention).
+  //     Checked first, and backend-agnostically, so it stays in lock-step
+  //     with `sourceLinkLabel` below (which shows "Open SLO" whenever
+  //     `slo_id` is present).
+  //   - OpenSearch alerts: `labels.monitor_id` is reliably populated. Match
+  //     on `monitor_id:<id>` so the Rules tab's `matchesSearch` narrows to
+  //     the originating monitor (rules carry the same id).
+  //   - Prometheus alerts: no `monitor_*` label exists; the closest stable
+  //     handle is `labels.alertname` (Prom convention) which equals the
+  //     rule's `name`. Match by name.
+  // Falls back to undefined when no usable handle exists, in which case the
+  // source-link surfaces are simply not rendered. Rules deep-links include
+  // the backing datasource id (`ds=\u2026`) so the Rules tab DS filter
+  // auto-selects the right cluster on landing (BUG-12).
+  const sourceLink = useMemo<{ path: string; appId?: string } | undefined>(() => {
     const dsId = alert.datasourceId;
     if (!dsId) return undefined;
     const labels = (allLabels as Record<string, string>) ?? {};
+    const sloId = labels.slo_id;
+    if (sloId) {
+      return { path: `#/slos/${encodeURIComponent(sloId)}`, appId: observabilityApmSloID };
+    }
     if (alert.datasourceType === 'opensearch') {
       const monitorId = labels.monitor_id;
       if (!monitorId) return undefined;
       const params = new URLSearchParams({ q: `monitor_id:${monitorId}`, ds: dsId });
-      return `#/rules?${params.toString()}`;
+      return { path: `#/rules?${params.toString()}` };
     }
     if (alert.datasourceType === 'prometheus') {
-      const sloId = labels.slo_id;
-      if (sloId) {
-        const params = new URLSearchParams({ q: `slo_id:${sloId}`, ds: dsId });
-        return `#/rules?${params.toString()}`;
-      }
       const alertname = labels.alertname;
       if (!alertname) return undefined;
       const params = new URLSearchParams({ q: alertname, ds: dsId });
-      return `#/rules?${params.toString()}`;
+      return { path: `#/rules?${params.toString()}` };
     }
     return undefined;
   }, [alert.datasourceId, alert.datasourceType, allLabels]);
@@ -199,13 +206,24 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
       });
 
   const navigateToSource = () => {
-    if (!sourceLinkPath) return;
-    // Same-app navigation: directly update the hash and dispatch a
-    // synthetic hashchange event so the AlarmsPage listener picks it up.
-    // Setting window.location.hash alone doesn't fire the event when
-    // called programmatically from within the same page.
+    if (!sourceLink) return;
     onClose();
-    window.location.hash = sourceLinkPath;
+    if (sourceLink.appId) {
+      // Cross-app navigation: the SLO detail page lives in a different OSD
+      // application than the alerting app, so go through
+      // `application.navigateToApp` to switch apps (workspace-aware), then
+      // fire a synthetic hashchange for the target app's HashRouter to pick
+      // up the route \u2014 navigateToApp uses pushState, which does not emit
+      // hashchange on its own.
+      coreRefs?.application?.navigateToApp(sourceLink.appId, { path: sourceLink.path });
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+      return;
+    }
+    // Same-app navigation: directly update the hash and dispatch a synthetic
+    // hashchange event so the AlarmsPage listener picks it up. Setting
+    // window.location.hash alone doesn't fire the event when called
+    // programmatically from within the same page.
+    window.location.hash = sourceLink.path;
     window.dispatchEvent(new HashChangeEvent('hashchange'));
   };
 
@@ -260,7 +278,7 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
               <EuiFlexItem grow={false}>
                 <EuiBadge color={SEVERITY_COLORS[alert.severity]}>{alert.severity}</EuiBadge>
               </EuiFlexItem>
-              {sourceLinkPath && (
+              {sourceLink && (
                 <EuiFlexItem grow={false}>
                   <EuiButton
                     size="s"
@@ -362,7 +380,7 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
                 }),
                 description: getAlertDuration(alert.startTime),
               },
-              ...(sourceLinkPath
+              ...(sourceLink
                 ? [
                     {
                       title: i18n.translate('observability.alerting.alertDetailFlyout.sourceRule', {
@@ -469,7 +487,9 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
               compressed
               listItems={Object.entries(annotations).map(([k, v]) => ({
                 title: k,
-                description: v || '\u2014',
+                // Annotations often hold runbook URLs \u2014 render them clickable
+                // (safe http/https only) instead of plain text (SRE2).
+                description: <LinkifyAnnotation value={v} />,
               }))}
             />
           ) : (

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -196,13 +196,36 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
     return undefined;
   }, [alert.datasourceId, alert.datasourceType, allLabels]);
 
-  const monitorDisplayName = (allLabels as Record<string, string>)?.monitor_name;
-  const sourceLinkLabel = (allLabels as Record<string, string>)?.slo_id
+  const sloId = (allLabels as Record<string, string>)?.slo_id;
+  const sourceLinkLabel = sloId
     ? i18n.translate('observability.alerting.alertDetailFlyout.openSlo', {
         defaultMessage: 'Open SLO',
       })
     : i18n.translate('observability.alerting.alertDetailFlyout.openMonitor', {
         defaultMessage: 'Open rule',
+      });
+
+  // The description-list row names the *source*, so it must never fall back to
+  // the action label (`sourceLinkLabel`) — that both duplicates the header
+  // button verbatim and mislabels an SLO as if "Open SLO" were its name.
+  // Preference order per backend: the monitor's own name (OpenSearch), the SLO
+  // name then its id (SLO burn-rate alerts, both carry `slo_name`/`slo_id` per
+  // `slo_promql_generator`), then the Prometheus `alertname`, then the raw
+  // `monitor_id`. `sourceLink` only exists when one of `slo_id` / `monitor_id` /
+  // `alertname` is present, so this chain always resolves to a string.
+  const labelRecord = allLabels as Record<string, string>;
+  const sourceDisplayName =
+    labelRecord?.monitor_name ??
+    labelRecord?.slo_name ??
+    sloId ??
+    labelRecord?.alertname ??
+    labelRecord?.monitor_id;
+  const sourceRowTitle = sloId
+    ? i18n.translate('observability.alerting.alertDetailFlyout.sourceSlo', {
+        defaultMessage: 'Source SLO',
+      })
+    : i18n.translate('observability.alerting.alertDetailFlyout.sourceRule', {
+        defaultMessage: 'Source rule',
       });
 
   const navigateToSource = () => {
@@ -383,15 +406,13 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
               ...(sourceLink
                 ? [
                     {
-                      title: i18n.translate('observability.alerting.alertDetailFlyout.sourceRule', {
-                        defaultMessage: 'Source rule',
-                      }),
+                      title: sourceRowTitle,
                       description: (
                         <EuiLink
                           onClick={navigateToSource}
                           data-test-subj="alertDetailSourceRuleLink"
                         >
-                          {monitorDisplayName ?? sourceLinkLabel}
+                          {sourceDisplayName}
                         </EuiLink>
                       ),
                     },

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -298,7 +298,9 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
-                <EuiHealth color={STATE_COLORS[alert.state]}>{getStateLabel(alert.state)}</EuiHealth>
+                <EuiHealth color={STATE_COLORS[alert.state]}>
+                  {getStateLabel(alert.state)}
+                </EuiHealth>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiBadge color={SEVERITY_COLORS[alert.severity]}>

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -37,6 +37,8 @@ import { AnomalyDetailContent } from './anomaly_detail_flyout';
 import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
 import { LinkifyAnnotation } from './linkify_annotation';
 import { SEVERITY_COLORS, STATE_COLORS } from './shared_constants';
+import { EMPTY_VALUE, getSeverityLabel, getStateLabel } from './enum_labels';
+import { formatTimestamp } from './time_format';
 
 /** Internal label keys filtered from the Labels accordion display. */
 const INTERNAL_LABEL_KEYS = new Set([
@@ -296,10 +298,12 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
-                <EuiHealth color={STATE_COLORS[alert.state]}>{alert.state}</EuiHealth>
+                <EuiHealth color={STATE_COLORS[alert.state]}>{getStateLabel(alert.state)}</EuiHealth>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiBadge color={SEVERITY_COLORS[alert.severity]}>{alert.severity}</EuiBadge>
+                <EuiBadge color={SEVERITY_COLORS[alert.severity]}>
+                  {getSeverityLabel(alert.severity)}
+                </EuiBadge>
               </EuiFlexItem>
               {sourceLink && (
                 <EuiFlexItem grow={false}>
@@ -355,25 +359,25 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
                 title: i18n.translate('observability.alerting.alertDetailFlyout.alertId', {
                   defaultMessage: 'Alert ID',
                 }),
-                description: alert.id || '\u2014',
+                description: alert.id || EMPTY_VALUE,
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.state', {
                   defaultMessage: 'State',
                 }),
-                description: alert.state || '\u2014',
+                description: getStateLabel(alert.state),
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.severity', {
                   defaultMessage: 'Severity',
                 }),
-                description: alert.severity || '\u2014',
+                description: getSeverityLabel(alert.severity),
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.backend', {
                   defaultMessage: 'Backend',
                 }),
-                description: alert.datasourceType || '\u2014',
+                description: alert.datasourceType || EMPTY_VALUE,
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.datasource', {
@@ -385,17 +389,16 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
                 title: i18n.translate('observability.alerting.alertDetailFlyout.started', {
                   defaultMessage: 'Started',
                 }),
-                description: alert.startTime
-                  ? new Date(alert.startTime).toLocaleString()
-                  : '\u2014',
+                // Zone-labelled so this reads identically to the Started column in
+                // the alerts table; a bare `toLocaleString()` hides which zone it
+                // rendered in, so two readers see different "start" times.
+                description: formatTimestamp(alert.startTime),
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.lastUpdated', {
                   defaultMessage: 'Last Updated',
                 }),
-                description: alert.lastUpdated
-                  ? new Date(alert.lastUpdated).toLocaleString()
-                  : '\u2014',
+                description: formatTimestamp(alert.lastUpdated),
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.duration', {

--- a/public/components/alerting/enum_labels.ts
+++ b/public/components/alerting/enum_labels.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../common/types/alerting';
+
+/**
+ * Human-readable, translatable labels for the raw alert enums.
+ *
+ * The wire format uses lowercase machine values (`critical`, `at_risk`, …).
+ * Rendering those directly leaks the data model into the UI and cannot be
+ * localised, so every surface that shows a severity or state to a user should
+ * go through the getters below rather than interpolating the raw value.
+ */
+
+/**
+ * Single placeholder for an absent value. Kept here — alongside the other
+ * "how do we render a raw value as human text" rules — so surfaces stop
+ * drifting between `—`, `---`, and `N/A` for the same empty cell.
+ */
+export const EMPTY_VALUE = '—';
+
+export const SEVERITY_LABELS: Record<UnifiedAlertSeverity, string> = {
+  critical: i18n.translate('observability.alerting.severityLabel.critical', {
+    defaultMessage: 'Critical',
+  }),
+  high: i18n.translate('observability.alerting.severityLabel.high', {
+    defaultMessage: 'High',
+  }),
+  medium: i18n.translate('observability.alerting.severityLabel.medium', {
+    defaultMessage: 'Medium',
+  }),
+  low: i18n.translate('observability.alerting.severityLabel.low', {
+    defaultMessage: 'Low',
+  }),
+  info: i18n.translate('observability.alerting.severityLabel.info', {
+    defaultMessage: 'Info',
+  }),
+};
+
+export const STATE_LABELS: Record<UnifiedAlertState, string> = {
+  active: i18n.translate('observability.alerting.stateLabel.active', {
+    defaultMessage: 'Active',
+  }),
+  pending: i18n.translate('observability.alerting.stateLabel.pending', {
+    defaultMessage: 'Pending',
+  }),
+  acknowledged: i18n.translate('observability.alerting.stateLabel.acknowledged', {
+    defaultMessage: 'Acknowledged',
+  }),
+  silenced: i18n.translate('observability.alerting.stateLabel.silenced', {
+    defaultMessage: 'Silenced',
+  }),
+  resolved: i18n.translate('observability.alerting.stateLabel.resolved', {
+    defaultMessage: 'Resolved',
+  }),
+  error: i18n.translate('observability.alerting.stateLabel.error', {
+    defaultMessage: 'Error',
+  }),
+};
+
+/**
+ * Best-effort label for a value that isn't in the known enum — a backend may
+ * add a state before the UI knows about it. Turns `awaiting_data` into
+ * "Awaiting data" so an unrecognised value still reads as prose instead of
+ * disappearing behind a placeholder.
+ */
+function humanizeUnknown(value: string): string {
+  const spaced = value.replace(/[_-]+/g, ' ').trim();
+  if (!spaced) return EMPTY_VALUE;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/** Display label for an alert severity. Returns {@link EMPTY_VALUE} when absent. */
+export function getSeverityLabel(severity?: string | null): string {
+  if (!severity) return EMPTY_VALUE;
+  return SEVERITY_LABELS[severity as UnifiedAlertSeverity] ?? humanizeUnknown(severity);
+}
+
+/** Display label for an alert state. Returns {@link EMPTY_VALUE} when absent. */
+export function getStateLabel(state?: string | null): string {
+  if (!state) return EMPTY_VALUE;
+  return STATE_LABELS[state as UnifiedAlertState] ?? humanizeUnknown(state);
+}

--- a/public/components/alerting/enum_labels.ts
+++ b/public/components/alerting/enum_labels.ts
@@ -84,3 +84,44 @@ export function getStateLabel(state?: string | null): string {
   if (!state) return EMPTY_VALUE;
   return STATE_LABELS[state as UnifiedAlertState] ?? humanizeUnknown(state);
 }
+
+/**
+ * Rule/monitor status and health values, which are a different vocabulary from
+ * alert state. Only the OpenSearch-alerting side sends lowercase tokens; the
+ * AD/forecaster side already sends display-ready sentences ("Running",
+ * "Awaiting data to init"), which fall through {@link humanizeUnknown}
+ * unchanged. Only the tokens that actually need translating are mapped.
+ */
+const MONITOR_STATE_LABELS: Record<string, string> = {
+  active: i18n.translate('observability.alerting.monitorStateLabel.active', {
+    defaultMessage: 'Active',
+  }),
+  pending: i18n.translate('observability.alerting.monitorStateLabel.pending', {
+    defaultMessage: 'Pending',
+  }),
+  muted: i18n.translate('observability.alerting.monitorStateLabel.muted', {
+    defaultMessage: 'Muted',
+  }),
+  disabled: i18n.translate('observability.alerting.monitorStateLabel.disabled', {
+    defaultMessage: 'Disabled',
+  }),
+  healthy: i18n.translate('observability.alerting.monitorStateLabel.healthy', {
+    defaultMessage: 'Healthy',
+  }),
+  failing: i18n.translate('observability.alerting.monitorStateLabel.failing', {
+    defaultMessage: 'Failing',
+  }),
+  no_data: i18n.translate('observability.alerting.monitorStateLabel.noData', {
+    defaultMessage: 'No data',
+  }),
+};
+
+/**
+ * Display label for a rule/monitor `status` or `healthStatus`. Returns
+ * {@link EMPTY_VALUE} when absent. Unmapped values are humanized rather than
+ * dropped, so a status the UI doesn't know yet still reads as prose.
+ */
+export function getMonitorStateLabel(value?: string | null): string {
+  if (!value) return EMPTY_VALUE;
+  return MONITOR_STATE_LABELS[value] ?? humanizeUnknown(value);
+}

--- a/public/components/alerting/linkify_annotation.tsx
+++ b/public/components/alerting/linkify_annotation.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Renders an annotation value as a clickable link when it is a safe URL, and
+ * as plain text otherwise. Alert/SLO annotations frequently hold runbook URLs;
+ * on-call engineers need to click through rather than copy-paste (SRE2).
+ *
+ * SECURITY: only `http:`/`https:` URLs are linkified. Any other scheme
+ * (`javascript:`, `data:`, `file:`, …) — or anything the `URL` constructor
+ * rejects — falls back to plain text so we never emit an executable link.
+ */
+
+import React from 'react';
+import { EuiLink } from '@elastic/eui';
+
+const EM_DASH = '—';
+
+/**
+ * True only for absolute `http:`/`https:` URLs. Parsing goes through the `URL`
+ * constructor (throws on relative/garbage input) so scheme validation is done
+ * on the parsed `protocol`, never on a string prefix.
+ */
+export function isSafeHttpUrl(value: string): boolean {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export interface LinkifyAnnotationProps {
+  /** The raw annotation value. */
+  value?: string | null;
+  /** Rendered when the value is empty/whitespace. Defaults to an em dash. */
+  fallback?: string;
+  'data-test-subj'?: string;
+}
+
+export const LinkifyAnnotation: React.FC<LinkifyAnnotationProps> = ({
+  value,
+  fallback = EM_DASH,
+  'data-test-subj': dataTestSubj,
+}) => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) {
+    return <span data-test-subj={dataTestSubj}>{fallback}</span>;
+  }
+  if (isSafeHttpUrl(trimmed)) {
+    // External links open in a new tab; `rel="noreferrer"` also implies
+    // `noopener`, so the opened runbook can't reach back through `window.opener`.
+    return (
+      <EuiLink
+        href={trimmed}
+        target="_blank"
+        rel="noreferrer"
+        external
+        data-test-subj={dataTestSubj}
+      >
+        {trimmed}
+      </EuiLink>
+    );
+  }
+  return <span data-test-subj={dataTestSubj}>{value}</span>;
+};

--- a/public/components/alerting/time_format.ts
+++ b/public/components/alerting/time_format.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import moment from 'moment-timezone';
+import { uiSettingsService } from '../../../common/utils';
+import { EMPTY_VALUE } from './enum_labels';
+
+/**
+ * Timezone-explicit timestamp formatting for alert surfaces.
+ *
+ * `Date#toLocaleString()` renders in the browser's zone and never says which
+ * zone that was, so two engineers reading the same incident see two different
+ * "start" times with no way to tell them apart. Everything here honours the
+ * `dateFormat:tz` advanced setting and labels the zone it rendered in.
+ */
+
+const DEFAULT_TIMESTAMP_FORMAT = 'MMM D, YYYY @ HH:mm:ss';
+
+/**
+ * Resolve the timezone the user configured via `dateFormat:tz`, falling back to
+ * the browser's zone when the setting is unset or left at `Browser`. Mirrors the
+ * resolution Discover and APM use so one instant renders identically everywhere.
+ */
+export function resolveDisplayTz(): string {
+  const tz = uiSettingsService.get('dateFormat:tz');
+  if (!tz || tz === 'Browser') {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+  return tz;
+}
+
+/**
+ * Short label for a zone at a given instant — `UTC`, `PDT`, or a numeric offset
+ * such as `+05:30` for zones without an abbreviation.
+ */
+export function getTimezoneLabel(
+  value: string | number | Date = Date.now(),
+  tz: string = resolveDisplayTz()
+): string {
+  return moment.tz(value, tz).format('z');
+}
+
+export interface FormatTimestampOptions {
+  /** Append the timezone label. Defaults to `true` — that's the point of this helper. */
+  withZone?: boolean;
+  /** moment format string. Defaults to `MMM D, YYYY @ HH:mm:ss`. */
+  format?: string;
+  /** Rendered when the input is missing or unparseable. Defaults to {@link EMPTY_VALUE}. */
+  fallback?: string;
+}
+
+/**
+ * Format an instant in the user's configured timezone, with that zone named.
+ * Returns the fallback (an em dash by default) for missing or unparseable input
+ * rather than the `Invalid date` string moment would otherwise produce.
+ */
+export function formatTimestamp(
+  value?: string | number | Date | null,
+  options: FormatTimestampOptions = {}
+): string {
+  const {
+    withZone = true,
+    format = DEFAULT_TIMESTAMP_FORMAT,
+    fallback = EMPTY_VALUE,
+  } = options;
+
+  if (value === null || value === undefined || value === '') return fallback;
+
+  // Normalise through `Date` first: handing moment an unparseable string makes it
+  // fall back to the `Date` constructor anyway, but with a deprecation warning
+  // that would fire on every malformed timestamp the backend hands us.
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+
+  const tz = resolveDisplayTz();
+  const instant = moment.tz(date, tz);
+  if (!instant.isValid()) return fallback;
+
+  return withZone ? `${instant.format(format)} ${instant.format('z')}` : instant.format(format);
+}

--- a/public/components/alerting/time_format.ts
+++ b/public/components/alerting/time_format.ts
@@ -60,11 +60,7 @@ export function formatTimestamp(
   value?: string | number | Date | null,
   options: FormatTimestampOptions = {}
 ): string {
-  const {
-    withZone = true,
-    format = DEFAULT_TIMESTAMP_FORMAT,
-    fallback = EMPTY_VALUE,
-  } = options;
+  const { withZone = true, format = DEFAULT_TIMESTAMP_FORMAT, fallback = EMPTY_VALUE } = options;
 
   if (value === null || value === undefined || value === '') return fallback;
 

--- a/public/components/apm/pages/slos/__tests__/slo_metadata_panel.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_metadata_panel.test.tsx
@@ -117,6 +117,21 @@ describe('SloMetadataPanel', () => {
     expect(button!.getAttribute('aria-expanded')).toBe('false');
   });
 
+  it('renders a runbook-URL annotation value as a clickable external link (SRE2)', () => {
+    render(<SloMetadataPanel slo={makeSlo()} />);
+    // makeSlo() seeds `annotations: { runbook: 'https://runbooks.example/api' }`.
+    const link = screen.getByText('https://runbooks.example/api');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', 'https://runbooks.example/api');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders a non-URL annotation value as plain text, not a link', () => {
+    render(<SloMetadataPanel slo={makeSlo({ annotations: { note: 'ask oncall' } })} />);
+    const node = screen.getByText('ask oncall');
+    expect(node.tagName).not.toBe('A');
+  });
+
   it('renders empty-state text when labels, annotations, and exclusion windows are missing', () => {
     render(
       <SloMetadataPanel slo={makeSlo({ labels: {}, annotations: {}, exclusionWindows: [] })} />

--- a/public/components/apm/pages/slos/slo_metadata_panel.tsx
+++ b/public/components/apm/pages/slos/slo_metadata_panel.tsx
@@ -36,6 +36,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
+import { LinkifyAnnotation } from '../../../alerting/linkify_annotation';
 import type {
   BudgetWarningThreshold,
   BurnRateConfig,
@@ -129,6 +130,11 @@ const ANNOTATION_COLUMNS: Array<EuiBasicTableColumn<{ key: string; value: string
       defaultMessage: 'Value',
     }),
     width: '70%',
+    // Annotation values are often runbook URLs — render them clickable (safe
+    // http/https only) rather than plain table text (SRE2).
+    render: (value: string) => (
+      <LinkifyAnnotation value={value} data-test-subj="slosDetailMetadataAnnotationValue" />
+    ),
   },
 ];
 


### PR DESCRIPTION
## What & why
The alert-detail flyout contradicted the alerts table it was opened from, for the **same alert**: State/Severity shown as raw enums (`active`/`critical`), timestamps via `toLocaleString()` with no timezone, and the 'Source' row repeating the action label 'Open rule' instead of naming the rule/SLO. Now: Title-cased chips, zone-labelled timestamps (… PDT), the source row names the actual rule/SLO, URL-shaped annotations (runbooks) linkify as external links (**SRE2**), and SLO burn-rate alerts pivot to the SLO detail page (**OBS1**).

**Findings:** SRE2, OBS1, plus flyout↔table parity (State/Severity/timestamps/empty-glyph).

## Before / after

**Before / after**

![Before / after](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR3/before-after.png)

**Flow**

![Flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR3/flow.gif)

## Testing
`alert_detail_flyout.test.tsx` + `linkify_annotation.test.tsx`: 27 tests pass. Centrally green.

## Review
Independent review agent: **APPROVE** — verified the protocol-based XSS gate on linkify (only http/https), the cross-app SLO pivot, and full flyout↔table parity.

## Regression check
The before/after above is a **full-viewport** capture, so adjacent components on the same surface are visible and unchanged — the diff is scoped to what's called out. Cross-component safety is also verified centrally: this change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. Aside from the merge-order note below, it can be reviewed, merged, and reverted independently.

## Dependency
Stacked on #2826 (shared primitives). This branch **includes** #2826's files so it builds and tests standalone in CI; merge #2826 first, then a rebase drops those files from this diff.

> Draft — see the merge-order note above.
