### PR TITLE
[a11y] Remove nested interactive controls; enforce >=24px targets; aria-expanded on tree

### DIFF
--- a/public/components/alerting/__tests__/facet_filter_panel.test.tsx
+++ b/public/components/alerting/__tests__/facet_filter_panel.test.tsx
@@ -146,6 +146,18 @@ describe('FacetFilterGroup — accessibility (no nested interactive controls)', 
     expect(region).toHaveAttribute('aria-label', 'Status');
   });
 
+  it('drops aria-controls while collapsed so it never dangles at an unmounted region', () => {
+    const { getByTestId, container } = render(
+      <FacetFilterGroup {...defaultProps} isCollapsed={true} />
+    );
+    const toggle = getByTestId('facetGroup-status-toggle');
+    // Collapsed: the region is not rendered, so the toggle must not reference it
+    // (axe aria-valid-attr-value). aria-expanded conveys the state instead.
+    expect(toggle).not.toHaveAttribute('aria-controls');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(container.querySelector('#facetGroup-status-region')).toBeNull();
+  });
+
   it('gives the per-option error button a >=24px target via the shared class', () => {
     const { getByTestId } = render(
       <FacetFilterGroup {...defaultProps} errorMap={{ active: 'Cluster unreachable (timeout)' }} />

--- a/public/components/alerting/__tests__/facet_filter_panel.test.tsx
+++ b/public/components/alerting/__tests__/facet_filter_panel.test.tsx
@@ -133,6 +133,28 @@ describe('FacetFilterGroup — accessibility (no nested interactive controls)', 
     expect(getByTestId('facetGroup-status-toggle')).toHaveAttribute('aria-expanded', 'false');
   });
 
+  it('wires aria-controls on the toggle to the id/role="region" of the options region', () => {
+    const { getByTestId, container } = render(
+      <FacetFilterGroup {...defaultProps} isCollapsed={false} />
+    );
+    const toggle = getByTestId('facetGroup-status-toggle');
+    const controls = toggle.getAttribute('aria-controls');
+    expect(controls).toBe('facetGroup-status-region');
+    const region = container.querySelector(`#${controls}`);
+    expect(region).not.toBeNull();
+    expect(region).toHaveAttribute('role', 'region');
+    expect(region).toHaveAttribute('aria-label', 'Status');
+  });
+
+  it('gives the per-option error button a >=24px target via the shared class', () => {
+    const { getByTestId } = render(
+      <FacetFilterGroup {...defaultProps} errorMap={{ active: 'Cluster unreachable (timeout)' }} />
+    );
+    // The 24px hit-target rule lives in the shared `.altFacetTarget` SCSS class
+    // (jsdom doesn't apply stylesheets, so we assert the class is present).
+    expect(getByTestId('facetGroup-status-error-active').className).toContain('altFacetTarget');
+  });
+
   it('toggles the accordion when the header toggle button is clicked', () => {
     const onToggleCollapse = jest.fn();
     const { getByTestId } = render(

--- a/public/components/alerting/__tests__/facet_filter_panel.test.tsx
+++ b/public/components/alerting/__tests__/facet_filter_panel.test.tsx
@@ -105,6 +105,61 @@ describe('FacetFilterGroup', () => {
   });
 });
 
+describe('FacetFilterGroup — accessibility (no nested interactive controls)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the error indicator OUTSIDE the checkbox label (not a nested interactive control)', () => {
+    const { getByTestId } = render(
+      <FacetFilterGroup {...defaultProps} errorMap={{ active: 'Cluster unreachable (timeout)' }} />
+    );
+    const errorButton = getByTestId('facetGroup-status-error-active');
+    // The interactive error button must not be nested inside a <label> element.
+    expect(errorButton.closest('label')).toBeNull();
+    // And it must not live inside the option's checkbox label wrapper.
+    const checkboxLabel = document.querySelector('label[for="status-active"]');
+    expect(checkboxLabel).not.toBeNull();
+    expect(checkboxLabel?.contains(errorButton)).toBe(false);
+  });
+
+  it('exposes aria-expanded on the header toggle button reflecting the open state', () => {
+    const { getByTestId, rerender } = render(
+      <FacetFilterGroup {...defaultProps} isCollapsed={false} />
+    );
+    const toggle = getByTestId('facetGroup-status-toggle');
+    // A real <button> element, not a div with role="button".
+    expect(toggle.tagName.toLowerCase()).toBe('button');
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    rerender(<FacetFilterGroup {...defaultProps} isCollapsed={true} />);
+    expect(getByTestId('facetGroup-status-toggle')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('toggles the accordion when the header toggle button is clicked', () => {
+    const onToggleCollapse = jest.fn();
+    const { getByTestId } = render(
+      <FacetFilterGroup {...defaultProps} onToggleCollapse={onToggleCollapse} />
+    );
+    fireEvent.click(getByTestId('facetGroup-status-toggle'));
+    expect(onToggleCollapse).toHaveBeenCalledWith('status');
+  });
+
+  it('clears the selection without toggling the accordion when Clear is clicked', () => {
+    const onChange = jest.fn();
+    const onToggleCollapse = jest.fn();
+    const { getByTestId } = render(
+      <FacetFilterGroup
+        {...defaultProps}
+        selected={['active']}
+        onChange={onChange}
+        onToggleCollapse={onToggleCollapse}
+      />
+    );
+    // Clear must be a sibling of the toggle, so activating it never expands/collapses.
+    fireEvent.click(getByTestId('facetGroup-status-clear'));
+    expect(onChange).toHaveBeenCalledWith([]);
+    expect(onToggleCollapse).not.toHaveBeenCalled();
+  });
+});
+
 describe('useFacetCollapse', () => {
   it('honors per-call defaultCollapsed when no override is set, then persists toggles', () => {
     let snapshot: ReturnType<typeof useFacetCollapse> | null = null;

--- a/public/components/alerting/alerting.scss
+++ b/public/components/alerting/alerting.scss
@@ -16,6 +16,22 @@
   flex-shrink: 0;
 }
 
+/*
+ * Shared >=24px hit target (WCAG 2.5.8 AA) for the small interactive controls
+ * in the facet header — the per-option error button and the "Clear" link. Kept
+ * as one class so the target-size rule lives in SCSS alongside the other facet
+ * styling instead of being re-declared inline per control (which is how the
+ * error button was missed the first time). `min-width`/`min-height` win over
+ * any smaller intrinsic size EUI sets on `size="xs"` controls.
+ */
+.altFacetTarget {
+  min-width: 24px;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .altFacetErrorPopover {
   max-width: 260px;
 }

--- a/public/components/alerting/facet_filter_panel.tsx
+++ b/public/components/alerting/facet_filter_panel.tsx
@@ -260,7 +260,12 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
             iconSide="left"
             onClick={() => onToggleCollapse(id)}
             aria-expanded={!isCollapsed}
-            aria-controls={`facetGroup-${id}-region`}
+            // Only reference the region while it's actually in the DOM. The
+            // options region renders under `!isCollapsed`, so pointing
+            // `aria-controls` at it while collapsed would be a dangling
+            // reference (axe `aria-valid-attr-value`). `aria-expanded` already
+            // conveys the collapsed state; `aria-controls` is optional here.
+            aria-controls={isCollapsed ? undefined : `facetGroup-${id}-region`}
             data-test-subj={`facetGroup-${id}-toggle`}
           >
             <strong>{label}</strong>

--- a/public/components/alerting/facet_filter_panel.tsx
+++ b/public/components/alerting/facet_filter_panel.tsx
@@ -140,7 +140,7 @@ const FacetErrorIndicator: React.FC<FacetErrorIndicatorProps> = ({
           iconType="alert"
           color="danger"
           size="xs"
-          className="altFacetErrorBtn"
+          className="altFacetErrorBtn altFacetTarget"
           aria-label={ariaLabel}
           onClick={() => setOpen((v) => !v)}
           data-test-subj={`facetGroup-${facetId}-error-${option}`}
@@ -260,6 +260,7 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
             iconSide="left"
             onClick={() => onToggleCollapse(id)}
             aria-expanded={!isCollapsed}
+            aria-controls={`facetGroup-${id}-region`}
             data-test-subj={`facetGroup-${id}-toggle`}
           >
             <strong>{label}</strong>
@@ -288,14 +289,8 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
               color="primary"
               onClick={() => onChange([])}
               data-test-subj={`facetGroup-${id}-clear`}
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                minWidth: 24,
-                minHeight: 24,
-                padding: '0 4px',
-              }}
+              className="altFacetTarget"
+              style={{ padding: '0 4px' }}
             >
               <EuiText size="xs">
                 <FormattedMessage
@@ -308,7 +303,12 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
         )}
       </EuiFlexGroup>
       {!isCollapsed && (
-        <div style={{ paddingLeft: 4 }}>
+        <div
+          id={`facetGroup-${id}-region`}
+          role="region"
+          aria-label={label}
+          style={{ paddingLeft: 4 }}
+        >
           {searchable && (
             <>
               <EuiFieldSearch

--- a/public/components/alerting/facet_filter_panel.tsx
+++ b/public/components/alerting/facet_filter_panel.tsx
@@ -15,8 +15,10 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
+  EuiButtonEmpty,
   EuiButtonIcon,
   EuiText,
+  EuiTextColor,
   EuiBadge,
   EuiCheckbox,
   EuiHealth,
@@ -105,13 +107,11 @@ export interface FacetFilterGroupProps extends FacetGroupConfig {
 // ============================================================================
 //
 // Per-option error icon. Extracted into a sub-component so each row can own
-// its popover state (a hook inside .map() is not permitted). The button lives
-// inside the checkbox row's `<label>`, so it stops event propagation on
-// pointer AND keyboard activation (click / mousedown / keydown / keyup) — a
-// nested control does not activate the labeled input per spec, but stopping
-// propagation also prevents React's synthetic bubbling from reaching the row's
-// handlers and toggling the datasource selection when the user only wanted to
-// read the error.
+// its popover state (a hook inside .map() is not permitted). It renders as a
+// SIBLING of the row's checkbox — NOT inside the checkbox's `<label>` — so an
+// interactive button is never nested inside a label (WCAG 4.1.2). Because it
+// is no longer nested in an activatable control, it needs no event-propagation
+// workaround: clicking it only toggles the error popover.
 interface FacetErrorIndicatorProps {
   facetId: string;
   option: string;
@@ -125,7 +125,6 @@ const FacetErrorIndicator: React.FC<FacetErrorIndicatorProps> = ({
   error,
 }) => {
   const [open, setOpen] = useState(false);
-  const stop = (e: React.SyntheticEvent) => e.stopPropagation();
   const ariaLabel = i18n.translate('observability.alerting.facetFilterPanel.errorIconAriaLabel', {
     defaultMessage: '{displayLabel} — connection error, click for details',
     values: { displayLabel },
@@ -143,13 +142,7 @@ const FacetErrorIndicator: React.FC<FacetErrorIndicatorProps> = ({
           size="xs"
           className="altFacetErrorBtn"
           aria-label={ariaLabel}
-          onClick={(e: React.MouseEvent) => {
-            stop(e);
-            setOpen((v) => !v);
-          }}
-          onMouseDown={stop}
-          onKeyDown={stop}
-          onKeyUp={stop}
+          onClick={() => setOpen((v) => !v)}
           data-test-subj={`facetGroup-${facetId}-error-${option}`}
         />
       }
@@ -242,38 +235,47 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
         gutterSize="xs"
         alignItems="center"
         responsive={false}
-        style={{ cursor: 'pointer', marginBottom: 4 }}
-        onClick={() => onToggleCollapse(id)}
-        role="button"
-        tabIndex={0}
-        aria-expanded={!isCollapsed}
-        onKeyDown={(e: React.KeyboardEvent) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onToggleCollapse(id);
-          }
-        }}
+        style={{ marginBottom: 4 }}
       >
-        <EuiFlexItem grow={false}>
-          <EuiIcon type={isCollapsed ? 'arrowRight' : 'arrowDown'} size="s" />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText size="xs">
+        {/*
+         * The expand/collapse control is a real <button> (EuiButtonEmpty) so it
+         * is natively keyboard-operable (Enter/Space toggle) and exposes
+         * `aria-expanded`. It covers only the toggle/title area; the "Clear"
+         * link is a SIBLING outside it (never a link nested inside a button),
+         * which is why Clear no longer needs a stopPropagation workaround.
+         */}
+        <EuiFlexItem grow={true}>
+          <EuiButtonEmpty
+            size="xs"
+            color="text"
+            flush="left"
+            // The button spans the full facet width (a large keyboard/touch
+            // target), but its content span defaults to `justify-content:
+            // center`, which centers the arrow + title instead of leaving them
+            // flush-left. Pin the content to the start so the header aligns
+            // with the plain-text groups (e.g. "Labels") at every panel width.
+            // `flush="left"` only strips padding, not alignment.
+            contentProps={{ style: { justifyContent: 'flex-start', width: '100%' } }}
+            iconType={isCollapsed ? 'arrowRight' : 'arrowDown'}
+            iconSide="left"
+            onClick={() => onToggleCollapse(id)}
+            aria-expanded={!isCollapsed}
+            data-test-subj={`facetGroup-${id}-toggle`}
+          >
             <strong>{label}</strong>
             {showOptionCount && (
               <>
                 {' '}
-                <EuiText
-                  size="xs"
+                <EuiTextColor
                   color="subdued"
                   className="altFacetCount"
                   data-test-subj={`facetGroup-${id}-optionCount`}
                 >
                   {options.length}
-                </EuiText>
+                </EuiTextColor>
               </>
             )}
-          </EuiText>
+          </EuiButtonEmpty>
         </EuiFlexItem>
         {activeCount > 0 && (
           <EuiFlexItem grow={false}>
@@ -284,11 +286,16 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
           <EuiFlexItem grow={false}>
             <EuiLink
               color="primary"
-              onClick={(e: React.MouseEvent) => {
-                e.stopPropagation();
-                onChange([]);
-              }}
+              onClick={() => onChange([])}
               data-test-subj={`facetGroup-${id}-clear`}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minWidth: 24,
+                minHeight: 24,
+                padding: '0 4px',
+              }}
             >
               <EuiText size="xs">
                 <FormattedMessage
@@ -373,14 +380,6 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
                   )}
                   {/* Explicit 12/18 preserves Alert Manager's existing look. */}
                   <TruncatedLabel text={displayLabel} fontSize={12} lineHeight={18} />
-                  {errorMap?.[opt] && (
-                    <FacetErrorIndicator
-                      facetId={id}
-                      option={opt}
-                      displayLabel={displayLabel}
-                      error={errorMap[opt]}
-                    />
-                  )}
                 </span>
                 {showCounts && (
                   <EuiText size="xs" color="subdued" className="altFacetCount">
@@ -391,36 +390,53 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
             );
 
             return (
+              // The error indicator is a SIBLING of the checkbox (not part of
+              // the checkbox `label`), so no interactive button is nested inside
+              // a `<label>` (WCAG 4.1.2 nested-interactive).
               <div key={opt} className="altFacetCheckboxRow">
-                <EuiCheckbox
-                  id={checkboxId}
-                  label={labelContent}
-                  checked={isActive}
-                  disabled={isDisabled}
-                  aria-label={
-                    isDisabled
-                      ? i18n.translate(
-                          'observability.alerting.facetFilterPanel.disabledAriaLabel',
-                          {
-                            defaultMessage: '{displayLabel} (maximum datasources reached)',
-                            values: { displayLabel },
-                          }
-                        )
-                      : undefined
-                  }
-                  onChange={() => {
-                    if (isActive) {
-                      onChange(selected.filter((s) => s !== opt));
-                      return;
-                    }
-                    if (capReached && onCapReached) {
-                      onCapReached();
-                      return;
-                    }
-                    onChange([...selected, opt]);
-                  }}
-                  compressed
-                />
+                <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                  <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
+                    <EuiCheckbox
+                      id={checkboxId}
+                      label={labelContent}
+                      checked={isActive}
+                      disabled={isDisabled}
+                      aria-label={
+                        isDisabled
+                          ? i18n.translate(
+                              'observability.alerting.facetFilterPanel.disabledAriaLabel',
+                              {
+                                defaultMessage: '{displayLabel} (maximum datasources reached)',
+                                values: { displayLabel },
+                              }
+                            )
+                          : undefined
+                      }
+                      onChange={() => {
+                        if (isActive) {
+                          onChange(selected.filter((s) => s !== opt));
+                          return;
+                        }
+                        if (capReached && onCapReached) {
+                          onCapReached();
+                          return;
+                        }
+                        onChange([...selected, opt]);
+                      }}
+                      compressed
+                    />
+                  </EuiFlexItem>
+                  {errorMap?.[opt] && (
+                    <EuiFlexItem grow={false}>
+                      <FacetErrorIndicator
+                        facetId={id}
+                        option={opt}
+                        displayLabel={displayLabel}
+                        error={errorMap[opt]}
+                      />
+                    </EuiFlexItem>
+                  )}
+                </EuiFlexGroup>
               </div>
             );
           })}

--- a/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
@@ -165,6 +165,27 @@ describe('ServiceTreeTable', () => {
     expect(region).toHaveAttribute('role', 'region');
   });
 
+  it('drops aria-controls on a collapsed row so it never dangles at an unmounted region', () => {
+    render(
+      <ServiceTreeTable
+        serviceRows={[row({ serviceName: 'cart' })]}
+        expandedMap={{ cart: false }}
+        onToggleExpand={jest.fn()}
+        onToggleServiceSelection={jest.fn()}
+        selected={new Set()}
+        overrides={{}}
+        onToggleDraft={jest.fn()}
+        onOverrideChange={jest.fn()}
+      />
+    );
+    const expander = screen.getByTestId('slosSuggestServiceExpand-cart');
+    // Collapsed: the expanded panel isn't rendered, so the expander must not
+    // reference it (axe aria-valid-attr-value); aria-expanded conveys the state.
+    expect(expander).not.toHaveAttribute('aria-controls');
+    expect(expander).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('slosSuggestServiceExpanded-cart')).not.toBeInTheDocument();
+  });
+
   it('fires onToggleServiceSelection when the service-level checkbox is clicked', () => {
     const onToggleServiceSelection = jest.fn();
     const r = row();

--- a/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
@@ -122,6 +122,29 @@ describe('ServiceTreeTable', () => {
     expect(onToggleExpand).toHaveBeenCalledWith('cart');
   });
 
+  it('exposes aria-expanded on the row expander reflecting the expanded state', () => {
+    render(
+      <ServiceTreeTable
+        serviceRows={[row({ serviceName: 'cart' }), row({ serviceName: 'checkout' })]}
+        expandedMap={{ cart: true, checkout: false }}
+        onToggleExpand={jest.fn()}
+        onToggleServiceSelection={jest.fn()}
+        selected={new Set()}
+        overrides={{}}
+        onToggleDraft={jest.fn()}
+        onOverrideChange={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('slosSuggestServiceExpand-cart')).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(screen.getByTestId('slosSuggestServiceExpand-checkout')).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  });
+
   it('fires onToggleServiceSelection when the service-level checkbox is clicked', () => {
     const onToggleServiceSelection = jest.fn();
     const r = row();

--- a/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/suggest_service_tree_table.test.tsx
@@ -145,6 +145,26 @@ describe('ServiceTreeTable', () => {
     );
   });
 
+  it('wires aria-controls on the expander to the id/role="region" of the expanded panel', () => {
+    render(
+      <ServiceTreeTable
+        serviceRows={[row({ serviceName: 'cart' })]}
+        expandedMap={{ cart: true }}
+        onToggleExpand={jest.fn()}
+        onToggleServiceSelection={jest.fn()}
+        selected={new Set()}
+        overrides={{}}
+        onToggleDraft={jest.fn()}
+        onOverrideChange={jest.fn()}
+      />
+    );
+    const expander = screen.getByTestId('slosSuggestServiceExpand-cart');
+    expect(expander).toHaveAttribute('aria-controls', 'slosSuggestServiceExpanded-cart');
+    const region = screen.getByTestId('slosSuggestServiceExpanded-cart');
+    expect(region).toHaveAttribute('id', 'slosSuggestServiceExpanded-cart');
+    expect(region).toHaveAttribute('role', 'region');
+  });
+
   it('fires onToggleServiceSelection when the service-level checkbox is clicked', () => {
     const onToggleServiceSelection = jest.fn();
     const r = row();

--- a/public/components/apm/pages/slos/suggest_service_tree_table.tsx
+++ b/public/components/apm/pages/slos/suggest_service_tree_table.tsx
@@ -266,7 +266,14 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
                     }
                     iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
                     aria-expanded={isExpanded}
-                    aria-controls={`slosSuggestServiceExpanded-${row.serviceName}`}
+                    // Only reference the region while it's mounted. The expanded
+                    // panel renders under `isExpanded`, so pointing
+                    // `aria-controls` at it while collapsed would be a dangling
+                    // reference (axe `aria-valid-attr-value`). `aria-expanded`
+                    // already conveys state; `aria-controls` is optional here.
+                    aria-controls={
+                      isExpanded ? `slosSuggestServiceExpanded-${row.serviceName}` : undefined
+                    }
                     onClick={() => onToggleExpand(row.serviceName)}
                     data-test-subj={`slosSuggestServiceExpand-${row.serviceName}`}
                   />

--- a/public/components/apm/pages/slos/suggest_service_tree_table.tsx
+++ b/public/components/apm/pages/slos/suggest_service_tree_table.tsx
@@ -266,6 +266,7 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
                     }
                     iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
                     aria-expanded={isExpanded}
+                    aria-controls={`slosSuggestServiceExpanded-${row.serviceName}`}
                     onClick={() => onToggleExpand(row.serviceName)}
                     data-test-subj={`slosSuggestServiceExpand-${row.serviceName}`}
                   />
@@ -364,7 +365,12 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
               {isExpanded && (
                 <>
                   <EuiSpacer size="m" />
-                  <div data-test-subj={`slosSuggestServiceExpanded-${row.serviceName}`}>
+                  <div
+                    id={`slosSuggestServiceExpanded-${row.serviceName}`}
+                    role="region"
+                    aria-label={row.serviceName}
+                    data-test-subj={`slosSuggestServiceExpanded-${row.serviceName}`}
+                  >
                     {row.drafts.map((draft) => (
                       <SuggestionInlineRow
                         key={draft.key}

--- a/public/components/apm/pages/slos/suggest_service_tree_table.tsx
+++ b/public/components/apm/pages/slos/suggest_service_tree_table.tsx
@@ -265,6 +265,7 @@ export const ServiceTreeTable: React.FC<ServiceTreeTableProps> = ({
                           )
                     }
                     iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
+                    aria-expanded={isExpanded}
                     onClick={() => onToggleExpand(row.serviceName)}
                     data-test-subj={`slosSuggestServiceExpand-${row.serviceName}`}
                   />


### PR DESCRIPTION
## What & why
The facet error button was nested inside a checkbox `<label>` and the section header was a `div role=button` with a stopPropagation hack. Now the error button is a sibling, the header is a real `<button>` (hack removed), targets are ≥24px, and the tree expander exposes `aria-expanded`.

**Findings:** AXE2, AXE3, A11Y4.

## Before / after

**Before / after (facet panel; pixels match by design — see note)**

![Before / after (facet panel; pixels match by design — see note)](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR9/before-after.png)

**Flow**

![Flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR9/flow.gif)

## Testing
RTL tests assert no nested interactive/label and `aria-expanded`. **Note:** these are DOM/ARIA changes, not pixel changes.

## Review
Independent review agent: **APPROVE** — confirmed the hacks are removed (not retained) and keyboard behaviour is preserved by the native button.

## Regression check
The before/after above is a **full-viewport** capture, so adjacent components on the same surface are visible and unchanged — the diff is scoped to what's called out. Cross-component safety is also verified centrally: this change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. Aside from the merge-order note below, it can be reviewed, merged, and reverted independently.

## Dependency
None.

> Draft — see the merge-order note above.
