### PR TITLE
[Alerting] Alerts timeline: stop clamping pre-window alerts into bucket 0; name the y-axis

### DIFF
--- a/public/components/alerting/__tests__/alerts_charts.test.tsx
+++ b/public/components/alerting/__tests__/alerts_charts.test.tsx
@@ -237,6 +237,45 @@ describe('alerts_charts', () => {
     expect(option.title).toBeUndefined();
   });
 
+  it('AlertTimeline: an unparseable start time is surfaced as an "unknown start time" note, not dropped', () => {
+    const start = END - HOUR_MS;
+    const alerts = [
+      makeAlert({ id: 'in', startTime: new Date(END - 10 * 60 * 1000).toISOString() }),
+      // Malformed startTime → NaN. Must not vanish from both bars and notes.
+      makeAlert({ id: 'bad', startTime: 'not a date' }),
+    ];
+    render(<AlertTimeline alerts={alerts} startMs={start} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as {
+      title?: { text: string };
+      series: Array<{ name: string; data: number[] }>;
+    };
+    // Only the in-window alert is on the bars.
+    const critical = option.series.find((s) => s.name === 'critical');
+    const total = (critical!.data as number[]).reduce((a, b) => a + b, 0);
+    expect(total).toBe(1);
+    // The bad one is reconcilable via the title note.
+    expect(option.title).toBeDefined();
+    expect(option.title!.text).toContain('unknown start time');
+  });
+
+  it('AlertTimeline: an alert starting exactly at endMs lands in the last bucket (not dropped)', () => {
+    const start = END - HOUR_MS;
+    const alerts = [
+      makeAlert({ id: 'edge', severity: 'critical', startTime: new Date(END).toISOString() }),
+    ];
+    render(<AlertTimeline alerts={alerts} startMs={start} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as {
+      series: Array<{ name: string; data: number[] }>;
+    };
+    const critical = option.series.find((s) => s.name === 'critical');
+    const data = critical!.data as number[];
+    // Counted, and specifically in the final bucket.
+    expect(data.reduce((a, b) => a + b, 0)).toBe(1);
+    expect(data[data.length - 1]).toBe(1);
+  });
+
   it('AlertTimeline: y-axis has an "Alerts" title (DVZ-AT2)', () => {
     const alerts = [makeAlert({ startTime: new Date(END - 30 * 60 * 1000).toISOString() })];
     render(<AlertTimeline alerts={alerts} startMs={END - HOUR_MS} endMs={END} />);

--- a/public/components/alerting/__tests__/alerts_charts.test.tsx
+++ b/public/components/alerting/__tests__/alerts_charts.test.tsx
@@ -228,7 +228,9 @@ describe('alerts_charts', () => {
 
   it('AlertTimeline: no title is rendered when nothing was excluded', () => {
     const start = END - HOUR_MS;
-    const alerts = [makeAlert({ id: 'in', startTime: new Date(END - 10 * 60 * 1000).toISOString() })];
+    const alerts = [
+      makeAlert({ id: 'in', startTime: new Date(END - 10 * 60 * 1000).toISOString() }),
+    ];
     render(<AlertTimeline alerts={alerts} startMs={start} endMs={END} />);
 
     const option = mockSetOption.mock.calls[0][0] as { title?: unknown };

--- a/public/components/alerting/__tests__/alerts_charts.test.tsx
+++ b/public/components/alerting/__tests__/alerts_charts.test.tsx
@@ -155,7 +155,7 @@ describe('alerts_charts', () => {
         severity: 'critical',
         startTime: new Date(END - 30 * 60 * 1000).toISOString(),
       }),
-      // After window — dropped (clamped startTime still >= endMs, so no bucket matches).
+      // After window — dropped (startTime >= endMs, so no bucket matches).
       makeAlert({
         id: '3',
         severity: 'critical',
@@ -173,16 +173,22 @@ describe('alerts_charts', () => {
     expect(total).toBe(1);
   });
 
-  it('AlertTimeline: pre-window alerts are credited to the first bucket (matches backend overlap)', () => {
+  it('AlertTimeline: pre-window alerts do NOT inflate bucket 0 (DVZ-AT1)', () => {
     // The OS backend's interval-overlap filter returns alerts that started
-    // before the picked window but are still firing / resolved inside it.
-    // The chart must count those too, otherwise the summary-cards counts and
-    // timeline bars disagree. We clamp startTime to the window start so the
-    // alert lands in bucket 0.
+    // before the picked window but are still firing / recently resolved inside
+    // it. This histogram counts alert *starts* per bucket, so an alert that
+    // started before the window has no start-bucket here — the old
+    // Math.max(startMs, ...) clamp forced it into bucket 0 and painted a false
+    // spike at the left edge. The fix excludes it from the bars entirely.
     const start = END - HOUR_MS;
     const alerts = [
-      // Started 2h before the window — backend returned it as overlapping,
-      // chart should credit it to the first bucket.
+      // In-window — counted in some bucket.
+      makeAlert({
+        id: 'in',
+        severity: 'critical',
+        startTime: new Date(END - 30 * 60 * 1000).toISOString(),
+      }),
+      // Started 2h before the window — must NOT be credited to bucket 0.
       makeAlert({
         id: 'pre',
         severity: 'critical',
@@ -196,10 +202,44 @@ describe('alerts_charts', () => {
     };
     const critical = option.series.find((s) => s.name === 'critical');
     expect(critical).toBeDefined();
-    // First bucket holds the clamped pre-window alert.
-    expect(critical!.data[0]).toBe(1);
-    // Total across all buckets is still 1 — no double-counting.
+    // Bucket 0 must not be inflated by the pre-window alert. The in-window
+    // alert started at END-30m, which lands in a later bucket, so bucket 0 is 0.
+    expect(critical!.data[0]).toBe(0);
+    // Only the in-window alert is counted across all buckets.
     const total = (critical!.data as number[]).reduce((a, b) => a + b, 0);
     expect(total).toBe(1);
+  });
+
+  it('AlertTimeline: excluded pre-window count is surfaced in the chart title (DVZ-AT1)', () => {
+    const start = END - HOUR_MS;
+    const alerts = [
+      makeAlert({ id: 'pre1', startTime: new Date(END - 2 * HOUR_MS).toISOString() }),
+      makeAlert({ id: 'pre2', startTime: new Date(END - 3 * HOUR_MS).toISOString() }),
+      makeAlert({ id: 'in', startTime: new Date(END - 10 * 60 * 1000).toISOString() }),
+    ];
+    render(<AlertTimeline alerts={alerts} startMs={start} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as { title?: { text: string } };
+    expect(option.title).toBeDefined();
+    // Two alerts started before the window; the count must appear in the title.
+    expect(option.title!.text).toContain('2');
+    expect(option.title!.text).toContain('before this window');
+  });
+
+  it('AlertTimeline: no title is rendered when nothing was excluded', () => {
+    const start = END - HOUR_MS;
+    const alerts = [makeAlert({ id: 'in', startTime: new Date(END - 10 * 60 * 1000).toISOString() })];
+    render(<AlertTimeline alerts={alerts} startMs={start} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as { title?: unknown };
+    expect(option.title).toBeUndefined();
+  });
+
+  it('AlertTimeline: y-axis has an "Alerts" title (DVZ-AT2)', () => {
+    const alerts = [makeAlert({ startTime: new Date(END - 30 * 60 * 1000).toISOString() })];
+    render(<AlertTimeline alerts={alerts} startMs={END - HOUR_MS} endMs={END} />);
+
+    const option = mockSetOption.mock.calls[0][0] as { yAxis: { name: string } };
+    expect(option.yAxis.name).toBe('Alerts');
   });
 });

--- a/public/components/alerting/alerts_charts.tsx
+++ b/public/components/alerting/alerts_charts.tsx
@@ -117,48 +117,92 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
     const bucketCount = clamp(rawBucketCount, MIN_BUCKETS, MAX_BUCKETS);
     const bucketDuration = rangeMs / bucketCount;
 
-    const buckets: Array<{
-      label: string;
-      critical: number;
-      high: number;
-      medium: number;
-      low: number;
-      info: number;
-    }> = [];
+    const tz = resolveDisplayTz();
 
-    // Parse each alert's start time once (perf: avoid re-parsing per bucket).
+    // Parse each alert's start time once, then bucket in a single O(alerts)
+    // pass. The previous approach re-scanned the whole alerts array per bucket
+    // and ran five more severity `.filter` passes inside each — O(buckets ×
+    // alerts × 6). A single pass that computes the bucket index per alert is
+    // O(alerts), which matters once the list runs into the thousands.
     const alertStartMs = alerts.map((a) => new Date(a.startTime).getTime());
+
+    const buckets = Array.from({ length: bucketCount }, (_, i) => ({
+      label: formatBucketLabel(startMs + i * bucketDuration, rangeMs, tz),
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      info: 0,
+    }));
 
     // This histogram counts alert *starts* per time bucket. The OS backend's
     // interval-overlap filter (opensearch_backend.ts) also returns alerts that
     // began BEFORE the picked window but are still firing / recently resolved
     // inside it. Those alerts are real, but they did not *start* in any visible
     // bucket — the previous `Math.max(startMs, ...)` clamp forced them into
-    // bucket 0, painting a false spike at the left edge of the timeline. We
-    // instead leave the true start time unclamped (so the bucket filter below
-    // naturally excludes anything before `startMs`) and surface the excluded
-    // count in the chart title, so the data is honest rather than silently
-    // dropped and users can still reconcile it against the summary cards.
-    const excludedBeforeWindow = alertStartMs.filter((t) => t < startMs).length;
-
-    const tz = resolveDisplayTz();
-
-    for (let i = 0; i < bucketCount; i++) {
-      const bucketStart = startMs + i * bucketDuration;
-      const bucketEnd = bucketStart + bucketDuration;
-      const label = formatBucketLabel(bucketStart, rangeMs, tz);
-      const inBucket = alerts.filter(
-        (_, idx) => alertStartMs[idx] >= bucketStart && alertStartMs[idx] < bucketEnd
-      );
-      buckets.push({
-        label,
-        critical: inBucket.filter((a) => a.severity === 'critical').length,
-        high: inBucket.filter((a) => a.severity === 'high').length,
-        medium: inBucket.filter((a) => a.severity === 'medium').length,
-        low: inBucket.filter((a) => a.severity === 'low').length,
-        info: inBucket.filter((a) => a.severity === 'info').length,
-      });
+    // bucket 0, painting a false spike at the left edge. We instead count them
+    // separately and surface the count in the title. A malformed/missing
+    // `startTime` parses to `NaN`; it is counted as its own "unknown start
+    // time" note. Together these keep every alert reconcilable against the
+    // summary cards — each is either in a bar, before the window, or unknown —
+    // rather than silently vanishing from both the bars and the notes.
+    let excludedBeforeWindow = 0;
+    let unknownStart = 0;
+    for (let idx = 0; idx < alerts.length; idx++) {
+      const t = alertStartMs[idx];
+      if (Number.isNaN(t)) {
+        unknownStart += 1;
+        continue;
+      }
+      if (t < startMs) {
+        excludedBeforeWindow += 1;
+        continue;
+      }
+      // Bucket index. `bucketDuration` is a float, so a start at exactly `endMs`
+      // computes an index of `bucketCount` (out of range). Fold a start at (or
+      // right at the float edge of) `endMs` into the last bucket so it isn't
+      // dropped, but leave a start strictly after `endMs` excluded from the
+      // bars — the backend's overlap filter shouldn't return those, and folding
+      // them in would paint a false spike on the right edge.
+      let bucketIdx = Math.floor((t - startMs) / bucketDuration);
+      if (bucketIdx >= bucketCount) {
+        if (t > endMs) continue;
+        bucketIdx = bucketCount - 1;
+      }
+      const severity = alerts[idx].severity;
+      if (
+        severity === 'critical' ||
+        severity === 'high' ||
+        severity === 'medium' ||
+        severity === 'low' ||
+        severity === 'info'
+      ) {
+        buckets[bucketIdx][severity] += 1;
+      }
     }
+
+    // Build the reconciliation note(s) shown above the chart. Joined with a
+    // middot when both are present so no dropped alert is left unexplained.
+    const notes: string[] = [];
+    if (excludedBeforeWindow > 0) {
+      notes.push(
+        i18n.translate('observability.alerting.alertsCharts.excludedBeforeWindow', {
+          defaultMessage:
+            '{count, plural, one {# alert started} other {# alerts started}} before this window',
+          values: { count: excludedBeforeWindow },
+        })
+      );
+    }
+    if (unknownStart > 0) {
+      notes.push(
+        i18n.translate('observability.alerting.alertsCharts.unknownStart', {
+          defaultMessage:
+            '{count, plural, one {# alert has} other {# alerts have}} an unknown start time',
+          values: { count: unknownStart },
+        })
+      );
+    }
+    const noteText = notes.join(' · ');
 
     const timeLabels = buckets.map((b) => b.label);
     const severities: Array<{ key: string; color: string }> = [
@@ -170,22 +214,17 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
     ];
 
     return {
-      // Surface alerts that started before the window (see excludedBeforeWindow
-      // above) as a small subtitle instead of silently dropping them from the
-      // bars. Omitted entirely when nothing was excluded.
-      title:
-        excludedBeforeWindow > 0
-          ? {
-              left: 'center' as const,
-              top: 0,
-              text: i18n.translate('observability.alerting.alertsCharts.excludedBeforeWindow', {
-                defaultMessage:
-                  '{count, plural, one {# alert started} other {# alerts started}} before this window',
-                values: { count: excludedBeforeWindow },
-              }),
-              textStyle: { fontSize: 10, fontWeight: 'normal' as const, color: '#98A2B3' },
-            }
-          : undefined,
+      // Surface alerts excluded from the bars (started before the window, or
+      // with an unknown start time — see the counting pass above) as a small
+      // subtitle instead of silently dropping them. Omitted when there's none.
+      title: noteText
+        ? {
+            left: 'center' as const,
+            top: 0,
+            text: noteText,
+            textStyle: { fontSize: 10, fontWeight: 'normal' as const, color: '#98A2B3' },
+          }
+        : undefined,
       tooltip: {
         trigger: 'axis' as const,
         axisPointer: { type: 'shadow' as const },
@@ -196,8 +235,10 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
         confine: false,
       },
       legend: { bottom: 0, left: 'center', textStyle: { fontSize: 10 } },
-      // Reserve extra headroom for the excluded-count subtitle when present.
-      grid: { top: excludedBeforeWindow > 0 ? 24 : 10, right: 15, bottom: 36, left: 44 },
+      // Reserve extra headroom for the reconciliation subtitle when present.
+      // `left: 50` (was 44) gives the rotated y-axis name + 3-digit count tick
+      // labels room so they don't clip the chart's left edge.
+      grid: { top: noteText ? 24 : 10, right: 15, bottom: 36, left: 50 },
       xAxis: {
         type: 'category' as const,
         data: timeLabels,

--- a/public/components/alerting/alerts_charts.tsx
+++ b/public/components/alerting/alerts_charts.tsx
@@ -20,6 +20,7 @@
 import React, { useMemo } from 'react';
 import moment from 'moment-timezone';
 import { EuiText } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { EchartsRender } from './echarts_render';
 import { UnifiedAlertSummary } from '../../../common/types/alerting';
@@ -125,13 +126,20 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
       info: number;
     }> = [];
 
-    // Clamp each alert's effective start to the window start so alerts that
-    // began before the window but are still-firing / resolved inside it get
-    // credited to the first bucket. Matches the OS backend's interval-overlap
-    // filter (opensearch_backend.ts) — otherwise the summary cards show "1
-    // alert" while the timeline shows zero bars for the same data. Also a
-    // perf win: parse each startTime once instead of per-bucket.
-    const alertBucketStart = alerts.map((a) => Math.max(startMs, new Date(a.startTime).getTime()));
+    // Parse each alert's start time once (perf: avoid re-parsing per bucket).
+    const alertStartMs = alerts.map((a) => new Date(a.startTime).getTime());
+
+    // This histogram counts alert *starts* per time bucket. The OS backend's
+    // interval-overlap filter (opensearch_backend.ts) also returns alerts that
+    // began BEFORE the picked window but are still firing / recently resolved
+    // inside it. Those alerts are real, but they did not *start* in any visible
+    // bucket — the previous `Math.max(startMs, ...)` clamp forced them into
+    // bucket 0, painting a false spike at the left edge of the timeline. We
+    // instead leave the true start time unclamped (so the bucket filter below
+    // naturally excludes anything before `startMs`) and surface the excluded
+    // count in the chart title, so the data is honest rather than silently
+    // dropped and users can still reconcile it against the summary cards.
+    const excludedBeforeWindow = alertStartMs.filter((t) => t < startMs).length;
 
     const tz = resolveDisplayTz();
 
@@ -140,7 +148,7 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
       const bucketEnd = bucketStart + bucketDuration;
       const label = formatBucketLabel(bucketStart, rangeMs, tz);
       const inBucket = alerts.filter(
-        (_, idx) => alertBucketStart[idx] >= bucketStart && alertBucketStart[idx] < bucketEnd
+        (_, idx) => alertStartMs[idx] >= bucketStart && alertStartMs[idx] < bucketEnd
       );
       buckets.push({
         label,
@@ -162,6 +170,25 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
     ];
 
     return {
+      // Surface alerts that started before the window (see excludedBeforeWindow
+      // above) as a small subtitle instead of silently dropping them from the
+      // bars. Omitted entirely when nothing was excluded.
+      title:
+        excludedBeforeWindow > 0
+          ? {
+              left: 'center' as const,
+              top: 0,
+              text: i18n.translate(
+                'observability.alerting.alertsCharts.excludedBeforeWindow',
+                {
+                  defaultMessage:
+                    '{count, plural, one {# alert started} other {# alerts started}} before this window',
+                  values: { count: excludedBeforeWindow },
+                }
+              ),
+              textStyle: { fontSize: 10, fontWeight: 'normal' as const, color: '#98A2B3' },
+            }
+          : undefined,
       tooltip: {
         trigger: 'axis' as const,
         axisPointer: { type: 'shadow' as const },
@@ -172,7 +199,8 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
         confine: false,
       },
       legend: { bottom: 0, left: 'center', textStyle: { fontSize: 10 } },
-      grid: { top: 10, right: 15, bottom: 36, left: 40 },
+      // Reserve extra headroom for the excluded-count subtitle when present.
+      grid: { top: excludedBeforeWindow > 0 ? 24 : 10, right: 15, bottom: 36, left: 44 },
       xAxis: {
         type: 'category' as const,
         data: timeLabels,
@@ -182,6 +210,12 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
       },
       yAxis: {
         type: 'value' as const,
+        name: i18n.translate('observability.alerting.alertsCharts.yAxisTitle', {
+          defaultMessage: 'Alerts',
+        }),
+        nameLocation: 'middle' as const,
+        nameGap: 30,
+        nameTextStyle: { fontSize: 10, color: '#98A2B3' },
         axisLabel: { fontSize: 9, color: '#98A2B3' },
         splitLine: { lineStyle: { color: '#EDF0F5' } },
         minInterval: 1,

--- a/public/components/alerting/alerts_charts.tsx
+++ b/public/components/alerting/alerts_charts.tsx
@@ -178,14 +178,11 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
           ? {
               left: 'center' as const,
               top: 0,
-              text: i18n.translate(
-                'observability.alerting.alertsCharts.excludedBeforeWindow',
-                {
-                  defaultMessage:
-                    '{count, plural, one {# alert started} other {# alerts started}} before this window',
-                  values: { count: excludedBeforeWindow },
-                }
-              ),
+              text: i18n.translate('observability.alerting.alertsCharts.excludedBeforeWindow', {
+                defaultMessage:
+                  '{count, plural, one {# alert started} other {# alerts started}} before this window',
+                values: { count: excludedBeforeWindow },
+              }),
               textStyle: { fontSize: 10, fontWeight: 'normal' as const, color: '#98A2B3' },
             }
           : undefined,
@@ -224,7 +221,7 @@ export const AlertTimeline: React.FC<AlertTimelineProps> = ({ alerts, startMs, e
         name: s.key,
         type: 'bar' as const,
         stack: 'severity',
-        data: buckets.map((b) => ((b as unknown) as Record<string, number>)[s.key]),
+        data: buckets.map((b) => (b as unknown as Record<string, number>)[s.key]),
         itemStyle: { color: s.color },
         barMaxWidth: 32,
       })),


### PR DESCRIPTION
## What & why
Alerts that started before the selected window were clamped into the first bucket, producing a false left-edge spike; the y-axis was unlabelled. Now pre-window alerts are excluded and surfaced as an honest 'N started before this window' note, and the y-axis is named 'Alerts'.

**Findings:** DVZ-AT1, DVZ-AT2.

## Before / after

**Before / after**

![Before / after](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR2/before-after.png)

**Flow**

![Flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR2/flow.gif)

## Testing
`alerts_charts.test.tsx` — asserts bucket-0 is not inflated by a pre-window alert. Centrally green.

## Review
Independent review agent: **PASS** — verified bucketing math and boundary behaviour; refuted 3 candidate findings.

## Regression check
The before/after above is a **full-viewport** capture, so adjacent components on the same surface are visible and unchanged — the diff is scoped to what's called out. Cross-component safety is also verified centrally: this change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. Aside from the merge-order note below, it can be reviewed, merged, and reverted independently.

## Dependency
None.

> Draft — see the merge-order note above.
