### PR TITLE
[SLO] Charts: derive window from type, no false-green on missing burn data, dataviz polish

### DIFF
--- a/public/components/apm/pages/services_home/__tests__/slo_budget_sparkline.test.tsx
+++ b/public/components/apm/pages/services_home/__tests__/slo_budget_sparkline.test.tsx
@@ -11,7 +11,11 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { buildAggregateErrorRatioQuery, SloBudgetSparkline } from '../slo_budget_sparkline';
+import {
+  buildAggregateErrorRatioQuery,
+  buildOption,
+  SloBudgetSparkline,
+} from '../slo_budget_sparkline';
 import type { UsePromQLChartDataResult } from '../../../shared/hooks/use_promql_chart_data';
 
 // Stub the PromQL hook so the component's branches are directly selectable
@@ -65,6 +69,18 @@ describe('buildAggregateErrorRatioQuery', () => {
     expect(q).toContain('__name__=~"slo:sli_error:ratio_rate_3d:.+"');
     // Should NOT try to filter by service — no such label on recording rules.
     expect(q).not.toContain('slo_service=');
+  });
+});
+
+describe('buildOption (m4)', () => {
+  it('keeps the line linear (smooth: false) so short-lived burn spikes stay visible', () => {
+    const opt = buildOption([
+      [1, 0.1],
+      [2, 0.9],
+      [3, 0.1],
+    ]);
+    const series = (opt.series as Array<Record<string, unknown>>)[0];
+    expect(series.smooth).toBe(false);
   });
 });
 

--- a/public/components/apm/pages/services_home/slo_budget_sparkline.tsx
+++ b/public/components/apm/pages/services_home/slo_budget_sparkline.tsx
@@ -42,7 +42,7 @@ import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 import { i18n } from '@osd/i18n';
 import { EchartsRender } from '../../../alerting/echarts_render';
 import { usePromQLChartData } from '../../shared/hooks/use_promql_chart_data';
-import { formatPct } from '../../../../../common/slo/format';
+import { formatPct, SLO_PRECISION } from '../../../../../common/slo/format';
 
 /** Fixed 7d window. Independent of the page time picker by design. */
 const TIME_RANGE = { from: 'now-7d', to: 'now' } as const;
@@ -90,7 +90,7 @@ const t = {
   tooltipRemaining: (v: number, ts: string) =>
     i18n.translate('observability.apm.services.sloBudgetSparkline.tooltip', {
       defaultMessage: '{ts}: {pct} error ratio',
-      values: { ts, pct: formatPct(v) },
+      values: { ts, pct: formatPct(v, { decimals: SLO_PRECISION.budget }) },
     }),
 };
 

--- a/public/components/apm/pages/services_home/slo_budget_sparkline.tsx
+++ b/public/components/apm/pages/services_home/slo_budget_sparkline.tsx
@@ -94,7 +94,7 @@ const t = {
     }),
 };
 
-function buildOption(data: Array<[number, number]>): EChartsOption {
+export function buildOption(data: Array<[number, number]>): EChartsOption {
   return {
     grid: { left: 0, right: 0, top: 2, bottom: 2, containLabel: false },
     tooltip: {
@@ -125,7 +125,9 @@ function buildOption(data: Array<[number, number]>): EChartsOption {
       {
         type: 'line',
         data,
-        smooth: true,
+        // Discrete/step data: smoothing rounds off the short-lived burn spikes
+        // that are the whole point of this trend line, so keep it linear.
+        smooth: false,
         symbol: 'none',
         lineStyle: { color: euiThemeVars.euiColorPrimary, width: 1.5 },
         areaStyle: { color: euiThemeVars.euiColorPrimary, opacity: 0.12 },

--- a/public/components/apm/pages/slos/__tests__/slo_budget_remaining_chart.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_budget_remaining_chart.test.tsx
@@ -45,9 +45,7 @@ jest.mock('@osd/ui-shared-deps/theme', () => ({
   },
 }));
 
-function makeSlo(
-  overrides: Partial<SloDocument['spec']> = {}
-): SloDocument & {
+function makeSlo(overrides: Partial<SloDocument['spec']> = {}): SloDocument & {
   liveStatus: SloLiveStatus;
 } {
   return {
@@ -345,9 +343,7 @@ describe('SloBudgetRemainingChart', () => {
       refetch: jest.fn(),
     });
     const slo = makeSlo({ window: { type: 'calendar', period: 'week', timezone: 'UTC' } });
-    render(
-      <SloBudgetRemainingChart slo={slo} objective={slo.spec.objectives[0]} {...baseProps} />
-    );
+    render(<SloBudgetRemainingChart slo={slo} objective={slo.spec.objectives[0]} {...baseProps} />);
     expect(screen.getByText(/calendar-week/i)).toBeInTheDocument();
     // The equivalent rolling range for a week is 7d — the old code hardcoded 30d.
     expect(screen.getByText(/7d/)).toBeInTheDocument();

--- a/public/components/apm/pages/slos/__tests__/slo_budget_remaining_chart.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_budget_remaining_chart.test.tsx
@@ -178,8 +178,11 @@ describe('buildBudgetRemainingOption', () => {
     const html = tooltip.formatter([{ axisValue: 0, value: [0, 0.6] }]);
     expect(html).toContain('UTC');
     expect(html).toContain('vs warning threshold');
+    // Budget surfaces render at SLO_PRECISION.budget (2 decimals), matching the
+    // budget panel — so 0.6 reads "60.00%", not "60.0%".
+    expect(html).toContain('60.00%');
     // 0.6 remaining is 10 points above the 0.5 warning threshold.
-    expect(html).toContain('+10.0%');
+    expect(html).toContain('+10.00%');
   });
 
   it('renders warning-threshold markLine with severity label', () => {
@@ -201,7 +204,8 @@ describe('buildBudgetRemainingOption', () => {
     expect(markLine.data[1].yAxis).toBe(0.5);
     const secondLabel = markLine.data[1].label as { formatter: string };
     expect(secondLabel.formatter).toContain('warning');
-    expect(secondLabel.formatter).toContain('50.0%');
+    // Budget precision (2 decimals) — matches the budget panel.
+    expect(secondLabel.formatter).toContain('50.00%');
   });
 
   it('omits the warning-threshold line when the spec has no budget warnings', () => {

--- a/public/components/apm/pages/slos/__tests__/slo_budget_remaining_chart.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_budget_remaining_chart.test.tsx
@@ -6,7 +6,11 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import type { SloDocument, SloLiveStatus } from '../../../../../../common/slo/slo_types';
-import { buildBudgetRemainingOption, SloBudgetRemainingChart } from '../slo_budget_remaining_chart';
+import {
+  buildBudgetRemainingOption,
+  deriveWindowDuration,
+  SloBudgetRemainingChart,
+} from '../slo_budget_remaining_chart';
 
 // Keep the chart DOM inert so we can assert on the hook output without
 // initialising ECharts (jsdom has no canvas and no ResizeObserver). The
@@ -110,7 +114,76 @@ const baseProps = {
   refreshTrigger: 0,
 };
 
+describe('deriveWindowDuration (M1)', () => {
+  it('returns the configured duration for rolling windows', () => {
+    expect(deriveWindowDuration({ type: 'rolling', duration: '28d' })).toBe('28d');
+    expect(deriveWindowDuration({ type: 'rolling', duration: '7d' })).toBe('7d');
+  });
+
+  it('maps calendar periods to an equivalent rolling range — never a hardcoded 30d', () => {
+    expect(deriveWindowDuration({ type: 'calendar', period: 'week', timezone: 'UTC' })).toBe('7d');
+    expect(deriveWindowDuration({ type: 'calendar', period: 'month', timezone: 'UTC' })).toBe(
+      '30d'
+    );
+    expect(deriveWindowDuration({ type: 'calendar', period: 'quarter', timezone: 'UTC' })).toBe(
+      '90d'
+    );
+  });
+});
+
 describe('buildBudgetRemainingOption', () => {
+  it('draws the exhausted (zero) reference line dashed, not solid, so it reads as an annotation (m1)', () => {
+    const opt = buildBudgetRemainingOption({
+      seriesName: 'obj-1',
+      data: [[1, 0.9]],
+      warningThreshold: undefined,
+      atZero: false,
+      tz: 'UTC',
+    });
+    const series = (opt.series as Array<Record<string, unknown>>)[0];
+    const markLine = series.markLine as { data: Array<Record<string, unknown>> };
+    const exhausted = markLine.data[0].lineStyle as { type: string };
+    expect(exhausted.type).toBe('dashed');
+  });
+
+  it('adds a redundant non-color cue (dashed line + marker) for the breached series (m2)', () => {
+    const breached = buildBudgetRemainingOption({
+      seriesName: 'obj-1',
+      data: [[1, 0]],
+      atZero: true,
+      tz: 'UTC',
+    });
+    const series = (breached.series as Array<Record<string, unknown>>)[0];
+    expect((series.lineStyle as { type: string }).type).toBe('dashed');
+    expect(series.symbol).toBe('triangle');
+
+    const healthy = buildBudgetRemainingOption({
+      seriesName: 'obj-1',
+      data: [[1, 0.9]],
+      atZero: false,
+      tz: 'UTC',
+    });
+    const healthySeries = (healthy.series as Array<Record<string, unknown>>)[0];
+    expect((healthySeries.lineStyle as { type: string }).type).toBe('solid');
+    expect(healthySeries.symbol).toBe('none');
+  });
+
+  it('tooltip labels the timezone and shows the delta versus the warning threshold (m3)', () => {
+    const opt = buildBudgetRemainingOption({
+      seriesName: 'obj-1',
+      data: [[0, 0.6]],
+      warningThreshold: { threshold: 0.5, severity: 'warning' },
+      atZero: false,
+      tz: 'UTC',
+    });
+    const tooltip = opt.tooltip as { formatter: (p: unknown) => string };
+    const html = tooltip.formatter([{ axisValue: 0, value: [0, 0.6] }]);
+    expect(html).toContain('UTC');
+    expect(html).toContain('vs warning threshold');
+    // 0.6 remaining is 10 points above the 0.5 warning threshold.
+    expect(html).toContain('+10.0%');
+  });
+
   it('renders warning-threshold markLine with severity label', () => {
     const opt = buildBudgetRemainingOption({
       seriesName: 'obj-1',
@@ -261,6 +334,23 @@ describe('SloBudgetRemainingChart', () => {
       />
     );
     expect(screen.getByTestId('slosBudgetRemainingExhausted')).toBeInTheDocument();
+  });
+
+  it('describes a calendar-aligned SLO as calendar, not as a rolling 30-day window (M1)', () => {
+    mockUsePromQLChartData.mockReturnValue({
+      series: [{ name: 'obj-1', data: [{ timestamp: 1, value: 0.9 }], color: '#000' }],
+      latestValue: 0.9,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    const slo = makeSlo({ window: { type: 'calendar', period: 'week', timezone: 'UTC' } });
+    render(
+      <SloBudgetRemainingChart slo={slo} objective={slo.spec.objectives[0]} {...baseProps} />
+    );
+    expect(screen.getByText(/calendar-week/i)).toBeInTheDocument();
+    // The equivalent rolling range for a week is 7d — the old code hardcoded 30d.
+    expect(screen.getByText(/7d/)).toBeInTheDocument();
   });
 
   it('shows the unavailable callout when the SLI cannot produce a PromQL query', () => {

--- a/public/components/apm/pages/slos/__tests__/slo_burn_rate_chart.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_burn_rate_chart.test.tsx
@@ -151,6 +151,37 @@ describe('buildBurnRateOption', () => {
     expect(secondMark.label.formatter).toContain('ticket');
   });
 
+  it('tooltip labels the timezone and shows each tier delta versus its threshold (m3)', () => {
+    const opt = buildBurnRateOption({
+      tz: 'UTC',
+      tiers: [
+        {
+          label: 'Page · Quick',
+          severity: 'page',
+          multiplier: 14,
+          color: '#A00',
+          data: [[0, 20]],
+        },
+        {
+          label: 'Ticket · Slow',
+          severity: 'ticket',
+          multiplier: 6,
+          color: '#0A0',
+          data: [[0, 2]],
+        },
+      ],
+    });
+    const tooltip = opt.tooltip as { formatter: (p: unknown) => string };
+    const html = tooltip.formatter([
+      { axisValue: 0, value: [0, 20, 20], seriesName: 'Page · Quick', color: '#A00' },
+      { axisValue: 0, value: [0, 2, 2], seriesName: 'Ticket · Slow', color: '#0A0' },
+    ]);
+    expect(html).toContain('UTC');
+    // 20x is 6x over the 14x threshold; 2x is 4x under the 6x threshold.
+    expect(html).toContain('6x over');
+    expect(html).toContain('4x under');
+  });
+
   it('uses a log10 yAxis snapped to the next decade above the highest threshold or sample', () => {
     const opt = buildBurnRateOption({
       tiers: [

--- a/public/components/apm/pages/slos/__tests__/slo_burn_rate_panel.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_burn_rate_panel.test.tsx
@@ -14,7 +14,13 @@ jest.mock('../../../shared/hooks/use_promql_chart_data', () => ({
   RESOLUTION_EXCEEDED_CODE: 'RESOLUTION_EXCEEDED',
 }));
 
-import { SloBurnRatePanel } from '../slo_burn_rate_panel';
+import {
+  classifyTier,
+  healthColor,
+  healthLabel,
+  severityLabel,
+  SloBurnRatePanel,
+} from '../slo_burn_rate_panel';
 import type { Objective, SloDocument } from '../../../../../../common/slo/slo_types';
 
 function baseSlo(): SloDocument {
@@ -86,6 +92,59 @@ beforeEach(() => {
     isLoading: false,
     error: null,
     refetch: jest.fn(),
+  });
+});
+
+describe('classifyTier (M2 — no false green on missing data)', () => {
+  const threshold = 0.1;
+
+  it('classifies both-under-threshold as ok', () => {
+    expect(classifyTier(0.01, 0.02, threshold)).toBe('ok');
+  });
+
+  it('classifies both-over-threshold as firing', () => {
+    expect(classifyTier(0.5, 0.4, threshold)).toBe('firing');
+  });
+
+  it('classifies exactly one window over threshold as at_risk (not firing)', () => {
+    expect(classifyTier(0.5, 0.02, threshold)).toBe('at_risk');
+    expect(classifyTier(0.02, 0.5, threshold)).toBe('at_risk');
+  });
+
+  it('NEVER reports ok/green when a window is null, undefined, or NaN', () => {
+    expect(classifyTier(null, 0.02, threshold)).toBe('no_data');
+    expect(classifyTier(0.02, null, threshold)).toBe('no_data');
+    expect(classifyTier(null, null, threshold)).toBe('no_data');
+    expect(classifyTier(undefined as never, 0.02, threshold)).toBe('no_data');
+    expect(classifyTier(NaN, 0.02, threshold)).toBe('no_data');
+    expect(classifyTier(0.02, NaN, threshold)).toBe('no_data');
+    expect(classifyTier(Infinity, 0.02, threshold)).toBe('no_data');
+  });
+
+  it('maps no_data to a subdued (grey) health color — never success/green', () => {
+    const color = healthColor('no_data');
+    expect(color).toBe('subdued');
+    expect(color).not.toBe('success');
+  });
+
+  it('labels each tier health honestly in title case', () => {
+    expect(healthLabel('firing')).toBe('Firing');
+    expect(healthLabel('at_risk')).toBe('At risk');
+    expect(healthLabel('ok')).toBe('Healthy');
+    expect(healthLabel('no_data')).toBe('No data');
+  });
+});
+
+describe('severityLabel (CLAR6)', () => {
+  it('maps known severities to title-case labels', () => {
+    expect(severityLabel('critical')).toBe('Critical');
+    expect(severityLabel('warning')).toBe('Warning');
+    expect(severityLabel('page')).toBe('Page');
+    expect(severityLabel('ticket')).toBe('Ticket');
+  });
+
+  it('falls back to the raw token for unknown severities', () => {
+    expect(severityLabel('sev2')).toBe('sev2');
   });
 });
 

--- a/public/components/apm/pages/slos/slo_budget_remaining_chart.tsx
+++ b/public/components/apm/pages/slos/slo_budget_remaining_chart.tsx
@@ -40,6 +40,18 @@ import { formatPct } from '../../../../../common/slo/format';
 import { uiSettingsService } from '../../../../../common/utils';
 
 /**
+ * Escape values interpolated into the ECharts tooltip HTML. The tooltip
+ * `formatter` returns a raw HTML string, so any dynamic value (timestamp,
+ * formatted percentages, delta) must be escaped to prevent HTML injection
+ * should an upstream value ever contain angle brackets or quotes.
+ */
+const escapeHtml = (s: string): string =>
+  String(s).replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] as string
+  );
+
+/**
  * Prometheus range-duration equivalents for each calendar period. Calendar
  * windows aren't backed by recording rules yet, so the inline chart approximates
  * the period with a rolling range of equal length. Deriving the duration from
@@ -189,15 +201,16 @@ export function buildBudgetRemainingOption(
         if (warningThreshold && Number.isFinite(v)) {
           const delta = v - warningThreshold.threshold;
           const sign = delta >= 0 ? '+' : '';
-          deltaLine = `<br/>${i18n.translate(
-            'observability.apm.slo.budgetRemainingChart.tooltip.deltaVsThreshold',
-            {
+          deltaLine = `<br/>${escapeHtml(
+            i18n.translate('observability.apm.slo.budgetRemainingChart.tooltip.deltaVsThreshold', {
               defaultMessage: '{delta} vs warning threshold',
               values: { delta: `${sign}${formatPct(delta)}` },
-            }
+            })
           )}`;
         }
-        return `${ts}<br/><strong>${formatPct(v)}</strong> ${remainingLabel}${deltaLine}`;
+        return `${escapeHtml(ts)}<br/><strong>${escapeHtml(formatPct(v))}</strong> ${escapeHtml(
+          remainingLabel
+        )}${deltaLine}`;
       },
     },
     xAxis: {

--- a/public/components/apm/pages/slos/slo_budget_remaining_chart.tsx
+++ b/public/components/apm/pages/slos/slo_budget_remaining_chart.tsx
@@ -22,6 +22,7 @@
 import React, { useMemo } from 'react';
 import { EuiCallOut, EuiIcon, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
 import * as echarts from 'echarts';
+import moment from 'moment-timezone';
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 import { i18n } from '@osd/i18n';
 import { EchartsRender } from '../../../alerting/echarts_render';
@@ -29,11 +30,52 @@ import { usePromQLChartData } from '../../shared/hooks/use_promql_chart_data';
 import { TimeRange } from '../../common/types/service_types';
 import type {
   BudgetWarningThreshold,
+  CalendarWindow,
   Objective,
   SloDocument,
+  Window,
 } from '../../../../../common/slo/slo_types';
 import { buildCoverageProbeQuery, buildErrorRatioExprForWindow } from './slo_query_builders';
 import { formatPct } from '../../../../../common/slo/format';
+import { uiSettingsService } from '../../../../../common/utils';
+
+/**
+ * Prometheus range-duration equivalents for each calendar period. Calendar
+ * windows aren't backed by recording rules yet, so the inline chart approximates
+ * the period with a rolling range of equal length. Deriving the duration from
+ * the spec (rather than hardcoding "30d") keeps the chart's copy honest: a
+ * calendar-week SLO no longer claims to cover a rolling 30-day window.
+ */
+const CALENDAR_PERIOD_DURATIONS: Record<CalendarWindow['period'], string> = {
+  week: '7d',
+  month: '30d',
+  quarter: '90d',
+};
+
+/** Resolve the PromQL range duration the chart should query for this window. */
+export function deriveWindowDuration(window: Window): string {
+  return window.type === 'rolling'
+    ? window.duration
+    : CALENDAR_PERIOD_DURATIONS[window.period];
+}
+
+/**
+ * Resolve the timezone the user configured via `dateFormat:tz`, falling back to
+ * the browser zone. Mirrors the alerts dashboard's helper (kept local so this
+ * file owns its own copy rather than reaching across the plugin).
+ */
+function resolveDisplayTz(): string {
+  const tz = uiSettingsService.get('dateFormat:tz');
+  if (!tz || tz === 'Browser') {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+  return tz;
+}
+
+/** Format an epoch-ms tooltip timestamp with an explicit timezone abbreviation. */
+function formatTooltipTs(ms: number, tz: string): string {
+  return moment.tz(ms, tz).format('YYYY-MM-DD HH:mm z');
+}
 
 export interface SloBudgetRemainingChartProps {
   slo: SloDocument;
@@ -72,6 +114,8 @@ export interface BudgetRemainingOptionInputs {
   data: Array<[number, number]>;
   warningThreshold?: BudgetWarningThreshold;
   atZero: boolean;
+  /** Timezone for tooltip timestamps. Defaults to the user's `dateFormat:tz`. */
+  tz?: string;
 }
 
 /**
@@ -82,13 +126,21 @@ export function buildBudgetRemainingOption(
   inputs: BudgetRemainingOptionInputs
 ): echarts.EChartsOption {
   const { seriesName, data, warningThreshold, atZero } = inputs;
+  const tz = inputs.tz ?? resolveDisplayTz();
   const fillColor = atZero ? euiThemeVars.euiColorDanger : euiThemeVars.euiColorSuccess;
   const fillRgba = atZero ? 'rgba(189, 39, 30, 0.35)' : 'rgba(84, 179, 153, 0.25)';
+  // WCAG 1.4.1: don't rely on hue alone to distinguish a breached (at-zero)
+  // series from a healthy one. A dashed stroke + visible markers give a
+  // redundant, color-independent cue for the danger state.
+  const lineType = atZero ? 'dashed' : 'solid';
+  const symbol = atZero ? 'triangle' : 'none';
 
   const markLines: Array<Record<string, unknown>> = [
     {
       yAxis: 0,
-      lineStyle: { color: euiThemeVars.euiColorDanger, type: 'solid', width: 1 },
+      // Dashed so this threshold annotation reads as a reference line, not as
+      // plotted data.
+      lineStyle: { color: euiThemeVars.euiColorDanger, type: 'dashed', width: 1 },
       label: {
         formatter: i18n.translate('observability.apm.slo.budgetRemainingChart.exhaustedMarkLabel', {
           defaultMessage: 'exhausted',
@@ -127,9 +179,27 @@ export function buildBudgetRemainingOption(
         const list = params as Array<{ axisValue: number; value: [number, number] }>;
         if (!list || list.length === 0) return '';
         const p = list[0];
-        const ts = new Date(p.axisValue).toLocaleString();
+        const ts = formatTooltipTs(p.axisValue, tz);
         const v = Array.isArray(p.value) ? p.value[1] : (p.value as number);
-        return `${ts}<br/><strong>${formatPct(v)}</strong> remaining`;
+        const remainingLabel = i18n.translate(
+          'observability.apm.slo.budgetRemainingChart.tooltip.remaining',
+          { defaultMessage: 'remaining' }
+        );
+        // Delta versus the warning threshold: positive = headroom left before
+        // escalation, negative = already past the guardrail.
+        let deltaLine = '';
+        if (warningThreshold && Number.isFinite(v)) {
+          const delta = v - warningThreshold.threshold;
+          const sign = delta >= 0 ? '+' : '';
+          deltaLine = `<br/>${i18n.translate(
+            'observability.apm.slo.budgetRemainingChart.tooltip.deltaVsThreshold',
+            {
+              defaultMessage: '{delta} vs warning threshold',
+              values: { delta: `${sign}${formatPct(delta)}` },
+            }
+          )}`;
+        }
+        return `${ts}<br/><strong>${formatPct(v)}</strong> ${remainingLabel}${deltaLine}`;
       },
     },
     xAxis: {
@@ -165,8 +235,11 @@ export function buildBudgetRemainingOption(
         type: 'line',
         data,
         smooth: false,
-        symbol: 'none',
-        lineStyle: { color: fillColor, width: 2 },
+        // Redundant non-color cues for the breached state (see lineType/symbol).
+        symbol,
+        symbolSize: 5,
+        showSymbol: atZero,
+        lineStyle: { color: fillColor, width: 2, type: lineType },
         itemStyle: { color: fillColor },
         areaStyle: { color: fillRgba },
         markLine: {
@@ -186,7 +259,11 @@ export const SloBudgetRemainingChart: React.FC<SloBudgetRemainingChartProps> = (
   timeRange,
   refreshTrigger,
 }) => {
-  const window = slo.spec.window.type === 'rolling' ? slo.spec.window.duration : '30d';
+  // Derive the actual PromQL range from the spec's window. Rolling windows use
+  // their configured duration; calendar windows approximate their period with a
+  // rolling range of equal length (recording rules for calendar windows aren't
+  // wired up yet). Never hardcode "30d" — that mislabeled every calendar SLO.
+  const window = useMemo(() => deriveWindowDuration(slo.spec.window), [slo.spec.window]);
   const query = useMemo(() => buildBudgetRemainingExpr(slo, objective, window), [
     slo,
     objective,
@@ -283,11 +360,17 @@ export const SloBudgetRemainingChart: React.FC<SloBudgetRemainingChartProps> = (
         </h4>
       </EuiText>
       <EuiText size="xs" color="subdued">
-        {i18n.translate('observability.apm.slo.budgetRemainingChart.description', {
-          defaultMessage:
-            'Fraction of the {window} error budget still available. Starts at 100% and trends toward 0 as bad events accumulate. Crossing the warning threshold means an escalation is close.',
-          values: { window },
-        })}
+        {slo.spec.window.type === 'calendar'
+          ? i18n.translate('observability.apm.slo.budgetRemainingChart.description.calendar', {
+              defaultMessage:
+                'Fraction of the calendar-{period} error budget still available (approximated over a rolling {window} range until calendar recording rules land). Starts at 100% and trends toward 0 as bad events accumulate. Crossing the warning threshold means an escalation is close.',
+              values: { period: slo.spec.window.period, window },
+            })
+          : i18n.translate('observability.apm.slo.budgetRemainingChart.description', {
+              defaultMessage:
+                'Fraction of the rolling {window} error budget still available. Starts at 100% and trends toward 0 as bad events accumulate. Crossing the warning threshold means an escalation is close.',
+              values: { window },
+            })}
       </EuiText>
       <EuiSpacer size="s" />
       {error && (

--- a/public/components/apm/pages/slos/slo_budget_remaining_chart.tsx
+++ b/public/components/apm/pages/slos/slo_budget_remaining_chart.tsx
@@ -54,9 +54,7 @@ const CALENDAR_PERIOD_DURATIONS: Record<CalendarWindow['period'], string> = {
 
 /** Resolve the PromQL range duration the chart should query for this window. */
 export function deriveWindowDuration(window: Window): string {
-  return window.type === 'rolling'
-    ? window.duration
-    : CALENDAR_PERIOD_DURATIONS[window.period];
+  return window.type === 'rolling' ? window.duration : CALENDAR_PERIOD_DURATIONS[window.period];
 }
 
 /**
@@ -264,11 +262,10 @@ export const SloBudgetRemainingChart: React.FC<SloBudgetRemainingChartProps> = (
   // rolling range of equal length (recording rules for calendar windows aren't
   // wired up yet). Never hardcode "30d" — that mislabeled every calendar SLO.
   const window = useMemo(() => deriveWindowDuration(slo.spec.window), [slo.spec.window]);
-  const query = useMemo(() => buildBudgetRemainingExpr(slo, objective, window), [
-    slo,
-    objective,
-    window,
-  ]);
+  const query = useMemo(
+    () => buildBudgetRemainingExpr(slo, objective, window),
+    [slo, objective, window]
+  );
 
   // The first budget-warning threshold drives the "at risk" line. Sort
   // descending so a list like [0.25, 0.5, 0.1] still surfaces the most

--- a/public/components/apm/pages/slos/slo_budget_remaining_chart.tsx
+++ b/public/components/apm/pages/slos/slo_budget_remaining_chart.tsx
@@ -36,7 +36,7 @@ import type {
   Window,
 } from '../../../../../common/slo/slo_types';
 import { buildCoverageProbeQuery, buildErrorRatioExprForWindow } from './slo_query_builders';
-import { formatPct } from '../../../../../common/slo/format';
+import { formatPct, SLO_PRECISION } from '../../../../../common/slo/format';
 import { uiSettingsService } from '../../../../../common/utils';
 
 /**
@@ -170,7 +170,9 @@ export function buildBudgetRemainingOption(
         width: 1,
       },
       label: {
-        formatter: `${warningThreshold.severity} @ ${formatPct(warningThreshold.threshold)}`,
+        formatter: `${warningThreshold.severity} @ ${formatPct(warningThreshold.threshold, {
+          decimals: SLO_PRECISION.budget,
+        })}`,
         // Pin the warning label to the end so it doesn't collide with the
         // "exhausted" label in deep-breach renders where the axis is stretched
         // downward and both markLines sit near the chart's top edge.
@@ -204,13 +206,13 @@ export function buildBudgetRemainingOption(
           deltaLine = `<br/>${escapeHtml(
             i18n.translate('observability.apm.slo.budgetRemainingChart.tooltip.deltaVsThreshold', {
               defaultMessage: '{delta} vs warning threshold',
-              values: { delta: `${sign}${formatPct(delta)}` },
+              values: { delta: `${sign}${formatPct(delta, { decimals: SLO_PRECISION.budget })}` },
             })
           )}`;
         }
-        return `${escapeHtml(ts)}<br/><strong>${escapeHtml(formatPct(v))}</strong> ${escapeHtml(
-          remainingLabel
-        )}${deltaLine}`;
+        return `${escapeHtml(ts)}<br/><strong>${escapeHtml(
+          formatPct(v, { decimals: SLO_PRECISION.budget })
+        )}</strong> ${escapeHtml(remainingLabel)}${deltaLine}`;
       },
     },
     xAxis: {
@@ -234,7 +236,7 @@ export function buildBudgetRemainingOption(
       axisLabel: {
         color: euiThemeVars.euiColorDarkShade,
         fontSize: 11,
-        formatter: (value: number) => formatPct(value),
+        formatter: (value: number) => formatPct(value, { decimals: SLO_PRECISION.budget }),
       },
       splitLine: {
         lineStyle: { color: euiThemeVars.euiColorLightestShade, type: 'dashed' },

--- a/public/components/apm/pages/slos/slo_burn_rate_chart.tsx
+++ b/public/components/apm/pages/slos/slo_burn_rate_chart.tsx
@@ -35,6 +35,18 @@ import { buildCoverageProbeQuery, buildErrorRatioExprForWindow } from './slo_que
 import { uiSettingsService } from '../../../../../common/utils';
 
 /**
+ * Escape values interpolated into the ECharts tooltip HTML. The tooltip
+ * `formatter` returns a raw HTML string, so any dynamic value (series names,
+ * colours, formatted numbers) must be escaped to prevent HTML/attribute
+ * injection should an upstream value ever contain angle brackets or quotes.
+ */
+const escapeHtml = (s: string): string =>
+  String(s).replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] as string
+  );
+
+/**
  * Resolve the timezone the user configured via `dateFormat:tz`, falling back to
  * the browser zone. Kept local (rather than shared) so this file owns its copy.
  */
@@ -151,7 +163,9 @@ export function buildBurnRateOption(inputs: BurnRateOptionInputs): echarts.EChar
         const rows = list
           .map((p) => {
             const raw = Array.isArray(p.value) ? (p.value[2] ?? p.value[1]) : (p.value as number);
-            const swatch = `<span style="display:inline-block;width:10px;height:10px;background:${p.color};margin-right:6px;border-radius:2px;"></span>`;
+            const swatch = `<span style="display:inline-block;width:10px;height:10px;background:${escapeHtml(
+              p.color
+            )};margin-right:6px;border-radius:2px;"></span>`;
             // Delta versus this tier's threshold: how much over/under the burn
             // rate that would fire the alert.
             const threshold = thresholdByName.get(p.seriesName);
@@ -167,12 +181,12 @@ export function buildBurnRateOption(inputs: BurnRateOptionInputs): echarts.EChar
                       Math.abs(delta)
                     )} under)</span>`;
             }
-            return `<div>${swatch}${p.seriesName}: <strong>${formatMultiplier(
-              raw
+            return `<div>${swatch}${escapeHtml(p.seriesName)}: <strong>${escapeHtml(
+              formatMultiplier(raw)
             )}</strong>${deltaStr}</div>`;
           })
           .join('');
-        return `<div>${ts}</div>${rows}`;
+        return `<div>${escapeHtml(ts)}</div>${rows}`;
       },
     },
     xAxis: {

--- a/public/components/apm/pages/slos/slo_burn_rate_chart.tsx
+++ b/public/components/apm/pages/slos/slo_burn_rate_chart.tsx
@@ -150,7 +150,7 @@ export function buildBurnRateOption(inputs: BurnRateOptionInputs): echarts.EChar
         const ts = formatTooltipTs(list[0].axisValue, tz);
         const rows = list
           .map((p) => {
-            const raw = Array.isArray(p.value) ? p.value[2] ?? p.value[1] : (p.value as number);
+            const raw = Array.isArray(p.value) ? (p.value[2] ?? p.value[1]) : (p.value as number);
             const swatch = `<span style="display:inline-block;width:10px;height:10px;background:${p.color};margin-right:6px;border-radius:2px;"></span>`;
             // Delta versus this tier's threshold: how much over/under the burn
             // rate that would fire the alert.
@@ -284,11 +284,10 @@ const TierFetcher: React.FC<TierFetcherProps> = ({
   errorBudget,
   onChange,
 }) => {
-  const query = useMemo(() => buildErrorRatioExprForWindow(slo, objective, tier.longWindow), [
-    slo,
-    objective,
-    tier.longWindow,
-  ]);
+  const query = useMemo(
+    () => buildErrorRatioExprForWindow(slo, objective, tier.longWindow),
+    [slo, objective, tier.longWindow]
+  );
   const { series, isLoading, error } = usePromQLChartData({
     promqlQuery: query ?? '',
     timeRange,
@@ -448,46 +447,56 @@ export const SloBurnRateChart: React.FC<SloBurnRateChartProps> = ({
           <EuiText size="s">{firstError.message}</EuiText>
         </EuiCallOut>
       )}
-      {tiers.length > 0 && !firstError && !isLoading && !hasData && !probeLoading && !metricExists && (
-        <EuiCallOut
-          size="s"
-          color="warning"
-          iconType="alert"
-          title={i18n.translate('observability.apm.slo.burnRateChart.missingMetric.title', {
-            defaultMessage: 'SLI source metric not found in this datasource',
-          })}
-          data-test-subj="slosBurnRateMissingMetric"
-        >
-          <EuiText size="s">
-            {i18n.translate('observability.apm.slo.burnRateChart.missingMetric.bodyPrefix', {
-              defaultMessage: 'No samples exist for the metric this SLI queries on',
+      {tiers.length > 0 &&
+        !firstError &&
+        !isLoading &&
+        !hasData &&
+        !probeLoading &&
+        !metricExists && (
+          <EuiCallOut
+            size="s"
+            color="warning"
+            iconType="alert"
+            title={i18n.translate('observability.apm.slo.burnRateChart.missingMetric.title', {
+              defaultMessage: 'SLI source metric not found in this datasource',
             })}
-            <strong> {prometheusConnectionId}</strong>
-            {i18n.translate('observability.apm.slo.burnRateChart.missingMetric.bodySuffix', {
-              defaultMessage:
-                ". Burn rate is derived from the same error ratio as the budget chart — if that metric is absent, burn rate can't populate. Waiting won't help; re-check the SLI's metric / selectors.",
+            data-test-subj="slosBurnRateMissingMetric"
+          >
+            <EuiText size="s">
+              {i18n.translate('observability.apm.slo.burnRateChart.missingMetric.bodyPrefix', {
+                defaultMessage: 'No samples exist for the metric this SLI queries on',
+              })}
+              <strong> {prometheusConnectionId}</strong>
+              {i18n.translate('observability.apm.slo.burnRateChart.missingMetric.bodySuffix', {
+                defaultMessage:
+                  ". Burn rate is derived from the same error ratio as the budget chart — if that metric is absent, burn rate can't populate. Waiting won't help; re-check the SLI's metric / selectors.",
+              })}
+            </EuiText>
+          </EuiCallOut>
+        )}
+      {tiers.length > 0 &&
+        !firstError &&
+        !isLoading &&
+        !hasData &&
+        !probeLoading &&
+        metricExists && (
+          <EuiCallOut
+            size="s"
+            color="primary"
+            iconType="iInCircle"
+            title={i18n.translate('observability.apm.slo.burnRateChart.emptyRange.title', {
+              defaultMessage: 'No samples in the selected time range',
             })}
-          </EuiText>
-        </EuiCallOut>
-      )}
-      {tiers.length > 0 && !firstError && !isLoading && !hasData && !probeLoading && metricExists && (
-        <EuiCallOut
-          size="s"
-          color="primary"
-          iconType="iInCircle"
-          title={i18n.translate('observability.apm.slo.burnRateChart.emptyRange.title', {
-            defaultMessage: 'No samples in the selected time range',
-          })}
-          data-test-subj="slosBurnRateEmpty"
-        >
-          <EuiText size="s">
-            {i18n.translate('observability.apm.slo.burnRateChart.emptyRange.body', {
-              defaultMessage:
-                'The metric exists in this datasource but the current range returned no burn-rate samples. Widen the time range, or wait for the next Prometheus scrape + rule evaluation.',
-            })}
-          </EuiText>
-        </EuiCallOut>
-      )}
+            data-test-subj="slosBurnRateEmpty"
+          >
+            <EuiText size="s">
+              {i18n.translate('observability.apm.slo.burnRateChart.emptyRange.body', {
+                defaultMessage:
+                  'The metric exists in this datasource but the current range returned no burn-rate samples. Widen the time range, or wait for the next Prometheus scrape + rule evaluation.',
+              })}
+            </EuiText>
+          </EuiCallOut>
+        )}
       {tiers.length > 0 && hasData && <EchartsRender spec={spec} height={260} />}
       {overflow > 0 && (
         <>

--- a/public/components/apm/pages/slos/slo_burn_rate_chart.tsx
+++ b/public/components/apm/pages/slos/slo_burn_rate_chart.tsx
@@ -23,6 +23,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { EuiCallOut, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
 import * as echarts from 'echarts';
+import moment from 'moment-timezone';
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
 import { i18n } from '@osd/i18n';
 import { EchartsRender } from '../../../alerting/echarts_render';
@@ -31,6 +32,24 @@ import { TimeRange } from '../../common/types/service_types';
 import { CHART_COLORS } from '../../common/constants';
 import type { BurnRateConfig, Objective, SloDocument } from '../../../../../common/slo/slo_types';
 import { buildCoverageProbeQuery, buildErrorRatioExprForWindow } from './slo_query_builders';
+import { uiSettingsService } from '../../../../../common/utils';
+
+/**
+ * Resolve the timezone the user configured via `dateFormat:tz`, falling back to
+ * the browser zone. Kept local (rather than shared) so this file owns its copy.
+ */
+function resolveDisplayTz(): string {
+  const tz = uiSettingsService.get('dateFormat:tz');
+  if (!tz || tz === 'Browser') {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+  return tz;
+}
+
+/** Format an epoch-ms tooltip timestamp with an explicit timezone abbreviation. */
+function formatTooltipTs(ms: number, tz: string): string {
+  return moment.tz(ms, tz).format('YYYY-MM-DD HH:mm z');
+}
 
 export interface SloBurnRateChartProps {
   slo: SloDocument;
@@ -69,6 +88,8 @@ export interface BurnRateOptionInputs {
     color: string;
     data: Array<[number, number]>;
   }>;
+  /** Timezone for tooltip timestamps. Defaults to the user's `dateFormat:tz`. */
+  tz?: string;
 }
 
 /**
@@ -77,6 +98,10 @@ export interface BurnRateOptionInputs {
  */
 export function buildBurnRateOption(inputs: BurnRateOptionInputs): echarts.EChartsOption {
   const { tiers } = inputs;
+  const tz = inputs.tz ?? resolveDisplayTz();
+  // Series name → threshold multiplier, so the tooltip can show how far each
+  // tier's current burn sits above/below the threshold that would fire it.
+  const thresholdByName = new Map(tiers.map((t) => [t.label, t.multiplier]));
 
   // Y-axis is log10: default MWMBR tiers span 14.4x / 6x / 3x / 1x, and a linear
   // axis dominated by the top tier crushes the 1x / 3x lines (and any <10x burn
@@ -122,12 +147,29 @@ export function buildBurnRateOption(inputs: BurnRateOptionInputs): echarts.EChar
           color: string;
         }>;
         if (!list || list.length === 0) return '';
-        const ts = new Date(list[0].axisValue).toLocaleString();
+        const ts = formatTooltipTs(list[0].axisValue, tz);
         const rows = list
           .map((p) => {
             const raw = Array.isArray(p.value) ? p.value[2] ?? p.value[1] : (p.value as number);
             const swatch = `<span style="display:inline-block;width:10px;height:10px;background:${p.color};margin-right:6px;border-radius:2px;"></span>`;
-            return `<div>${swatch}${p.seriesName}: <strong>${formatMultiplier(raw)}</strong></div>`;
+            // Delta versus this tier's threshold: how much over/under the burn
+            // rate that would fire the alert.
+            const threshold = thresholdByName.get(p.seriesName);
+            let deltaStr = '';
+            if (threshold !== undefined && Number.isFinite(raw)) {
+              const delta = raw - threshold;
+              deltaStr =
+                delta >= 0
+                  ? ` <span style="color:${euiThemeVars.euiColorDanger};">(${formatMultiplier(
+                      delta
+                    )} over)</span>`
+                  : ` <span style="color:${euiThemeVars.euiColorDarkShade};">(${formatMultiplier(
+                      Math.abs(delta)
+                    )} under)</span>`;
+            }
+            return `<div>${swatch}${p.seriesName}: <strong>${formatMultiplier(
+              raw
+            )}</strong>${deltaStr}</div>`;
           })
           .join('');
         return `<div>${ts}</div>${rows}`;

--- a/public/components/apm/pages/slos/slo_burn_rate_chart.tsx
+++ b/public/components/apm/pages/slos/slo_burn_rate_chart.tsx
@@ -174,12 +174,12 @@ export function buildBurnRateOption(inputs: BurnRateOptionInputs): echarts.EChar
               const delta = raw - threshold;
               deltaStr =
                 delta >= 0
-                  ? ` <span style="color:${euiThemeVars.euiColorDanger};">(${formatMultiplier(
-                      delta
-                    )} over)</span>`
-                  : ` <span style="color:${euiThemeVars.euiColorDarkShade};">(${formatMultiplier(
-                      Math.abs(delta)
-                    )} under)</span>`;
+                  ? ` <span style="color:${escapeHtml(
+                      euiThemeVars.euiColorDanger
+                    )};">(${escapeHtml(formatMultiplier(delta))} over)</span>`
+                  : ` <span style="color:${escapeHtml(
+                      euiThemeVars.euiColorDarkShade
+                    )};">(${escapeHtml(formatMultiplier(Math.abs(delta)))} under)</span>`;
             }
             return `<div>${swatch}${escapeHtml(p.seriesName)}: <strong>${escapeHtml(
               formatMultiplier(raw)

--- a/public/components/apm/pages/slos/slo_burn_rate_panel.tsx
+++ b/public/components/apm/pages/slos/slo_burn_rate_panel.tsx
@@ -272,16 +272,14 @@ const TierCard: React.FC<TierCardProps> = ({
   reportKey,
   onHealthChange,
 }) => {
-  const shortQuery = useMemo(() => buildErrorRatioExprForWindow(slo, objective, tier.shortWindow), [
-    slo,
-    objective,
-    tier.shortWindow,
-  ]);
-  const longQuery = useMemo(() => buildErrorRatioExprForWindow(slo, objective, tier.longWindow), [
-    slo,
-    objective,
-    tier.longWindow,
-  ]);
+  const shortQuery = useMemo(
+    () => buildErrorRatioExprForWindow(slo, objective, tier.shortWindow),
+    [slo, objective, tier.shortWindow]
+  );
+  const longQuery = useMemo(
+    () => buildErrorRatioExprForWindow(slo, objective, tier.longWindow),
+    [slo, objective, tier.longWindow]
+  );
 
   const shortData = usePromQLChartData({
     promqlQuery: shortQuery ?? '',

--- a/public/components/apm/pages/slos/slo_burn_rate_panel.tsx
+++ b/public/components/apm/pages/slos/slo_burn_rate_panel.tsx
@@ -79,52 +79,97 @@ function formatMultiplier(n: number): string {
 }
 
 /**
- * Health of a single tier: a tier is "firing" when BOTH windows exceed the
- * threshold (mirroring the alert expression `short > t AND long > t`). When
- * only one window exceeds, we show "warming" since the `and` prevents the alert.
+ * Health of a single tier:
+ *  - `firing`   — BOTH windows exceed the threshold (mirrors the alert
+ *    expression `short > t AND long > t`).
+ *  - `at_risk`  — exactly one window exceeds; the `and` prevents the alert from
+ *    firing yet, but the tier is trending toward it.
+ *  - `ok`       — both windows are under the threshold.
+ *  - `no_data`  — at least one window has no (finite) sample. This MUST NOT read
+ *    as healthy: absent data is not the same as a passing check.
  */
-type TierHealth = 'firing' | 'warming' | 'ok' | 'no_data';
+export type TierHealth = 'firing' | 'at_risk' | 'ok' | 'no_data';
 
-function classifyTier(short: number | null, long: number | null, threshold: number): TierHealth {
-  if (short === null && long === null) return 'no_data';
-  const s = short ?? 0;
-  const l = long ?? 0;
+/** A window value is usable only when it's a finite number. */
+function isMissingWindow(value: number | null | undefined): boolean {
+  return value === null || value === undefined || !Number.isFinite(value);
+}
+
+export function classifyTier(
+  short: number | null,
+  long: number | null,
+  threshold: number
+): TierHealth {
+  // A missing window can never be coerced to 0 → "ok" → green. If either
+  // window is absent we genuinely don't know the tier's health.
+  if (isMissingWindow(short) || isMissingWindow(long)) return 'no_data';
+  const s = short as number;
+  const l = long as number;
   if (s > threshold && l > threshold) return 'firing';
-  if (s > threshold || l > threshold) return 'warming';
+  if (s > threshold || l > threshold) return 'at_risk';
   return 'ok';
 }
 
-function healthColor(h: TierHealth): string {
+export function healthColor(h: TierHealth): string {
   switch (h) {
     case 'firing':
       return 'danger';
-    case 'warming':
+    case 'at_risk':
       return 'warning';
     case 'ok':
       return 'success';
     default:
+      // no_data — subdued/grey, never green.
       return 'subdued';
   }
 }
 
-function healthLabel(h: TierHealth): string {
+export function healthLabel(h: TierHealth): string {
   switch (h) {
     case 'firing':
       return i18n.translate('observability.apm.slo.burnRatePanel.health.firing', {
-        defaultMessage: 'firing',
+        defaultMessage: 'Firing',
       });
-    case 'warming':
-      return i18n.translate('observability.apm.slo.burnRatePanel.health.warming', {
-        defaultMessage: 'warming',
+    case 'at_risk':
+      return i18n.translate('observability.apm.slo.burnRatePanel.health.atRisk', {
+        defaultMessage: 'At risk',
       });
     case 'ok':
       return i18n.translate('observability.apm.slo.burnRatePanel.health.healthy', {
-        defaultMessage: 'healthy',
+        defaultMessage: 'Healthy',
       });
     default:
       return i18n.translate('observability.apm.slo.burnRatePanel.health.noData', {
-        defaultMessage: 'no data',
+        defaultMessage: 'No data',
       });
+  }
+}
+
+/**
+ * Map a raw burn-rate severity token to a user-facing label. Severity is an
+ * open string (orgs use critical/warning, page/ticket, sev1..sev4), so unknown
+ * values fall through to the raw token rather than being dropped.
+ */
+export function severityLabel(severity: string): string {
+  switch (severity.toLowerCase()) {
+    case 'critical':
+      return i18n.translate('observability.apm.slo.burnRatePanel.severity.critical', {
+        defaultMessage: 'Critical',
+      });
+    case 'warning':
+      return i18n.translate('observability.apm.slo.burnRatePanel.severity.warning', {
+        defaultMessage: 'Warning',
+      });
+    case 'page':
+      return i18n.translate('observability.apm.slo.burnRatePanel.severity.page', {
+        defaultMessage: 'Page',
+      });
+    case 'ticket':
+      return i18n.translate('observability.apm.slo.burnRatePanel.severity.ticket', {
+        defaultMessage: 'Ticket',
+      });
+    default:
+      return severity;
   }
 }
 
@@ -140,6 +185,9 @@ const BurnBar: React.FC<{ ratio: number | null; threshold: number }> = ({ ratio,
   const thresholdPct = Math.min(100, (threshold / (threshold * 1.5)) * 100); // always 66.6%
   const exceeded = ratio !== null && ratio > threshold;
   const fillColor = exceeded ? euiThemeVars.euiColorDanger : euiThemeVars.euiColorSuccess;
+  // WCAG 1.4.1: the exceeded (danger) fill also carries a diagonal hatch so it's
+  // distinguishable from the healthy fill without relying on the red/green hue.
+  const exceededTexture = `repeating-linear-gradient(45deg, rgba(255,255,255,0.45) 0, rgba(255,255,255,0.45) 2px, transparent 2px, transparent 4px)`;
 
   return (
     <div
@@ -156,6 +204,7 @@ const BurnBar: React.FC<{ ratio: number | null; threshold: number }> = ({ ratio,
           width: `${Math.min(100, pct / 1.5)}%`,
           height: '100%',
           background: fillColor,
+          backgroundImage: exceeded ? exceededTexture : undefined,
           transition: 'width 200ms ease',
         }}
       />
@@ -300,7 +349,7 @@ const TierCard: React.FC<TierCardProps> = ({
               defaultMessage: '{multiplier} burn · {severity}',
               values: {
                 multiplier: formatMultiplier(tier.burnRateMultiplier),
-                severity: tier.severity,
+                severity: severityLabel(tier.severity),
               },
             })}
           </EuiText>


### PR DESCRIPTION
## What & why
Derives the window from `window.type` (kills a hard-coded '30d'), renders a null/empty window as `no_data` instead of false-green, dashes the reference line, adds non-hue status encoding, UTC + delta-vs-target tooltips, and `smooth:false` over step data.

**Findings:** M1, M2, CLAR5, CLAR6, m1, m2, m3, m4.

## Before / after

**Before / after**

![Before / after](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR7/before-after.png)

## Testing
chart/panel tests (`classifyTier` null-window, etc.). Centrally green. **Note:** the local stack has no burn data, so these data-dependent deltas are near-identical on screen — correctness is covered by jest and flagged for managed-env re-verify.

## Review
Independent review agent: **PASS** — verified all eight fixes; refuted two out-of-scope observations.

## Regression check
The before/after above is a **full-viewport** capture, so adjacent components on the same surface are visible and unchanged — the diff is scoped to what's called out. Cross-component safety is also verified centrally: this change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. Aside from the merge-order note below, it can be reviewed, merged, and reverted independently.

## Dependency
None.

> Draft — see the merge-order note above.
