### PR TITLE
[Alerting] Decouple rule-creation enablement from the datasource browse filter

### DIFF
--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -244,6 +244,35 @@ describe('MonitorsTable', () => {
     expect(onCreateMonitor).toHaveBeenCalledWith('metrics');
   });
 
+  // Logs symmetric counterpart of the metrics test above, and the case that
+  // actually distinguishes the fix from the pre-fix behaviour: an OpenSearch
+  // datasource EXISTS but is not in the facet selection (only a Prometheus DS
+  // is selected). The old selection-keyed logic disabled Logs create here
+  // (every selected DS was Prometheus); the fix keeps it enabled because the
+  // capability follows the available datasources, not the browse filter.
+  it('keeps logs creation enabled when an OpenSearch datasource exists but is not selected', () => {
+    const onCreateMonitor = jest.fn();
+    render(
+      <MonitorsTable
+        {...defaultProps}
+        datasources={
+          [
+            { id: 'os-1', name: 'cluster1', type: 'opensearch' },
+            { id: 'prom-1', name: 'prom1', type: 'prometheus' },
+          ] as unknown as Datasource[]
+        }
+        selectedDsIds={['prom-1']}
+        onCreateMonitor={onCreateMonitor}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
+    fireEvent.click(screen.getByText('Logs alert rule'));
+    expect(onCreateMonitor).toHaveBeenCalledWith('logs');
+  });
+
+  // Disable direction still holds: with no OpenSearch datasource available at
+  // all, Logs create is greyed out (the wizard would have no valid target).
   it('disables logs creation when no OpenSearch datasource exists', () => {
     const onCreateMonitor = jest.fn();
     render(

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -222,6 +222,47 @@ describe('MonitorsTable', () => {
     ).toHaveClass('euiListGroupItem-isDisabled');
   });
 
+  // Regression (audit M8): rule-creation enablement must follow the
+  // datasources AVAILABLE to the user, not the current facet (browse)
+  // selection. A Prometheus datasource exists, so Metrics create stays enabled
+  // even with nothing selected in the facet.
+  it('keeps metrics creation enabled with a Prometheus datasource and no facet selection', () => {
+    const onCreateMonitor = jest.fn();
+    render(
+      <MonitorsTable
+        {...defaultProps}
+        datasources={
+          [{ id: 'prom-1', name: 'prom1', type: 'prometheus' }] as unknown as Datasource[]
+        }
+        selectedDsIds={[]}
+        onCreateMonitor={onCreateMonitor}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
+    fireEvent.click(screen.getByText('Metrics alert rule'));
+    expect(onCreateMonitor).toHaveBeenCalledWith('metrics');
+  });
+
+  it('disables logs creation when no OpenSearch datasource exists', () => {
+    const onCreateMonitor = jest.fn();
+    render(
+      <MonitorsTable
+        {...defaultProps}
+        datasources={
+          [{ id: 'prom-1', name: 'prom1', type: 'prometheus' }] as unknown as Datasource[]
+        }
+        selectedDsIds={['prom-1']}
+        onCreateMonitor={onCreateMonitor}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('alertManagerCreateResourceButton'));
+    expect(screen.getByLabelText('Create logs rule').closest('.euiListGroupItem')).toHaveClass(
+      'euiListGroupItem-isDisabled'
+    );
+  });
+
   // Regression: deselecting all datasources must wipe both the dependent
   // facet selections AND the search box, mirroring the cascade-clear in
   // alerts_dashboard.tsx. Keep the two tabs aligned.

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -164,23 +164,20 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
     [datasources, selectedDsIds]
   );
 
-  // Logs / Metrics popover entries are grayed out when the parent's selection
-  // can't satisfy them: Logs needs at least one OpenSearch datasource, Metrics
-  // needs at least one Prometheus. The empty-selection case is "no datasource
-  // selected → no create options viable", so gate both. When a selection
-  // exists, each option is disabled iff EVERY selected datasource is the wrong
-  // type for it — i.e. only-Prometheus disables Logs, only-OpenSearch disables
-  // Metrics (symmetric).
-  const [logsCreateDisabled, metricsCreateDisabled] = useMemo(() => {
-    const selected = selectedDsIds
-      .map((id) => datasources.find((d) => d.id === id))
-      .filter((d): d is Datasource => !!d);
-    if (selected.length === 0) return [true, true];
-    return [
-      selected.every((d) => d.type === 'prometheus'),
-      selected.every((d) => d.type === 'opensearch'),
-    ];
-  }, [datasources, selectedDsIds]);
+  // Logs / Metrics popover entries reflect what the user is ALLOWED to create,
+  // which depends on the datasources AVAILABLE to them — not on the current
+  // facet (browse) selection. Logs create needs at least one OpenSearch
+  // datasource to exist; Metrics create needs at least one Prometheus. The user
+  // then picks the specific datasource inside the create wizard. Keying this on
+  // the facet selection wrongly hid a capability whenever the unrelated browse
+  // filter didn't happen to include a matching datasource (audit M8).
+  const [logsCreateDisabled, metricsCreateDisabled] = useMemo(
+    () => [
+      !datasources.some((d) => d.type === 'opensearch'),
+      !datasources.some((d) => d.type === 'prometheus'),
+    ],
+    [datasources]
+  );
 
   const adCreateDisabled = !selectedDatasources.some(isStandardOpenSearchDatasource);
 


### PR DESCRIPTION
## What & why
The Create button's enablement was tied to the datasource browse facet, so selecting a browse facet could disable creation. Fixes the `useMemo` gating in this file only, leaving the `MonitorsMainPanel` prop contract intact.

**Findings:** M8.

## Before / after

**Before / after — Create ▸ Logs alert rule with only Prometheus selected (disabled → enabled)**

![Before / after — Create ▸ Logs alert rule with only Prometheus selected (disabled → enabled)](https://raw.githubusercontent.com/lezzago/dashboards-observability/ad146b101d730883f0f4010923d6ec8faa2857bb/PR10/before-after.png)

**Before flow — narrowing the browse filter to only Prometheus wrongly DISABLES 'Create ▸ Logs alert rule'**

![Before flow — narrowing the browse filter to only Prometheus wrongly DISABLES 'Create ▸ Logs alert rule'](https://raw.githubusercontent.com/lezzago/dashboards-observability/ad146b101d730883f0f4010923d6ec8faa2857bb/PR10/before-flow.gif)

**After flow — same steps, 'Create ▸ Logs alert rule' stays ENABLED (gated on capability, not the browse filter)**

![After flow — same steps, 'Create ▸ Logs alert rule' stays ENABLED (gated on capability, not the browse filter)](https://raw.githubusercontent.com/lezzago/dashboards-observability/ad146b101d730883f0f4010923d6ec8faa2857bb/PR10/after-flow.gif)

## Testing
Covered by test. **Note:** behavioural, not pixel-visible in the happy path.

## Review
Independent review agent: **APPROVE** (review commit applied).

## Regression check
The before/after above is a **full-viewport** capture, so adjacent components on the same surface are visible and unchanged — the diff is scoped to what's called out. Cross-component safety is also verified centrally: this change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. Aside from the merge-order note below, it can be reviewed, merged, and reverted independently.

## Dependency
No dependencies — can merge independently (file-disjoint from #2829's prop change).

> Draft — see the merge-order note above.
