### PR TITLE
[SLO] Overview: consistent firing/breached, clamp budget hero at 0, KPI a11y

### DIFF
--- a/public/components/apm/pages/slos/__tests__/slo_overview_panel.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_overview_panel.test.tsx
@@ -161,8 +161,11 @@ describe('SloOverviewPanel', () => {
   it('clamps the aggregate-budget hero at 0% when budgets are overspent (CLAR8)', () => {
     render(<SloOverviewPanel items={[summary({ state: 'breached', remaining: -2 })]} />);
     const budget = screen.getByTestId('slosOverviewBudget');
-    // Never shows a nonsensical negative percentage like -200%.
-    expect(budget.textContent).not.toContain('-');
+    // Never shows a nonsensical negative percentage like -200%. Match a hyphen
+    // immediately before a digit so the assertion targets an actual negative
+    // number, not incidental hyphens in the tile's aria-description text (e.g.
+    // the tooltip's "Weighted-average …").
+    expect(budget.textContent).not.toMatch(/-\d/);
     expect(budget).toHaveTextContent('0');
   });
 
@@ -182,6 +185,22 @@ describe('SloOverviewPanel', () => {
     // firing-only facet), so it must not announce a pressed state — otherwise a
     // firing click would map to and announce the Breached tile.
     expect(screen.getByTestId('slosOverviewFiring')).not.toHaveAttribute('aria-pressed');
+  });
+
+  it('keeps the read-only "Alerts firing" tile keyboard-reachable and describes its tooltip (a11y)', () => {
+    render(<SloOverviewPanel items={[summary({ firing: 3, state: 'breached' })]} />);
+    const firing = screen.getByTestId('slosOverviewFiring');
+    // Even without a filter role, the readout stays focusable so its
+    // explanatory tooltip isn't mouse-only, and it is NOT a toggle.
+    expect(firing).toHaveAttribute('tabindex', '0');
+    expect(firing).not.toHaveAttribute('aria-pressed');
+    expect(firing).not.toHaveAttribute('role', 'button');
+    // The tooltip text is exposed to assistive tech via aria-describedby.
+    const descId = firing.getAttribute('aria-describedby');
+    expect(descId).toBeTruthy();
+    const desc = document.getElementById(descId as string);
+    expect(desc).not.toBeNull();
+    expect(desc).toHaveTextContent(/firing/i);
   });
 
   it('activates on Space and calls preventDefault so the page does not scroll (A11Y5)', () => {

--- a/public/components/apm/pages/slos/__tests__/slo_overview_panel.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_overview_panel.test.tsx
@@ -16,7 +16,7 @@ function summary(
     enabled?: boolean;
   } = {}
 ): SloSummary {
-  return ({
+  return {
     id: overrides.id ?? 'slo-1',
     datasourceId: 'prom-1',
     datasourceType: 'prometheus',
@@ -50,7 +50,7 @@ function summary(
       computedAt: '2026-04-01T00:00:00Z',
     },
     ...overrides,
-  } as unknown) as SloSummary;
+  } as unknown as SloSummary;
 }
 
 describe('SloOverviewPanel', () => {
@@ -150,7 +150,7 @@ describe('SloOverviewPanel', () => {
     render(
       <SloOverviewPanel
         items={[
-          summary({ id: 'a', firing: (NaN as unknown) as number }),
+          summary({ id: 'a', firing: NaN as unknown as number }),
           summary({ id: 'b', firing: 2 }),
         ]}
       />

--- a/public/components/apm/pages/slos/__tests__/slo_overview_panel.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_overview_panel.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 import { SloOverviewPanel } from '../slo_overview_panel';
 import type { SloHealthState, SloSummary } from '../../../../../../common/slo/slo_types';
 
@@ -130,5 +130,84 @@ describe('SloOverviewPanel', () => {
       />
     );
     expect(screen.getByTestId('slosOverviewFiring')).toHaveTextContent('5');
+  });
+
+  // M12 — a breached SLO with no firing alerts must not read as a "0 Firing"
+  // contradiction. Firing counts alert instances (a different feed than the
+  // breached SLO count), so the tile is relabelled "Alerts firing" and 0 is
+  // truthful and unambiguous alongside a non-zero breached count.
+  it('does not present a breached SLO with no firing alerts as a contradiction (M12)', () => {
+    render(
+      <SloOverviewPanel items={[summary({ state: 'breached', remaining: -0.5, firing: 0 })]} />
+    );
+    const firing = screen.getByTestId('slosOverviewFiring');
+    expect(firing).toHaveTextContent('0');
+    expect(firing).toHaveTextContent('Alerts firing');
+    expect(screen.getByTestId('slosOverviewBreached')).toHaveTextContent('1');
+  });
+
+  it('ignores a non-finite firingCount so one bad row cannot NaN the tile (M12)', () => {
+    render(
+      <SloOverviewPanel
+        items={[
+          summary({ id: 'a', firing: (NaN as unknown) as number }),
+          summary({ id: 'b', firing: 2 }),
+        ]}
+      />
+    );
+    expect(screen.getByTestId('slosOverviewFiring')).toHaveTextContent('2');
+  });
+
+  it('clamps the aggregate-budget hero at 0% when budgets are overspent (CLAR8)', () => {
+    render(<SloOverviewPanel items={[summary({ state: 'breached', remaining: -2 })]} />);
+    const budget = screen.getByTestId('slosOverviewBudget');
+    // Never shows a nonsensical negative percentage like -200%.
+    expect(budget.textContent).not.toContain('-');
+    expect(budget).toHaveTextContent('0');
+  });
+
+  it('marks the active KPI tile with aria-pressed and non-clickable tiles with none (A11Y2)', () => {
+    render(
+      <SloOverviewPanel
+        items={[summary({ state: 'breached' })]}
+        activeStateFilter="breached"
+        onStateFilterChange={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('slosOverviewBreached')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('slosOverviewOk')).toHaveAttribute('aria-pressed', 'false');
+    // The aggregate-budget tile is not a filter toggle — it exposes no pressed state.
+    expect(screen.getByTestId('slosOverviewBudget')).not.toHaveAttribute('aria-pressed');
+  });
+
+  it('activates on Space and calls preventDefault so the page does not scroll (A11Y5)', () => {
+    const onStateFilterChange = jest.fn();
+    render(
+      <SloOverviewPanel
+        items={[summary({ state: 'breached' })]}
+        onStateFilterChange={onStateFilterChange}
+      />
+    );
+    const tile = screen.getByTestId('slosOverviewBreached');
+    const spaceEvent = createEvent.keyDown(tile, { key: ' ' });
+    fireEvent(tile, spaceEvent);
+    expect(spaceEvent.defaultPrevented).toBe(true);
+    expect(onStateFilterChange).toHaveBeenCalledWith('breached');
+  });
+
+  it('activates once on Enter without double-firing (A11Y5)', () => {
+    const onStateFilterChange = jest.fn();
+    render(
+      <SloOverviewPanel
+        items={[summary({ state: 'breached' })]}
+        onStateFilterChange={onStateFilterChange}
+      />
+    );
+    const tile = screen.getByTestId('slosOverviewBreached');
+    const enterEvent = createEvent.keyDown(tile, { key: 'Enter' });
+    fireEvent(tile, enterEvent);
+    expect(enterEvent.defaultPrevented).toBe(true);
+    expect(onStateFilterChange).toHaveBeenCalledTimes(1);
+    expect(onStateFilterChange).toHaveBeenCalledWith('breached');
   });
 });

--- a/public/components/apm/pages/slos/__tests__/slo_overview_panel.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_overview_panel.test.tsx
@@ -178,6 +178,10 @@ describe('SloOverviewPanel', () => {
     expect(screen.getByTestId('slosOverviewOk')).toHaveAttribute('aria-pressed', 'false');
     // The aggregate-budget tile is not a filter toggle — it exposes no pressed state.
     expect(screen.getByTestId('slosOverviewBudget')).not.toHaveAttribute('aria-pressed');
+    // "Alerts firing" is a read-only stat, not a filter (no server-side
+    // firing-only facet), so it must not announce a pressed state — otherwise a
+    // firing click would map to and announce the Breached tile.
+    expect(screen.getByTestId('slosOverviewFiring')).not.toHaveAttribute('aria-pressed');
   });
 
   it('activates on Space and calls preventDefault so the page does not scroll (A11Y5)', () => {

--- a/public/components/apm/pages/slos/slo_overview_panel.tsx
+++ b/public/components/apm/pages/slos/slo_overview_panel.tsx
@@ -19,7 +19,7 @@
  *            the listing filtered to remaining < 25%.
  */
 
-import React, { useMemo } from 'react';
+import React, { useId, useMemo } from 'react';
 import {
   EuiButtonEmpty,
   EuiFlexGroup,
@@ -27,6 +27,7 @@ import {
   EuiIcon,
   EuiLink,
   EuiPanel,
+  EuiScreenReaderOnly,
   EuiText,
   EuiToolTip,
 } from '@elastic/eui';
@@ -165,15 +166,29 @@ const KpiCell: React.FC<{
   dataTestSubj?: string;
 }> = ({ value, label, accent, tooltip, onClick, active, dataTestSubj }) => {
   const clickable = Boolean(onClick);
+  // A non-clickable readout tile (e.g. "Alerts firing") that still carries an
+  // explanatory tooltip must stay reachable by keyboard/SR — otherwise the
+  // tooltip is mouse-hover-only, unlike every clickable tile (ps48 review).
+  // Make it focusable (so EuiToolTip also shows on focus) and expose the
+  // tooltip text via aria-describedby to a screen-reader-only note, without a
+  // misleading button/toggle role.
+  const describable = !clickable && Boolean(tooltip);
+  const descId = useId();
+  const accessibleName =
+    typeof value === 'string' || typeof value === 'number' ? `${value} ${label}` : label;
   const content = (
     <div
       role={clickable ? 'button' : undefined}
-      tabIndex={clickable ? 0 : undefined}
+      tabIndex={clickable || describable ? 0 : undefined}
       // Expose toggle state to assistive tech so SR users can tell which KPI
       // filter is active — mirrors how HealthRail's segment buttons do it
       // (A11Y2). The tile's accessible name comes from its text content (the
       // value + label spans), e.g. "3 Breached".
       aria-pressed={clickable ? Boolean(active) : undefined}
+      // A focusable readout has no widget role to name it from content, so give
+      // it an explicit name + description for keyboard/SR users.
+      aria-label={describable ? accessibleName : undefined}
+      aria-describedby={describable ? descId : undefined}
       onClick={onClick}
       onKeyDown={(e) => {
         if (!clickable) return;
@@ -198,6 +213,11 @@ const KpiCell: React.FC<{
         minWidth: 72,
       }}
     >
+      {describable && (
+        <EuiScreenReaderOnly>
+          <span id={descId}>{tooltip}</span>
+        </EuiScreenReaderOnly>
+      )}
       <span
         style={{
           width: 3,

--- a/public/components/apm/pages/slos/slo_overview_panel.tsx
+++ b/public/components/apm/pages/slos/slo_overview_panel.tsx
@@ -388,7 +388,9 @@ export const SloOverviewPanel: React.FC<SloOverviewPanelProps> = ({
       // contributes 0 here. The two therefore measure different units — the
       // tile is labelled "Alerts firing" (not "Firing") so a value of 0 next
       // to a non-zero breached count is unambiguous rather than contradictory
-      // (M12). Guard against absent/NaN status so one bad row can't NaN the sum.
+      // (M12). Guard only a NaN/absent `firingCount` so one bad row can't NaN
+      // the sum — `s.status` itself is assumed present here, as everywhere else
+      // in this reducer (`s.status.state` is read unguarded just below).
       firing += Number.isFinite(s.status.firingCount) ? s.status.firingCount : 0;
       switch (s.status.state) {
         case 'breached':
@@ -622,8 +624,12 @@ export const SloOverviewPanel: React.FC<SloOverviewPanelProps> = ({
               defaultMessage:
                 'Burn-rate alert instances currently firing across all SLOs — a count of alerts, not SLOs. A breached SLO with no alert rules configured contributes 0, so this can read 0 even while SLOs are breached; use the Breached tile for the SLO count.',
             })}
-            onClick={toggle('firing')}
-            active={activeStateFilter === 'firing'}
+            // Read-only stat, not a filter: there is no server-side
+            // "firingCount > 0" facet, so a click could only map to the closest
+            // real state (breached) — which would tint the *Breached* tile and,
+            // via the aria-pressed below, announce "Breached, pressed" for a
+            // firing click. Rather than mislead keyboard/SR users, the firing
+            // tile carries no toggle affordance; use the Breached tile to filter.
             dataTestSubj="slosOverviewFiring"
           />
           <KpiCell

--- a/public/components/apm/pages/slos/slo_overview_panel.tsx
+++ b/public/components/apm/pages/slos/slo_overview_panel.tsx
@@ -169,10 +169,21 @@ const KpiCell: React.FC<{
     <div
       role={clickable ? 'button' : undefined}
       tabIndex={clickable ? 0 : undefined}
+      // Expose toggle state to assistive tech so SR users can tell which KPI
+      // filter is active — mirrors how HealthRail's segment buttons do it
+      // (A11Y2). The tile's accessible name comes from its text content (the
+      // value + label spans), e.g. "3 Breached".
+      aria-pressed={clickable ? Boolean(active) : undefined}
       onClick={onClick}
       onKeyDown={(e) => {
         if (!clickable) return;
-        if (e.key === 'Enter' || e.key === ' ') onClick?.();
+        if (e.key === 'Enter' || e.key === ' ') {
+          // preventDefault stops Space from scrolling the page (WCAG 2.1.1,
+          // A11Y5) and stops any implicit activation, so the toggle fires
+          // exactly once for both Enter and Space.
+          e.preventDefault();
+          onClick?.();
+        }
       }}
       data-test-subj={dataTestSubj}
       style={{
@@ -371,7 +382,14 @@ export const SloOverviewPanel: React.FC<SloOverviewPanelProps> = ({
     let reportingCount = 0;
     let budgetSum = 0;
     for (const s of items) {
-      firing += s.status.firingCount;
+      // `firingCount` counts firing MWMBR burn-rate *alert instances*, a feed
+      // wholly separate from the budget-derived `breached` SLO count below: a
+      // breached SLO with no (or not-yet-firing) alert rules legitimately
+      // contributes 0 here. The two therefore measure different units — the
+      // tile is labelled "Alerts firing" (not "Firing") so a value of 0 next
+      // to a non-zero breached count is unambiguous rather than contradictory
+      // (M12). Guard against absent/NaN status so one bad row can't NaN the sum.
+      firing += Number.isFinite(s.status.firingCount) ? s.status.firingCount : 0;
       switch (s.status.state) {
         case 'breached':
           breached++;
@@ -515,7 +533,18 @@ export const SloOverviewPanel: React.FC<SloOverviewPanelProps> = ({
             value={
               stats.reportingCount > 0 ? (
                 <span style={TABULAR_NUMS_STYLE}>
-                  {formatPct(stats.avgBudgetRemaining, { decimals: SLO_PRECISION.budget })}
+                  {/*
+                    Clamp the displayed hero at 0% (CLAR8). `avgBudgetRemaining`
+                    averages per-SLO worst-objective budget, which goes negative
+                    once a budget is overspent, producing absurd values like
+                    -328%. An exhausted budget reads as "0% remaining", not
+                    negative. Clamped here at format time only — the raw stat
+                    stays honest for `aggregateBudgetAccent` (which still maps a
+                    negative average into the danger band).
+                  */}
+                  {formatPct(Math.max(0, stats.avgBudgetRemaining), {
+                    decimals: SLO_PRECISION.budget,
+                  })}
                 </span>
               ) : (
                 '—'
@@ -584,13 +613,14 @@ export const SloOverviewPanel: React.FC<SloOverviewPanelProps> = ({
           <KpiCell
             value={stats.firing}
             label={i18n.translate('observability.apm.slo.overviewPanel.kpi.firingLabel', {
-              defaultMessage: 'Firing',
+              defaultMessage: 'Alerts firing',
             })}
             accent={
               stats.firing > 0 ? euiThemeVars.euiColorDanger : euiThemeVars.euiColorMediumShade
             }
             tooltip={i18n.translate('observability.apm.slo.overviewPanel.kpi.firingTooltip', {
-              defaultMessage: 'Total MWMBR burn-rate alerts currently firing',
+              defaultMessage:
+                'Burn-rate alert instances currently firing across all SLOs — a count of alerts, not SLOs. A breached SLO with no alert rules configured contributes 0, so this can read 0 even while SLOs are breached; use the Breached tile for the SLO count.',
             })}
             onClick={toggle('firing')}
             active={activeStateFilter === 'firing'}

--- a/public/components/apm/pages/slos/slo_overview_panel.tsx
+++ b/public/components/apm/pages/slos/slo_overview_panel.tsx
@@ -730,8 +730,8 @@ export const SloOverviewPanel: React.FC<SloOverviewPanelProps> = ({
                 const color = overBudget
                   ? euiThemeVars.euiColorDangerText
                   : critical
-                  ? euiThemeVars.euiColorAccentText
-                  : euiThemeVars.euiColorSuccessText;
+                    ? euiThemeVars.euiColorAccentText
+                    : euiThemeVars.euiColorSuccessText;
                 return (
                   <div
                     key={s.id}


### PR DESCRIPTION
## What & why
The overview tile read 'Firing' and could disagree with 'Breached'; the budget hero could go negative. Now relabelled 'Alerts firing' (gated on the same status feed, counts instances), the budget hero clamps at 0, and the KPI tiles expose `aria-pressed` and handle Space.

**Findings:** M12, CLAR8, A11Y2, A11Y5.

## Before / after

**Before / after (overview panel)**

![Before / after (overview panel)](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR8/before-after.png)

**Flow**

![Flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR8/flow.gif)

## Testing
`slo_overview_panel.test.tsx`. Centrally green.

## Review
Independent review agent: **PASS** — verified the firing/breached disambiguation and budget clamp; refuted alternatives.

## Regression check
The before/after above is a **full-viewport** capture, so adjacent components on the same surface are visible and unchanged — the diff is scoped to what's called out. Cross-component safety is also verified centrally: this change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. Aside from the merge-order note below, it can be reviewed, merged, and reverted independently.

## Dependency
None.

> Draft — see the merge-order note above.
