### PR TITLE
[SLO] Detail: header layout, not-found state, re-poll rule health, 'View alerts' pivot

### DIFF
--- a/.cypress/integration/slo_test/detail_panels.spec.js
+++ b/.cypress/integration/slo_test/detail_panels.spec.js
@@ -150,7 +150,8 @@ describe('SLO detail page — panels render', () => {
     cy.get('[data-test-subj="slosDetailSliList"]').should('be.visible');
 
     // Objectives table renders one row for the single objective.
-    cy.get('[data-test-subj="slosDetailObjectivesTable"]').should('be.visible')
+    cy.get('[data-test-subj="slosDetailObjectivesTable"]')
+      .should('be.visible')
       .and('contain.text', 'primary');
   });
 
@@ -195,19 +196,23 @@ describe('SLO detail page — panels render', () => {
     cy.get('[data-test-subj="slosDetailAdvancedAccordion"]').click();
     cy.get('[data-test-subj="slosDetailAdvancedOps"]').should('exist');
     cy.get('[data-test-subj="slosDetailRecordingRulesAccordion"]').click();
-    cy.get('[data-test-subj^="slosDetailRecordingRule-"]')
-      .should('have.length.greaterThan', 0);
+    cy.get('[data-test-subj^="slosDetailRecordingRule-"]').should('have.length.greaterThan', 0);
   });
 
-  it('active SLO: View alert rules + Toggle + Delete buttons exist in the header', function () {
+  it('active SLO: View alerts + Toggle + Delete buttons exist in the header', function () {
     if (!activeId) {
       this.skip();
       return;
     }
     cy.visit(`${WORKSPACE_PREFIX}/app/${APP_ID}#/slos/${encodeURIComponent(activeId)}`);
     cy.get('[data-test-subj="sloDetailPage"]', { timeout: 30000 }).should('be.visible');
-    cy.get('[data-test-subj="slosDetailViewRules"]').should('exist');
-    cy.get('[data-test-subj="slosDetailToggle"]').should('be.visible')
+    // Header pivot renamed to "View alerts": it now deep-links to Alert Manager's
+    // Alerts (firing) tab rather than the Rules definition list (OBS1).
+    cy.get('[data-test-subj="slosDetailViewAlerts"]')
+      .should('exist')
+      .and('contain.text', 'View alerts');
+    cy.get('[data-test-subj="slosDetailToggle"]')
+      .should('be.visible')
       .and('contain.text', 'Disable');
     cy.get('[data-test-subj="slosDetailDelete"]').should('be.visible');
     cy.get('[data-test-subj="slosBack"]').should('exist');

--- a/.cypress/integration/slo_test/rule_health.spec.js
+++ b/.cypress/integration/slo_test/rule_health.spec.js
@@ -212,15 +212,22 @@ describe('SLO rule health — recovery flow (real Cortex)', () => {
       });
     };
     recheck(0);
-    cy.get(`[data-test-subj="slosRulesBadge-${sloId}"]`)
-      .should('have.attr', 'data-test-rule-state', 'missing');
+    cy.get(`[data-test-subj="slosRulesBadge-${sloId}"]`).should(
+      'have.attr',
+      'data-test-rule-state',
+      'missing'
+    );
 
     // -----------------------------------------------------------------------
     // Step D — Restore flow
     // -----------------------------------------------------------------------
     cy.visit(`${WORKSPACE_PREFIX}/app/${APP_ID}#/slos/${encodeURIComponent(sloId)}`);
     cy.get('[data-test-subj="sloDetailPage"]', { timeout: 30000 }).should('be.visible');
-    cy.get('[data-test-subj="slosDetailRuleHealthCallout"]', { timeout: 20000 }).should(
+    // F-CRUD2 grace window: the destructive "rules missing" callout is held
+    // back for RULE_HEALTH_MAX_RETRIES (5) × RULE_HEALTH_RETRY_INTERVAL_MS (5s)
+    // = 25s of re-probing, showing a soft "propagating" callout first. Wait
+    // past that window before asserting the alarm callout appears.
+    cy.get('[data-test-subj="slosDetailRuleHealthCallout"]', { timeout: 35000 }).should(
       'be.visible'
     );
 
@@ -248,7 +255,11 @@ describe('SLO rule health — recovery flow (real Cortex)', () => {
 
     cy.visit(`${WORKSPACE_PREFIX}/app/${APP_ID}#/slos/${encodeURIComponent(sloId)}`);
     cy.get('[data-test-subj="sloDetailPage"]', { timeout: 30000 }).should('be.visible');
-    cy.get('[data-test-subj="slosDetailRuleHealthCallout"]', { timeout: 20000 }).should(
+    // F-CRUD2 grace window: the destructive "rules missing" callout is held
+    // back for RULE_HEALTH_MAX_RETRIES (5) × RULE_HEALTH_RETRY_INTERVAL_MS (5s)
+    // = 25s of re-probing, showing a soft "propagating" callout first. Wait
+    // past that window before asserting the alarm callout appears.
+    cy.get('[data-test-subj="slosDetailRuleHealthCallout"]', { timeout: 35000 }).should(
       'be.visible'
     );
 

--- a/.cypress/integration/slo_test/rule_health.spec.js
+++ b/.cypress/integration/slo_test/rule_health.spec.js
@@ -156,6 +156,33 @@ describe('SLO rule health — recovery flow (real Cortex)', () => {
   });
 
   it('surfaces a healthy badge, flips to missing after ruler loss, restores, and lets users delete a broken SLO', () => {
+    // Warm the rule-health checker cache to `missing` by polling the listing's
+    // Refresh until the badge flips, then assert it. Used before every detail
+    // navigation that expects the "rules missing" callout: the detail page now
+    // trusts the live probe (a healthy probe wins over a stale liveStatus, so a
+    // freshly-created SLO never false-alarms — F-CRUD2), which means the detail
+    // probe itself must read `missing`. Warming the shared checker cache via the
+    // listing guarantees that, independent of TTL/reconciler timing.
+    const confirmMissingViaListing = () => {
+      cy.visit(`${WORKSPACE_PREFIX}/app/${APP_ID}#/slos`);
+      cy.get('[data-test-subj="slosPage"]', { timeout: 30000 }).should('be.visible');
+      const recheck = (attempt) => {
+        if (attempt >= 12) return;
+        cy.get('[data-test-subj="slosRefresh"]').click();
+        cy.wait(3000);
+        cy.get(`[data-test-subj="slosRulesBadge-${sloId}"]`).then(($el) => {
+          if ($el.attr('data-test-rule-state') === 'missing') return;
+          recheck(attempt + 1);
+        });
+      };
+      recheck(0);
+      cy.get(`[data-test-subj="slosRulesBadge-${sloId}"]`).should(
+        'have.attr',
+        'data-test-rule-state',
+        'missing'
+      );
+    };
+
     // -----------------------------------------------------------------------
     // Step A — Baseline: rules exist (badge is healthy or no-data depending
     // on whether the source metric has traffic; CI has neither so it sits at
@@ -198,25 +225,7 @@ describe('SLO rule health — recovery flow (real Cortex)', () => {
     // listing's Refresh button — cy.get retry only re-checks the DOM,
     // React doesn't re-fetch without a navigation or refresh trigger.
     cy.wait(75000);
-    cy.visit(`${WORKSPACE_PREFIX}/app/${APP_ID}#/slos`);
-    cy.get('[data-test-subj="slosPage"]', { timeout: 30000 }).should('be.visible');
-    // Loop: click Refresh, give the fetch ~3s, check the badge. Up to 10
-    // tries (≈30s of polling) — the cache should expire mid-loop.
-    const recheck = (attempt) => {
-      if (attempt >= 10) return;
-      cy.get('[data-test-subj="slosRefresh"]').click();
-      cy.wait(3000);
-      cy.get(`[data-test-subj="slosRulesBadge-${sloId}"]`).then(($el) => {
-        if ($el.attr('data-test-rule-state') === 'missing') return;
-        recheck(attempt + 1);
-      });
-    };
-    recheck(0);
-    cy.get(`[data-test-subj="slosRulesBadge-${sloId}"]`).should(
-      'have.attr',
-      'data-test-rule-state',
-      'missing'
-    );
+    confirmMissingViaListing();
 
     // -----------------------------------------------------------------------
     // Step D — Restore flow
@@ -249,9 +258,13 @@ describe('SLO rule health — recovery flow (real Cortex)', () => {
       namespace: rulerNamespace,
       groupName: ruleGroupName,
     });
-    // Same 90s wait so the rule_health/status caches expire before the
-    // detail page revisits.
-    cy.wait(90000);
+    // Wait past the checker TTL, then warm the checker cache to `missing` via
+    // the listing before navigating — the detail page now trusts the live
+    // probe, so the probe must read `missing` for the callout to escalate
+    // (see confirmMissingViaListing). This replaces the old "wait and hope the
+    // first detail probe is fresh", which raced the TTL/reconciler.
+    cy.wait(45000);
+    confirmMissingViaListing();
 
     cy.visit(`${WORKSPACE_PREFIX}/app/${APP_ID}#/slos/${encodeURIComponent(sloId)}`);
     cy.get('[data-test-subj="sloDetailPage"]', { timeout: 30000 }).should('be.visible');

--- a/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
@@ -430,6 +430,34 @@ describe('SloDetailPage — rule-health grace window + re-poll (F-CRUD2)', () =>
     await exhaustRetries();
     expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
   });
+
+  it('keeps probing on a stale cached-healthy probe while liveStatus is missing, then escalates once the probe catches up', async () => {
+    // Mirrors rule_health.spec Step E: the group was really deleted, but the
+    // server-cached rule-health probe (~90s TTL) first returns a stale `ok`
+    // while the persisted liveStatus is already `rules_missing`. Polling is
+    // driven by liveStatus (not the callout state), so it must keep re-probing
+    // until the probe re-reads `rules_missing` and then escalate — rather than
+    // trusting the stale healthy probe, going quiet, and never surfacing the
+    // genuine "rules missing" alarm.
+    const getRuleHealth = jest
+      .fn()
+      .mockResolvedValueOnce(makeHealth({ state: 'ok' })) // stale cached read
+      .mockResolvedValue(makeHealth({ state: 'rules_missing', missingGroups: ['grp-a'] }));
+    renderPage({
+      get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'rules_missing' })),
+      getRuleHealth,
+    });
+
+    await settle();
+    // Stale healthy probe wins the callout (no false alarm), but polling continues.
+    expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
+
+    await exhaustRetries();
+
+    // Probe caught up to missing and the budget is spent → escalate.
+    expect(screen.getByTestId('slosDetailRuleHealthCallout')).toBeInTheDocument();
+    expect(getRuleHealth.mock.calls.length).toBeGreaterThan(1);
+  });
 });
 
 describe('SloDetailPage — rule-health callout (escalated) actions', () => {

--- a/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
@@ -151,9 +151,10 @@ interface MockClient {
   getRuleHealth: jest.Mock;
 }
 
-function renderPage(
-  clientOverrides: Partial<MockClient> = {}
-): { client: MockClient; notifications: { toasts: { [k: string]: jest.Mock } } } {
+function renderPage(clientOverrides: Partial<MockClient> = {}): {
+  client: MockClient;
+  notifications: { toasts: { [k: string]: jest.Mock } };
+} {
   const client: MockClient = {
     get: jest.fn(),
     delete: jest.fn(),
@@ -178,10 +179,10 @@ function renderPage(
     <MemoryRouter initialEntries={['/slos/slo-1']}>
       <Route path="/slos/:id">
         <SloDetailPage
-          apiClient={(client as unknown) as SloApiClient}
-          chrome={(chrome as unknown) as Parameters<typeof SloDetailPage>[0]['chrome']}
+          apiClient={client as unknown as SloApiClient}
+          chrome={chrome as unknown as Parameters<typeof SloDetailPage>[0]['chrome']}
           notifications={
-            (notifications as unknown) as Parameters<typeof SloDetailPage>[0]['notifications']
+            notifications as unknown as Parameters<typeof SloDetailPage>[0]['notifications']
           }
           parentBreadcrumb={{ text: 'APM', href: '#/' }}
         />
@@ -199,7 +200,6 @@ function renderPage(
 
 const settle = async () => {
   for (let i = 0; i < 5; i++) {
-    // eslint-disable-next-line no-await-in-loop
     await act(async () => {
       await jest.advanceTimersByTimeAsync(0);
     });
@@ -214,7 +214,6 @@ const advanceOneRetry = async () => {
 
 const exhaustRetries = async () => {
   for (let i = 0; i < RULE_HEALTH_MAX_RETRIES; i++) {
-    // eslint-disable-next-line no-await-in-loop
     await advanceOneRetry();
   }
   await settle();
@@ -302,7 +301,9 @@ describe('SloDetailPage — rule-health grace window + re-poll (F-CRUD2)', () =>
       get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'rules_missing' })),
       getRuleHealth: jest
         .fn()
-        .mockResolvedValue(makeHealth({ state: 'rules_missing', missingGroups: ['grp-a', 'grp-b'] })),
+        .mockResolvedValue(
+          makeHealth({ state: 'rules_missing', missingGroups: ['grp-a', 'grp-b'] })
+        ),
     });
 
     await settle();
@@ -477,7 +478,10 @@ describe('SloDetailPage — rule-health callout (escalated) actions', () => {
       .mockResolvedValue(
         makeHealth({ state: 'ruler_unreachable', rulerErrorCode: 'RULER_UNREACHABLE' })
       );
-    renderPage({ get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'ok' })), getRuleHealth });
+    renderPage({
+      get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'ok' })),
+      getRuleHealth,
+    });
 
     await settle();
 

--- a/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
@@ -226,8 +226,14 @@ describe('deriveSloCalloutState', () => {
     expect(deriveSloCalloutState('ruler_unreachable', 'ok')).toBe('ruler_unreachable');
   });
 
-  it('falls back to the live-status flag when the probe is healthy or absent', () => {
-    expect(deriveSloCalloutState('ok', 'rules_missing')).toBe('rules_missing');
+  it('lets a concrete healthy probe win over a stale rules_missing live-status (F-CRUD2)', () => {
+    // The fresh-create shape: rules have propagated (probe → ok) but the
+    // persisted liveStatus.state hasn't been recomputed yet. The probe must
+    // win so the destructive callout never shows on a healthy SLO.
+    expect(deriveSloCalloutState('ok', 'rules_missing')).toBeNull();
+  });
+
+  it('falls back to the live-status flag only when the probe is absent', () => {
     expect(deriveSloCalloutState(undefined, 'rules_missing')).toBe('rules_missing');
   });
 
@@ -246,6 +252,17 @@ describe('SloDetailPage — not-found / loading / error states', () => {
     expect(prompt).toHaveTextContent(/slo-1/);
     expect(screen.getByTestId('slosDetailNotFoundBack')).toBeInTheDocument();
     // Not the fetch-error branch.
+    expect(screen.queryByText(/Unable to load SLO/i)).not.toBeInTheDocument();
+  });
+
+  it('routes a 404 rejection to the not-found prompt, not the error branch (CLAR16)', async () => {
+    // Production path: apiClient.get rejects with an IHttpFetchError-shaped 404
+    // (a deleted SLO / stale deep link) rather than resolving null.
+    renderPage({ get: jest.fn().mockRejectedValue({ response: { status: 404 } }) });
+
+    const prompt = await screen.findByTestId('slosDetailNotFound');
+    expect(prompt).toHaveTextContent(/SLO not found/i);
+    // The raw fetch-error branch must NOT render for a 404.
     expect(screen.queryByText(/Unable to load SLO/i)).not.toBeInTheDocument();
   });
 
@@ -381,6 +398,36 @@ describe('SloDetailPage — rule-health grace window + re-poll (F-CRUD2)', () =>
     await settle();
 
     expect(screen.queryByTestId('slosDetailRulePropagatingCallout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
+  });
+
+  it('never escalates on the real fresh-create shape: liveStatus stays rules_missing but the probe recovers to ok', async () => {
+    // The scenario F-CRUD2 exists for: the SLO was just created, so the
+    // persisted liveStatus.state is still `rules_missing` (server hasn't
+    // recomputed), and `doc` is never reloaded by the poll — but the rule-health
+    // probe recovers to `ok` once the groups propagate. The concrete healthy
+    // probe must win so the destructive alarm never shows.
+    const getRuleHealth = jest
+      .fn()
+      .mockResolvedValueOnce(makeHealth({ state: 'rules_missing', missingGroups: ['grp-a'] }))
+      .mockResolvedValue(makeHealth({ state: 'ok' }));
+    renderPage({
+      get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'rules_missing' })),
+      getRuleHealth,
+    });
+
+    await settle();
+    expect(screen.getByTestId('slosDetailRulePropagatingCallout')).toBeInTheDocument();
+
+    await advanceOneRetry();
+    await settle();
+
+    expect(screen.queryByTestId('slosDetailRulePropagatingCallout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailRestore')).not.toBeInTheDocument();
+
+    // And it must not keep escalating even if we let the full retry budget run.
+    await exhaustRetries();
     expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
   });
 });

--- a/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
@@ -4,15 +4,22 @@
  */
 
 import React from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route } from 'react-router-dom';
-import { SloDetailPage } from '../slo_detail_page';
+import {
+  deriveSloCalloutState,
+  RULE_HEALTH_MAX_RETRIES,
+  RULE_HEALTH_RETRY_INTERVAL_MS,
+  SloDetailPage,
+} from '../slo_detail_page';
 import type { RepairResponse, RuleHealthResponse, SloApiClient } from '../slo_api_client';
 import type {
   SloDocument,
   SloLiveStatus,
   SloHealthState,
 } from '../../../../../../common/slo/slo_types';
+import { observabilityAlertingID } from '../../../../../../common/constants/shared';
+import { coreRefs } from '../../../../../framework/core_refs';
 
 // The chart + metadata subtrees hit portals, SQL fetches, and chrome services
 // that aren't wired in jsdom. Stub them so the detail page mounts cleanly and
@@ -30,6 +37,9 @@ jest.mock('../slo_metadata_panel', () => ({
 }));
 jest.mock('../slo_alerts_panel', () => ({
   SloAlertsPanel: () => <div data-test-subj="slosAlertsPanelStub" />,
+}));
+jest.mock('../../../../../framework/core_refs', () => ({
+  coreRefs: { application: { navigateToApp: jest.fn() } },
 }));
 
 type FullDoc = SloDocument & { liveStatus: SloLiveStatus };
@@ -181,31 +191,213 @@ function renderPage(
   return { client, notifications };
 }
 
-describe('SloDetailPage — rule-health callout', () => {
-  it('renders the danger callout with Restore + Delete when liveStatus is rules_missing and health is rules_missing', async () => {
-    const doc = makeDoc({ liveStatusState: 'rules_missing' });
-    const health = makeHealth({
-      state: 'rules_missing',
-      missingGroups: ['grp-a', 'grp-b'],
-      presentGroups: [],
+// ---- Fake-timer helpers for the re-poll / grace-window tests ---------------
+//
+// `settle` flushes the promise chains behind the initial `get` +
+// `getRuleHealth` (and any state updates they trigger) without moving the
+// clock; `advanceOneRetry` fires exactly one bounded re-probe interval.
+
+const settle = async () => {
+  for (let i = 0; i < 5; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
     });
+  }
+};
+
+const advanceOneRetry = async () => {
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(RULE_HEALTH_RETRY_INTERVAL_MS);
+  });
+};
+
+const exhaustRetries = async () => {
+  for (let i = 0; i < RULE_HEALTH_MAX_RETRIES; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await advanceOneRetry();
+  }
+  await settle();
+};
+
+describe('deriveSloCalloutState', () => {
+  it('prefers a concrete rule-health probe state over the live-status flag', () => {
+    expect(deriveSloCalloutState('rules_missing', 'ok')).toBe('rules_missing');
+    expect(deriveSloCalloutState('rules_partial', 'ok')).toBe('rules_partial');
+    expect(deriveSloCalloutState('ruler_unreachable', 'ok')).toBe('ruler_unreachable');
+  });
+
+  it('falls back to the live-status flag when the probe is healthy or absent', () => {
+    expect(deriveSloCalloutState('ok', 'rules_missing')).toBe('rules_missing');
+    expect(deriveSloCalloutState(undefined, 'rules_missing')).toBe('rules_missing');
+  });
+
+  it('returns null when neither signal indicates a problem', () => {
+    expect(deriveSloCalloutState('ok', 'ok')).toBeNull();
+    expect(deriveSloCalloutState(undefined, 'breached')).toBeNull();
+  });
+});
+
+describe('SloDetailPage — not-found / loading / error states', () => {
+  it('renders the SLO-not-found empty state when the id resolves to no doc', async () => {
+    renderPage({ get: jest.fn().mockResolvedValue(null) });
+
+    const prompt = await screen.findByTestId('slosDetailNotFound');
+    expect(prompt).toHaveTextContent(/SLO not found/i);
+    expect(prompt).toHaveTextContent(/slo-1/);
+    expect(screen.getByTestId('slosDetailNotFoundBack')).toBeInTheDocument();
+    // Not the fetch-error branch.
+    expect(screen.queryByText(/Unable to load SLO/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the loading spinner (not the not-found prompt) while the fetch is in flight', () => {
+    // A never-resolving get keeps the page in its loading state.
+    renderPage({ get: jest.fn(() => new Promise<never>(() => undefined)) });
+
+    expect(screen.queryByTestId('slosDetailNotFound')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailHeader')).not.toBeInTheDocument();
+  });
+
+  it('renders the fetch-error branch (not the not-found prompt) when get rejects', async () => {
+    renderPage({ get: jest.fn().mockRejectedValue(new Error('boom')) });
+
+    expect(await screen.findByText(/Unable to load SLO/i)).toBeInTheDocument();
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailNotFound')).not.toBeInTheDocument();
+  });
+});
+
+describe('SloDetailPage — View alerts pivot (OBS1)', () => {
+  it('navigates to the alerting app Alerts tab (not the Rules list) scoped to this SLO', async () => {
+    const navigateToApp = coreRefs?.application?.navigateToApp as jest.Mock;
+    navigateToApp.mockClear();
+    renderPage({ get: jest.fn().mockResolvedValue(makeDoc()) });
+
+    const viewAlerts = await screen.findByTestId('slosDetailViewAlerts');
+    fireEvent.click(viewAlerts);
+
+    expect(navigateToApp).toHaveBeenCalledWith(
+      observabilityAlertingID,
+      expect.objectContaining({ path: expect.stringContaining('#/alerts?') })
+    );
+    const path = navigateToApp.mock.calls[0][1].path as string;
+    expect(path).toContain('slo_id%3Aslo-1'); // q=slo_id:slo-1, url-encoded
+    expect(path).toContain('ds=ds-1');
+    // Regression guard: must not drop the user on the Rules definition list.
+    expect(path).not.toContain('#/rules');
+  });
+});
+
+describe('SloDetailPage — rule-health grace window + re-poll (F-CRUD2)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('shows the soft "propagating" callout (no destructive CTA) before retries are exhausted', async () => {
     const { client } = renderPage({
-      get: jest.fn().mockResolvedValue(doc),
-      getRuleHealth: jest.fn().mockResolvedValue(health),
+      get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'rules_missing' })),
+      getRuleHealth: jest
+        .fn()
+        .mockResolvedValue(makeHealth({ state: 'rules_missing', missingGroups: ['grp-a', 'grp-b'] })),
     });
 
-    const callout = await screen.findByTestId('slosDetailRuleHealthCallout');
+    await settle();
+
+    expect(screen.getByTestId('slosDetailRulePropagatingCallout')).toBeInTheDocument();
+    // The alarming callout and its destructive CTAs stay hidden during grace.
+    expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailRestore')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailBrokenDelete')).not.toBeInTheDocument();
+    // The probe fired at least once on mount.
+    expect(client.getRuleHealth).toHaveBeenCalledWith('slo-1');
+  });
+
+  it('re-polls rule health on the bounded interval while rules read as missing', async () => {
+    const getRuleHealth = jest
+      .fn()
+      .mockResolvedValue(makeHealth({ state: 'rules_missing', missingGroups: ['grp-a'] }));
+    renderPage({
+      get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'rules_missing' })),
+      getRuleHealth,
+    });
+
+    await settle();
+    expect(getRuleHealth).toHaveBeenCalledTimes(1); // initial mount probe
+
+    await advanceOneRetry();
+    expect(getRuleHealth).toHaveBeenCalledTimes(2);
+
+    await advanceOneRetry();
+    expect(getRuleHealth).toHaveBeenCalledTimes(3);
+  });
+
+  it('escalates to the alarming "missing" callout only after retries are exhausted', async () => {
+    const getRuleHealth = jest
+      .fn()
+      .mockResolvedValue(makeHealth({ state: 'rules_missing', missingGroups: ['grp-a', 'grp-b'] }));
+    renderPage({
+      get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'rules_missing' })),
+      getRuleHealth,
+    });
+
+    await settle();
+    expect(screen.getByTestId('slosDetailRulePropagatingCallout')).toBeInTheDocument();
+
+    await exhaustRetries();
+
+    const callout = screen.getByTestId('slosDetailRuleHealthCallout');
     expect(callout).toHaveTextContent(/Rule groups missing in Cortex/i);
     expect(callout).toHaveTextContent(/2 of 2 expected rule groups/i);
     expect(screen.getByTestId('slosDetailRestore')).toBeInTheDocument();
     expect(screen.getByTestId('slosDetailBrokenDelete')).toBeInTheDocument();
-    expect(client.getRuleHealth).toHaveBeenCalledWith('slo-1');
+    expect(screen.queryByTestId('slosDetailRulePropagatingCallout')).not.toBeInTheDocument();
+    // Probing stopped once the budget was spent: one mount probe + MAX retries.
+    expect(getRuleHealth).toHaveBeenCalledTimes(RULE_HEALTH_MAX_RETRIES + 1);
+    // And it did not keep polling forever.
+    await advanceOneRetry();
+    expect(getRuleHealth).toHaveBeenCalledTimes(RULE_HEALTH_MAX_RETRIES + 1);
+  });
+
+  it('never escalates when rule health recovers during the grace window', async () => {
+    // Missing on the first probe, healthy on every re-poll afterwards.
+    const getRuleHealth = jest
+      .fn()
+      .mockResolvedValueOnce(makeHealth({ state: 'rules_missing', missingGroups: ['grp-a'] }))
+      .mockResolvedValue(makeHealth({ state: 'ok' }));
+    renderPage({
+      get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'ok' })),
+      getRuleHealth,
+    });
+
+    await settle();
+    expect(screen.getByTestId('slosDetailRulePropagatingCallout')).toBeInTheDocument();
+
+    await advanceOneRetry();
+    await settle();
+
+    expect(screen.queryByTestId('slosDetailRulePropagatingCallout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
+  });
+});
+
+describe('SloDetailPage — rule-health callout (escalated) actions', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   it('hides the callout after Restore when follow-up rule-health returns ok', async () => {
     const missingDoc = makeDoc({ liveStatusState: 'rules_missing' });
     const healthyDoc = makeDoc({ liveStatusState: 'ok' });
-    const get = jest.fn().mockResolvedValueOnce(missingDoc).mockResolvedValueOnce(healthyDoc);
+    // Mount fetch returns the broken doc; the post-repair reload returns healthy.
+    const get = jest.fn().mockResolvedValueOnce(missingDoc).mockResolvedValue(healthyDoc);
     const repairResponse: RepairResponse = {
       sloId: 'slo-1',
       repaired: true,
@@ -214,29 +406,27 @@ describe('SloDetailPage — rule-health callout', () => {
     const repair = jest.fn().mockResolvedValue(repairResponse);
     const getRuleHealth = jest
       .fn()
-      .mockResolvedValueOnce(makeHealth({ state: 'rules_missing', missingGroups: ['x'] }));
+      .mockResolvedValue(makeHealth({ state: 'rules_missing', missingGroups: ['x', 'y'] }));
 
     const { notifications } = renderPage({ get, repair, getRuleHealth });
 
-    await screen.findByTestId('slosDetailRuleHealthCallout');
+    await settle();
+    await exhaustRetries();
+    expect(screen.getByTestId('slosDetailRestore')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('slosDetailRestore'));
     });
+    await settle();
 
-    await waitFor(() => {
-      expect(repair).toHaveBeenCalledWith('slo-1');
-    });
-    await waitFor(() => {
-      expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
-    });
+    expect(repair).toHaveBeenCalledWith('slo-1');
+    expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
     expect(notifications.toasts.addSuccess).toHaveBeenCalledWith(
       expect.objectContaining({ title: expect.stringMatching(/Restored 2 rule groups/) })
     );
   });
 
   it('shows the "already present" info toast when repair returns repaired:false', async () => {
-    const doc = makeDoc({ liveStatusState: 'rules_missing' });
     const repair = jest.fn().mockResolvedValue({
       sloId: 'slo-1',
       repaired: false,
@@ -244,79 +434,77 @@ describe('SloDetailPage — rule-health callout', () => {
     } as RepairResponse);
     const getRuleHealth = jest
       .fn()
-      .mockResolvedValueOnce(makeHealth({ state: 'rules_missing', missingGroups: ['x'] }));
+      .mockResolvedValue(makeHealth({ state: 'rules_missing', missingGroups: ['x'] }));
 
     const { notifications } = renderPage({
-      get: jest.fn().mockResolvedValue(doc),
+      get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'rules_missing' })),
       repair,
       getRuleHealth,
     });
-    await screen.findByTestId('slosDetailRestore');
+
+    await settle();
+    await exhaustRetries();
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('slosDetailRestore'));
     });
+    await settle();
 
-    await waitFor(() => {
-      expect(notifications.toasts.addInfo).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: expect.stringMatching(/already present/i),
-        })
-      );
-    });
+    expect(notifications.toasts.addInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.stringMatching(/already present/i) })
+    );
   });
 
   it('opens the confirm-delete modal when the callout Delete button is clicked', async () => {
-    const doc = makeDoc({ liveStatusState: 'rules_missing' });
     renderPage({
-      get: jest.fn().mockResolvedValue(doc),
+      get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'rules_missing' })),
       getRuleHealth: jest
         .fn()
         .mockResolvedValue(makeHealth({ state: 'rules_missing', missingGroups: ['x'] })),
     });
 
-    await screen.findByTestId('slosDetailBrokenDelete');
+    await settle();
+    await exhaustRetries();
+
     fireEvent.click(screen.getByTestId('slosDetailBrokenDelete'));
 
-    expect(await screen.findByText(/Delete SLO "api-availability"\?/)).toBeInTheDocument();
+    expect(screen.getByText(/Delete SLO "api-availability"\?/)).toBeInTheDocument();
   });
 
-  it('renders a ruler-unreachable warning callout with a Retry button that re-calls getRuleHealth', async () => {
-    const doc = makeDoc({ liveStatusState: 'ok' });
+  it('renders a ruler-unreachable warning callout with a Retry that re-calls getRuleHealth', async () => {
     const getRuleHealth = jest
       .fn()
       .mockResolvedValue(
         makeHealth({ state: 'ruler_unreachable', rulerErrorCode: 'RULER_UNREACHABLE' })
       );
-    renderPage({ get: jest.fn().mockResolvedValue(doc), getRuleHealth });
+    renderPage({ get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'ok' })), getRuleHealth });
 
-    const callout = await screen.findByTestId('slosDetailRuleHealthCallout');
+    await settle();
+
+    const callout = screen.getByTestId('slosDetailRuleHealthCallout');
     expect(callout).toHaveTextContent(/Ruler unreachable/i);
     expect(callout).toHaveTextContent(/RULER_UNREACHABLE/);
+    // ruler_unreachable is not a "missing" state, so no grace window applies.
+    expect(screen.queryByTestId('slosDetailRulePropagatingCallout')).not.toBeInTheDocument();
 
-    const retry = screen.getByTestId('slosDetailRuleHealthRetry');
     await act(async () => {
-      fireEvent.click(retry);
+      fireEvent.click(screen.getByTestId('slosDetailRuleHealthRetry'));
     });
+    await settle();
 
-    await waitFor(() => {
-      expect(getRuleHealth).toHaveBeenCalledTimes(2);
-    });
+    expect(getRuleHealth).toHaveBeenCalledTimes(2);
   });
 
   it('renders no callout when liveStatus.state is ok and ruleHealth.state is ok', async () => {
-    const doc = makeDoc({ liveStatusState: 'ok' });
     renderPage({
-      get: jest.fn().mockResolvedValue(doc),
+      get: jest.fn().mockResolvedValue(makeDoc({ liveStatusState: 'ok' })),
       getRuleHealth: jest.fn().mockResolvedValue(makeHealth({ state: 'ok' })),
     });
 
-    // Wait for the page to finish loading + rule-health to resolve. The header
-    // is a reliable signal because it mounts on the same cycle.
-    await screen.findByTestId('slosDetailHeader');
-    await waitFor(() => {
-      expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
-    });
+    await settle();
+    expect(screen.getByTestId('slosDetailHeader')).toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailRuleHealthCallout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailRulePropagatingCallout')).not.toBeInTheDocument();
   });
 });
 

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -680,9 +680,24 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
   // leak or poll forever.
   useEffect(() => {
     if (!doc) return undefined;
-    const calloutState = deriveSloCalloutState(ruleHealth?.state, doc.liveStatus.state);
-    const missing = calloutState === 'rules_missing' || calloutState === 'rules_partial';
-    if (!missing) {
+    // Keep re-probing while EITHER the live probe OR the persisted live-status
+    // flag reads missing — deliberately NOT `deriveSloCalloutState`, which lets
+    // a healthy probe win for the *callout* (so a fresh-create SLO never shows a
+    // false destructive alarm). For *polling* we must be more eager: the
+    // rule-health probe is cached server-side (~90s TTL), so right after a real
+    // regression the first probe can still read a stale `ok` while the persisted
+    // state already flipped to `rules_missing`. If we stopped polling on that
+    // stale `ok`, we'd never re-check and the genuine "missing" callout would
+    // never surface. Polling while `liveState` is missing lets a later probe
+    // catch the fresh `rules_missing` and escalate; a genuinely-healthy probe
+    // just runs the bounded budget out harmlessly without ever escalating.
+    const probeState = ruleHealth?.state;
+    const probeMissing =
+      probeState === 'rules_missing' ||
+      probeState === 'rules_partial' ||
+      probeState === 'ruler_unreachable';
+    const keepProbing = probeMissing || doc.liveStatus.state === 'rules_missing';
+    if (!keepProbing) {
       if (ruleHealthRetries !== 0) setRuleHealthRetries(0);
       return undefined;
     }

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -829,7 +829,7 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
                 <p>
                   {i18n.translate('observability.apm.slo.detail.notFound.body', {
                     defaultMessage:
-                      "We couldn't find an SLO with the id \"{id}\". It may have been deleted, or the link may be out of date.",
+                      'We couldn\'t find an SLO with the id "{id}". It may have been deleted, or the link may be out of date.',
                     values: { id },
                   })}
                 </p>
@@ -1104,9 +1104,12 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
                     isLoading={ruleHealthLoading}
                     data-test-subj="slosDetailRulePropagatingCheckNow"
                   >
-                    {i18n.translate('observability.apm.slo.detail.rulesPropagatingCallout.checkNow', {
-                      defaultMessage: 'Check now',
-                    })}
+                    {i18n.translate(
+                      'observability.apm.slo.detail.rulesPropagatingCallout.checkNow',
+                      {
+                        defaultMessage: 'Check now',
+                      }
+                    )}
                   </EuiButtonEmpty>
                 </EuiCallOut>
                 <EuiSpacer size="m" />

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -610,6 +610,25 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
     setRuleHealthRetries(0);
   }, [id]);
 
+  // Stale-write guard for the auto-poll below. Its re-probe resolves
+  // asynchronously; if we've navigated to a different SLO or unmounted before
+  // it lands, the result belongs to a stale id and must be dropped rather than
+  // clobbering the current SLO's rule-health state. A retry-count increment is
+  // NOT stale (`id` is unchanged then), so the guard keys on id + mount only —
+  // never on the retry counter. The mount effect re-arms `mounted` on remount
+  // so a StrictMode double-mount doesn't wedge it permanently false.
+  const pollLiveIdRef = useRef(id);
+  const pollMountedRef = useRef(true);
+  useEffect(() => {
+    pollLiveIdRef.current = id;
+  }, [id]);
+  useEffect(() => {
+    pollMountedRef.current = true;
+    return () => {
+      pollMountedRef.current = false;
+    };
+  }, []);
+
   // While rule health reads as missing/partial, re-probe on a bounded
   // interval (F-CRUD2). A freshly-created SLO's rule groups take time to
   // propagate through the Cortex/AMP ruler, so a "missing" reading is
@@ -627,12 +646,16 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
       return undefined;
     }
     if (ruleHealthRetries >= RULE_HEALTH_MAX_RETRIES) return undefined;
+    const scheduledId = id;
     const timer = setTimeout(() => {
       setRuleHealthRetries((n) => n + 1);
-      loadRuleHealth();
+      // Gate the async re-probe so a response that arrives after navigating
+      // away (or unmounting) is discarded instead of writing another SLO's
+      // rule health onto this view. See pollLiveIdRef/pollMountedRef above.
+      loadRuleHealth(() => pollMountedRef.current && pollLiveIdRef.current === scheduledId);
     }, RULE_HEALTH_RETRY_INTERVAL_MS);
     return () => clearTimeout(timer);
-  }, [doc, ruleHealth, ruleHealthRetries, loadRuleHealth]);
+  }, [doc, ruleHealth, ruleHealthRetries, loadRuleHealth, id]);
 
   const onRepair = useCallback(async () => {
     try {

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -122,6 +122,18 @@ export const RULE_HEALTH_MAX_RETRIES = 5;
 export const RULE_HEALTH_RETRY_INTERVAL_MS = 5000;
 
 /**
+ * Detect an OSD `IHttpFetchError` that surfaced as a 404 — the SLO was deleted
+ * or the deep link is stale. Mirrors the helper in `slo_health_summary.ts`
+ * (kept local so this file stays self-contained). Routes to the "not found"
+ * prompt instead of the generic load-error branch.
+ */
+export function isNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const status = (err as { response?: { status?: number } }).response?.status;
+  return status === 404;
+}
+
+/**
  * Fold the fresh rule-health probe and the persisted live-status flag into a
  * single callout mode. The probe wins whenever it reports a concrete state;
  * we fall back to the live-status flag so the callout still surfaces before
@@ -132,13 +144,20 @@ export function deriveSloCalloutState(
   ruleHealthState: SloRuleHealthState | undefined,
   liveState: SloHealthState
 ): 'rules_missing' | 'rules_partial' | 'ruler_unreachable' | null {
-  if (
-    ruleHealthState === 'rules_missing' ||
-    ruleHealthState === 'rules_partial' ||
-    ruleHealthState === 'ruler_unreachable'
-  ) {
-    return ruleHealthState;
+  // A concrete probe result always wins — it's the fresh truth, and the
+  // persisted `liveState` can lag server-side recomputation. In particular, a
+  // freshly-created SLO whose rules have finished propagating reports a healthy
+  // probe while `liveStatus.state` is still `rules_missing`; letting the probe
+  // win there is exactly what prevents the false destructive callout (F-CRUD2).
+  if (ruleHealthState !== undefined) {
+    return ruleHealthState === 'rules_missing' ||
+      ruleHealthState === 'rules_partial' ||
+      ruleHealthState === 'ruler_unreachable'
+      ? ruleHealthState
+      : null;
   }
+  // No probe result yet — fall back to the persisted flag so the callout still
+  // surfaces before the first probe returns.
   return liveState === 'rules_missing' ? 'rules_missing' : null;
 }
 
@@ -322,13 +341,13 @@ const DetailHeader: React.FC<DetailHeaderProps> = ({
                         { defaultMessage: 'percentage points' }
                       )}
                     >
-                      <abbr
-                        title={i18n.translate(
-                          'observability.apm.slo.detail.percentagePointsTooltip',
-                          { defaultMessage: 'percentage points' }
-                        )}
-                        data-test-subj="slosDetailAttainmentDeltaUnit"
-                      >
+                      {/*
+                        No native `title` here: the wrapping EuiToolTip already
+                        provides the "percentage points" hover text, and a
+                        `title` on the <abbr> too would render a second (native)
+                        tooltip and translate the message twice.
+                      */}
+                      <abbr data-test-subj="slosDetailAttainmentDeltaUnit">
                         {i18n.translate('observability.apm.slo.detail.percentagePointsAbbr', {
                           defaultMessage: 'pp',
                         })}
@@ -514,6 +533,11 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
   const [doc, setDoc] = useState<FullDoc | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  // A 404 (deleted SLO / stale deep link) is distinct from a generic load
+  // failure: it routes to the friendly "SLO not found" prompt (CLAR16) instead
+  // of the raw error branch. `apiClient.get` rejects on 404, so we must detect
+  // it in the catch — the resolved-but-falsy path never happens in production.
+  const [notFound, setNotFound] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   // Shared, persisted time range (sessionStorage) so the SLO detail picker
   // stays in sync with the rest of APM. Falls back to a 1h window — a more
@@ -545,12 +569,21 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
     async (isCurrent: () => boolean = ALWAYS_CURRENT) => {
       setLoading(true);
       setError(null);
+      setNotFound(false);
       try {
         const result = await apiClient.get(id);
         if (!isCurrent()) return;
         setDoc(result);
       } catch (e) {
         if (!isCurrent()) return;
+        // A 404 means the SLO doesn't exist — show the "not found" prompt
+        // (CLAR16), not the raw error branch. Clear any stale doc so a
+        // re-load that 404s doesn't keep rendering the previous SLO.
+        if (isNotFoundError(e)) {
+          setDoc(null);
+          setNotFound(true);
+          return;
+        }
         const err = e instanceof Error ? e : new Error(String(e));
         setError(err);
       } finally {
@@ -569,7 +602,10 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
   }, [load]);
 
   const loadRuleHealth = useCallback(
-    async (isCurrent: () => boolean = ALWAYS_CURRENT) => {
+    async (
+      isCurrent: () => boolean = ALWAYS_CURRENT,
+      { silent = false }: { silent?: boolean } = {}
+    ) => {
       setRuleHealthLoading(true);
       try {
         const result = await apiClient.getRuleHealth(id);
@@ -580,13 +616,18 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
         const err = e instanceof Error ? e : new Error(String(e));
         // Don't render the callout on fetch failure — fall back to the
         // live-status-derived state. Surface the fetch error as a neutral toast
-        // so users have a breadcrumb if they want to investigate.
-        notifications.toasts.addDanger({
-          title: i18n.translate('observability.apm.slo.detail.ruleHealthLoadFailed', {
-            defaultMessage: 'Could not load rule health',
-          }),
-          text: err.message,
-        });
+        // so users have a breadcrumb — but only for the initial/manual probe.
+        // The bounded re-poll (up to RULE_HEALTH_MAX_RETRIES) passes
+        // `silent: true` so a flapping endpoint can't spew ~6 identical toasts
+        // in the ~25s grace window.
+        if (!silent) {
+          notifications.toasts.addDanger({
+            title: i18n.translate('observability.apm.slo.detail.ruleHealthLoadFailed', {
+              defaultMessage: 'Could not load rule health',
+            }),
+            text: err.message,
+          });
+        }
         setRuleHealth(null);
       } finally {
         if (isCurrent()) setRuleHealthLoading(false);
@@ -652,7 +693,10 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
       // Gate the async re-probe so a response that arrives after navigating
       // away (or unmounting) is discarded instead of writing another SLO's
       // rule health onto this view. See pollLiveIdRef/pollMountedRef above.
-      loadRuleHealth(() => pollMountedRef.current && pollLiveIdRef.current === scheduledId);
+      // `silent: true` — poll failures don't toast (see loadRuleHealth).
+      loadRuleHealth(() => pollMountedRef.current && pollLiveIdRef.current === scheduledId, {
+        silent: true,
+      });
     }, RULE_HEALTH_RETRY_INTERVAL_MS);
     return () => clearTimeout(timer);
   }, [doc, ruleHealth, ruleHealthRetries, loadRuleHealth, id]);
@@ -805,12 +849,12 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
     );
   }
 
-  // We only reach here with no doc once loading has finished and no fetch
-  // error was raised (both handled above) — i.e. the id genuinely resolved to
-  // nothing. Surface an explicit "not found" state (CLAR16) rather than a
-  // blank page, distinct from the fetch-error branch above. The loading guard
-  // upstream ensures a still-resolving request never flashes this prompt.
-  if (!doc) {
+  // Reached when the id resolved to nothing: either a 404 (deleted SLO / stale
+  // deep link, flagged via `notFound`) or a resolved-but-empty body. Surface an
+  // explicit "not found" state (CLAR16) rather than a blank page, distinct from
+  // the fetch-error branch above. The loading guard upstream ensures a
+  // still-resolving request never flashes this prompt.
+  if (notFound || !doc) {
     return (
       <EuiPage>
         <EuiPageBody>

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -31,6 +31,7 @@ import {
   EuiSpacer,
   EuiStat,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 import { i18n } from '@osd/i18n';
@@ -43,10 +44,11 @@ import { usePersistentTimeRange } from '../../shared/hooks/use_persistent_time_r
 import { SloVisualizations } from './slo_visualizations';
 import { SloMetadataPanel } from './slo_metadata_panel';
 import { SloAlertsPanel } from './slo_alerts_panel';
-import type { RuleHealthResponse, SloApiClient } from './slo_api_client';
+import type { RuleHealthResponse, SloApiClient, SloRuleHealthState } from './slo_api_client';
 import type {
   Objective,
   SloDocument,
+  SloHealthState,
   SloLiveStatus,
   SloSummary,
 } from '../../../../../common/slo/slo_types';
@@ -107,6 +109,39 @@ function iconSummaryFromDoc(doc: SloDocument): SloSummary {
   };
 }
 
+/**
+ * Rule-health re-poll bounds (F-CRUD2). A freshly-created SLO's rule groups
+ * take a little while to propagate through the Cortex/AMP ruler, during which
+ * the health probe legitimately reports them as missing. Rather than alarm
+ * immediately, we re-probe up to {@link RULE_HEALTH_MAX_RETRIES} times, one
+ * every {@link RULE_HEALTH_RETRY_INTERVAL_MS}, and only escalate to the
+ * destructive "rules missing" callout once those retries are exhausted. The
+ * bound also guarantees the polling can't leak or run forever.
+ */
+export const RULE_HEALTH_MAX_RETRIES = 5;
+export const RULE_HEALTH_RETRY_INTERVAL_MS = 5000;
+
+/**
+ * Fold the fresh rule-health probe and the persisted live-status flag into a
+ * single callout mode. The probe wins whenever it reports a concrete state;
+ * we fall back to the live-status flag so the callout still surfaces before
+ * the first probe returns. Exported so the grace-window logic can be
+ * unit-tested in isolation.
+ */
+export function deriveSloCalloutState(
+  ruleHealthState: SloRuleHealthState | undefined,
+  liveState: SloHealthState
+): 'rules_missing' | 'rules_partial' | 'ruler_unreachable' | null {
+  if (
+    ruleHealthState === 'rules_missing' ||
+    ruleHealthState === 'rules_partial' ||
+    ruleHealthState === 'ruler_unreachable'
+  ) {
+    return ruleHealthState;
+  }
+  return liveState === 'rules_missing' ? 'rules_missing' : null;
+}
+
 interface DetailHeaderProps {
   doc: FullDoc;
   primaryObjective: Objective;
@@ -163,7 +198,12 @@ const DetailHeader: React.FC<DetailHeaderProps> = ({
 
   return (
     <EuiPanel data-test-subj="slosDetailHeader">
-      <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
+      {/* `wrap` + responsive lets the health dot / title / hero stat stack at
+          narrow widths instead of the title being squeezed to one glyph per
+          line (CLAR14 / BUG-S1). The title item below carries `minWidth: 0`
+          so it can shrink below its intrinsic content width and wrap on word
+          boundaries rather than per character. */}
+      <EuiFlexGroup alignItems="center" gutterSize="m" wrap>
         <EuiFlexItem grow={false}>
           <EuiHealth
             color={healthColor}
@@ -176,9 +216,12 @@ const DetailHeader: React.FC<DetailHeaderProps> = ({
             <span style={{ fontWeight: 600 }}>{healthLabel}</span>
           </EuiHealth>
         </EuiFlexItem>
-        <EuiFlexItem>
+        <EuiFlexItem style={{ minWidth: 0 }}>
           <EuiText size="m">
-            <h2 style={{ marginBottom: 4 }} data-test-subj="slosDetailTitle">
+            <h2
+              style={{ marginBottom: 4, overflowWrap: 'break-word', wordBreak: 'break-word' }}
+              data-test-subj="slosDetailTitle"
+            >
               {doc.spec.name}
             </h2>
           </EuiText>
@@ -272,7 +315,25 @@ const DetailHeader: React.FC<DetailHeaderProps> = ({
                   {' · '}
                   <span style={{ ...TABULAR_NUMS_STYLE, color: deltaColor, fontWeight: 600 }}>
                     {deltaSign}
-                    {attainmentDelta.toFixed(SLO_PRECISION.attainment)} pp
+                    {attainmentDelta.toFixed(SLO_PRECISION.attainment)}{' '}
+                    <EuiToolTip
+                      content={i18n.translate(
+                        'observability.apm.slo.detail.percentagePointsTooltip',
+                        { defaultMessage: 'percentage points' }
+                      )}
+                    >
+                      <abbr
+                        title={i18n.translate(
+                          'observability.apm.slo.detail.percentagePointsTooltip',
+                          { defaultMessage: 'percentage points' }
+                        )}
+                        data-test-subj="slosDetailAttainmentDeltaUnit"
+                      >
+                        {i18n.translate('observability.apm.slo.detail.percentagePointsAbbr', {
+                          defaultMessage: 'pp',
+                        })}
+                      </abbr>
+                    </EuiToolTip>
                   </span>
                 </>
               )}
@@ -463,6 +524,11 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
   const advancedRef = useRef<HTMLDivElement | null>(null);
   const [ruleHealth, setRuleHealth] = useState<RuleHealthResponse | null>(null);
   const [ruleHealthLoading, setRuleHealthLoading] = useState(false);
+  // Count of re-probes we've fired while rule health reads as missing/partial
+  // (F-CRUD2). Bounded by RULE_HEALTH_MAX_RETRIES; drives both the polling
+  // effect and the grace-window decision (soft "propagating" callout vs. the
+  // destructive "missing" one).
+  const [ruleHealthRetries, setRuleHealthRetries] = useState(0);
 
   const onRefresh = useCallback(() => {
     setRefreshTrigger((v) => v + 1);
@@ -536,6 +602,37 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
       cancelled = true;
     };
   }, [loadRuleHealth]);
+
+  // Reset the retry budget whenever we navigate to a different SLO so the
+  // grace window starts fresh (breadcrumb SLO → SLO navigation reuses the
+  // component instance).
+  useEffect(() => {
+    setRuleHealthRetries(0);
+  }, [id]);
+
+  // While rule health reads as missing/partial, re-probe on a bounded
+  // interval (F-CRUD2). A freshly-created SLO's rule groups take time to
+  // propagate through the Cortex/AMP ruler, so a "missing" reading is
+  // routinely transient right after create. Each probe that still comes back
+  // missing schedules the next one until RULE_HEALTH_MAX_RETRIES is hit; once
+  // health recovers we reset the budget so a later regression re-polls. The
+  // timer is cleared on unmount and whenever the inputs change, so it can't
+  // leak or poll forever.
+  useEffect(() => {
+    if (!doc) return undefined;
+    const calloutState = deriveSloCalloutState(ruleHealth?.state, doc.liveStatus.state);
+    const missing = calloutState === 'rules_missing' || calloutState === 'rules_partial';
+    if (!missing) {
+      if (ruleHealthRetries !== 0) setRuleHealthRetries(0);
+      return undefined;
+    }
+    if (ruleHealthRetries >= RULE_HEALTH_MAX_RETRIES) return undefined;
+    const timer = setTimeout(() => {
+      setRuleHealthRetries((n) => n + 1);
+      loadRuleHealth();
+    }, RULE_HEALTH_RETRY_INTERVAL_MS);
+    return () => clearTimeout(timer);
+  }, [doc, ruleHealth, ruleHealthRetries, loadRuleHealth]);
 
   const onRepair = useCallback(async () => {
     try {
@@ -685,7 +782,53 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
     );
   }
 
-  if (!doc) return null;
+  // We only reach here with no doc once loading has finished and no fetch
+  // error was raised (both handled above) — i.e. the id genuinely resolved to
+  // nothing. Surface an explicit "not found" state (CLAR16) rather than a
+  // blank page, distinct from the fetch-error branch above. The loading guard
+  // upstream ensures a still-resolving request never flashes this prompt.
+  if (!doc) {
+    return (
+      <EuiPage>
+        <EuiPageBody>
+          <EuiPanel>
+            <EuiEmptyPrompt
+              iconType="search"
+              data-test-subj="slosDetailNotFound"
+              title={
+                <h2>
+                  {i18n.translate('observability.apm.slo.detail.notFound.title', {
+                    defaultMessage: 'SLO not found',
+                  })}
+                </h2>
+              }
+              body={
+                <p>
+                  {i18n.translate('observability.apm.slo.detail.notFound.body', {
+                    defaultMessage:
+                      "We couldn't find an SLO with the id \"{id}\". It may have been deleted, or the link may be out of date.",
+                    values: { id },
+                  })}
+                </p>
+              }
+              actions={
+                <EuiButton
+                  fill
+                  iconType="arrowLeft"
+                  onClick={() => history.push('/slos')}
+                  data-test-subj="slosDetailNotFoundBack"
+                >
+                  {i18n.translate('observability.apm.slo.detail.notFound.backToList', {
+                    defaultMessage: 'Back to SLOs',
+                  })}
+                </EuiButton>
+              }
+            />
+          </EuiPanel>
+        </EuiPageBody>
+      </EuiPage>
+    );
+  }
 
   const sli = doc.spec.sli.type === 'single' ? doc.spec.sli : null;
   const primaryObjective = doc.spec.objectives[0];
@@ -696,15 +839,18 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
   // rule-health probe is preferred when available; fall back to the
   // persisted live-status flag so the callout still shows when the probe
   // hasn't returned yet.
-  const ruleHealthState = ruleHealth?.state;
-  const derivedCalloutState: 'rules_missing' | 'rules_partial' | 'ruler_unreachable' | null =
-    ruleHealthState === 'rules_missing' ||
-    ruleHealthState === 'rules_partial' ||
-    ruleHealthState === 'ruler_unreachable'
-      ? ruleHealthState
-      : doc.liveStatus.state === 'rules_missing'
-        ? 'rules_missing'
-        : null;
+  const derivedCalloutState = deriveSloCalloutState(ruleHealth?.state, doc.liveStatus.state);
+  const rulesMissing =
+    derivedCalloutState === 'rules_missing' || derivedCalloutState === 'rules_partial';
+  // Grace window (F-CRUD2): until the bounded re-probes are exhausted, a
+  // "missing" reading is treated as still-propagating and shown with a soft,
+  // non-destructive callout. Only after the retries run out do we escalate to
+  // the alarming "rules missing" callout with its Restore/Delete CTAs — so a
+  // freshly-created SLO whose rules are simply mid-propagation never flashes a
+  // scary false alarm.
+  const ruleHealthRetriesExhausted = ruleHealthRetries >= RULE_HEALTH_MAX_RETRIES;
+  const showRulesPropagating = rulesMissing && !ruleHealthRetriesExhausted;
+  const showRulesMissingAlarm = rulesMissing && ruleHealthRetriesExhausted;
 
   // Recording-rule names from the persisted provisioning record. Dedup
   // shape: SLOs carry `recordingFingerprints` (objective name → fingerprint).
@@ -830,38 +976,37 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
       compressed
     />,
     <EuiButtonEmpty
-      key="viewRules"
+      key="viewAlerts"
       size="s"
       iconType="popout"
-      data-test-subj="slosDetailViewRules"
+      data-test-subj="slosDetailViewAlerts"
       onClick={() => {
-        // Deep-link to Alert Manager's Rules tab filtered to this SLO's
-        // alert rules. The alarms page parses `?q=…` from the hash and
-        // seeds MonitorsTable's searchQuery (alarms_page.tsx ::
-        // parseAlarmsHashRoute). matchesSearch supports `label:value`
-        // syntax, and every alert rule we emit carries `slo_id=<id>`,
-        // so the table narrows to exactly this SLO's alert rules.
-        // Recording rules don't surface in Alert Manager (they're
-        // filtered to `type === 'alerting'` in alert_service.ts) — the
-        // recording-rule list on this page is informational only.
+        // Deep-link to Alert Manager's *Alerts* tab (the firing alerts view)
+        // rather than the Rules definition list (OBS1). Operators arriving
+        // from an SLO page overwhelmingly want to see what is firing right
+        // now, not the rule definitions. The alarms page's
+        // `parseAlarmsHashRoute` maps the `#/alerts` segment to the Alerts
+        // tab and applies the `ds=<datasourceId>` param to the datasource
+        // selection regardless of which tab is active — so the Alerts view
+        // lands with this SLO's Prometheus datasource already selected.
         //
-        // Also pass `ds=<spec.datasourceId>` so the alarms page can
-        // include the SLO's Prometheus datasource in `selectedDsIds`.
-        // Without this, the search filter narrows to zero rows whenever
-        // the user's last-used datasource selection didn't include the
-        // SLO's Prometheus DS — see BUG-12 in the bug report.
+        // `q=slo_id:<id>` is carried through for the day the Alerts tab
+        // honours the deep-link query the way the Rules tab already does
+        // (today only MonitorsTable seeds its search from `deepLink.q`); it
+        // is harmless until then. The recording-rule list on this page stays
+        // informational — recording rules never surface in Alert Manager.
         const params = new URLSearchParams({
           q: `slo_id:${doc.id}`,
           ds: doc.spec.datasourceId,
         });
         coreRefs?.application?.navigateToApp(observabilityAlertingID, {
-          path: `#/rules?${params.toString()}`,
+          path: `#/alerts?${params.toString()}`,
         });
         window.dispatchEvent(new HashChangeEvent('hashchange'));
       }}
     >
-      {i18n.translate('observability.apm.slo.detail.viewAlertRulesButton', {
-        defaultMessage: 'View alert rules',
+      {i18n.translate('observability.apm.slo.detail.viewAlertsButton', {
+        defaultMessage: 'View alerts',
       })}
     </EuiButtonEmpty>,
     <EuiButton key="toggle" size="s" onClick={onToggleEnabled} data-test-subj="slosDetailToggle">
@@ -901,7 +1046,49 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
 
             <EuiSpacer size="m" />
 
-            {derivedCalloutState === 'rules_missing' || derivedCalloutState === 'rules_partial' ? (
+            {showRulesPropagating ? (
+              <>
+                <EuiCallOut
+                  color="primary"
+                  iconType="clock"
+                  title={i18n.translate(
+                    'observability.apm.slo.detail.rulesPropagatingCallout.title',
+                    { defaultMessage: 'Setting up rule groups' }
+                  )}
+                  data-test-subj="slosDetailRulePropagatingCallout"
+                >
+                  <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                    <EuiFlexItem grow={false}>
+                      <EuiLoadingSpinner size="m" />
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <p>
+                        {i18n.translate(
+                          'observability.apm.slo.detail.rulesPropagatingCallout.body',
+                          {
+                            defaultMessage:
+                              "This SLO's rule groups are still propagating to the ruler. This is normal for a few moments after creating or editing an SLO — alerts and status will start updating once propagation finishes.",
+                          }
+                        )}
+                      </p>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                  <EuiSpacer size="s" />
+                  <EuiButtonEmpty
+                    size="s"
+                    iconType="refresh"
+                    onClick={() => loadRuleHealth()}
+                    isLoading={ruleHealthLoading}
+                    data-test-subj="slosDetailRulePropagatingCheckNow"
+                  >
+                    {i18n.translate('observability.apm.slo.detail.rulesPropagatingCallout.checkNow', {
+                      defaultMessage: 'Check now',
+                    })}
+                  </EuiButtonEmpty>
+                </EuiCallOut>
+                <EuiSpacer size="m" />
+              </>
+            ) : showRulesMissingAlarm ? (
               <>
                 <EuiCallOut
                   color="danger"


### PR DESCRIPTION
## What & why
Fixes the real cause of the clipped title at 1024px (`responsive={false}` + min-width), adds a proper 'SLO not found' EmptyPrompt before the null return, spells out 'pp', re-polls rule health (suppressing the callout during the post-create propagation window), and pivots 'View alerts' to firing alerts.

**Findings:** CLAR14/BUG-S1, CLAR16, CLAR12, F-CRUD2, OBS1.

## Before / after

**Before / after (header pivot)**

![Before / after (header pivot)](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR6/before-after.png)

**Flow**

![Flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR6/flow.gif)

## Testing
`slo_detail_page.test.tsx`. Centrally green.

## Review
Independent review agent: **APPROVE** (review commit applied).

## Regression check
The before/after above is a **full-viewport** capture, so adjacent components on the same surface are visible and unchanged — the diff is scoped to what's called out. Cross-component safety is also verified centrally: this change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. Aside from the merge-order note below, it can be reviewed, merged, and reverted independently.

## Dependency
No dependencies — can merge independently. Note: #2838 (SLO edit path) is stacked on this and should merge after it.

> Draft — see the merge-order note above.
