### PR TITLE
[SLO] Add the missing edit path: #/slos/:id/edit with wizard prefill + update

### DIFF
--- a/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
@@ -304,6 +304,15 @@ describe('SloDetailPage — View alerts pivot (OBS1)', () => {
   });
 });
 
+describe('SloDetailPage — Edit affordance (BUG-S3)', () => {
+  it('renders an Edit action linking to the SLO edit route', async () => {
+    renderPage({ get: jest.fn().mockResolvedValue(makeDoc()) });
+
+    const editButton = await screen.findByTestId('slosDetailEdit');
+    expect(editButton).toHaveAttribute('href', '#/slos/slo-1/edit');
+  });
+});
+
 describe('SloDetailPage — rule-health grace window + re-poll (F-CRUD2)', () => {
   beforeEach(() => {
     jest.useFakeTimers();

--- a/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
@@ -311,6 +311,18 @@ describe('SloDetailPage — Edit affordance (BUG-S3)', () => {
     const editButton = await screen.findByTestId('slosDetailEdit');
     expect(editButton).toHaveAttribute('href', '#/slos/slo-1/edit');
   });
+
+  it('hides Edit for an SLO the wizard cannot edit (no dead-end round trip)', async () => {
+    // Calendar-window SLO is unsupported by the wizard, so the detail page must
+    // not offer Edit (it would only land on "This SLO can't be edited here").
+    const doc = makeDoc();
+    doc.spec.window = { type: 'calendar', period: 'month' };
+    renderPage({ get: jest.fn().mockResolvedValue(doc) });
+
+    // The page rendered (Delete is always present), but Edit is absent.
+    expect(await screen.findByTestId('slosDetailDelete')).toBeInTheDocument();
+    expect(screen.queryByTestId('slosDetailEdit')).not.toBeInTheDocument();
+  });
 });
 
 describe('SloDetailPage — rule-health grace window + re-poll (F-CRUD2)', () => {

--- a/public/components/apm/pages/slos/__tests__/slo_edit_wizard.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_edit_wizard.test.tsx
@@ -1,0 +1,294 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Edit-path coverage for the SLO wizard (BUG-S3). Each test is written so it
+ * FAILS if the corresponding production change is reverted:
+ *   - the `#/slos/:id/edit` route resolves and renders the wizard prefilled
+ *   - submitting on the edit route calls `update` (not `create`) — no duplicate
+ *   - the datasource is not silently editable in edit mode (key field)
+ *   - the create route still starts from an empty form
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { SloWizardPage } from '../slo_wizard_page';
+import { SlosPage } from '../slos_page';
+import type { SloApiClient } from '../slo_api_client';
+import type { SloDocument } from '../../../../../../common/slo/slo_types';
+import { OBSERVABILITY_BASE } from '../../../../../../common/constants/shared';
+
+jest.useFakeTimers();
+
+// HeaderControlledComponentsWrapper reaches into OSD's chrome pipeline (unwired
+// in jsdom). Render its children inline so the wizard body still mounts.
+jest.mock('../../../../../plugin_helpers/plugin_headerControl', () => ({
+  HeaderControlledComponentsWrapper: ({ components }: { components: React.ReactNode[] }) => (
+    <div data-test-subj="header-wrapper">{components}</div>
+  ),
+}));
+
+// Datasource + metadata hooks reach coreRefs.http / savedObjectsClient. Stub
+// them to inert shapes so the wizard renders without live services.
+jest.mock('../../../../alerting/hooks/use_datasources', () => ({
+  useDatasources: () => ({
+    datasources: [
+      {
+        id: 'ds-2',
+        name: 'Prod Prometheus',
+        type: 'prometheus',
+        url: 'prom_conn',
+        enabled: true,
+        directQueryName: 'prom_conn',
+      },
+    ],
+    isLoading: false,
+    error: null,
+    refresh: () => {},
+  }),
+}));
+jest.mock('../../../../alerting/hooks/use_prometheus_metadata', () => ({
+  usePrometheusMetadata: () => ({
+    metricOptions: [],
+    metricsLoading: false,
+    searchMetrics: jest.fn(),
+    labelNames: [],
+    labelNamesLoading: false,
+    labelValues: {},
+    labelValuesLoading: {},
+    fetchLabelValues: jest.fn(),
+    metricMetadata: [],
+    error: false,
+    applyTemplate: jest.fn(),
+  }),
+}));
+
+// The sibling pages are heavy and irrelevant to these assertions. Stub them so
+// the route-resolution test can prove the WIZARD renders on `/slos/:id/edit`
+// (and would render the listing stub instead if the route were removed).
+jest.mock('../slo_listing_page', () => ({
+  SloListingPage: () => <div data-test-subj="slosListingStub" />,
+}));
+jest.mock('../slo_suggest_page', () => ({
+  SloSuggestPage: () => <div data-test-subj="slosSuggestStub" />,
+}));
+jest.mock('../slo_detail_page', () => ({
+  SloDetailPage: () => <div data-test-subj="slosDetailStub" />,
+}));
+
+const SLO_BASE = `${OBSERVABILITY_BASE}/v1/slos`;
+
+function makeDoc(): SloDocument {
+  return {
+    id: 'slo-1',
+    spec: {
+      datasourceId: 'prom_conn',
+      name: 'api-availability',
+      description: 'checkout availability',
+      enabled: true,
+      mode: 'active',
+      service: 'checkout',
+      owner: { teams: ['sre'], primaryUser: 'alice' },
+      tier: 'tier-1',
+      sli: {
+        type: 'single',
+        definition: {
+          backend: 'prometheus',
+          type: 'availability',
+          calcMethod: 'events',
+          metric: 'http_requests_total',
+          goodEventsFilter: 'status!~"5.."',
+        },
+        dimensions: [{ name: 'service', value: 'checkout' }],
+      },
+      objectives: [{ name: 'obj-1', target: 0.99 }],
+      budgetWarningThresholds: [{ threshold: 0.5, severity: 'warning' }],
+      window: { type: 'rolling', duration: '28d' },
+      alerting: {
+        strategy: 'mwmbr',
+        burnRates: [
+          {
+            shortWindow: '5m',
+            longWindow: '1h',
+            burnRateMultiplier: 14,
+            severity: 'page',
+            createAlarm: true,
+            forDuration: '2m',
+          },
+        ],
+      },
+      alarms: {
+        sliHealth: { enabled: false },
+        attainmentBreach: { enabled: false },
+        budgetWarning: { enabled: true },
+        noData: { enabled: false, forDuration: '10m' },
+        resolved: { enabled: false },
+      },
+      exclusionWindows: [],
+      labels: {},
+      annotations: {},
+    },
+    status: {
+      version: 3,
+      createdAt: '2026-01-01T00:00:00Z',
+      createdBy: 'tester',
+      updatedAt: '2026-01-01T00:00:00Z',
+      updatedBy: 'tester',
+      provisioning: {
+        backend: 'prometheus',
+        alertGroupName: 'slo:alerts:api',
+        rulerNamespace: 'slo-generated-prom',
+        recordingFingerprints: { 'obj-1': 'abcd1234' },
+      },
+    },
+  };
+}
+
+function makeClient(overrides: Partial<SloApiClient> = {}): Partial<SloApiClient> {
+  return {
+    get: jest.fn().mockResolvedValue(makeDoc()),
+    update: jest.fn().mockImplementation((id: string, input: { version: number }) =>
+      Promise.resolve({
+        ...makeDoc(),
+        status: { ...makeDoc().status, version: input.version + 1 },
+      })
+    ),
+    create: jest.fn(),
+    preview: jest.fn().mockResolvedValue({ groupName: 'g', interval: 30, rules: [], yaml: '' }),
+    list: jest.fn().mockResolvedValue({ results: [], total: 0 }),
+    labelValues: jest.fn().mockResolvedValue({ values: [] }),
+    ...overrides,
+  };
+}
+
+function makeChrome() {
+  return { setBreadcrumbs: jest.fn() } as unknown as Parameters<typeof SloWizardPage>[0]['chrome'];
+}
+function makeNotifications() {
+  return {
+    toasts: { addSuccess: jest.fn(), addWarning: jest.fn(), addDanger: jest.fn() },
+  } as unknown as Parameters<typeof SloWizardPage>[0]['notifications'];
+}
+
+function renderEditWizard(apiClient: Partial<SloApiClient>) {
+  return render(
+    <MemoryRouter initialEntries={['/slos/slo-1/edit']}>
+      <Route path="/slos/:id/edit">
+        <SloWizardPage
+          apiClient={apiClient as SloApiClient}
+          chrome={makeChrome()}
+          notifications={makeNotifications()}
+          parentBreadcrumb={{ text: 'APM', href: '#/' }}
+          editSloId="slo-1"
+        />
+      </Route>
+    </MemoryRouter>
+  );
+}
+
+/** Flush the async edit-load (apiClient.get) + any queued timers. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await act(async () => {
+    jest.runOnlyPendingTimers();
+  });
+}
+
+describe('SLO wizard — edit path (BUG-S3)', () => {
+  it('resolves the #/slos/:id/edit route and renders the wizard prefilled from the doc', async () => {
+    // Drive the REAL router in SlosPage via an http mock so this fails if the
+    // `/slos/:id/edit` route is removed (it would redirect to the listing stub).
+    const httpGet = jest.fn((url: string) => {
+      if (url === `${SLO_BASE}/slo-1`) return Promise.resolve(makeDoc());
+      if (url === SLO_BASE) return Promise.resolve({ results: [], total: 0 });
+      return Promise.resolve({ values: [] });
+    });
+    const http = {
+      get: httpGet,
+      post: jest.fn().mockResolvedValue({ groupName: 'g', interval: 30, rules: [], yaml: '' }),
+      put: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as Parameters<typeof SlosPage>[0]['http'];
+
+    window.location.hash = '#/slos/slo-1/edit';
+    render(
+      <SlosPage
+        http={http}
+        chrome={makeChrome()}
+        notifications={makeNotifications()}
+        parentBreadcrumb={{ text: 'APM', href: '#/' }}
+      />
+    );
+    await flush();
+
+    // The wizard (not the listing) rendered, prefilled with the saved name.
+    expect(screen.getByTestId('slosWizardName')).toHaveValue('api-availability');
+    expect(screen.queryByTestId('slosListingStub')).toBeNull();
+    window.location.hash = '';
+  });
+
+  it('submitting on the edit route calls update (not create) — no duplicate SLO', async () => {
+    const apiClient = makeClient();
+    renderEditWizard(apiClient);
+    await flush();
+
+    // Prefill sanity — the form is populated before we submit.
+    expect(screen.getByTestId('slosWizardName')).toHaveValue('api-availability');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('slosWizardSubmit'));
+    });
+    await flush();
+
+    await waitFor(() => expect(apiClient.update).toHaveBeenCalledTimes(1));
+    const [calledId, calledInput] = (apiClient.update as jest.Mock).mock.calls[0];
+    expect(calledId).toBe('slo-1');
+    // Optimistic-concurrency version echoed from the loaded doc.
+    expect(calledInput.version).toBe(3);
+    expect(calledInput.spec.name).toBe('api-availability');
+    // Crucially: it must NOT create a second SLO.
+    expect(apiClient.create).not.toHaveBeenCalled();
+  });
+
+  it('renders the datasource as read-only in edit mode (key field not silently editable)', async () => {
+    const apiClient = makeClient();
+    renderEditWizard(apiClient);
+    await flush();
+
+    // The read-only field is shown, prefilled with the persisted datasource...
+    const readOnly = screen.getByTestId('slosWizardDatasourceReadOnly');
+    expect(readOnly).toHaveValue('prom_conn');
+    expect(readOnly).toBeDisabled();
+    // ...and the interactive datasource picker is NOT rendered.
+    expect(screen.queryByTestId('slosWizardDatasourceId')).toBeNull();
+  });
+
+  it('the create route still starts from an empty form', () => {
+    const apiClient = makeClient();
+    render(
+      <MemoryRouter initialEntries={['/slos/create/http-availability']}>
+        <Route path="/slos/create/:templateId">
+          <SloWizardPage
+            apiClient={apiClient as SloApiClient}
+            chrome={makeChrome()}
+            notifications={makeNotifications()}
+            parentBreadcrumb={{ text: 'APM', href: '#/' }}
+          />
+        </Route>
+      </MemoryRouter>
+    );
+
+    // No prefill: the name starts blank, and the interactive datasource picker
+    // (not the read-only field) is shown.
+    expect(screen.getByTestId('slosWizardName')).toHaveValue('');
+    expect(screen.getByTestId('slosWizardDatasourceId')).toBeInTheDocument();
+    expect(screen.queryByTestId('slosWizardDatasourceReadOnly')).toBeNull();
+    // The edit-only load path never fires for create.
+    expect(apiClient.get).not.toHaveBeenCalled();
+  });
+});

--- a/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
+++ b/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
@@ -4,7 +4,9 @@
  */
 
 import { SLO_TEMPLATES } from '../../../../../../common/slo/slo_templates';
-import { initialState, reducer, applyTemplate } from '../wizard_state';
+import type { SloDocument } from '../../../../../../common/slo/slo_types';
+import { hydrateFromDoc, initialState, reducer, applyTemplate } from '../wizard_state';
+import { buildCreateInput } from '../wizard_builders';
 
 describe('wizard_state reducer', () => {
   it('starts with a single objective and the 28d window default', () => {
@@ -193,8 +195,112 @@ describe('wizard_state reducer', () => {
     const oneoff =
       schedule.type === 'oneoff'
         ? schedule
-        : ((undefined as never) as typeof schedule & { type: 'oneoff' });
+        : (undefined as never as typeof schedule & { type: 'oneoff' });
     expect(oneoff.start).toMatch(/T/);
     expect(oneoff.end).toMatch(/T/);
+  });
+});
+
+describe('hydrateFromDoc (edit-mode prefill)', () => {
+  function makeDoc(): SloDocument {
+    return {
+      id: 'slo-1',
+      spec: {
+        datasourceId: 'prom_conn',
+        name: 'api-availability',
+        description: 'checkout availability',
+        enabled: true,
+        mode: 'shadow',
+        service: 'checkout',
+        owner: { teams: ['sre'], primaryUser: 'alice' },
+        tier: 'tier-1',
+        sli: {
+          type: 'single',
+          definition: {
+            backend: 'prometheus',
+            type: 'availability',
+            calcMethod: 'events',
+            metric: 'http_requests_total',
+            goodEventsFilter: 'status!~"5.."',
+          },
+          dimensions: [{ name: 'service', value: 'checkout' }],
+        },
+        objectives: [{ name: 'obj-1', target: 0.999 }],
+        budgetWarningThresholds: [{ threshold: 0.5, severity: 'warning' }],
+        window: { type: 'rolling', duration: '14d' },
+        alerting: {
+          strategy: 'mwmbr',
+          burnRates: [
+            {
+              shortWindow: '5m',
+              longWindow: '1h',
+              burnRateMultiplier: 14,
+              severity: 'page',
+              createAlarm: true,
+              forDuration: '2m',
+            },
+          ],
+        },
+        alarms: {
+          sliHealth: { enabled: false },
+          attainmentBreach: { enabled: false },
+          budgetWarning: { enabled: true },
+          noData: { enabled: false, forDuration: '10m' },
+          resolved: { enabled: false },
+        },
+        exclusionWindows: [],
+        labels: { compliance: 'pci' },
+        annotations: { runbook: 'https://wiki/slo' },
+      },
+      status: {
+        version: 4,
+        createdAt: '2026-01-01T00:00:00Z',
+        createdBy: 'tester',
+        updatedAt: '2026-01-02T00:00:00Z',
+        updatedBy: 'tester',
+        provisioning: { backend: 'prometheus', rulerNamespace: 'ns' },
+      },
+    };
+  }
+
+  it('maps a persisted spec back into the form state and carries the version', () => {
+    const hydrated = hydrateFromDoc(makeDoc());
+    expect(hydrated).not.toBeNull();
+    const { state, version } = hydrated!;
+    expect(version).toBe(4);
+    expect(state.datasourceId).toBe('prom_conn');
+    expect(state.name).toBe('api-availability');
+    expect(state.service).toBe('checkout');
+    expect(state.ownerTeam).toBe('sre');
+    expect(state.ownerPrimaryUser).toBe('alice');
+    expect(state.windowDuration).toBe('14d');
+    expect(state.shadow).toBe(true);
+    // Decimal target → percent string, no float artifacts.
+    expect(state.objectives[0].target).toBe('99.9');
+    expect(state.metric).toBe('http_requests_total');
+    expect(state.labels).toEqual([{ key: 'compliance', value: 'pci' }]);
+    expect(state.annotations).toEqual([{ key: 'runbook', value: 'https://wiki/slo' }]);
+  });
+
+  it('round-trips: buildCreateInput(hydrated) reproduces the persisted spec', () => {
+    const doc = makeDoc();
+    const hydrated = hydrateFromDoc(doc)!;
+    const rebuilt = buildCreateInput(hydrated.state, hydrated.template);
+    expect(rebuilt.spec.name).toBe(doc.spec.name);
+    expect(rebuilt.spec.service).toBe(doc.spec.service);
+    expect(rebuilt.spec.mode).toBe('shadow');
+    expect(rebuilt.spec.objectives[0].target).toBeCloseTo(0.999, 6);
+    expect(rebuilt.spec.sli.definition.type).toBe('availability');
+    expect(rebuilt.spec.window).toEqual({ type: 'rolling', duration: '14d' });
+  });
+
+  it('returns null for composite SLIs (cannot be edited in the wizard)', () => {
+    const doc = makeDoc();
+    (doc.spec.sli as unknown) = {
+      type: 'composite',
+      operator: 'all',
+      members: [{ sloId: 'a' }],
+    };
+    expect(hydrateFromDoc(doc)).toBeNull();
   });
 });

--- a/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
+++ b/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
@@ -290,13 +290,17 @@ describe('hydrateFromDoc (edit-mode prefill)', () => {
     expect(rebuilt.spec.service).toBe(doc.spec.service);
     expect(rebuilt.spec.mode).toBe('shadow');
     expect(rebuilt.spec.objectives[0].target).toBeCloseTo(0.999, 6);
-    expect(rebuilt.spec.sli.definition.type).toBe('availability');
+    const rebuiltSli = rebuilt.spec.sli;
+    expect(rebuiltSli.type).toBe('single');
+    if (rebuiltSli.type === 'single') {
+      expect(rebuiltSli.definition.type).toBe('availability');
+    }
     expect(rebuilt.spec.window).toEqual({ type: 'rolling', duration: '14d' });
   });
 
   it('returns null for composite SLIs (cannot be edited in the wizard)', () => {
     const doc = makeDoc();
-    (doc.spec.sli as unknown) = {
+    doc.spec.sli = {
       type: 'composite',
       operator: 'all',
       members: [{ sloId: 'a' }],

--- a/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
+++ b/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
@@ -5,7 +5,13 @@
 
 import { SLO_TEMPLATES } from '../../../../../../common/slo/slo_templates';
 import type { SloDocument } from '../../../../../../common/slo/slo_types';
-import { hydrateFromDoc, initialState, reducer, applyTemplate } from '../wizard_state';
+import {
+  hydrateFromDoc,
+  initialState,
+  isSloEditable,
+  reducer,
+  applyTemplate,
+} from '../wizard_state';
 import { buildCreateInput } from '../wizard_builders';
 
 describe('wizard_state reducer', () => {
@@ -298,6 +304,22 @@ describe('hydrateFromDoc (edit-mode prefill)', () => {
     expect(rebuilt.spec.window).toEqual({ type: 'rolling', duration: '14d' });
   });
 
+  it('preserves array-valued labels through an edit instead of flattening them to CSV', () => {
+    // SloSpec.labels is Record<string, string | string[]>. The wizard editor
+    // only authors scalars, so an API-created array label must round-trip
+    // verbatim — otherwise hydrate would flatten {region:['us','eu']} to the
+    // scalar 'us,eu' and the server's shallow labels merge would persist it.
+    const doc = makeDoc();
+    doc.spec.labels = { compliance: 'pci', region: ['us', 'eu'] };
+    const hydrated = hydrateFromDoc(doc)!;
+    // The array label is carried out-of-band, NOT shown as an editable scalar row.
+    expect(hydrated.state.preservedArrayLabels).toEqual({ region: ['us', 'eu'] });
+    expect(hydrated.state.labels).toEqual([{ key: 'compliance', value: 'pci' }]);
+    // …and re-emitted verbatim (still an array) on save.
+    const rebuilt = buildCreateInput(hydrated.state, hydrated.template);
+    expect(rebuilt.spec.labels).toEqual({ region: ['us', 'eu'], compliance: 'pci' });
+  });
+
   it('preserves secondary owner teams through an edit (no truncation to primary)', () => {
     // The saved object supports up to 5 teams, but the wizard only edits the
     // primary. A multi-team SLO (API-created) must keep teams[1..] on save,
@@ -349,5 +371,29 @@ describe('hydrateFromDoc (edit-mode prefill)', () => {
     const doc = makeDoc();
     doc.spec.window = { type: 'calendar', period: 'month' };
     expect(hydrateFromDoc(doc)).toBeNull();
+  });
+
+  describe('isSloEditable (detail-page Edit gating)', () => {
+    it('agrees with hydrateFromDoc across editable and unsupported SLOs', () => {
+      // Editable: single Prometheus SLI + representable rolling window.
+      const ok = makeDoc();
+      expect(isSloEditable(ok)).toBe(true);
+      expect(hydrateFromDoc(ok)).not.toBeNull();
+
+      // Composite SLI → not editable.
+      const composite = makeDoc();
+      composite.spec.sli = { type: 'composite', operator: 'all', members: [{ sloId: 'a' }] };
+      expect(isSloEditable(composite)).toBe(false);
+
+      // Calendar window → not editable.
+      const calendar = makeDoc();
+      calendar.spec.window = { type: 'calendar', period: 'month' };
+      expect(isSloEditable(calendar)).toBe(false);
+
+      // Non-representable rolling window → not editable.
+      const oddWindow = makeDoc();
+      oddWindow.spec.window = { type: 'rolling', duration: '21d' };
+      expect(isSloEditable(oddWindow)).toBe(false);
+    });
   });
 });

--- a/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
+++ b/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
@@ -307,4 +307,22 @@ describe('hydrateFromDoc (edit-mode prefill)', () => {
     };
     expect(hydrateFromDoc(doc)).toBeNull();
   });
+
+  it('returns null for a rolling window the wizard cannot represent (no silent coercion)', () => {
+    // The server accepts any 1d–30d rolling window, but the wizard only offers
+    // 7/14/28/30d. A 21d SLO must be reported UNSUPPORTED — not coerced to 28d —
+    // otherwise saving an edit to any unrelated field would silently rewrite the
+    // window (and its alert/error-budget math) via the server's shallow merge.
+    const doc = makeDoc();
+    doc.spec.window = { type: 'rolling', duration: '21d' };
+    expect(hydrateFromDoc(doc)).toBeNull();
+  });
+
+  it('returns null for a calendar window (wizard only models rolling windows)', () => {
+    // A calendar window isn't representable at all; coercing would silently
+    // change the window TYPE (calendar → 28d rolling) on save.
+    const doc = makeDoc();
+    doc.spec.window = { type: 'calendar', period: 'month' };
+    expect(hydrateFromDoc(doc)).toBeNull();
+  });
 });

--- a/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
+++ b/public/components/apm/pages/slos/__tests__/wizard_state.test.ts
@@ -298,6 +298,31 @@ describe('hydrateFromDoc (edit-mode prefill)', () => {
     expect(rebuilt.spec.window).toEqual({ type: 'rolling', duration: '14d' });
   });
 
+  it('preserves secondary owner teams through an edit (no truncation to primary)', () => {
+    // The saved object supports up to 5 teams, but the wizard only edits the
+    // primary. A multi-team SLO (API-created) must keep teams[1..] on save,
+    // else the server's shallow owner merge would drop them.
+    const doc = makeDoc();
+    doc.spec.owner = { teams: ['sre', 'oncall', 'platform'], primaryUser: 'alice' };
+    const hydrated = hydrateFromDoc(doc)!;
+    expect(hydrated.state.ownerTeam).toBe('sre');
+    expect(hydrated.state.ownerTeamsSecondary).toEqual(['oncall', 'platform']);
+    const rebuilt = buildCreateInput(hydrated.state, hydrated.template);
+    expect(rebuilt.spec.owner.teams).toEqual(['sre', 'oncall', 'platform']);
+  });
+
+  it('dedupes when the edited primary team already appears among the secondaries', () => {
+    const doc = makeDoc();
+    doc.spec.owner = { teams: ['sre', 'oncall'], primaryUser: 'alice' };
+    const hydrated = hydrateFromDoc(doc)!;
+    expect(hydrated.state.ownerTeamsSecondary).toEqual(['oncall']);
+    // User sets the primary team to one that's already a secondary: the result
+    // must not contain a duplicate, and primary stays first.
+    const state = { ...hydrated.state, ownerTeam: 'oncall' };
+    const rebuilt = buildCreateInput(state, hydrated.template);
+    expect(rebuilt.spec.owner.teams).toEqual(['oncall']);
+  });
+
   it('returns null for composite SLIs (cannot be edited in the wizard)', () => {
     const doc = makeDoc();
     doc.spec.sli = {

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -1091,6 +1091,18 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
         defaultMessage: 'View alerts',
       })}
     </EuiButtonEmpty>,
+    <EuiButton
+      key="edit"
+      size="s"
+      fill
+      iconType="pencil"
+      href={`#/slos/${encodeURIComponent(doc.id)}/edit`}
+      data-test-subj="slosDetailEdit"
+    >
+      {i18n.translate('observability.apm.slo.detail.editButton', {
+        defaultMessage: 'Edit',
+      })}
+    </EuiButton>,
     <EuiButton key="toggle" size="s" onClick={onToggleEnabled} data-test-subj="slosDetailToggle">
       {doc.spec.enabled
         ? i18n.translate('observability.apm.slo.detail.disableButton', {

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -1072,10 +1072,14 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
         // selection regardless of which tab is active — so the Alerts view
         // lands with this SLO's Prometheus datasource already selected.
         //
-        // `q=slo_id:<id>` is carried through for the day the Alerts tab
-        // honours the deep-link query the way the Rules tab already does
-        // (today only MonitorsTable seeds its search from `deepLink.q`); it
-        // is harmless until then. The recording-rule list on this page stays
+        // `q=slo_id:<id>` scopes the Alerts view to this SLO once the Alerts
+        // tab honours the deep-link query. That support lands in #2827
+        // (`alertMatchesSearch` treats a single `key:value` term as a label
+        // match, used by `filterAlerts`; `alarms_page` already forwards
+        // `deepLink.q` to `AlertsDashboard`). Until #2827 merges the Alerts tab
+        // ignores `q` (only MonitorsTable seeds its search from `deepLink.q`),
+        // so the pivot degrades gracefully to a datasource-scoped view rather
+        // than erroring. The recording-rule list on this page stays
         // informational — recording rules never surface in Alert Manager.
         const params = new URLSearchParams({
           q: `slo_id:${doc.id}`,

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -55,6 +55,7 @@ import type {
 import { getSloHealthColor, getSloHealthLabel } from '../../../../../common/slo/state';
 import { formatPct, SLO_PRECISION, TABULAR_NUMS_STYLE } from '../../../../../common/slo/format';
 import { templateIconFor } from './template_icons';
+import { isSloEditable } from './wizard_state';
 import { observabilityAlertingID } from '../../../../../common/constants/shared';
 import { coreRefs } from '../../../../framework/core_refs';
 
@@ -1095,18 +1096,26 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
         defaultMessage: 'View alerts',
       })}
     </EuiButtonEmpty>,
-    <EuiButton
-      key="edit"
-      size="s"
-      fill
-      iconType="pencil"
-      href={`#/slos/${encodeURIComponent(doc.id)}/edit`}
-      data-test-subj="slosDetailEdit"
-    >
-      {i18n.translate('observability.apm.slo.detail.editButton', {
-        defaultMessage: 'Edit',
-      })}
-    </EuiButton>,
+    // Only offer Edit for SLOs the wizard can actually edit (single Prometheus
+    // SLI + representable rolling window). For composite / non-Prometheus /
+    // calendar-window SLOs, editing lands on the wizard's "can't be edited here"
+    // message, so we don't show a dead-end button. Not `fill`: Edit is one of
+    // several equal header actions, not the primary CTA.
+    ...(isSloEditable(doc)
+      ? [
+          <EuiButton
+            key="edit"
+            size="s"
+            iconType="pencil"
+            href={`#/slos/${encodeURIComponent(doc.id)}/edit`}
+            data-test-subj="slosDetailEdit"
+          >
+            {i18n.translate('observability.apm.slo.detail.editButton', {
+              defaultMessage: 'Edit',
+            })}
+          </EuiButton>,
+        ]
+      : []),
     <EuiButton key="toggle" size="s" onClick={onToggleEnabled} data-test-subj="slosDetailToggle">
       {doc.spec.enabled
         ? i18n.translate('observability.apm.slo.detail.disableButton', {

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -181,6 +181,11 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   const [editLoading, setEditLoading] = useState<boolean>(isEditMode);
   const [editLoadError, setEditLoadError] = useState<string | null>(null);
   const [editUnsupported, setEditUnsupported] = useState<boolean>(false);
+  // The wizard has no "enabled" control (enable/disable lives on the detail
+  // page), and `buildCreateInput` hardcodes `enabled: true`. Preserve the
+  // loaded SLO's enabled flag so saving an edit to a *disabled* SLO doesn't
+  // silently re-enable it (the server merges the PUT spec over the stored one).
+  const [editEnabled, setEditEnabled] = useState<boolean>(true);
 
   // Sync template state with URL param — CREATE mode only. In edit mode there
   // is no `:templateId` param and the template is synthesized from the loaded
@@ -215,6 +220,7 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
         dispatch({ kind: 'hydrate', state: hydrated.state });
         setEditTemplate(hydrated.template);
         setEditVersion(hydrated.version);
+        setEditEnabled(doc.spec.enabled);
         setEditLoading(false);
       } catch (e) {
         if (cancelled) return;
@@ -352,7 +358,12 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
           setSubmitting(false);
           return;
         }
-        const doc = await apiClient.update(editSloId, { spec: input.spec, version: editVersion });
+        const doc = await apiClient.update(editSloId, {
+          // Preserve the SLO's enabled state — `buildCreateInput` always emits
+          // `enabled: true`, which would re-enable a disabled SLO on save.
+          spec: { ...input.spec, enabled: editEnabled },
+          version: editVersion,
+        });
         // Advance the version so a second save in the same session doesn't 409.
         setEditVersion(doc.status.version);
         notifications.toasts.addSuccess({
@@ -401,7 +412,17 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
     } finally {
       setSubmitting(false);
     }
-  }, [apiClient, history, notifications, state, template, isEditMode, editSloId, editVersion]);
+  }, [
+    apiClient,
+    history,
+    notifications,
+    state,
+    template,
+    isEditMode,
+    editSloId,
+    editVersion,
+    editEnabled,
+  ]);
 
   // Edit-mode gate states — the template selector is never shown for edits.
   if (isEditMode) {

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -46,6 +46,7 @@ import { redactForDisplay } from '../../../../../common/error';
 import type { SloApiClient, SloRulerErrorEnvelope } from './slo_api_client';
 import { GeneratedRulesPreview } from './generated_rules_preview';
 import { DatasourceSelect } from './datasource_select';
+import { useDatasources } from '../../../alerting/hooks/use_datasources';
 import { SuggestingComboBox } from './suggesting_combo_box';
 import { useOwnerSuggestions } from './use_owner_suggestions';
 import { ObjectivesSection } from './objectives_section';
@@ -908,6 +909,30 @@ interface PanelProps {
   dispatch: React.Dispatch<import('./wizard_state').Action>;
 }
 
+/**
+ * Read-only datasource display for edit mode. Resolves the connection id
+ * (`spec.datasourceId`) to the friendly name the interactive `DatasourceSelect`
+ * shows, via the same `useDatasources` source, so the read-only view isn't less
+ * legible than the picker it replaces. Falls back to the raw id if the
+ * datasource can't be resolved (e.g. list still loading).
+ */
+const ReadOnlyDatasourceField: React.FC<{ datasourceId: string }> = ({ datasourceId }) => {
+  const { datasources } = useDatasources();
+  const displayName = datasources.find((d) => d.id === datasourceId)?.name ?? datasourceId;
+  return (
+    <EuiFieldText
+      value={displayName}
+      readOnly
+      disabled
+      data-test-subj="slosWizardDatasourceReadOnly"
+      aria-label={i18n.translate(
+        'observability.apm.slo.wizard.identity.datasourceReadOnlyAriaLabel',
+        { defaultMessage: 'Datasource (read-only)' }
+      )}
+    />
+  );
+};
+
 const IdentityPanel: React.FC<PanelProps & { template: string; readOnlyDatasource?: boolean }> = ({
   state,
   errors,
@@ -944,17 +969,9 @@ const IdentityPanel: React.FC<PanelProps & { template: string; readOnlyDatasourc
         // Datasource is IMMUTABLE on edit: the server pins rules to the
         // create-time datasource, so allowing a change here would orphan the
         // already-provisioned Prometheus/Cortex rule groups. Render a disabled
-        // field rather than the interactive picker.
-        <EuiFieldText
-          value={state.datasourceId}
-          readOnly
-          disabled
-          data-test-subj="slosWizardDatasourceReadOnly"
-          aria-label={i18n.translate(
-            'observability.apm.slo.wizard.identity.datasourceReadOnlyAriaLabel',
-            { defaultMessage: 'Datasource (read-only)' }
-          )}
-        />
+        // field showing the friendly name (matching the interactive picker),
+        // not the raw connection id.
+        <ReadOnlyDatasourceField datasourceId={state.datasourceId} />
       ) : (
         <DatasourceSelect
           value={state.datasourceId}

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -26,6 +26,7 @@ import {
   EuiForm,
   EuiFormRow,
   EuiIcon,
+  EuiLoadingSpinner,
   EuiPage,
   EuiPageBody,
   EuiPageContent,
@@ -55,9 +56,10 @@ import { AdvancedSection } from './advanced_section';
 import { ExclusionWindowsEditor } from './exclusion_windows_editor';
 import type { SloCreateInput } from '../../../../../common/slo/slo_types';
 import { SLO_TEMPLATES } from '../../../../../common/slo/slo_templates';
+import type { SloTemplate } from '../../../../../common/slo/slo_templates';
 import { buildProbeQueries } from '../../../../../common/slo/slo_promql_generator';
 import { validateSloSpec } from '../../../../../common/slo/slo_validators';
-import { initialState, reducer } from './wizard_state';
+import { hydrateFromDoc, initialState, reducer } from './wizard_state';
 import type { FormState } from './wizard_state';
 import { buildCreateInput } from './wizard_builders';
 import { WizardNav } from './wizard_nav';
@@ -81,6 +83,12 @@ export interface SloWizardPageProps {
   chrome: ChromeStart;
   notifications: NotificationsStart;
   parentBreadcrumb: { text: string; href: string };
+  /**
+   * When present, the wizard runs in EDIT mode: it loads the existing SLO,
+   * hydrates the form from it, and its submit PUTs an update rather than
+   * POSTing a new SLO. Absent → the create flow, unchanged.
+   */
+  editSloId?: string;
 }
 
 // ============================================================================
@@ -154,8 +162,10 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   chrome,
   notifications,
   parentBreadcrumb: _parentBreadcrumb,
+  editSloId,
 }) => {
   const history = useHistory();
+  const isEditMode = !!editSloId;
   const { templateId: urlTemplateId } = useParams<{ templateId?: string }>();
   const [state, dispatch] = useReducer(reducer, undefined, initialState);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -163,15 +173,59 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
   const [rulerError, setRulerError] = useState<SloRulerErrorEnvelope | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  // Sync template state with URL param.
+  // Edit-mode: the template is synthesized from the loaded doc (not a picker
+  // template), and `editVersion` carries the optimistic-concurrency version
+  // the update PUT must echo back.
+  const [editTemplate, setEditTemplate] = useState<SloTemplate | null>(null);
+  const [editVersion, setEditVersion] = useState<number | null>(null);
+  const [editLoading, setEditLoading] = useState<boolean>(isEditMode);
+  const [editLoadError, setEditLoadError] = useState<string | null>(null);
+  const [editUnsupported, setEditUnsupported] = useState<boolean>(false);
+
+  // Sync template state with URL param — CREATE mode only. In edit mode there
+  // is no `:templateId` param and the template is synthesized from the loaded
+  // doc, so running this effect would wrongly clear the hydrated selection.
   useEffect(() => {
+    if (isEditMode) return;
     if (urlTemplateId && state.templateId !== urlTemplateId) {
       dispatch({ kind: 'setTemplate', templateId: urlTemplateId });
     } else if (!urlTemplateId && state.templateId) {
       // User navigated back to /slos/create (no templateId in URL) — clear selection
       dispatch({ kind: 'setTemplate', templateId: null });
     }
-  }, [urlTemplateId, state.templateId]);
+  }, [isEditMode, urlTemplateId, state.templateId]);
+
+  // Edit-mode: load the existing SLO once and hydrate the form from it.
+  useEffect(() => {
+    if (!editSloId) return;
+    let cancelled = false;
+    setEditLoading(true);
+    setEditLoadError(null);
+    setEditUnsupported(false);
+    (async () => {
+      try {
+        const doc = await apiClient.get(editSloId);
+        if (cancelled) return;
+        const hydrated = hydrateFromDoc(doc);
+        if (!hydrated) {
+          setEditUnsupported(true);
+          setEditLoading(false);
+          return;
+        }
+        dispatch({ kind: 'hydrate', state: hydrated.state });
+        setEditTemplate(hydrated.template);
+        setEditVersion(hydrated.version);
+        setEditLoading(false);
+      } catch (e) {
+        if (cancelled) return;
+        setEditLoadError(e instanceof Error ? e.message : String(e));
+        setEditLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiClient, editSloId]);
 
   useEffect(() => {
     chrome.setBreadcrumbs([
@@ -182,16 +236,21 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
         href: '#/slos',
       },
       {
-        text: i18n.translate('observability.apm.slo.wizard.breadcrumb.create', {
-          defaultMessage: 'Create',
-        }),
+        text: isEditMode
+          ? i18n.translate('observability.apm.slo.wizard.breadcrumb.edit', {
+              defaultMessage: 'Edit',
+            })
+          : i18n.translate('observability.apm.slo.wizard.breadcrumb.create', {
+              defaultMessage: 'Create',
+            }),
       },
     ]);
-  }, [chrome]);
+  }, [chrome, isEditMode]);
 
   const template = useMemo(
-    () => SLO_TEMPLATES.find((t) => t.id === state.templateId) ?? null,
-    [state.templateId]
+    () =>
+      isEditMode ? editTemplate : (SLO_TEMPLATES.find((t) => t.id === state.templateId) ?? null),
+    [isEditMode, editTemplate, state.templateId]
   );
 
   // Reset scroll to the top whenever a template is (re)selected, so picking a
@@ -285,6 +344,29 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
     setRulerError(null);
     setSubmitting(true);
     try {
+      if (isEditMode && editSloId) {
+        // Optimistic concurrency: the server 409s if `version` is stale. If we
+        // somehow reach submit before the load resolved `editVersion`, bail
+        // rather than send an update with no version.
+        if (editVersion === null) {
+          setSubmitting(false);
+          return;
+        }
+        const doc = await apiClient.update(editSloId, { spec: input.spec, version: editVersion });
+        // Advance the version so a second save in the same session doesn't 409.
+        setEditVersion(doc.status.version);
+        notifications.toasts.addSuccess({
+          title: i18n.translate('observability.apm.slo.wizard.updateSuccess.title', {
+            defaultMessage: 'SLO updated',
+          }),
+          text: i18n.translate('observability.apm.slo.wizard.updateSuccess.text', {
+            defaultMessage: '{name} was saved.',
+            values: { name: doc.spec.name },
+          }),
+        });
+        history.push(`/slos/${encodeURIComponent(doc.id)}`);
+        return;
+      }
       const doc = await apiClient.create(input);
       notifications.toasts.addSuccess({
         title: i18n.translate('observability.apm.slo.wizard.createSuccess.title', {
@@ -306,16 +388,126 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
       } else {
         const err = e instanceof Error ? e : new Error(String(e));
         notifications.toasts.addDanger({
-          title: i18n.translate('observability.apm.slo.wizard.createFailed', {
-            defaultMessage: 'Failed to create SLO',
-          }),
+          title: isEditMode
+            ? i18n.translate('observability.apm.slo.wizard.updateFailed', {
+                defaultMessage: 'Failed to update SLO',
+              })
+            : i18n.translate('observability.apm.slo.wizard.createFailed', {
+                defaultMessage: 'Failed to create SLO',
+              }),
           text: err.message,
         });
       }
     } finally {
       setSubmitting(false);
     }
-  }, [apiClient, history, notifications, state, template]);
+  }, [apiClient, history, notifications, state, template, isEditMode, editSloId, editVersion]);
+
+  // Edit-mode gate states — the template selector is never shown for edits.
+  if (isEditMode) {
+    if (editLoading) {
+      return (
+        <EuiPage data-test-subj="sloWizardPage">
+          <EuiPageBody component="main">
+            <EuiPageContent color="transparent" hasBorder={false} paddingSize="none">
+              <EuiPageContentBody>
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="s"
+                  responsive={false}
+                  data-test-subj="sloWizardEditLoading"
+                >
+                  <EuiFlexItem grow={false}>
+                    <EuiLoadingSpinner size="m" />
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="s">
+                      {i18n.translate('observability.apm.slo.wizard.edit.loading', {
+                        defaultMessage: 'Loading SLO…',
+                      })}
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiPageContentBody>
+            </EuiPageContent>
+          </EuiPageBody>
+        </EuiPage>
+      );
+    }
+    if (editUnsupported) {
+      return (
+        <EuiPage data-test-subj="sloWizardPage">
+          <EuiPageBody component="main">
+            <EuiPageContent color="transparent" hasBorder={false} paddingSize="none">
+              <EuiPageContentBody>
+                <EuiCallOut
+                  color="warning"
+                  iconType="alert"
+                  title={i18n.translate('observability.apm.slo.wizard.edit.unsupportedTitle', {
+                    defaultMessage: 'This SLO can’t be edited here',
+                  })}
+                  data-test-subj="sloWizardEditUnsupported"
+                >
+                  <EuiText size="s">
+                    {i18n.translate('observability.apm.slo.wizard.edit.unsupportedBody', {
+                      defaultMessage:
+                        'Only single Prometheus-backed SLOs can be edited in this wizard. Composite or other-backend SLOs must be recreated.',
+                    })}
+                  </EuiText>
+                  <EuiSpacer size="s" />
+                  <EuiButton
+                    size="s"
+                    href={`#/slos/${encodeURIComponent(editSloId ?? '')}`}
+                    data-test-subj="sloWizardEditUnsupportedBack"
+                  >
+                    {i18n.translate('observability.apm.slo.wizard.edit.backToSlo', {
+                      defaultMessage: 'Back to SLO',
+                    })}
+                  </EuiButton>
+                </EuiCallOut>
+              </EuiPageContentBody>
+            </EuiPageContent>
+          </EuiPageBody>
+        </EuiPage>
+      );
+    }
+    if (editLoadError || !template) {
+      return (
+        <EuiPage data-test-subj="sloWizardPage">
+          <EuiPageBody component="main">
+            <EuiPageContent color="transparent" hasBorder={false} paddingSize="none">
+              <EuiPageContentBody>
+                <EuiCallOut
+                  color="danger"
+                  iconType="alert"
+                  title={i18n.translate('observability.apm.slo.wizard.edit.loadErrorTitle', {
+                    defaultMessage: 'Could not load this SLO',
+                  })}
+                  data-test-subj="sloWizardEditLoadError"
+                >
+                  {editLoadError && (
+                    <EuiText size="s">
+                      <p>{editLoadError}</p>
+                    </EuiText>
+                  )}
+                  <EuiSpacer size="s" />
+                  <EuiButton
+                    size="s"
+                    href={`#/slos/${encodeURIComponent(editSloId ?? '')}`}
+                    data-test-subj="sloWizardEditLoadErrorBack"
+                  >
+                    {i18n.translate('observability.apm.slo.wizard.edit.backToSlo', {
+                      defaultMessage: 'Back to SLO',
+                    })}
+                  </EuiButton>
+                </EuiCallOut>
+              </EuiPageContentBody>
+            </EuiPageContent>
+          </EuiPageBody>
+        </EuiPage>
+      );
+    }
+  }
 
   if (!template) {
     const pickActions = [
@@ -345,22 +537,38 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
     );
   }
 
-  // Header keeps only the contextual "Change template" affordance. The
-  // primary Create / Cancel actions live in a sticky bottom bar so they're
-  // always reachable on this long form — no scrolling back to the top.
-  const wizardActions = [
-    <EuiButtonEmpty
-      key="template-back"
-      iconType="arrowLeft"
-      onClick={() => history.replace('/slos/create')}
-      size="s"
-      data-test-subj="slosTemplateBack"
-    >
-      {i18n.translate('observability.apm.slo.wizard.changeTemplateButton', {
-        defaultMessage: 'Change template',
-      })}
-    </EuiButtonEmpty>,
-  ];
+  // Header keeps only the contextual navigation affordance. The primary
+  // Save/Create + Cancel actions live in a bottom bar so they're always
+  // reachable on this long form — no scrolling back to the top.
+  // In edit mode the "Change template" affordance is meaningless (the template
+  // is fixed by the persisted SLI), so it's replaced by a "Back to SLO" link.
+  const wizardActions = isEditMode
+    ? [
+        <EuiButtonEmpty
+          key="edit-back"
+          iconType="arrowLeft"
+          href={`#/slos/${encodeURIComponent(editSloId ?? '')}`}
+          size="s"
+          data-test-subj="slosEditBack"
+        >
+          {i18n.translate('observability.apm.slo.wizard.edit.backToSlo', {
+            defaultMessage: 'Back to SLO',
+          })}
+        </EuiButtonEmpty>,
+      ]
+    : [
+        <EuiButtonEmpty
+          key="template-back"
+          iconType="arrowLeft"
+          onClick={() => history.replace('/slos/create')}
+          size="s"
+          data-test-subj="slosTemplateBack"
+        >
+          {i18n.translate('observability.apm.slo.wizard.changeTemplateButton', {
+            defaultMessage: 'Change template',
+          })}
+        </EuiButtonEmpty>,
+      ];
 
   const visibleSectionIds: WizardSectionId[] = [
     'identity',
@@ -397,6 +605,7 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
                         errors={errors}
                         dispatch={dispatch}
                         template={template.name}
+                        readOnlyDatasource={isEditMode}
                       />
                     </div>
 
@@ -623,7 +832,13 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
                       data-test-subj="slosWizardActionFooter"
                     >
                       <EuiFlexItem grow={false}>
-                        <EuiButtonEmpty href="#/slos" size="s" data-test-subj="slosWizardCancel">
+                        <EuiButtonEmpty
+                          href={
+                            isEditMode ? `#/slos/${encodeURIComponent(editSloId ?? '')}` : '#/slos'
+                          }
+                          size="s"
+                          data-test-subj="slosWizardCancel"
+                        >
                           {i18n.translate('observability.apm.slo.wizard.cancelButton', {
                             defaultMessage: 'Cancel',
                           })}
@@ -637,9 +852,13 @@ export const SloWizardPage: React.FC<SloWizardPageProps> = ({
                           onClick={onSubmit}
                           data-test-subj="slosWizardSubmit"
                         >
-                          {i18n.translate('observability.apm.slo.wizard.submitButton', {
-                            defaultMessage: 'Create SLO',
-                          })}
+                          {isEditMode
+                            ? i18n.translate('observability.apm.slo.wizard.saveButton', {
+                                defaultMessage: 'Save changes',
+                              })
+                            : i18n.translate('observability.apm.slo.wizard.submitButton', {
+                                defaultMessage: 'Create SLO',
+                              })}
                         </EuiButton>
                       </EuiFlexItem>
                     </EuiFlexGroup>
@@ -668,11 +887,12 @@ interface PanelProps {
   dispatch: React.Dispatch<import('./wizard_state').Action>;
 }
 
-const IdentityPanel: React.FC<PanelProps & { template: string }> = ({
+const IdentityPanel: React.FC<PanelProps & { template: string; readOnlyDatasource?: boolean }> = ({
   state,
   errors,
   dispatch,
   template,
+  readOnlyDatasource,
 }) => (
   <EuiPanel>
     <EuiText size="m">
@@ -688,14 +908,39 @@ const IdentityPanel: React.FC<PanelProps & { template: string }> = ({
       label={i18n.translate('observability.apm.slo.wizard.identity.datasourceLabel', {
         defaultMessage: 'Datasource',
       })}
-      isInvalid={!!errors['spec.datasourceId']}
-      error={errors['spec.datasourceId']}
+      isInvalid={!readOnlyDatasource && !!errors['spec.datasourceId']}
+      error={readOnlyDatasource ? undefined : errors['spec.datasourceId']}
+      helpText={
+        readOnlyDatasource
+          ? i18n.translate('observability.apm.slo.wizard.identity.datasourceReadOnlyHelp', {
+              defaultMessage:
+                'The datasource is fixed after creation — the SLO’s recording and alerting rules are keyed to it. To move an SLO to another datasource, recreate it there.',
+            })
+          : undefined
+      }
     >
-      <DatasourceSelect
-        value={state.datasourceId}
-        isInvalid={!!errors['spec.datasourceId']}
-        onChange={(value) => dispatch({ kind: 'setField', field: 'datasourceId', value })}
-      />
+      {readOnlyDatasource ? (
+        // Datasource is IMMUTABLE on edit: the server pins rules to the
+        // create-time datasource, so allowing a change here would orphan the
+        // already-provisioned Prometheus/Cortex rule groups. Render a disabled
+        // field rather than the interactive picker.
+        <EuiFieldText
+          value={state.datasourceId}
+          readOnly
+          disabled
+          data-test-subj="slosWizardDatasourceReadOnly"
+          aria-label={i18n.translate(
+            'observability.apm.slo.wizard.identity.datasourceReadOnlyAriaLabel',
+            { defaultMessage: 'Datasource (read-only)' }
+          )}
+        />
+      ) : (
+        <DatasourceSelect
+          value={state.datasourceId}
+          isInvalid={!!errors['spec.datasourceId']}
+          onChange={(value) => dispatch({ kind: 'setField', field: 'datasourceId', value })}
+        />
+      )}
     </EuiFormRow>
     <EuiFormRow
       label={i18n.translate('observability.apm.slo.wizard.identity.nameLabel', {

--- a/public/components/apm/pages/slos/slos_page.tsx
+++ b/public/components/apm/pages/slos/slos_page.tsx
@@ -9,13 +9,14 @@
  *   /slos                       — listing
  *   /slos/create                — template selector (picks a template, then opens wizard)
  *   /slos/create/:templateId    — wizard prefilled from the named template
+ *   /slos/:id/edit              — wizard prefilled from an existing SLO (update path)
  *   /slos/:id                   — detail view
  */
 
 import React, { useMemo } from 'react';
 import { EuiCallOut, EuiCode, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
-import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
+import { HashRouter, Redirect, Route, Switch, useParams } from 'react-router-dom';
 import { ChromeStart, HttpStart, NotificationsStart } from '../../../../../../../src/core/public';
 import { SloListingPage } from './slo_listing_page';
 import { SloWizardPage } from './slo_wizard_page';
@@ -92,6 +93,29 @@ export interface SlosPageProps {
   [key: string]: unknown;
 }
 
+/**
+ * Reads the `:id` route param and renders the wizard in edit mode. Kept as a
+ * thin wrapper so `useParams` runs inside the router tree — the wizard itself
+ * stays route-shape-agnostic and just takes an `editSloId` prop.
+ */
+const SloWizardEditRoute: React.FC<{
+  apiClient: SloApiClient;
+  chrome: ChromeStart;
+  notifications: NotificationsStart;
+  parentBreadcrumb: { text: string; href: string };
+}> = ({ apiClient, chrome, notifications, parentBreadcrumb }) => {
+  const { id } = useParams<{ id: string }>();
+  return (
+    <SloWizardPage
+      apiClient={apiClient}
+      chrome={chrome}
+      notifications={notifications}
+      parentBreadcrumb={parentBreadcrumb}
+      editSloId={id}
+    />
+  );
+};
+
 export const SlosPage: React.FC<SlosPageProps> = ({
   http,
   chrome,
@@ -132,6 +156,14 @@ export const SlosPage: React.FC<SlosPageProps> = ({
           </Route>
           <Route exact path="/slos/create/:templateId">
             <SloWizardPage
+              apiClient={apiClient}
+              chrome={chrome}
+              notifications={notifications}
+              parentBreadcrumb={parentBreadcrumb}
+            />
+          </Route>
+          <Route exact path="/slos/:id/edit">
+            <SloWizardEditRoute
               apiClient={apiClient}
               chrome={chrome}
               notifications={notifications}

--- a/public/components/apm/pages/slos/wizard_builders.ts
+++ b/public/components/apm/pages/slos/wizard_builders.ts
@@ -114,7 +114,11 @@ export function buildCreateInput(state: FormState, template: SloTemplate): SloCr
     mode: state.shadow ? 'shadow' : 'active',
     service: state.service,
     owner: {
-      teams: state.ownerTeam ? [state.ownerTeam] : [],
+      // Primary team (the only one the wizard edits) first, then any secondary
+      // teams carried from an edited SLO — deduped, blanks dropped — so editing
+      // a multi-team SLO doesn't truncate `owner.teams` to just the primary.
+      // `ownerTeamsSecondary` is always empty in create mode.
+      teams: Array.from(new Set([state.ownerTeam, ...state.ownerTeamsSecondary].filter(Boolean))),
       primaryUser: state.ownerPrimaryUser || undefined,
     },
     tier: state.tier || undefined,

--- a/public/components/apm/pages/slos/wizard_builders.ts
+++ b/public/components/apm/pages/slos/wizard_builders.ts
@@ -138,7 +138,12 @@ export function buildCreateInput(state: FormState, template: SloTemplate): SloCr
       resolved: { enabled: state.alarms.resolved.enabled },
     },
     exclusionWindows: state.exclusionWindows.map((ew) => ({ ...ew, schedule: { ...ew.schedule } })),
-    labels: entriesToRecord(state.labels),
+    // Re-emit array-valued labels verbatim alongside the editable scalar rows.
+    // The editor only authors scalars; without this, an API-created SLO's array
+    // label (e.g. `{region: ['us','eu']}`) would be dropped on save because the
+    // server shallow-merges the whole `labels` object. `preservedArrayLabels` is
+    // always `{}` in create mode. Editable rows win on key collision.
+    labels: { ...state.preservedArrayLabels, ...entriesToRecord(state.labels) },
     annotations: entriesToRecord(state.annotations),
   };
   return { spec };

--- a/public/components/apm/pages/slos/wizard_state.ts
+++ b/public/components/apm/pages/slos/wizard_state.ts
@@ -57,6 +57,14 @@ export interface FormState {
   description: string;
   service: string;
   ownerTeam: string;
+  /**
+   * Secondary owner teams (`owner.teams[1..]`) carried through edit but not
+   * shown/edited in the wizard, which only authors the primary team. The saved
+   * object already supports up to 5 teams; without carrying these, editing a
+   * multi-team SLO (creatable via the API) would drop them on save because the
+   * server does a shallow top-level merge of `owner`. Always `[]` in create mode.
+   */
+  ownerTeamsSecondary: string[];
   ownerPrimaryUser: string;
   tier: string;
   windowDuration: '7d' | '14d' | '28d' | '30d';
@@ -229,6 +237,7 @@ export function initialState(): FormState {
     description: '',
     service: '',
     ownerTeam: '',
+    ownerTeamsSecondary: [],
     ownerPrimaryUser: '',
     tier: '',
     windowDuration: '28d',
@@ -747,6 +756,9 @@ export function hydrateFromDoc(doc: SloDocument): EditHydration | null {
     description: spec.description ?? '',
     service: spec.service,
     ownerTeam: spec.owner.teams[0] ?? '',
+    // Carry teams[1..] so a multi-team SLO isn't truncated to its primary on
+    // save (the wizard UI only edits the primary team).
+    ownerTeamsSecondary: spec.owner.teams.slice(1),
     ownerPrimaryUser: spec.owner.primaryUser ?? '',
     tier: spec.tier ?? '',
     windowDuration,

--- a/public/components/apm/pages/slos/wizard_state.ts
+++ b/public/components/apm/pages/slos/wizard_state.ts
@@ -15,7 +15,11 @@ import type {
   CustomPromQLExpr,
   Dimension,
   ExclusionWindow,
+  PrometheusSli,
   SloAlarmConfig,
+  SloDocument,
+  SloSpec,
+  Window,
 } from '../../../../../common/slo/slo_types';
 import {
   DEFAULT_MWMBR_TIERS,
@@ -87,6 +91,9 @@ export interface FormState {
 
 export type Action =
   | { kind: 'setTemplate'; templateId: string | null }
+  // Replace the entire form state in one shot. Used by the edit flow to
+  // hydrate the wizard from an existing SLO document (see `hydrateFromDoc`).
+  | { kind: 'hydrate'; state: FormState }
   | { kind: 'setField'; field: ScalarField; value: string | boolean }
   | { kind: 'setObjectiveField'; index: number; field: keyof ObjectiveRow; value: string }
   | { kind: 'addObjective' }
@@ -160,11 +167,7 @@ type ScalarField =
   | 'shadow';
 
 export type ToggleableAlarm =
-  | 'sliHealth'
-  | 'attainmentBreach'
-  | 'budgetWarning'
-  | 'noData'
-  | 'resolved';
+  'sliHealth' | 'attainmentBreach' | 'budgetWarning' | 'noData' | 'resolved';
 
 /**
  * Fields that can be edited on a single ExclusionWindow row regardless of
@@ -394,6 +397,8 @@ export function reducer(state: FormState, action: Action): FormState {
       const t = SLO_TEMPLATES.find((x) => x.id === action.templateId) ?? null;
       return applyTemplate(state, t);
     }
+    case 'hydrate':
+      return action.state;
     case 'setField': {
       const next = { ...state, [action.field]: action.value } as FormState;
       // When the Service field changes, re-derive the template's SLI query for
@@ -584,6 +589,181 @@ export function reducer(state: FormState, action: Action): FormState {
       return { ...state, annotations: next };
     }
   }
+}
+
+// ============================================================================
+// Edit-mode hydration — reverse of wizard_builders.buildCreateInput
+//
+// The create flow seeds the form from a picker template; the edit flow seeds it
+// from an already-persisted SloDocument. `hydrateFromDoc` walks the saved spec
+// back into a FormState and synthesizes a matching template so the same
+// section components + `buildCreateInput` round-trip the doc faithfully.
+// ============================================================================
+
+/** Result of hydrating the wizard from an existing SLO document. */
+export interface EditHydration {
+  state: FormState;
+  /**
+   * Template synthesized from the saved spec. Its id is NOT one of
+   * `SLO_TEMPLATES` — the edit flow holds it directly rather than looking it
+   * up, so the wizard renders the correct SLI editor (custom vs structured)
+   * and objective shape (availability vs latency) for the persisted SLI.
+   */
+  template: SloTemplate;
+  /** `status.version` of the loaded doc — required for the update's optimistic-concurrency check. */
+  version: number;
+}
+
+/** Synthetic template id prefix — never collides with a real picker template. */
+export const EDIT_TEMPLATE_ID_PREFIX = '__edit__:';
+
+/** Format a decimal target (0..1) back into the percent string the form edits. */
+function formatTargetPercent(target: number): string {
+  if (!Number.isFinite(target)) return '';
+  // toFixed(6) then Number() strips float artifacts (0.999 → "99.9", not
+  // "99.90000000000001"); buildObjective divides by 100 on the way back.
+  return String(Number((target * 100).toFixed(6)));
+}
+
+/** Only the four rolling windows the wizard offers are editable; anything else falls back. */
+function normalizeWindowDuration(window: Window): FormState['windowDuration'] {
+  if (window.type === 'rolling') {
+    if (
+      window.duration === '7d' ||
+      window.duration === '14d' ||
+      window.duration === '28d' ||
+      window.duration === '30d'
+    ) {
+      return window.duration;
+    }
+  }
+  return '28d';
+}
+
+/** Flatten a labels/annotations record back into ordered key/value rows. */
+function recordToEntries(record: Record<string, string | string[]>): KeyValueEntry[] {
+  return Object.keys(record).map((key) => {
+    const value = record[key];
+    return { key, value: Array.isArray(value) ? value.join(',') : value };
+  });
+}
+
+/** Rebuild the custom-PromQL editor state from a persisted custom SLI. */
+function deriveCustomPromqlState(def: PrometheusSli, base: CustomPromqlState): CustomPromqlState {
+  if (def.type !== 'custom' || !def.customExpr) return base;
+  if (def.customExpr.mode === 'events') {
+    return {
+      ...base,
+      mode: 'events',
+      goodQuery: def.customExpr.goodQuery,
+      totalQuery: def.customExpr.totalQuery,
+    };
+  }
+  return { ...base, mode: 'raw', errorRatioQuery: def.customExpr.errorRatioQuery };
+}
+
+/** Defensive merge so legacy docs missing `alarms.*` keys carry canonical defaults. */
+function mergeAlarms(alarms: SloAlarmConfig | undefined): SloAlarmConfig {
+  const d = defaultAlarms();
+  if (!alarms) return d;
+  return {
+    sliHealth: { ...d.sliHealth, ...alarms.sliHealth },
+    attainmentBreach: { ...d.attainmentBreach, ...alarms.attainmentBreach },
+    budgetWarning: { ...d.budgetWarning, ...alarms.budgetWarning },
+    noData: { ...d.noData, ...alarms.noData },
+    resolved: { ...d.resolved, ...alarms.resolved },
+  };
+}
+
+/**
+ * Synthesize a template from a persisted SLI so `buildCreateInput` reproduces
+ * the same spec. Carries the SLI's `type` / `calcMethod` / metric fields
+ * verbatim — those are what the builders read.
+ */
+function deriveEditTemplate(
+  spec: SloSpec,
+  def: PrometheusSli,
+  dimensions: Dimension[]
+): SloTemplate {
+  const serviceLabel = dimensions[0]?.name || 'service';
+  return {
+    id: `${EDIT_TEMPLATE_ID_PREFIX}${spec.name}`,
+    name: spec.name,
+    description: '',
+    icon: def.type === 'custom' ? 'wrench' : 'visLine',
+    category: 'custom',
+    sli: {
+      type: def.type,
+      calcMethod: def.calcMethod,
+      metric: def.metric,
+      goodEventsFilter: def.goodEventsFilter,
+      latencyThresholdUnit: def.latencyThresholdUnit,
+    },
+    dimensionHints: { serviceLabel, operationLabel: 'operation' },
+    defaultLatencyThreshold: spec.objectives[0]?.latencyThreshold,
+    expectedMetricType: def.type === 'latency_threshold' ? 'histogram' : 'counter',
+    detectionPattern: null,
+  };
+}
+
+/**
+ * Hydrate the wizard from an existing SLO document.
+ *
+ * Returns `null` when the SLO cannot be round-tripped through the wizard —
+ * i.e. a composite SLI (P2) or any non-Prometheus backend. Callers surface an
+ * "unsupported" state instead of a half-populated form.
+ */
+export function hydrateFromDoc(doc: SloDocument): EditHydration | null {
+  const spec = doc.spec;
+  const sli = spec.sli;
+  if (sli.type !== 'single') return null;
+  const def = sli.definition;
+  if (def.backend !== 'prometheus') return null;
+
+  const fresh = initialState();
+  const template = deriveEditTemplate(spec, def, sli.dimensions);
+
+  const state: FormState = {
+    ...fresh,
+    templateId: template.id,
+    datasourceId: spec.datasourceId,
+    name: spec.name,
+    description: spec.description ?? '',
+    service: spec.service,
+    ownerTeam: spec.owner.teams[0] ?? '',
+    ownerPrimaryUser: spec.owner.primaryUser ?? '',
+    tier: spec.tier ?? '',
+    windowDuration: normalizeWindowDuration(spec.window),
+    objectives:
+      spec.objectives.length > 0
+        ? spec.objectives.map((o) => ({
+            name: o.name,
+            target: formatTargetPercent(o.target),
+            latencyThreshold:
+              o.latencyThreshold !== undefined
+                ? String(o.latencyThreshold)
+                : fresh.objectives[0].latencyThreshold,
+          }))
+        : fresh.objectives,
+    dimensions:
+      sli.dimensions.length > 0
+        ? sli.dimensions.map((dim) => ({ ...dim }))
+        : [{ name: template.dimensionHints.serviceLabel, value: '' }],
+    metric: def.metric ?? '',
+    goodEventsFilter: def.goodEventsFilter ?? '',
+    latencyThresholdUnit: def.latencyThresholdUnit ?? 'seconds',
+    customPromql: deriveCustomPromqlState(def, fresh.customPromql),
+    labels: recordToEntries(spec.labels ?? {}),
+    annotations: recordToEntries(spec.annotations ?? {}),
+    shadow: spec.mode === 'shadow',
+    burnRates: spec.alerting.burnRates.map((b) => ({ ...b })),
+    budgetWarnings: spec.budgetWarningThresholds.map((b) => ({ ...b })),
+    alarms: mergeAlarms(spec.alarms),
+    exclusionWindows: spec.exclusionWindows.map((ew) => ({ ...ew, schedule: { ...ew.schedule } })),
+    submitAttempted: false,
+  };
+
+  return { state, template, version: doc.status.version };
 }
 
 // Re-export for wizard consumers who want the union type without a separate import.

--- a/public/components/apm/pages/slos/wizard_state.ts
+++ b/public/components/apm/pages/slos/wizard_state.ts
@@ -625,8 +625,17 @@ function formatTargetPercent(target: number): string {
   return String(Number((target * 100).toFixed(6)));
 }
 
-/** Only the four rolling windows the wizard offers are editable; anything else falls back. */
-function normalizeWindowDuration(window: Window): FormState['windowDuration'] {
+/**
+ * Map a persisted window to the wizard's editable set — the four rolling
+ * durations it offers. Returns `null` for anything the wizard cannot represent
+ * (a calendar window, or a rolling duration like `21d` the server accepts but
+ * the wizard doesn't). Callers MUST treat `null` as "unsupported" rather than
+ * substituting a default: `buildCreateInput` always re-emits `window`, and the
+ * server update does a shallow top-level merge, so coercing here would silently
+ * rewrite the stored window (and its alert/error-budget math) on any save —
+ * even when the user only edited an unrelated field.
+ */
+function toEditableWindowDuration(window: Window): FormState['windowDuration'] | null {
   if (window.type === 'rolling') {
     if (
       window.duration === '7d' ||
@@ -637,7 +646,7 @@ function normalizeWindowDuration(window: Window): FormState['windowDuration'] {
       return window.duration;
     }
   }
-  return '28d';
+  return null;
 }
 
 /** Flatten a labels/annotations record back into ordered key/value rows. */
@@ -720,6 +729,13 @@ export function hydrateFromDoc(doc: SloDocument): EditHydration | null {
   const def = sli.definition;
   if (def.backend !== 'prometheus') return null;
 
+  // The wizard only models the four rolling windows. A calendar window or a
+  // non-standard rolling duration cannot be edited without silently rewriting
+  // it on save, so treat it as unsupported (same contract as composite/
+  // non-Prometheus above) rather than coercing to a default.
+  const windowDuration = toEditableWindowDuration(spec.window);
+  if (windowDuration === null) return null;
+
   const fresh = initialState();
   const template = deriveEditTemplate(spec, def, sli.dimensions);
 
@@ -733,7 +749,7 @@ export function hydrateFromDoc(doc: SloDocument): EditHydration | null {
     ownerTeam: spec.owner.teams[0] ?? '',
     ownerPrimaryUser: spec.owner.primaryUser ?? '',
     tier: spec.tier ?? '',
-    windowDuration: normalizeWindowDuration(spec.window),
+    windowDuration,
     objectives:
       spec.objectives.length > 0
         ? spec.objectives.map((o) => ({

--- a/public/components/apm/pages/slos/wizard_state.ts
+++ b/public/components/apm/pages/slos/wizard_state.ts
@@ -80,6 +80,17 @@ export interface FormState {
   latencyThresholdUnit: 'seconds' | 'milliseconds';
   customPromql: CustomPromqlState;
   labels: KeyValueEntry[];
+  /**
+   * Array-valued labels (`Record<string, string[]>`) carried through edit but
+   * NOT shown in the key/value editor, which only authors scalar string values.
+   * `SloSpec.labels` is `Record<string, string | string[]>`; the wizard can only
+   * create scalar labels, so array labels only exist on API-created SLOs. Without
+   * carrying them out-of-band, hydration would flatten `{region: ['us','eu']}` to
+   * the scalar `'us,eu'` and — because the server shallow-merges the whole
+   * `labels` object on save — permanently rewrite the array to a CSV string.
+   * Re-emitted verbatim by `buildCreateInput`. Always `{}` in create mode.
+   */
+  preservedArrayLabels: Record<string, string[]>;
   annotations: KeyValueEntry[];
   shadow: boolean;
 
@@ -248,6 +259,7 @@ export function initialState(): FormState {
     latencyThresholdUnit: 'seconds',
     customPromql: { mode: 'events', goodQuery: '', totalQuery: '', errorRatioQuery: '' },
     labels: [],
+    preservedArrayLabels: {},
     annotations: [],
     shadow: false,
     burnRates: defaultBurnRates(),
@@ -666,6 +678,28 @@ function recordToEntries(record: Record<string, string | string[]>): KeyValueEnt
   });
 }
 
+/**
+ * Split a labels record into scalar rows the key/value editor can author and
+ * array-valued labels it can't. Array labels are carried out-of-band (see
+ * {@link FormState.preservedArrayLabels}) and re-emitted verbatim on save, so
+ * editing an API-created SLO with an array label like `{region: ['us','eu']}`
+ * no longer flattens it to the scalar `'us,eu'` (which the server's shallow
+ * `labels` merge would then persist).
+ */
+function splitLabels(record: Record<string, string | string[]>): {
+  entries: KeyValueEntry[];
+  arrays: Record<string, string[]>;
+} {
+  const entries: KeyValueEntry[] = [];
+  const arrays: Record<string, string[]> = {};
+  Object.keys(record).forEach((key) => {
+    const value = record[key];
+    if (Array.isArray(value)) arrays[key] = value.slice();
+    else entries.push({ key, value });
+  });
+  return { entries, arrays };
+}
+
 /** Rebuild the custom-PromQL editor state from a persisted custom SLI. */
 function deriveCustomPromqlState(def: PrometheusSli, base: CustomPromqlState): CustomPromqlState {
   if (def.type !== 'custom' || !def.customExpr) return base;
@@ -731,6 +765,20 @@ function deriveEditTemplate(
  * i.e. a composite SLI (P2) or any non-Prometheus backend. Callers surface an
  * "unsupported" state instead of a half-populated form.
  */
+/**
+ * Whether the wizard can edit this SLO in place. Mirrors the guards in
+ * {@link hydrateFromDoc} (single Prometheus SLI + a representable rolling
+ * window) without building the full form, so callers — e.g. the detail page's
+ * Edit button — can avoid offering a dead-end "Edit" that only lands on the
+ * wizard's "This SLO can't be edited here" message.
+ */
+export function isSloEditable(doc: SloDocument): boolean {
+  const { sli, window } = doc.spec;
+  if (sli.type !== 'single') return false;
+  if (sli.definition.backend !== 'prometheus') return false;
+  return toEditableWindowDuration(window) !== null;
+}
+
 export function hydrateFromDoc(doc: SloDocument): EditHydration | null {
   const spec = doc.spec;
   const sli = spec.sli;
@@ -747,6 +795,8 @@ export function hydrateFromDoc(doc: SloDocument): EditHydration | null {
 
   const fresh = initialState();
   const template = deriveEditTemplate(spec, def, sli.dimensions);
+  // Keep array-valued labels out of the editable rows and carry them verbatim.
+  const { entries: labelEntries, arrays: preservedArrayLabels } = splitLabels(spec.labels ?? {});
 
   const state: FormState = {
     ...fresh,
@@ -781,7 +831,8 @@ export function hydrateFromDoc(doc: SloDocument): EditHydration | null {
     goodEventsFilter: def.goodEventsFilter ?? '',
     latencyThresholdUnit: def.latencyThresholdUnit ?? 'seconds',
     customPromql: deriveCustomPromqlState(def, fresh.customPromql),
-    labels: recordToEntries(spec.labels ?? {}),
+    labels: labelEntries,
+    preservedArrayLabels,
     annotations: recordToEntries(spec.annotations ?? {}),
     shadow: spec.mode === 'shadow',
     burnRates: spec.alerting.burnRates.map((b) => ({ ...b })),


### PR DESCRIPTION
## What & why
SLO detail had no way to edit an existing SLO. Adds an `#/slos/:id/edit` route + an Edit action, prefilling the wizard from the saved SLO and calling the existing update path. The datasource is pinned read-only because the deployed rules are keyed to it.

**Findings:** BUG-S3.

## Before / after

**Before / after (Edit action appears)**

![Before / after (Edit action appears)](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR13/before-after.png)

**Flow**

![Flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR13/flow.gif)

**New edit wizard, prefilled**

![New edit wizard, prefilled](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR13/edit-wizard-annotated.png)

## Testing
`slo_edit_wizard.test.tsx` + `wizard_state.test.ts` + detail test. Centrally green.

## Review
Independent review agent: **APPROVE with fixes applied** — caught a real bug: editing a **paused** SLO silently re-enabled it (`buildCreateInput` hardcodes `enabled:true` and the server merges the PUT over stored). Fixed by preserving the loaded `enabled` flag. Also fixed two type errors in the test file (tsc had not been run).

## Regression check
The before/after above is a **full-viewport** capture, so adjacent components on the same surface are visible and unchanged — the diff is scoped to what's called out. Cross-component safety is also verified centrally: this change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. Aside from the merge-order note below, it can be reviewed, merged, and reverted independently.

## Dependency
**Stacked on #2831 (SLO detail) — merge #2831 first.** This branch includes #2831's commits; once it merges, a rebase drops them from this diff.

> Draft — see the merge-order note above.
