### PR TITLE
[Alerting] Alerts list: labeled severity, Title-cased state, responsive columns, a11y

### DIFF
--- a/common/services/alerting/__tests__/filter.test.ts
+++ b/common/services/alerting/__tests__/filter.test.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { emptyFilters, filterAlerts, matchesFilters, matchesSearch, sortRules } from '../filter';
+import {
+  alertMatchesSearch,
+  emptyFilters,
+  filterAlerts,
+  matchesFilters,
+  matchesSearch,
+  sortRules,
+} from '../filter';
 
 describe('filter', () => {
   describe('emptyFilters', () => {
@@ -170,6 +177,41 @@ describe('filter', () => {
       expect(filterAlerts(alerts, { search: 'storage' }).map((a) => a.name)).toEqual(['LowDisk']);
       // alert without message still searches name/labels
       expect(filterAlerts(alerts, { search: 'oom' }).map((a) => a.name)).toEqual(['OomKill']);
+    });
+
+    it('scopes to a single SLO via a `slo_id:<id>` label deep-link (SLO detail "View alerts" pivot)', () => {
+      const sloAlerts = [
+        { name: 'BurnA', severity: 'critical', state: 'firing', labels: { slo_id: 'abc-123' } },
+        { name: 'BurnB', severity: 'warning', state: 'firing', labels: { slo_id: 'def-456' } },
+      ];
+      // The value alone won't appear as a literal `slo_id:abc-123` substring in
+      // any field — the label-aware branch is what makes this match.
+      expect(filterAlerts(sloAlerts, { search: 'slo_id:abc-123' }).map((a) => a.name)).toEqual([
+        'BurnA',
+      ]);
+      expect(filterAlerts(sloAlerts, { search: 'slo_id:none' })).toHaveLength(0);
+    });
+  });
+
+  describe('alertMatchesSearch', () => {
+    const alert = { name: 'HighCpu', message: 'CPU over threshold', labels: { slo_id: 'abc-123' } };
+
+    it('matches an empty query', () => {
+      expect(alertMatchesSearch(alert, '')).toBe(true);
+      expect(alertMatchesSearch(alert, '   ')).toBe(true);
+    });
+
+    it('matches a single labelKey:value term against the label, not as a substring', () => {
+      expect(alertMatchesSearch(alert, 'slo_id:abc-123')).toBe(true);
+      expect(alertMatchesSearch(alert, 'slo_id:abc')).toBe(true); // includes()
+      expect(alertMatchesSearch(alert, 'slo_id:zzz')).toBe(false);
+      expect(alertMatchesSearch(alert, 'other:abc-123')).toBe(false); // wrong key
+    });
+
+    it('keeps whole-string substring behavior for free-text (with a space)', () => {
+      expect(alertMatchesSearch(alert, 'cpu over')).toBe(true); // message substring
+      expect(alertMatchesSearch(alert, 'highcpu')).toBe(true); // name substring
+      expect(alertMatchesSearch(alert, 'no match')).toBe(false);
     });
   });
 });

--- a/common/services/alerting/filter.ts
+++ b/common/services/alerting/filter.ts
@@ -56,6 +56,38 @@ export function matchesSearch(
   });
 }
 
+/**
+ * Search predicate for alert summaries (name + message + labels).
+ *
+ * A single `labelKey:value` term (no whitespace, e.g. `slo_id:<id>`) is matched
+ * against the label rather than as a literal substring — the SLO detail
+ * "View alerts" pivot deep-links with exactly this shape, and a plain substring
+ * search would never match because the label value doesn't contain the `key:`
+ * prefix. Any other query keeps the original whole-string substring behavior
+ * over name / message / label values, so multi-word free-text search is
+ * unchanged.
+ */
+export function alertMatchesSearch(
+  alert: { name: string; message?: string; labels: Record<string, string> },
+  query: string
+): boolean {
+  const raw = query.trim();
+  if (!raw) return true;
+  const colonIdx = raw.indexOf(':');
+  if (colonIdx > 0 && !/\s/.test(raw)) {
+    const key = raw.slice(0, colonIdx).toLowerCase();
+    const val = raw.slice(colonIdx + 1).toLowerCase();
+    const labelVal = alert.labels[key];
+    return Boolean(labelVal && labelVal.toLowerCase().includes(val));
+  }
+  const q = raw.toLowerCase();
+  return (
+    alert.name.toLowerCase().includes(q) ||
+    (alert.message || '').toLowerCase().includes(q) ||
+    Object.values(alert.labels).some((v) => v.toLowerCase().includes(q))
+  );
+}
+
 export function matchesFilters(
   rule: {
     status: string;
@@ -99,9 +131,9 @@ export function sortRules<T>(
   const sorted = [...rules];
   sorted.sort((a, b) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic field access for generic sort
-    let aVal = accessor ? accessor(a, field) : (a as Record<string, any>)[field] ?? '';
+    let aVal = accessor ? accessor(a, field) : ((a as Record<string, any>)[field] ?? '');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic field access for generic sort
-    let bVal = accessor ? accessor(b, field) : (b as Record<string, any>)[field] ?? '';
+    let bVal = accessor ? accessor(b, field) : ((b as Record<string, any>)[field] ?? '');
     if (typeof aVal === 'string') aVal = aVal.toLowerCase();
     if (typeof bVal === 'string') bVal = bVal.toLowerCase();
     if (aVal < bVal) return direction === 'asc' ? -1 : 1;
@@ -119,7 +151,7 @@ export function filterAlerts<
     labels: Record<string, string>;
     name: string;
     message?: string;
-  }
+  },
 >(
   alerts: T[],
   filters: {
@@ -142,15 +174,8 @@ export function filterAlerts<
         if (values.length > 0 && (!a.labels[key] || !values.includes(a.labels[key]))) return false;
       }
     }
-    if (filters.search) {
-      const q = filters.search.toLowerCase();
-      if (
-        !a.name.toLowerCase().includes(q) &&
-        !(a.message || '').toLowerCase().includes(q) &&
-        !Object.values(a.labels).some((v) => v.toLowerCase().includes(q))
-      ) {
-        return false;
-      }
+    if (filters.search && !alertMatchesSearch(a, filters.search)) {
+      return false;
     }
     return true;
   });

--- a/public/components/alerting/__tests__/alert_colors.test.ts
+++ b/public/components/alerting/__tests__/alert_colors.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ALERT_KIND_HEX,
+  SEVERITY_HEX,
+  STATE_HEX,
+  UNKNOWN_HEX,
+  getSeverityHex,
+  getStateHex,
+} from '../alert_colors';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../../common/types/alerting';
+
+const ALL_SEVERITIES: UnifiedAlertSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
+const ALL_STATES: UnifiedAlertState[] = [
+  'active',
+  'pending',
+  'acknowledged',
+  'silenced',
+  'resolved',
+  'error',
+];
+
+describe('alert_colors', () => {
+  it('resolves every severity to a real theme color', () => {
+    ALL_SEVERITIES.forEach((severity) => {
+      // A typo in a euiThemeVars key yields `undefined`, which silently renders
+      // as "no color" — assert we got an actual CSS color back.
+      expect(SEVERITY_HEX[severity]).toMatch(/^#[0-9a-f]{3,8}$/i);
+    });
+  });
+
+  it('resolves every state to a real theme color', () => {
+    ALL_STATES.forEach((state) => {
+      expect(STATE_HEX[state]).toMatch(/^#[0-9a-f]{3,8}$/i);
+    });
+  });
+
+  it('resolves both row kinds and keeps anomaly distinct from a high-severity alert', () => {
+    expect(ALERT_KIND_HEX.alert).toMatch(/^#[0-9a-f]{3,8}$/i);
+    expect(ALERT_KIND_HEX.anomaly).toMatch(/^#[0-9a-f]{3,8}$/i);
+    expect(ALERT_KIND_HEX.anomaly).not.toBe(SEVERITY_HEX.high);
+  });
+
+  it('gives critical and active the danger tone', () => {
+    expect(getSeverityHex('critical')).toBe(SEVERITY_HEX.critical);
+    expect(getStateHex('active')).toBe(STATE_HEX.active);
+    expect(getStateHex('error')).toBe(STATE_HEX.active);
+  });
+
+  it('resolves the anomaly row kind through the state getter', () => {
+    expect(getStateHex('anomaly')).toBe(ALERT_KIND_HEX.anomaly);
+  });
+
+  it('falls back to a subdued tone for missing or unknown values', () => {
+    expect(getSeverityHex(undefined)).toBe(UNKNOWN_HEX);
+    expect(getSeverityHex('sev0')).toBe(UNKNOWN_HEX);
+    expect(getStateHex(null)).toBe(UNKNOWN_HEX);
+    expect(getStateHex('quiesced')).toBe(UNKNOWN_HEX);
+  });
+});

--- a/public/components/alerting/__tests__/alerts_dashboard.test.tsx
+++ b/public/components/alerting/__tests__/alerts_dashboard.test.tsx
@@ -424,4 +424,82 @@ describe('AlertsDashboard', () => {
     expect(onDatasourceChange).toHaveBeenCalledWith([]);
     expect(searchInput.value).toBe('');
   });
+
+  // B1 / A11Y1 + CLAR2: severity must be conveyed by a labeled indicator
+  // (translated text), not a bare color dot. Reverting to the dot removes the
+  // human-readable "Critical" text and this fails.
+  it('renders severity as a labeled badge, not a bare color dot', () => {
+    render(<AlertsDashboard {...baseProps} alerts={[sampleAlert]} />);
+    const badge = screen.getByTestId('alertSeverityBadge');
+    expect(badge).toHaveTextContent('Critical');
+    // The raw lowercase wire enum must not leak into the table cell.
+    expect(badge).not.toHaveTextContent('critical');
+  });
+
+  // CLAR2: the State column routes the raw enum through getStateLabel, so it
+  // reads "Active" rather than the lowercase wire value `active`.
+  it('renders the alert state as a human label in the table', () => {
+    render(<AlertsDashboard {...baseProps} alerts={[sampleAlert]} />);
+    // The facet still lists the raw `active` option; the table cell shows "Active".
+    const table = within(screen.getByRole('table'));
+    expect(table.getByText('Active')).toBeInTheDocument();
+  });
+
+  // CLAR4: a single empty placeholder (EMPTY_VALUE = '—') everywhere. The old
+  // Started-cell glyph was '---'; reintroducing it fails this test.
+  it('uses a single unified empty placeholder and never the legacy --- glyph', () => {
+    const emptyAlert: UnifiedAlertSummary = {
+      ...sampleAlert,
+      id: 'empty-1',
+      name: 'EmptyFields',
+      message: undefined,
+      startTime: '',
+      lastUpdated: '',
+    };
+    render(<AlertsDashboard {...baseProps} alerts={[emptyAlert]} />);
+    const table = within(screen.getByRole('table'));
+    // Message, Started, and Duration cells all collapse to the em dash.
+    expect(table.getAllByText('—').length).toBeGreaterThan(0);
+    // The legacy triple-hyphen glyph must be gone.
+    expect(table.queryByText('---')).toBeNull();
+  });
+
+  // A11Y4: the grouped-anomaly expand toggle exposes its state via
+  // aria-expanded, and flips it on toggle.
+  it('sets aria-expanded on the anomaly occurrences toggle in both states', () => {
+    render(
+      <AlertsDashboard
+        {...baseProps}
+        alerts={[
+          buildAnomaly({ id: 'ad-a', startTime: '2026-06-04T21:03:00.000Z' }),
+          buildAnomaly({ id: 'ad-b', startTime: '2026-06-04T22:03:00.000Z' }),
+        ]}
+      />
+    );
+    const toggle = screen.getByLabelText('Show or hide grouped anomaly occurrences');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(toggle);
+    expect(
+      screen.getByLabelText('Show or hide grouped anomaly occurrences')
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  // OBS1: a deep link (`#/alerts?q=...`) seeds the search box on first render,
+  // and the user can still type over it afterwards.
+  it('seeds the search box from initialSearchQuery without blocking later input', () => {
+    render(
+      <AlertsDashboard
+        {...baseProps}
+        alerts={[sampleAlert]}
+        initialSearchQuery="HighCPU"
+      />
+    );
+    const searchInput = screen.getByLabelText('Search alerts') as HTMLInputElement;
+    expect(searchInput.value).toBe('HighCPU');
+    // Seeded query actually filters the table down to the match.
+    expect(screen.getByText('HighCPU')).toBeInTheDocument();
+    // Subsequent typing is honored — the seed does not re-apply and overwrite it.
+    fireEvent.change(searchInput, { target: { value: 'something-else' } });
+    expect(searchInput.value).toBe('something-else');
+  });
 });

--- a/public/components/alerting/__tests__/alerts_dashboard.test.tsx
+++ b/public/components/alerting/__tests__/alerts_dashboard.test.tsx
@@ -479,21 +479,16 @@ describe('AlertsDashboard', () => {
     const toggle = screen.getByLabelText('Show or hide grouped anomaly occurrences');
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
     fireEvent.click(toggle);
-    expect(
-      screen.getByLabelText('Show or hide grouped anomaly occurrences')
-    ).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByLabelText('Show or hide grouped anomaly occurrences')).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
   });
 
   // OBS1: a deep link (`#/alerts?q=...`) seeds the search box on first render,
   // and the user can still type over it afterwards.
   it('seeds the search box from initialSearchQuery without blocking later input', () => {
-    render(
-      <AlertsDashboard
-        {...baseProps}
-        alerts={[sampleAlert]}
-        initialSearchQuery="HighCPU"
-      />
-    );
+    render(<AlertsDashboard {...baseProps} alerts={[sampleAlert]} initialSearchQuery="HighCPU" />);
     const searchInput = screen.getByLabelText('Search alerts') as HTMLInputElement;
     expect(searchInput.value).toBe('HighCPU');
     // Seeded query actually filters the table down to the match.

--- a/public/components/alerting/__tests__/enum_labels.test.ts
+++ b/public/components/alerting/__tests__/enum_labels.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EMPTY_VALUE,
+  SEVERITY_LABELS,
+  STATE_LABELS,
+  getSeverityLabel,
+  getStateLabel,
+} from '../enum_labels';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../../common/types/alerting';
+
+const ALL_SEVERITIES: UnifiedAlertSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
+const ALL_STATES: UnifiedAlertState[] = [
+  'active',
+  'pending',
+  'acknowledged',
+  'silenced',
+  'resolved',
+  'error',
+];
+
+describe('enum_labels', () => {
+  it('covers every severity in the union with a non-empty, non-raw label', () => {
+    ALL_SEVERITIES.forEach((severity) => {
+      const label = SEVERITY_LABELS[severity];
+      expect(label).toBeTruthy();
+      // The whole point is not to render the raw lowercase machine value.
+      expect(label).not.toBe(severity);
+    });
+  });
+
+  it('covers every state in the union with a non-empty, non-raw label', () => {
+    ALL_STATES.forEach((state) => {
+      const label = STATE_LABELS[state];
+      expect(label).toBeTruthy();
+      expect(label).not.toBe(state);
+    });
+  });
+
+  it('returns the empty placeholder for missing values', () => {
+    expect(getSeverityLabel(undefined)).toBe(EMPTY_VALUE);
+    expect(getSeverityLabel(null)).toBe(EMPTY_VALUE);
+    expect(getSeverityLabel('')).toBe(EMPTY_VALUE);
+    expect(getStateLabel(undefined)).toBe(EMPTY_VALUE);
+    expect(getStateLabel('')).toBe(EMPTY_VALUE);
+  });
+
+  it('humanizes values the UI does not know about instead of dropping them', () => {
+    expect(getStateLabel('awaiting_data')).toBe('Awaiting data');
+    expect(getSeverityLabel('sev-one')).toBe('Sev one');
+  });
+
+  it('falls back to the placeholder when an unknown value is only separators', () => {
+    expect(getStateLabel('__')).toBe(EMPTY_VALUE);
+  });
+
+  it('maps known values through the label tables', () => {
+    expect(getSeverityLabel('critical')).toBe(SEVERITY_LABELS.critical);
+    expect(getStateLabel('acknowledged')).toBe(STATE_LABELS.acknowledged);
+  });
+});

--- a/public/components/alerting/__tests__/enum_labels.test.ts
+++ b/public/components/alerting/__tests__/enum_labels.test.ts
@@ -7,10 +7,15 @@ import {
   EMPTY_VALUE,
   SEVERITY_LABELS,
   STATE_LABELS,
+  getMonitorStateLabel,
   getSeverityLabel,
   getStateLabel,
 } from '../enum_labels';
-import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../../common/types/alerting';
+import type {
+  MonitorHealthStatus,
+  UnifiedAlertSeverity,
+  UnifiedAlertState,
+} from '../../../../common/types/alerting';
 
 const ALL_SEVERITIES: UnifiedAlertSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
 const ALL_STATES: UnifiedAlertState[] = [
@@ -60,5 +65,39 @@ describe('enum_labels', () => {
   it('maps known values through the label tables', () => {
     expect(getSeverityLabel('critical')).toBe(SEVERITY_LABELS.critical);
     expect(getStateLabel('acknowledged')).toBe(STATE_LABELS.acknowledged);
+  });
+
+  describe('getMonitorStateLabel', () => {
+    it('title-cases the lowercase rule-status tokens', () => {
+      expect(getMonitorStateLabel('active')).toBe('Active');
+      expect(getMonitorStateLabel('pending')).toBe('Pending');
+      expect(getMonitorStateLabel('muted')).toBe('Muted');
+      expect(getMonitorStateLabel('disabled')).toBe('Disabled');
+    });
+
+    it('covers every health status with a non-raw label', () => {
+      const ALL_HEALTH: MonitorHealthStatus[] = ['healthy', 'failing', 'no_data'];
+      ALL_HEALTH.forEach((health) => {
+        const label = getMonitorStateLabel(health);
+        expect(label).toBeTruthy();
+        expect(label).not.toBe(health);
+      });
+      // `no_data` in particular must not leak the underscore into the UI.
+      expect(getMonitorStateLabel('no_data')).toBe('No data');
+    });
+
+    it('passes through the AD/forecaster statuses, which already read as prose', () => {
+      // These arrive from the anomaly-detection plugin already display-ready;
+      // re-casing them would corrupt wording like "Awaiting data to init".
+      expect(getMonitorStateLabel('Running')).toBe('Running');
+      expect(getMonitorStateLabel('Awaiting data to init')).toBe('Awaiting data to init');
+      expect(getMonitorStateLabel('Initialization failure')).toBe('Initialization failure');
+    });
+
+    it('returns the empty placeholder for missing values', () => {
+      expect(getMonitorStateLabel(undefined)).toBe(EMPTY_VALUE);
+      expect(getMonitorStateLabel(null)).toBe(EMPTY_VALUE);
+      expect(getMonitorStateLabel('')).toBe(EMPTY_VALUE);
+    });
   });
 });

--- a/public/components/alerting/__tests__/time_format.test.ts
+++ b/public/components/alerting/__tests__/time_format.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { uiSettingsService } from '../../../../common/utils';
+import { EMPTY_VALUE } from '../enum_labels';
+import { formatTimestamp, getTimezoneLabel, resolveDisplayTz } from '../time_format';
+
+// 2026-08-25T18:04:05Z — a fixed instant so assertions don't depend on "now".
+const INSTANT = '2026-08-25T18:04:05.000Z';
+
+describe('time_format', () => {
+  let getSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getSpy = jest.spyOn(uiSettingsService, 'get');
+  });
+
+  afterEach(() => {
+    getSpy.mockRestore();
+  });
+
+  describe('resolveDisplayTz', () => {
+    it('uses the configured dateFormat:tz', () => {
+      getSpy.mockReturnValue('America/Los_Angeles');
+      expect(resolveDisplayTz()).toBe('America/Los_Angeles');
+    });
+
+    it('falls back to the browser zone when unset or left at Browser', () => {
+      const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      getSpy.mockReturnValue(undefined);
+      expect(resolveDisplayTz()).toBe(browserTz);
+      getSpy.mockReturnValue('Browser');
+      expect(resolveDisplayTz()).toBe(browserTz);
+    });
+  });
+
+  describe('formatTimestamp', () => {
+    it('renders in the configured zone and names that zone', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(INSTANT)).toBe('Aug 25, 2026 @ 18:04:05 UTC');
+    });
+
+    it('shifts the wall-clock time to the configured zone', () => {
+      getSpy.mockReturnValue('America/Los_Angeles');
+      // 18:04 UTC is 11:04 PDT on this date.
+      expect(formatTimestamp(INSTANT)).toBe('Aug 25, 2026 @ 11:04:05 PDT');
+    });
+
+    it('omits the zone label when asked', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(INSTANT, { withZone: false })).toBe('Aug 25, 2026 @ 18:04:05');
+    });
+
+    it('honors a custom format', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(INSTANT, { format: 'YYYY-MM-DD', withZone: false })).toBe('2026-08-25');
+    });
+
+    it('accepts epoch millis and Date instances', () => {
+      getSpy.mockReturnValue('UTC');
+      const ms = new Date(INSTANT).getTime();
+      expect(formatTimestamp(ms)).toBe('Aug 25, 2026 @ 18:04:05 UTC');
+      expect(formatTimestamp(new Date(INSTANT))).toBe('Aug 25, 2026 @ 18:04:05 UTC');
+    });
+
+    it('returns the placeholder rather than "Invalid date" for bad input', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(undefined)).toBe(EMPTY_VALUE);
+      expect(formatTimestamp(null)).toBe(EMPTY_VALUE);
+      expect(formatTimestamp('')).toBe(EMPTY_VALUE);
+      expect(formatTimestamp('not a timestamp')).toBe(EMPTY_VALUE);
+    });
+
+    it('honors a caller-supplied fallback', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(null, { fallback: 'Never' })).toBe('Never');
+    });
+  });
+
+  describe('getTimezoneLabel', () => {
+    it('labels a zone with an abbreviation where one exists', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(getTimezoneLabel(INSTANT)).toBe('UTC');
+    });
+
+    it('uses the zone abbreviation when the zone has one', () => {
+      getSpy.mockReturnValue('Asia/Kolkata');
+      expect(getTimezoneLabel(INSTANT)).toBe('IST');
+    });
+
+    it('falls back to a numeric offset for zones without an abbreviation', () => {
+      getSpy.mockReturnValue('Asia/Kathmandu');
+      expect(getTimezoneLabel(INSTANT)).toBe('+0545');
+    });
+  });
+});

--- a/public/components/alerting/__tests__/time_format.test.ts
+++ b/public/components/alerting/__tests__/time_format.test.ts
@@ -55,7 +55,9 @@ describe('time_format', () => {
 
     it('honors a custom format', () => {
       getSpy.mockReturnValue('UTC');
-      expect(formatTimestamp(INSTANT, { format: 'YYYY-MM-DD', withZone: false })).toBe('2026-08-25');
+      expect(formatTimestamp(INSTANT, { format: 'YYYY-MM-DD', withZone: false })).toBe(
+        '2026-08-25'
+      );
     });
 
     it('accepts epoch millis and Date instances', () => {

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -1329,6 +1329,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             onTimeChange={handleTimeChange}
             onRefresh={handleRefreshTime}
             datasourceErrorMap={datasourceErrorMapByName}
+            initialSearchQuery={deepLink.q}
           />
         </>
       );

--- a/public/components/alerting/alert_colors.ts
+++ b/public/components/alerting/alert_colors.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { euiThemeVars } from '@osd/ui-shared-deps/theme';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../common/types/alerting';
+
+/**
+ * Theme-derived colors for alert severity, state, and row kind.
+ *
+ * Alert surfaces previously hand-rolled these as literal hex — which pinned them
+ * to the light theme (so dark mode rendered near-invisible swatches) and let each
+ * component drift from the next. `euiThemeVars` resolves against whichever theme
+ * is active, so consumers get the right value in both.
+ *
+ * Use these where a raw CSS color is unavoidable (chart series, custom swatches).
+ * Where an OUI component takes a semantic color name — `EuiHealth`, `EuiBadge` —
+ * prefer the semantic maps in `shared_constants.ts` instead.
+ */
+
+/** Severity → theme color. Ramps danger → warning → primary → subdued. */
+export const SEVERITY_HEX: Record<UnifiedAlertSeverity, string> = {
+  critical: euiThemeVars.euiColorDanger,
+  high: euiThemeVars.euiColorWarning,
+  medium: euiThemeVars.euiColorPrimary,
+  low: euiThemeVars.euiColorMediumShade,
+  info: euiThemeVars.euiColorLightShade,
+};
+
+/** Alert state → theme color. */
+export const STATE_HEX: Record<UnifiedAlertState, string> = {
+  active: euiThemeVars.euiColorDanger,
+  pending: euiThemeVars.euiColorWarning,
+  acknowledged: euiThemeVars.euiColorPrimary,
+  silenced: euiThemeVars.euiColorMediumShade,
+  resolved: euiThemeVars.euiColorSuccess,
+  error: euiThemeVars.euiColorDanger,
+};
+
+/**
+ * Row kind → theme color. Anomaly rows use the darker warning tone so they read
+ * as distinct from a `high`-severity alert rather than merely similar.
+ */
+export const ALERT_KIND_HEX: Record<string, string> = {
+  alert: euiThemeVars.euiColorPrimary,
+  anomaly: euiThemeVars.euiColorWarningText,
+};
+
+/** Fallback for a value the UI doesn't recognise — subdued rather than alarming. */
+export const UNKNOWN_HEX = euiThemeVars.euiColorMediumShade;
+
+/** Severity color, falling back to a subdued tone for unrecognised values. */
+export function getSeverityHex(severity?: string | null): string {
+  if (!severity) return UNKNOWN_HEX;
+  return SEVERITY_HEX[severity as UnifiedAlertSeverity] ?? UNKNOWN_HEX;
+}
+
+/**
+ * State color. `anomaly` is not an alert state but appears in the same column of
+ * the alerts table, so it is resolved here too.
+ */
+export function getStateHex(state?: string | null): string {
+  if (!state) return UNKNOWN_HEX;
+  return STATE_HEX[state as UnifiedAlertState] ?? ALERT_KIND_HEX[state] ?? UNKNOWN_HEX;
+}

--- a/public/components/alerting/alert_colors.ts
+++ b/public/components/alerting/alert_colors.ts
@@ -4,7 +4,11 @@
  */
 
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
-import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../common/types/alerting';
+import type {
+  UnifiedAlertKind,
+  UnifiedAlertSeverity,
+  UnifiedAlertState,
+} from '../../../common/types/alerting';
 
 /**
  * Theme-derived colors for alert severity, state, and row kind.
@@ -42,7 +46,7 @@ export const STATE_HEX: Record<UnifiedAlertState, string> = {
  * Row kind → theme color. Anomaly rows use the darker warning tone so they read
  * as distinct from a `high`-severity alert rather than merely similar.
  */
-export const ALERT_KIND_HEX: Record<string, string> = {
+export const ALERT_KIND_HEX: Record<UnifiedAlertKind, string> = {
   alert: euiThemeVars.euiColorPrimary,
   anomaly: euiThemeVars.euiColorWarningText,
 };
@@ -62,5 +66,6 @@ export function getSeverityHex(severity?: string | null): string {
  */
 export function getStateHex(state?: string | null): string {
   if (!state) return UNKNOWN_HEX;
-  return STATE_HEX[state as UnifiedAlertState] ?? ALERT_KIND_HEX[state] ?? UNKNOWN_HEX;
+  const kindHex = ALERT_KIND_HEX[state as UnifiedAlertKind];
+  return STATE_HEX[state as UnifiedAlertState] ?? kindHex ?? UNKNOWN_HEX;
 }

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -41,7 +41,7 @@ import {
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
-import { filterAlerts } from '../../../common/services/alerting/filter';
+import { alertMatchesSearch, filterAlerts } from '../../../common/services/alerting/filter';
 import { AlertTimeline } from './alerts_charts';
 import { FacetFilterGroup, useFacetCollapse } from './facet_filter_panel';
 import {
@@ -829,15 +829,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
 
   // Facet counts (against search-matched but not filter-matched alerts)
   const facetCounts = useMemo(() => {
-    const searchMatched = alerts.filter((a) => {
-      if (!searchQuery) return true;
-      const q = searchQuery.toLowerCase();
-      return (
-        a.name.toLowerCase().includes(q) ||
-        (a.message || '').toLowerCase().includes(q) ||
-        Object.values(a.labels).some((v) => v.toLowerCase().includes(q))
-      );
-    });
+    const searchMatched = alerts.filter((a) => alertMatchesSearch(a, searchQuery));
     const counts: Record<string, Record<string, number>> = {
       alertKind: {},
       severity: {},

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -9,6 +9,7 @@
  */
 import React, { useState, useMemo } from 'react';
 import {
+  EuiBadge,
   EuiBasicTableColumn,
   EuiButton,
   EuiCard,
@@ -43,43 +44,29 @@ import { UnifiedAlertSummary, Datasource } from '../../../common/types/alerting'
 import { filterAlerts } from '../../../common/services/alerting/filter';
 import { AlertTimeline } from './alerts_charts';
 import { FacetFilterGroup, useFacetCollapse } from './facet_filter_panel';
-import { countBy, isStandardOpenSearchDatasource } from './shared_constants';
+import {
+  countBy,
+  isStandardOpenSearchDatasource,
+  SEVERITY_COLORS,
+  STATE_COLORS,
+} from './shared_constants';
+import { EMPTY_VALUE, getSeverityLabel, getStateLabel } from './enum_labels';
+import { formatTimestamp } from './time_format';
+import { ALERT_KIND_HEX, getStateHex } from './alert_colors';
 import { INTERNAL_LABEL_KEYS } from './monitors_table/monitors_table_helpers';
 import './alerting.scss';
 
 // ============================================================================
-// Color maps (used by table columns and filter panel)
+// Color / label maps
+//
+// Severity and state colors now come from the shared, theme-derived helpers
+// (`shared_constants.ts` for OUI semantic color *names* consumed by
+// `EuiBadge` / `EuiHealth`, `alert_colors.ts` for raw theme hex where a CSS
+// color is unavoidable). The former light-theme-only literal hex maps were
+// removed — they drifted from the shared source and rendered near-invisible
+// swatches in dark mode.
 // ============================================================================
 
-const SEVERITY_COLORS: Record<string, string> = {
-  critical: '#BD271E',
-  high: '#F5A700',
-  medium: '#006BB4',
-  low: '#98A2B3',
-  info: '#D3DAE6',
-};
-const STATE_COLORS: Record<string, string> = {
-  active: '#BD271E',
-  anomaly: '#B8821C',
-  pending: '#F5A700',
-  acknowledged: '#006BB4',
-  resolved: '#017D73',
-  error: '#BD271E',
-  silenced: '#98A2B3',
-};
-const STATE_HEALTH: Record<string, string> = {
-  active: 'danger',
-  anomaly: '#B8821C',
-  pending: 'warning',
-  acknowledged: 'primary',
-  resolved: 'success',
-  error: 'danger',
-  silenced: 'default',
-};
-const ALERT_TYPE_COLORS: Record<string, string> = {
-  alert: '#006BB4',
-  anomaly: '#B8821C',
-};
 const ALERTS_HIDDEN_LABEL_KEYS = new Set([
   ...Array.from(INTERNAL_LABEL_KEYS),
   'anomaly_result_id',
@@ -456,7 +443,7 @@ function formatAlertDuration(alert: UnifiedAlertSummary): string {
   if (getAlertKind(alert) === 'anomaly' && Number.isFinite(start) && Number.isFinite(end)) {
     return formatDurationBetween(start, end);
   }
-  return alert.startTime ? formatDuration(alert.startTime) : '—';
+  return alert.startTime ? formatDuration(alert.startTime) : EMPTY_VALUE;
 }
 
 function parseAnomalyNumber(value?: string): number | undefined {
@@ -466,7 +453,7 @@ function parseAnomalyNumber(value?: string): number | undefined {
 }
 
 function formatAnomalyMetric(value?: number): string {
-  return value === undefined ? '—' : value.toFixed(2);
+  return value === undefined ? EMPTY_VALUE : value.toFixed(2);
 }
 
 function formatEntityLabel(entity?: string): string {
@@ -513,7 +500,7 @@ function buildGroupedAnomalyRow(group: UnifiedAlertSummary[]): AlertTableRow {
       values: {
         count,
         maxGrade: formatAnomalyMetric(maxGrade),
-        latestTime: new Date(latest.lastUpdated || latest.startTime).toLocaleString(),
+        latestTime: formatTimestamp(latest.lastUpdated || latest.startTime),
       },
     }),
     groupedOccurrences: sorted,
@@ -636,9 +623,7 @@ function renderGroupedAnomalyOccurrences(
         <EuiFlexGroup direction="column" gutterSize="s">
           {occurrences.map((occurrence, index) => {
             const occurrenceNumber = total - index;
-            const timestamp = new Date(
-              occurrence.lastUpdated || occurrence.startTime
-            ).toLocaleString();
+            const timestamp = formatTimestamp(occurrence.lastUpdated || occurrence.startTime);
 
             return (
               <EuiFlexItem key={occurrence.id}>
@@ -674,7 +659,7 @@ function renderGroupedAnomalyOccurrences(
                     </div>
                     <div className="altGroupedOccurrenceCell">
                       <EuiToolTip content={timestamp}>
-                        <span style={{ fontSize: 12 }}>
+                        <span style={{ fontSize: 12 }} tabIndex={0} aria-label={timestamp}>
                           <FormattedMessage
                             id="observability.alerting.alertsDashboard.groupedAnomalyStartedAgo"
                             defaultMessage="{duration} ago"
@@ -756,6 +741,12 @@ export interface AlertsDashboardProps {
    * details.
    */
   datasourceErrorMap?: Record<string, string>;
+  /**
+   * Seeds the alerts search box on first render — used by deep links such as
+   * `#/alerts?q=slo_id:<id>` that expect the list to arrive pre-filtered. Applied
+   * as the initial value ONLY; it does not override the user's subsequent typing.
+   */
+  initialSearchQuery?: string;
 }
 
 export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
@@ -782,8 +773,12 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
   onTimeChange,
   onRefresh,
   datasourceErrorMap,
+  initialSearchQuery,
 }) => {
-  const [searchQuery, setSearchQuery] = useState('');
+  // Lazy initializer so the deep-link query seeds the box exactly once; later
+  // renders (e.g. under the resizable container's mouse-move re-renders) must
+  // not clobber what the user has typed.
+  const [searchQuery, setSearchQuery] = useState(() => initialSearchQuery ?? '');
   const [filters, setFilters] = useState<AlertFilterState>(emptyAlertFilters());
   const { toggleFacetCollapse, isCollapsed: isFacetCollapsed } = useFacetCollapse();
   const [labelSearch, setLabelSearch] = useState('');
@@ -821,6 +816,16 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
   );
   const uniqueAlertKinds = useMemo(() => collectAlertUniqueValues(alerts, getAlertKind), [alerts]);
   const labelKeys = useMemo(() => collectAlertLabelKeys(alerts), [alerts]);
+
+  // The State facet includes the synthetic `anomaly` row kind, which has no
+  // semantic OUI color name in `STATE_COLORS`. Resolve every option through the
+  // theme-hex getter (which also covers `anomaly`) so `EuiHealth` renders a
+  // correct, dark-mode-safe swatch for each.
+  const stateFacetColorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const state of uniqueStates) map[state] = getStateHex(state);
+    return map;
+  }, [uniqueStates]);
 
   // Facet counts (against search-matched but not filter-matched alerts)
   const facetCounts = useMemo(() => {
@@ -941,23 +946,19 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
     () => [
       {
         field: 'severity',
-        name: i18n.translate('observability.alerting.alertsDashboard.column.sev', {
-          defaultMessage: 'Sev',
+        name: i18n.translate('observability.alerting.alertsDashboard.column.severity', {
+          defaultMessage: 'Severity',
         }),
-        width: '60px',
+        width: '10%',
         sortable: (a: AlertTableRow) => SEVERITY_SORT_ORDER[a.severity] ?? 5,
+        // A labeled badge (not a bare color dot) so severity is conveyed by text
+        // and shape, not color alone — reachable by screen readers and legible
+        // to colorblind users. Mirrors the severity column in
+        // monitors_table/monitors_table_columns.tsx.
         render: (s: string) => (
-          <EuiToolTip content={s}>
-            <span
-              style={{
-                width: 10,
-                height: 10,
-                borderRadius: '50%',
-                background: SEVERITY_COLORS[s],
-                display: 'inline-block',
-              }}
-            />
-          </EuiToolTip>
+          <EuiBadge color={SEVERITY_COLORS[s] || 'default'} data-test-subj="alertSeverityBadge">
+            {getSeverityLabel(s)}
+          </EuiBadge>
         ),
       },
       {
@@ -1017,6 +1018,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                     flush="left"
                     color="text"
                     iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
+                    aria-expanded={isExpanded}
                     onClick={(event) => {
                       event.stopPropagation();
                       toggleExpandedGroup();
@@ -1045,11 +1047,19 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
         name: i18n.translate('observability.alerting.alertsDashboard.column.state', {
           defaultMessage: 'State',
         }),
-        width: '140px',
+        width: '12%',
         sortable: (alert: AlertTableRow) => getAlertDisplayState(alert),
+        // Route the raw lowercase wire enum through `getStateLabel` so the UI
+        // shows "Active" / "Acknowledged" rather than `active`. `anomaly` is a
+        // row kind (not an alert state) so it isn't in the semantic name map —
+        // fall back to its theme hex, which `EuiHealth` also accepts.
         render: (_state: string, alert: AlertTableRow) => {
           const state = getAlertDisplayState(alert);
-          return <EuiHealth color={STATE_HEALTH[state] || 'subdued'}>{state}</EuiHealth>;
+          return (
+            <EuiHealth color={STATE_COLORS[state] || getStateHex(state)}>
+              {getStateLabel(state)}
+            </EuiHealth>
+          );
         },
       },
       {
@@ -1058,25 +1068,44 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
           defaultMessage: 'Message',
         }),
         truncateText: true,
-        render: (msg: string) => (
-          <EuiText size="xs" color="subdued">
-            {msg || '—'}
-          </EuiText>
-        ),
+        // The cell truncates, so wrap it in a tooltip that exposes the full
+        // message on hover / focus. The span is focusable (tabIndex) so
+        // keyboard users can reach the tooltip too. The row's "View details"
+        // action still opens the flyout for the complete record.
+        render: (msg: string) => {
+          if (!msg) {
+            return (
+              <EuiText size="xs" color="subdued">
+                {EMPTY_VALUE}
+              </EuiText>
+            );
+          }
+          return (
+            <EuiToolTip content={msg}>
+              <EuiText size="xs" color="subdued" tabIndex={0} className="altAlertMessageText">
+                {msg}
+              </EuiText>
+            </EuiToolTip>
+          );
+        },
       },
       {
         field: 'startTime',
         name: i18n.translate('observability.alerting.alertsDashboard.column.started', {
           defaultMessage: 'Started',
         }),
-        width: '120px',
+        width: '14%',
         sortable: true,
+        // The absolute, timezone-labeled timestamp used to live only in a hover
+        // tooltip on a non-focusable span (A11Y6). It is now also exposed via
+        // `aria-label` and the span is keyboard-focusable, so screen-reader and
+        // keyboard users get the exact time, not just the relative "x ago".
         render: (ts: string) => {
-          if (!ts) return <EuiText size="xs">---</EuiText>;
-          const abs = new Date(ts).toLocaleString();
+          if (!ts) return <EuiText size="xs">{EMPTY_VALUE}</EuiText>;
+          const abs = formatTimestamp(ts);
           return (
             <EuiToolTip content={abs}>
-              <span style={{ fontSize: 12 }}>
+              <span style={{ fontSize: 12 }} tabIndex={0} aria-label={abs}>
                 <FormattedMessage
                   id="observability.alerting.alertsDashboard.startedAgo"
                   defaultMessage="{duration} ago"
@@ -1092,7 +1121,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
         name: i18n.translate('observability.alerting.alertsDashboard.column.duration', {
           defaultMessage: 'Duration',
         }),
-        width: '90px',
+        width: '9%',
         render: (_ts: string, alert: AlertTableRow) => (
           <EuiText size="xs">{formatAlertDuration(getRepresentativeAlert(alert))}</EuiText>
         ),
@@ -1101,7 +1130,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
         name: i18n.translate('observability.alerting.alertsDashboard.column.actions', {
           defaultMessage: 'Actions',
         }),
-        width: '150px',
+        width: '13%',
         render: (alert: AlertTableRow) => {
           const representative = getRepresentativeAlert(alert);
           return (
@@ -1133,6 +1162,15 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                       }
                     )}
                     size="s"
+                    // Guarantee a >=24x24 pointer target (WCAG 2.5.8). Inline
+                    // styles win over OUI's compressed button stylesheet.
+                    style={{
+                      minWidth: 24,
+                      minHeight: 24,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
                     onClick={() => onViewDetail(representative)}
                   />
                 </EuiToolTip>
@@ -1145,6 +1183,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                       iconType="check"
                       size="xs"
                       color="primary"
+                      style={{ minWidth: 24, minHeight: 24 }}
                       onClick={() => onAcknowledge(alert.id)}
                     >
                       <FormattedMessage
@@ -1296,7 +1335,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                   filters.alertKind,
                   (v) => updateFilter('alertKind', v),
                   facetCounts.counts.alertKind,
-                  ALERT_TYPE_COLORS
+                  ALERT_KIND_HEX
                 )}
                 {renderFacetGroup(
                   'severity',
@@ -1318,7 +1357,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                   filters.state,
                   (v) => updateFilter('state', v),
                   facetCounts.counts.state,
-                  STATE_COLORS
+                  stateFacetColorMap
                 )}
                 {(() => {
                   const visibleLabelKeys = labelKeys.filter(

--- a/public/components/alerting/enum_labels.ts
+++ b/public/components/alerting/enum_labels.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../common/types/alerting';
+
+/**
+ * Human-readable, translatable labels for the raw alert enums.
+ *
+ * The wire format uses lowercase machine values (`critical`, `at_risk`, …).
+ * Rendering those directly leaks the data model into the UI and cannot be
+ * localised, so every surface that shows a severity or state to a user should
+ * go through the getters below rather than interpolating the raw value.
+ */
+
+/**
+ * Single placeholder for an absent value. Kept here — alongside the other
+ * "how do we render a raw value as human text" rules — so surfaces stop
+ * drifting between `—`, `---`, and `N/A` for the same empty cell.
+ */
+export const EMPTY_VALUE = '—';
+
+export const SEVERITY_LABELS: Record<UnifiedAlertSeverity, string> = {
+  critical: i18n.translate('observability.alerting.severityLabel.critical', {
+    defaultMessage: 'Critical',
+  }),
+  high: i18n.translate('observability.alerting.severityLabel.high', {
+    defaultMessage: 'High',
+  }),
+  medium: i18n.translate('observability.alerting.severityLabel.medium', {
+    defaultMessage: 'Medium',
+  }),
+  low: i18n.translate('observability.alerting.severityLabel.low', {
+    defaultMessage: 'Low',
+  }),
+  info: i18n.translate('observability.alerting.severityLabel.info', {
+    defaultMessage: 'Info',
+  }),
+};
+
+export const STATE_LABELS: Record<UnifiedAlertState, string> = {
+  active: i18n.translate('observability.alerting.stateLabel.active', {
+    defaultMessage: 'Active',
+  }),
+  pending: i18n.translate('observability.alerting.stateLabel.pending', {
+    defaultMessage: 'Pending',
+  }),
+  acknowledged: i18n.translate('observability.alerting.stateLabel.acknowledged', {
+    defaultMessage: 'Acknowledged',
+  }),
+  silenced: i18n.translate('observability.alerting.stateLabel.silenced', {
+    defaultMessage: 'Silenced',
+  }),
+  resolved: i18n.translate('observability.alerting.stateLabel.resolved', {
+    defaultMessage: 'Resolved',
+  }),
+  error: i18n.translate('observability.alerting.stateLabel.error', {
+    defaultMessage: 'Error',
+  }),
+};
+
+/**
+ * Best-effort label for a value that isn't in the known enum — a backend may
+ * add a state before the UI knows about it. Turns `awaiting_data` into
+ * "Awaiting data" so an unrecognised value still reads as prose instead of
+ * disappearing behind a placeholder.
+ */
+function humanizeUnknown(value: string): string {
+  const spaced = value.replace(/[_-]+/g, ' ').trim();
+  if (!spaced) return EMPTY_VALUE;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/** Display label for an alert severity. Returns {@link EMPTY_VALUE} when absent. */
+export function getSeverityLabel(severity?: string | null): string {
+  if (!severity) return EMPTY_VALUE;
+  return SEVERITY_LABELS[severity as UnifiedAlertSeverity] ?? humanizeUnknown(severity);
+}
+
+/** Display label for an alert state. Returns {@link EMPTY_VALUE} when absent. */
+export function getStateLabel(state?: string | null): string {
+  if (!state) return EMPTY_VALUE;
+  return STATE_LABELS[state as UnifiedAlertState] ?? humanizeUnknown(state);
+}

--- a/public/components/alerting/enum_labels.ts
+++ b/public/components/alerting/enum_labels.ts
@@ -84,3 +84,44 @@ export function getStateLabel(state?: string | null): string {
   if (!state) return EMPTY_VALUE;
   return STATE_LABELS[state as UnifiedAlertState] ?? humanizeUnknown(state);
 }
+
+/**
+ * Rule/monitor status and health values, which are a different vocabulary from
+ * alert state. Only the OpenSearch-alerting side sends lowercase tokens; the
+ * AD/forecaster side already sends display-ready sentences ("Running",
+ * "Awaiting data to init"), which fall through {@link humanizeUnknown}
+ * unchanged. Only the tokens that actually need translating are mapped.
+ */
+const MONITOR_STATE_LABELS: Record<string, string> = {
+  active: i18n.translate('observability.alerting.monitorStateLabel.active', {
+    defaultMessage: 'Active',
+  }),
+  pending: i18n.translate('observability.alerting.monitorStateLabel.pending', {
+    defaultMessage: 'Pending',
+  }),
+  muted: i18n.translate('observability.alerting.monitorStateLabel.muted', {
+    defaultMessage: 'Muted',
+  }),
+  disabled: i18n.translate('observability.alerting.monitorStateLabel.disabled', {
+    defaultMessage: 'Disabled',
+  }),
+  healthy: i18n.translate('observability.alerting.monitorStateLabel.healthy', {
+    defaultMessage: 'Healthy',
+  }),
+  failing: i18n.translate('observability.alerting.monitorStateLabel.failing', {
+    defaultMessage: 'Failing',
+  }),
+  no_data: i18n.translate('observability.alerting.monitorStateLabel.noData', {
+    defaultMessage: 'No data',
+  }),
+};
+
+/**
+ * Display label for a rule/monitor `status` or `healthStatus`. Returns
+ * {@link EMPTY_VALUE} when absent. Unmapped values are humanized rather than
+ * dropped, so a status the UI doesn't know yet still reads as prose.
+ */
+export function getMonitorStateLabel(value?: string | null): string {
+  if (!value) return EMPTY_VALUE;
+  return MONITOR_STATE_LABELS[value] ?? humanizeUnknown(value);
+}

--- a/public/components/alerting/time_format.ts
+++ b/public/components/alerting/time_format.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import moment from 'moment-timezone';
+import { uiSettingsService } from '../../../common/utils';
+import { EMPTY_VALUE } from './enum_labels';
+
+/**
+ * Timezone-explicit timestamp formatting for alert surfaces.
+ *
+ * `Date#toLocaleString()` renders in the browser's zone and never says which
+ * zone that was, so two engineers reading the same incident see two different
+ * "start" times with no way to tell them apart. Everything here honours the
+ * `dateFormat:tz` advanced setting and labels the zone it rendered in.
+ */
+
+const DEFAULT_TIMESTAMP_FORMAT = 'MMM D, YYYY @ HH:mm:ss';
+
+/**
+ * Resolve the timezone the user configured via `dateFormat:tz`, falling back to
+ * the browser's zone when the setting is unset or left at `Browser`. Mirrors the
+ * resolution Discover and APM use so one instant renders identically everywhere.
+ */
+export function resolveDisplayTz(): string {
+  const tz = uiSettingsService.get('dateFormat:tz');
+  if (!tz || tz === 'Browser') {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+  return tz;
+}
+
+/**
+ * Short label for a zone at a given instant — `UTC`, `PDT`, or a numeric offset
+ * such as `+05:30` for zones without an abbreviation.
+ */
+export function getTimezoneLabel(
+  value: string | number | Date = Date.now(),
+  tz: string = resolveDisplayTz()
+): string {
+  return moment.tz(value, tz).format('z');
+}
+
+export interface FormatTimestampOptions {
+  /** Append the timezone label. Defaults to `true` — that's the point of this helper. */
+  withZone?: boolean;
+  /** moment format string. Defaults to `MMM D, YYYY @ HH:mm:ss`. */
+  format?: string;
+  /** Rendered when the input is missing or unparseable. Defaults to {@link EMPTY_VALUE}. */
+  fallback?: string;
+}
+
+/**
+ * Format an instant in the user's configured timezone, with that zone named.
+ * Returns the fallback (an em dash by default) for missing or unparseable input
+ * rather than the `Invalid date` string moment would otherwise produce.
+ */
+export function formatTimestamp(
+  value?: string | number | Date | null,
+  options: FormatTimestampOptions = {}
+): string {
+  const {
+    withZone = true,
+    format = DEFAULT_TIMESTAMP_FORMAT,
+    fallback = EMPTY_VALUE,
+  } = options;
+
+  if (value === null || value === undefined || value === '') return fallback;
+
+  // Normalise through `Date` first: handing moment an unparseable string makes it
+  // fall back to the `Date` constructor anyway, but with a deprecation warning
+  // that would fire on every malformed timestamp the backend hands us.
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+
+  const tz = resolveDisplayTz();
+  const instant = moment.tz(date, tz);
+  if (!instant.isValid()) return fallback;
+
+  return withZone ? `${instant.format(format)} ${instant.format('z')}` : instant.format(format);
+}

--- a/public/components/alerting/time_format.ts
+++ b/public/components/alerting/time_format.ts
@@ -60,11 +60,7 @@ export function formatTimestamp(
   value?: string | number | Date | null,
   options: FormatTimestampOptions = {}
 ): string {
-  const {
-    withZone = true,
-    format = DEFAULT_TIMESTAMP_FORMAT,
-    fallback = EMPTY_VALUE,
-  } = options;
+  const { withZone = true, format = DEFAULT_TIMESTAMP_FORMAT, fallback = EMPTY_VALUE } = options;
 
   if (value === null || value === undefined || value === '') return fallback;
 


### PR DESCRIPTION
## What & why
Severity was a bare colour dot under an abbreviated 'Sev' header with no text label; State/Message showed raw enums; empty cells drifted between `—`/`---`. Now: labelled `EuiHealth`/badges under a full 'Severity' header, Title-cased state, a single em-dash empty glyph, a Message tooltip, ≥24px targets, `aria-expanded`, and responsive column widths.

**Findings:** B1/A11Y1, CLAR1, CLAR2, CLAR4, CLAR9, A11Y3, A11Y4, A11Y6, RSP1, M6.

## Before / after

**Before / after**

![Before / after](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR1/before-after.png)

**Flow**

![Flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR1/flow.gif)

## Testing
`alerts_dashboard.test.tsx` (+ new assertions). Centrally green.

## Review
Independent review agent: **APPROVE** (mutation-checked tests).

## Regression check
The before/after above is a **full-viewport** capture, so adjacent components on the same surface are visible and unchanged — the diff is scoped to what's called out. Cross-component safety is also verified centrally: this change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. Aside from the merge-order note below, it can be reviewed, merged, and reverted independently.

## Dependency
Stacked on #2826 (shared primitives). This branch **includes** #2826's files so it builds and tests standalone in CI; merge #2826 first, then a rebase drops those files from this diff.

> Draft — see the merge-order note above.
