### PR TITLE
[Alerting] Align the forecaster edit gate with the running-state predicate

### DIFF
--- a/public/components/alerting/__tests__/forecaster_edit_gate.test.ts
+++ b/public/components/alerting/__tests__/forecaster_edit_gate.test.ts
@@ -54,10 +54,17 @@ const summaryForStatus = (status: MonitorStatus, enabled = false): UnifiedRuleSu
     enabled,
   }) as unknown as UnifiedRuleSummary;
 
+// A real forecaster `curState` is the backend UPPER_SNAKE enum (`RUNNING`,
+// `INITIALIZING_FORECAST`), NOT the prose `MonitorStatus`. Feed that enum so the
+// gate's raw→prose normalization + the shared `isAdResourceRunning` predicate are
+// what's actually exercised — the prose form is a domain the gate never receives
+// in production, so feeding it would prove a code path that doesn't run.
+const toRawEnum = (status: MonitorStatus): string => status.toUpperCase().replace(/ /g, '_');
+
 const rawForecasterForStatus = (status: MonitorStatus, enabled = false): ADForecaster =>
   ({
     id: 'forecast-1',
-    curState: status,
+    curState: toRawEnum(status),
     enabled,
   }) as unknown as ADForecaster;
 
@@ -100,6 +107,23 @@ describe('forecaster edit gate vs shared running-state predicate (BUG-AD1)', () 
     expect(
       getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Stopped', true), false)
     ).not.toBeNull();
+  });
+
+  it('engages the shared predicate on the raw UPPER_SNAKE curState a forecaster actually carries', () => {
+    // Explicit guard for the production shape: cur_state is the enum, not prose.
+    // The raw→prose normalization must let isAdResourceRunning fire so these block.
+    const raw = (curState: string, enabled = false): ADForecaster =>
+      ({ id: 'forecast-1', curState, enabled }) as unknown as ADForecaster;
+    expect(getEditLifecycleBlocker('forecaster', raw('RUNNING'), false)).not.toBeNull();
+    expect(getEditLifecycleBlocker('forecaster', raw('INITIALIZING'), false)).not.toBeNull();
+    expect(
+      getEditLifecycleBlocker('forecaster', raw('INITIALIZING_FORECAST'), false)
+    ).not.toBeNull();
+    expect(
+      getEditLifecycleBlocker('forecaster', raw('AWAITING_DATA_TO_INIT'), false)
+    ).not.toBeNull();
+    // A genuinely stopped, disabled forecaster carries no running enum → editable.
+    expect(getEditLifecycleBlocker('forecaster', raw('STOPPED'), false)).toBeNull();
   });
 });
 

--- a/public/components/alerting/__tests__/forecaster_edit_gate.test.ts
+++ b/public/components/alerting/__tests__/forecaster_edit_gate.test.ts
@@ -5,7 +5,11 @@
 
 import { getEditLifecycleBlocker, humanizeAdUpdateError } from '../create_ad_rule_flyout';
 import { isAdResourceRunning } from '../shared_constants';
-import type { ADForecaster, MonitorStatus, UnifiedRuleSummary } from '../../../../common/types/alerting';
+import type {
+  ADForecaster,
+  MonitorStatus,
+  UnifiedRuleSummary,
+} from '../../../../common/types/alerting';
 
 /**
  * BUG-AD1: the forecaster edit gate (getEditLifecycleBlocker) decided "is it running"
@@ -75,21 +79,27 @@ describe('forecaster edit gate vs shared running-state predicate (BUG-AD1)', () 
     // Regression guard for the exact state the shared predicate treats as running but
     // the old hand-maintained list omitted.
     expect(isAdResourceRunning(summaryForStatus('Initializing'))).toBe(true);
-    expect(getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Initializing'), false)).not.toBeNull();
+    expect(
+      getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Initializing'), false)
+    ).not.toBeNull();
   });
 
   it('routes an initializing test to the dedicated "forecaster-test" blocker', () => {
-    expect(getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Initializing test'), false)).toBe(
-      'forecaster-test'
-    );
+    expect(
+      getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Initializing test'), false)
+    ).toBe('forecaster-test');
   });
 
   it('does not block once the forecaster has been stopped for edit', () => {
-    expect(getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Running'), true)).toBeNull();
+    expect(
+      getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Running'), true)
+    ).toBeNull();
   });
 
   it('gates an enabled forecaster even when its status is not a running state', () => {
-    expect(getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Stopped', true), false)).not.toBeNull();
+    expect(
+      getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Stopped', true), false)
+    ).not.toBeNull();
   });
 });
 

--- a/public/components/alerting/__tests__/forecaster_edit_gate.test.ts
+++ b/public/components/alerting/__tests__/forecaster_edit_gate.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getEditLifecycleBlocker, humanizeAdUpdateError } from '../create_ad_rule_flyout';
+import { isAdResourceRunning } from '../shared_constants';
+import type { ADForecaster, MonitorStatus, UnifiedRuleSummary } from '../../../../common/types/alerting';
+
+/**
+ * BUG-AD1: the forecaster edit gate (getEditLifecycleBlocker) decided "is it running"
+ * with a hand-maintained state list that drifted from isAdResourceRunning — the shared
+ * predicate the detail flyout uses. States such as the generic "Initializing" slipped
+ * through the gate, so the backend rejected the update with a raw
+ * "Job is running: forecast-<id>" string. These tests assert the two predicates now
+ * agree for every forecaster status and that the raw string never reaches the user.
+ */
+
+// Every status a forecaster row can carry (MonitorStatus domain, unified_types.ts).
+const ALL_STATUSES: MonitorStatus[] = [
+  'active',
+  'pending',
+  'muted',
+  'disabled',
+  'Running',
+  'Stopped',
+  'Initializing',
+  'Finished',
+  'Feature required',
+  'Initialization failure',
+  'Unexpected failure',
+  'Failed',
+  'Inactive stopped',
+  'Inactive not started',
+  'Awaiting data to init',
+  'Awaiting data to restart',
+  'Initializing test',
+  'Initializing forecast',
+  'Test complete',
+  'Init forecast failure',
+  'Forecast failure',
+  'Init test failure',
+];
+
+const summaryForStatus = (status: MonitorStatus, enabled = false): UnifiedRuleSummary =>
+  (({
+    monitorType: 'forecaster',
+    definitionType: 'forecaster',
+    status,
+    enabled,
+  } as unknown) as UnifiedRuleSummary);
+
+const rawForecasterForStatus = (status: MonitorStatus, enabled = false): ADForecaster =>
+  (({
+    id: 'forecast-1',
+    curState: status,
+    enabled,
+  } as unknown) as ADForecaster);
+
+describe('forecaster edit gate vs shared running-state predicate (BUG-AD1)', () => {
+  it.each(ALL_STATUSES)(
+    'blocks editing whenever isAdResourceRunning reports "%s" as running',
+    (status) => {
+      const running = isAdResourceRunning(summaryForStatus(status));
+      const blocker = getEditLifecycleBlocker('forecaster', rawForecasterForStatus(status), false);
+
+      if (running) {
+        // The backend would reject the update — the gate MUST catch it first.
+        expect(blocker).not.toBeNull();
+      }
+    }
+  );
+
+  it('gates the generic "Initializing" state that previously slipped through', () => {
+    // Regression guard for the exact state the shared predicate treats as running but
+    // the old hand-maintained list omitted.
+    expect(isAdResourceRunning(summaryForStatus('Initializing'))).toBe(true);
+    expect(getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Initializing'), false)).not.toBeNull();
+  });
+
+  it('routes an initializing test to the dedicated "forecaster-test" blocker', () => {
+    expect(getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Initializing test'), false)).toBe(
+      'forecaster-test'
+    );
+  });
+
+  it('does not block once the forecaster has been stopped for edit', () => {
+    expect(getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Running'), true)).toBeNull();
+  });
+
+  it('gates an enabled forecaster even when its status is not a running state', () => {
+    expect(getEditLifecycleBlocker('forecaster', rawForecasterForStatus('Stopped', true), false)).not.toBeNull();
+  });
+});
+
+describe('humanizeAdUpdateError never leaks the internal job id (BUG-AD1)', () => {
+  const RAW = 'Job is running: forecast-abc123';
+
+  it('replaces the raw "Job is running: forecast-<id>" string with guidance', () => {
+    const message = humanizeAdUpdateError(RAW, 'forecaster');
+    expect(message).not.toContain('Job is running');
+    expect(message).not.toContain('forecast-abc123');
+    expect(message).toMatch(/stop the forecaster/i);
+  });
+
+  it('produces detector-specific guidance for the same rejection', () => {
+    const message = humanizeAdUpdateError('Job is running: detector-xyz', 'detector');
+    expect(message).not.toContain('Job is running');
+    expect(message).not.toContain('detector-xyz');
+    expect(message).toMatch(/stop the detector/i);
+  });
+
+  it('passes through unrelated error messages unchanged', () => {
+    const other = 'Index metrics-hosts does not exist';
+    expect(humanizeAdUpdateError(other, 'forecaster')).toBe(other);
+  });
+});

--- a/public/components/alerting/__tests__/forecaster_edit_gate.test.ts
+++ b/public/components/alerting/__tests__/forecaster_edit_gate.test.ts
@@ -47,19 +47,19 @@ const ALL_STATUSES: MonitorStatus[] = [
 ];
 
 const summaryForStatus = (status: MonitorStatus, enabled = false): UnifiedRuleSummary =>
-  (({
+  ({
     monitorType: 'forecaster',
     definitionType: 'forecaster',
     status,
     enabled,
-  } as unknown) as UnifiedRuleSummary);
+  }) as unknown as UnifiedRuleSummary;
 
 const rawForecasterForStatus = (status: MonitorStatus, enabled = false): ADForecaster =>
-  (({
+  ({
     id: 'forecast-1',
     curState: status,
     enabled,
-  } as unknown) as ADForecaster);
+  }) as unknown as ADForecaster;
 
 describe('forecaster edit gate vs shared running-state predicate (BUG-AD1)', () => {
   it.each(ALL_STATUSES)(

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -647,6 +647,23 @@ const getResourceState = (resource?: ADDetector | ADForecaster): string =>
 const getTaskState = (resource?: ADDetector | ADForecaster): string =>
   normalizeStateValue(getField(asRecord(resource), 'task_state', 'taskState'));
 
+/**
+ * Normalize a raw `curState` into the human-readable `MonitorStatus` domain that
+ * {@link isAdResourceRunning} keys its Sets on. A real forecaster/detector
+ * `cur_state` is the backend UPPER_SNAKE enum (`RUNNING`, `INITIALIZING_FORECAST`,
+ * `AWAITING_DATA_TO_INIT`), while the shared predicate compares against the
+ * prose form (`Running`, `Initializing forecast`, …). For every AD/forecaster
+ * state the prose form is exactly the enum humanized — lowercase, `_`→space,
+ * first letter capitalized — so normalizing here lets the shared predicate
+ * actually engage instead of comparing an enum against prose (which never
+ * matched). Values already in prose form are unchanged (idempotent).
+ */
+const toMonitorStatus = (rawState: string): MonitorStatus => {
+  const spaced = rawState.trim().toLowerCase().replace(/_+/g, ' ');
+  if (!spaced) return rawState as MonitorStatus;
+  return (spaced.charAt(0).toUpperCase() + spaced.slice(1)) as MonitorStatus;
+};
+
 const getDetectorJob = (resource?: ADDetector | ADForecaster): Record<string, unknown> =>
   asRecord(getField(asRecord(resource), 'anomaly_detector_job', 'anomalyDetectorJob'));
 
@@ -694,14 +711,21 @@ const getDetectorRunningJobsLabel = (resource?: ADDetector | ADForecaster): stri
 
 const isForecasterTestInitializing = (resource?: ADDetector | ADForecaster): boolean => {
   const state = getResourceState(resource);
-  return stateMatches(state, [FORECASTER_INIT_TEST_STATE, 'INIT_TEST']);
+  // Match both the prose form and the backend enum forms a real `curState` carries
+  // (`INIT_TEST` / `INITIALIZING_TEST`) so the test-initializing state routes to the
+  // dedicated "forecaster-test" blocker whether or not it was humanized upstream.
+  return stateMatches(state, [FORECASTER_INIT_TEST_STATE, 'INIT_TEST', 'INITIALIZING_TEST']);
 };
 
 /**
  * Adapts a raw forecaster resource into the minimal `UnifiedRuleSummary` shape that
  * `isAdResourceRunning` reads (`status` + `enabled` + resource kind).
- * `curState`/`cur_state` is typed as `MonitorStatus`, the same human-readable domain
- * the shared status sets are keyed on, so the shared predicate can be reused verbatim.
+ *
+ * The raw `curState`/`cur_state` is the backend UPPER_SNAKE enum, not the
+ * human-readable `MonitorStatus` the shared status Sets are keyed on, so it is
+ * run through {@link toMonitorStatus} first — otherwise `isAdResourceRunning`
+ * would compare an enum against prose and never match (it would silently fall
+ * back to `enabled`), defeating the point of sharing the predicate.
  *
  * The parameter type is the broad `ADDetector | ADForecaster` only because the single
  * caller (`isForecasterActiveForEdit`) holds that union; this adapter is forecaster-only
@@ -712,21 +736,22 @@ const asForecasterRunningInput = (resource?: ADDetector | ADForecaster): Unified
   ({
     monitorType: 'forecaster',
     definitionType: 'forecaster',
-    status: getResourceState(resource) as MonitorStatus,
+    status: toMonitorStatus(getResourceState(resource)),
     enabled: booleanValue(getField(asRecord(resource), 'enabled', 'enabled'), false),
   }) as unknown as UnifiedRuleSummary;
 
 const isForecasterActiveForEdit = (resource?: ADDetector | ADForecaster): boolean => {
   // This gate is a deliberate SUPERSET of `isAdResourceRunning` (the predicate the
   // detail flyout uses to show its Stop button) — the two do NOT fully agree, by design:
-  //   - It reuses `isAdResourceRunning` to block everything the backend treats as an
-  //     active job, including the generic "Initializing" state this gate used to miss —
-  //     the gap that let the backend reject the update with a raw
+  //   - It reuses `isAdResourceRunning` (via `asForecasterRunningInput`, which
+  //     normalizes the raw enum into the prose MonitorStatus domain) to block every
+  //     running/initializing state — including the generic "Initializing" this gate
+  //     used to miss, the gap that let the backend reject the update with a raw
   //     "Job is running: forecast-<id>" error.
-  //   - It additionally blocks failure states (e.g. `FORECAST_FAILURE`) that
-  //     `isAdResourceRunning` classifies as *not* running but that still can't be edited
-  //     in place, plus the uppercase enum forms of `curState` the human-readable status
-  //     map doesn't enumerate.
+  //   - It additionally blocks an enabled forecaster and the failure states (e.g.
+  //     `FORECAST_FAILURE`) that `isAdResourceRunning` classifies as *not* running but
+  //     that still can't be edited in place. The `stateMatches` list below (which also
+  //     compares the uppercase enum form) is retained as defense-in-depth.
   if (isAdResourceRunning(asForecasterRunningInput(resource))) return true;
   const state = getResourceState(resource);
   return (

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -698,10 +698,15 @@ const isForecasterTestInitializing = (resource?: ADDetector | ADForecaster): boo
 };
 
 /**
- * Adapts a raw forecaster/detector resource into the minimal `UnifiedRuleSummary`
- * shape that `isAdResourceRunning` reads (`status` + `enabled` + resource kind).
+ * Adapts a raw forecaster resource into the minimal `UnifiedRuleSummary` shape that
+ * `isAdResourceRunning` reads (`status` + `enabled` + resource kind).
  * `curState`/`cur_state` is typed as `MonitorStatus`, the same human-readable domain
  * the shared status sets are keyed on, so the shared predicate can be reused verbatim.
+ *
+ * The parameter type is the broad `ADDetector | ADForecaster` only because the single
+ * caller (`isForecasterActiveForEdit`) holds that union; this adapter is forecaster-only
+ * and intentionally hardcodes the `'forecaster'` kind (detectors use a different edit
+ * lifecycle and never reach this path).
  */
 const asForecasterRunningInput = (resource?: ADDetector | ADForecaster): UnifiedRuleSummary =>
   ({
@@ -712,13 +717,16 @@ const asForecasterRunningInput = (resource?: ADDetector | ADForecaster): Unified
   }) as unknown as UnifiedRuleSummary;
 
 const isForecasterActiveForEdit = (resource?: ADDetector | ADForecaster): boolean => {
-  // Gate edits on the same running-state predicate the detail flyout uses to show its
-  // Stop button. `isAdResourceRunning` enumerates every status the backend treats as an
-  // active job (including the generic "Initializing" state this list used to miss), so
-  // aligning here closes the gap that let the backend reject the update with a raw
-  // "Job is running: forecast-<id>" error. The explicit checks below remain as a
-  // defensive superset for the uppercase enum forms of `curState` that the
-  // human-readable status map does not enumerate.
+  // This gate is a deliberate SUPERSET of `isAdResourceRunning` (the predicate the
+  // detail flyout uses to show its Stop button) — the two do NOT fully agree, by design:
+  //   - It reuses `isAdResourceRunning` to block everything the backend treats as an
+  //     active job, including the generic "Initializing" state this gate used to miss —
+  //     the gap that let the backend reject the update with a raw
+  //     "Job is running: forecast-<id>" error.
+  //   - It additionally blocks failure states (e.g. `FORECAST_FAILURE`) that
+  //     `isAdResourceRunning` classifies as *not* running but that still can't be edited
+  //     in place, plus the uppercase enum forms of `curState` the human-readable status
+  //     map doesn't enumerate.
   if (isAdResourceRunning(asForecasterRunningInput(resource))) return true;
   const state = getResourceState(resource);
   return (

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -55,13 +55,19 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import { ADDetector, ADForecaster, Datasource } from '../../../common/types/alerting';
+import {
+  ADDetector,
+  ADForecaster,
+  Datasource,
+  MonitorStatus,
+  UnifiedRuleSummary,
+} from '../../../common/types/alerting';
 import { coreRefs } from '../../framework/core_refs';
 import { toAdApiDataSourceId, withAdApiDataSource } from './utils/ad_api_paths';
 import { useIndexMappings } from './hooks/use_index_mappings';
 import { useIndices } from './hooks/use_indices';
 import { useRuleDetail } from './hooks/use_rule_detail';
-import { isStandardOpenSearchDatasource } from './shared_constants';
+import { isAdResourceRunning, isStandardOpenSearchDatasource } from './shared_constants';
 
 export type CreateAdRuleType = 'detector' | 'forecaster';
 type AdRuleFlyoutMode = 'create' | 'edit';
@@ -691,7 +697,29 @@ const isForecasterTestInitializing = (resource?: ADDetector | ADForecaster): boo
   return stateMatches(state, [FORECASTER_INIT_TEST_STATE, 'INIT_TEST']);
 };
 
+/**
+ * Adapts a raw forecaster/detector resource into the minimal `UnifiedRuleSummary`
+ * shape that `isAdResourceRunning` reads (`status` + `enabled` + resource kind).
+ * `curState`/`cur_state` is typed as `MonitorStatus`, the same human-readable domain
+ * the shared status sets are keyed on, so the shared predicate can be reused verbatim.
+ */
+const asForecasterRunningInput = (resource?: ADDetector | ADForecaster): UnifiedRuleSummary =>
+  (({
+    monitorType: 'forecaster',
+    definitionType: 'forecaster',
+    status: getResourceState(resource) as MonitorStatus,
+    enabled: booleanValue(getField(asRecord(resource), 'enabled', 'enabled'), false),
+  } as unknown) as UnifiedRuleSummary);
+
 const isForecasterActiveForEdit = (resource?: ADDetector | ADForecaster): boolean => {
+  // Gate edits on the same running-state predicate the detail flyout uses to show its
+  // Stop button. `isAdResourceRunning` enumerates every status the backend treats as an
+  // active job (including the generic "Initializing" state this list used to miss), so
+  // aligning here closes the gap that let the backend reject the update with a raw
+  // "Job is running: forecast-<id>" error. The explicit checks below remain as a
+  // defensive superset for the uppercase enum forms of `curState` that the
+  // human-readable status map does not enumerate.
+  if (isAdResourceRunning(asForecasterRunningInput(resource))) return true;
   const state = getResourceState(resource);
   return (
     booleanValue(getField(asRecord(resource), 'enabled', 'enabled'), false) ||
@@ -710,7 +738,7 @@ const isForecasterActiveForEdit = (resource?: ADDetector | ADForecaster): boolea
   );
 };
 
-const getEditLifecycleBlocker = (
+export const getEditLifecycleBlocker = (
   ruleType: CreateAdRuleType,
   resource: ADDetector | ADForecaster | undefined,
   hasStoppedForEdit: boolean
@@ -942,6 +970,26 @@ const buildErrorMessage = (error: unknown): string => {
   return i18n.translate('observability.alerting.createAdRuleFlyout.unknownError', {
     defaultMessage: 'Unknown error',
   });
+};
+
+/**
+ * The AD/forecasting backend rejects updates to a running resource with a raw
+ * `Job is running: forecast-<id>` (or `detector-<id>`) string that leaks an internal
+ * job id and offers no guidance. Detect that rejection and swap in actionable copy.
+ */
+const RUNNING_JOB_ERROR_PATTERN = /job is running/i;
+
+export const humanizeAdUpdateError = (rawMessage: string, ruleType: CreateAdRuleType): string => {
+  if (!RUNNING_JOB_ERROR_PATTERN.test(rawMessage)) return rawMessage;
+  return ruleType === 'detector'
+    ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorRunningUpdateGuidance', {
+        defaultMessage:
+          'Stop the detector before editing its configuration, then restart it after your changes are saved.',
+      })
+    : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterRunningUpdateGuidance', {
+        defaultMessage:
+          'Stop the forecaster before editing its configuration, then restart it after your changes are saved.',
+      });
 };
 
 const featureErrorKey = (
@@ -2519,7 +2567,9 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
         }
       }
     } catch (error) {
-      const message = buildErrorMessage(error);
+      // Never surface the backend's raw "Job is running: forecast-<id>" string — it
+      // leaks an internal job id and gives no guidance. Swap in actionable copy.
+      const message = humanizeAdUpdateError(buildErrorMessage(error), ruleType);
       setSubmitError(message);
       coreRefs.toasts?.addDanger({
         title: isEdit

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -704,12 +704,12 @@ const isForecasterTestInitializing = (resource?: ADDetector | ADForecaster): boo
  * the shared status sets are keyed on, so the shared predicate can be reused verbatim.
  */
 const asForecasterRunningInput = (resource?: ADDetector | ADForecaster): UnifiedRuleSummary =>
-  (({
+  ({
     monitorType: 'forecaster',
     definitionType: 'forecaster',
     status: getResourceState(resource) as MonitorStatus,
     enabled: booleanValue(getField(asRecord(resource), 'enabled', 'enabled'), false),
-  } as unknown) as UnifiedRuleSummary);
+  }) as unknown as UnifiedRuleSummary;
 
 const isForecasterActiveForEdit = (resource?: ADDetector | ADForecaster): boolean => {
   // Gate edits on the same running-state predicate the detail flyout uses to show its


### PR DESCRIPTION
## What & why
The forecaster edit gate decided "is it running?" with a hand-maintained state list that had drifted from `isAdResourceRunning` — the shared predicate the detail flyout uses for its Stop button. Generic states like `Initializing` slipped through, so the backend rejected the edit with a raw internal string. This makes the gate reuse the shared predicate as a deliberate **superset** — it blocks everything `isAdResourceRunning` treats as running, **plus** failure states (`FORECAST_FAILURE`) that predicate classifies as not-running but that still can't be edited in place — and swaps the raw error for guidance.

**Code before / after** (no runtime screenshot — see note):

_Before_ — gate used its own drifting list; the raw backend error reached the user:
```ts
const message = buildErrorMessage(error); // "Job is running: forecast-3f9c…"
```
_After_ — gate reuses the shared predicate; the leak is replaced with actionable copy:
```ts
if (isAdResourceRunning(asForecasterRunningInput(resource))) return true; // catches "Initializing" too
// …
const message = humanizeAdUpdateError(buildErrorMessage(error), ruleType);
// → "Stop the forecaster before editing its configuration, then restart it after your changes are saved."
```

**Findings:** BUG-AD1.

## Testing
`forecaster_edit_gate.test.ts` asserts the safety-critical direction — the gate blocks **every** status `isAdResourceRunning` treats as running (so the backend never rejects a permitted edit) — plus the failure states the gate additionally blocks, and that the raw 'Job is running' string never reaches the user. **Note:** no runtime before/after screenshot — the local Docker stack has no running forecaster (the forecast `_search` proxy returns 'No Living connections'); flagged for managed-env visual verification.

## Review
Independent review agent (earlier round): review commit applied.

## Regression check
This PR ships no runtime screenshot (see the Testing note); regression safety rests on the unit tests above plus central verification: the change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. It can be reviewed, merged, and reverted independently.

## Dependency
None.

> Draft — see the merge-order note above.
