### PR TITLE
[Alerting] Label the Rules-table Status / Severity / Health cells

### DIFF
--- a/public/components/alerting/__tests__/alert_colors.test.ts
+++ b/public/components/alerting/__tests__/alert_colors.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ALERT_KIND_HEX,
+  SEVERITY_HEX,
+  STATE_HEX,
+  UNKNOWN_HEX,
+  getSeverityHex,
+  getStateHex,
+} from '../alert_colors';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../../common/types/alerting';
+
+const ALL_SEVERITIES: UnifiedAlertSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
+const ALL_STATES: UnifiedAlertState[] = [
+  'active',
+  'pending',
+  'acknowledged',
+  'silenced',
+  'resolved',
+  'error',
+];
+
+describe('alert_colors', () => {
+  it('resolves every severity to a real theme color', () => {
+    ALL_SEVERITIES.forEach((severity) => {
+      // A typo in a euiThemeVars key yields `undefined`, which silently renders
+      // as "no color" — assert we got an actual CSS color back.
+      expect(SEVERITY_HEX[severity]).toMatch(/^#[0-9a-f]{3,8}$/i);
+    });
+  });
+
+  it('resolves every state to a real theme color', () => {
+    ALL_STATES.forEach((state) => {
+      expect(STATE_HEX[state]).toMatch(/^#[0-9a-f]{3,8}$/i);
+    });
+  });
+
+  it('resolves both row kinds and keeps anomaly distinct from a high-severity alert', () => {
+    expect(ALERT_KIND_HEX.alert).toMatch(/^#[0-9a-f]{3,8}$/i);
+    expect(ALERT_KIND_HEX.anomaly).toMatch(/^#[0-9a-f]{3,8}$/i);
+    expect(ALERT_KIND_HEX.anomaly).not.toBe(SEVERITY_HEX.high);
+  });
+
+  it('gives critical and active the danger tone', () => {
+    expect(getSeverityHex('critical')).toBe(SEVERITY_HEX.critical);
+    expect(getStateHex('active')).toBe(STATE_HEX.active);
+    expect(getStateHex('error')).toBe(STATE_HEX.active);
+  });
+
+  it('resolves the anomaly row kind through the state getter', () => {
+    expect(getStateHex('anomaly')).toBe(ALERT_KIND_HEX.anomaly);
+  });
+
+  it('falls back to a subdued tone for missing or unknown values', () => {
+    expect(getSeverityHex(undefined)).toBe(UNKNOWN_HEX);
+    expect(getSeverityHex('sev0')).toBe(UNKNOWN_HEX);
+    expect(getStateHex(null)).toBe(UNKNOWN_HEX);
+    expect(getStateHex('quiesced')).toBe(UNKNOWN_HEX);
+  });
+});

--- a/public/components/alerting/__tests__/enum_labels.test.ts
+++ b/public/components/alerting/__tests__/enum_labels.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EMPTY_VALUE,
+  SEVERITY_LABELS,
+  STATE_LABELS,
+  getSeverityLabel,
+  getStateLabel,
+} from '../enum_labels';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../../common/types/alerting';
+
+const ALL_SEVERITIES: UnifiedAlertSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
+const ALL_STATES: UnifiedAlertState[] = [
+  'active',
+  'pending',
+  'acknowledged',
+  'silenced',
+  'resolved',
+  'error',
+];
+
+describe('enum_labels', () => {
+  it('covers every severity in the union with a non-empty, non-raw label', () => {
+    ALL_SEVERITIES.forEach((severity) => {
+      const label = SEVERITY_LABELS[severity];
+      expect(label).toBeTruthy();
+      // The whole point is not to render the raw lowercase machine value.
+      expect(label).not.toBe(severity);
+    });
+  });
+
+  it('covers every state in the union with a non-empty, non-raw label', () => {
+    ALL_STATES.forEach((state) => {
+      const label = STATE_LABELS[state];
+      expect(label).toBeTruthy();
+      expect(label).not.toBe(state);
+    });
+  });
+
+  it('returns the empty placeholder for missing values', () => {
+    expect(getSeverityLabel(undefined)).toBe(EMPTY_VALUE);
+    expect(getSeverityLabel(null)).toBe(EMPTY_VALUE);
+    expect(getSeverityLabel('')).toBe(EMPTY_VALUE);
+    expect(getStateLabel(undefined)).toBe(EMPTY_VALUE);
+    expect(getStateLabel('')).toBe(EMPTY_VALUE);
+  });
+
+  it('humanizes values the UI does not know about instead of dropping them', () => {
+    expect(getStateLabel('awaiting_data')).toBe('Awaiting data');
+    expect(getSeverityLabel('sev-one')).toBe('Sev one');
+  });
+
+  it('falls back to the placeholder when an unknown value is only separators', () => {
+    expect(getStateLabel('__')).toBe(EMPTY_VALUE);
+  });
+
+  it('maps known values through the label tables', () => {
+    expect(getSeverityLabel('critical')).toBe(SEVERITY_LABELS.critical);
+    expect(getStateLabel('acknowledged')).toBe(STATE_LABELS.acknowledged);
+  });
+});

--- a/public/components/alerting/__tests__/enum_labels.test.ts
+++ b/public/components/alerting/__tests__/enum_labels.test.ts
@@ -7,10 +7,15 @@ import {
   EMPTY_VALUE,
   SEVERITY_LABELS,
   STATE_LABELS,
+  getMonitorStateLabel,
   getSeverityLabel,
   getStateLabel,
 } from '../enum_labels';
-import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../../common/types/alerting';
+import type {
+  MonitorHealthStatus,
+  UnifiedAlertSeverity,
+  UnifiedAlertState,
+} from '../../../../common/types/alerting';
 
 const ALL_SEVERITIES: UnifiedAlertSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
 const ALL_STATES: UnifiedAlertState[] = [
@@ -60,5 +65,39 @@ describe('enum_labels', () => {
   it('maps known values through the label tables', () => {
     expect(getSeverityLabel('critical')).toBe(SEVERITY_LABELS.critical);
     expect(getStateLabel('acknowledged')).toBe(STATE_LABELS.acknowledged);
+  });
+
+  describe('getMonitorStateLabel', () => {
+    it('title-cases the lowercase rule-status tokens', () => {
+      expect(getMonitorStateLabel('active')).toBe('Active');
+      expect(getMonitorStateLabel('pending')).toBe('Pending');
+      expect(getMonitorStateLabel('muted')).toBe('Muted');
+      expect(getMonitorStateLabel('disabled')).toBe('Disabled');
+    });
+
+    it('covers every health status with a non-raw label', () => {
+      const ALL_HEALTH: MonitorHealthStatus[] = ['healthy', 'failing', 'no_data'];
+      ALL_HEALTH.forEach((health) => {
+        const label = getMonitorStateLabel(health);
+        expect(label).toBeTruthy();
+        expect(label).not.toBe(health);
+      });
+      // `no_data` in particular must not leak the underscore into the UI.
+      expect(getMonitorStateLabel('no_data')).toBe('No data');
+    });
+
+    it('passes through the AD/forecaster statuses, which already read as prose', () => {
+      // These arrive from the anomaly-detection plugin already display-ready;
+      // re-casing them would corrupt wording like "Awaiting data to init".
+      expect(getMonitorStateLabel('Running')).toBe('Running');
+      expect(getMonitorStateLabel('Awaiting data to init')).toBe('Awaiting data to init');
+      expect(getMonitorStateLabel('Initialization failure')).toBe('Initialization failure');
+    });
+
+    it('returns the empty placeholder for missing values', () => {
+      expect(getMonitorStateLabel(undefined)).toBe(EMPTY_VALUE);
+      expect(getMonitorStateLabel(null)).toBe(EMPTY_VALUE);
+      expect(getMonitorStateLabel('')).toBe(EMPTY_VALUE);
+    });
   });
 });

--- a/public/components/alerting/__tests__/time_format.test.ts
+++ b/public/components/alerting/__tests__/time_format.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { uiSettingsService } from '../../../../common/utils';
+import { EMPTY_VALUE } from '../enum_labels';
+import { formatTimestamp, getTimezoneLabel, resolveDisplayTz } from '../time_format';
+
+// 2026-08-25T18:04:05Z — a fixed instant so assertions don't depend on "now".
+const INSTANT = '2026-08-25T18:04:05.000Z';
+
+describe('time_format', () => {
+  let getSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getSpy = jest.spyOn(uiSettingsService, 'get');
+  });
+
+  afterEach(() => {
+    getSpy.mockRestore();
+  });
+
+  describe('resolveDisplayTz', () => {
+    it('uses the configured dateFormat:tz', () => {
+      getSpy.mockReturnValue('America/Los_Angeles');
+      expect(resolveDisplayTz()).toBe('America/Los_Angeles');
+    });
+
+    it('falls back to the browser zone when unset or left at Browser', () => {
+      const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      getSpy.mockReturnValue(undefined);
+      expect(resolveDisplayTz()).toBe(browserTz);
+      getSpy.mockReturnValue('Browser');
+      expect(resolveDisplayTz()).toBe(browserTz);
+    });
+  });
+
+  describe('formatTimestamp', () => {
+    it('renders in the configured zone and names that zone', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(INSTANT)).toBe('Aug 25, 2026 @ 18:04:05 UTC');
+    });
+
+    it('shifts the wall-clock time to the configured zone', () => {
+      getSpy.mockReturnValue('America/Los_Angeles');
+      // 18:04 UTC is 11:04 PDT on this date.
+      expect(formatTimestamp(INSTANT)).toBe('Aug 25, 2026 @ 11:04:05 PDT');
+    });
+
+    it('omits the zone label when asked', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(INSTANT, { withZone: false })).toBe('Aug 25, 2026 @ 18:04:05');
+    });
+
+    it('honors a custom format', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(INSTANT, { format: 'YYYY-MM-DD', withZone: false })).toBe('2026-08-25');
+    });
+
+    it('accepts epoch millis and Date instances', () => {
+      getSpy.mockReturnValue('UTC');
+      const ms = new Date(INSTANT).getTime();
+      expect(formatTimestamp(ms)).toBe('Aug 25, 2026 @ 18:04:05 UTC');
+      expect(formatTimestamp(new Date(INSTANT))).toBe('Aug 25, 2026 @ 18:04:05 UTC');
+    });
+
+    it('returns the placeholder rather than "Invalid date" for bad input', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(undefined)).toBe(EMPTY_VALUE);
+      expect(formatTimestamp(null)).toBe(EMPTY_VALUE);
+      expect(formatTimestamp('')).toBe(EMPTY_VALUE);
+      expect(formatTimestamp('not a timestamp')).toBe(EMPTY_VALUE);
+    });
+
+    it('honors a caller-supplied fallback', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(formatTimestamp(null, { fallback: 'Never' })).toBe('Never');
+    });
+  });
+
+  describe('getTimezoneLabel', () => {
+    it('labels a zone with an abbreviation where one exists', () => {
+      getSpy.mockReturnValue('UTC');
+      expect(getTimezoneLabel(INSTANT)).toBe('UTC');
+    });
+
+    it('uses the zone abbreviation when the zone has one', () => {
+      getSpy.mockReturnValue('Asia/Kolkata');
+      expect(getTimezoneLabel(INSTANT)).toBe('IST');
+    });
+
+    it('falls back to a numeric offset for zones without an abbreviation', () => {
+      getSpy.mockReturnValue('Asia/Kathmandu');
+      expect(getTimezoneLabel(INSTANT)).toBe('+0545');
+    });
+  });
+});

--- a/public/components/alerting/__tests__/time_format.test.ts
+++ b/public/components/alerting/__tests__/time_format.test.ts
@@ -55,7 +55,9 @@ describe('time_format', () => {
 
     it('honors a custom format', () => {
       getSpy.mockReturnValue('UTC');
-      expect(formatTimestamp(INSTANT, { format: 'YYYY-MM-DD', withZone: false })).toBe('2026-08-25');
+      expect(formatTimestamp(INSTANT, { format: 'YYYY-MM-DD', withZone: false })).toBe(
+        '2026-08-25'
+      );
     });
 
     it('accepts epoch millis and Date instances', () => {

--- a/public/components/alerting/alert_colors.ts
+++ b/public/components/alerting/alert_colors.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { euiThemeVars } from '@osd/ui-shared-deps/theme';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../common/types/alerting';
+
+/**
+ * Theme-derived colors for alert severity, state, and row kind.
+ *
+ * Alert surfaces previously hand-rolled these as literal hex — which pinned them
+ * to the light theme (so dark mode rendered near-invisible swatches) and let each
+ * component drift from the next. `euiThemeVars` resolves against whichever theme
+ * is active, so consumers get the right value in both.
+ *
+ * Use these where a raw CSS color is unavoidable (chart series, custom swatches).
+ * Where an OUI component takes a semantic color name — `EuiHealth`, `EuiBadge` —
+ * prefer the semantic maps in `shared_constants.ts` instead.
+ */
+
+/** Severity → theme color. Ramps danger → warning → primary → subdued. */
+export const SEVERITY_HEX: Record<UnifiedAlertSeverity, string> = {
+  critical: euiThemeVars.euiColorDanger,
+  high: euiThemeVars.euiColorWarning,
+  medium: euiThemeVars.euiColorPrimary,
+  low: euiThemeVars.euiColorMediumShade,
+  info: euiThemeVars.euiColorLightShade,
+};
+
+/** Alert state → theme color. */
+export const STATE_HEX: Record<UnifiedAlertState, string> = {
+  active: euiThemeVars.euiColorDanger,
+  pending: euiThemeVars.euiColorWarning,
+  acknowledged: euiThemeVars.euiColorPrimary,
+  silenced: euiThemeVars.euiColorMediumShade,
+  resolved: euiThemeVars.euiColorSuccess,
+  error: euiThemeVars.euiColorDanger,
+};
+
+/**
+ * Row kind → theme color. Anomaly rows use the darker warning tone so they read
+ * as distinct from a `high`-severity alert rather than merely similar.
+ */
+export const ALERT_KIND_HEX: Record<string, string> = {
+  alert: euiThemeVars.euiColorPrimary,
+  anomaly: euiThemeVars.euiColorWarningText,
+};
+
+/** Fallback for a value the UI doesn't recognise — subdued rather than alarming. */
+export const UNKNOWN_HEX = euiThemeVars.euiColorMediumShade;
+
+/** Severity color, falling back to a subdued tone for unrecognised values. */
+export function getSeverityHex(severity?: string | null): string {
+  if (!severity) return UNKNOWN_HEX;
+  return SEVERITY_HEX[severity as UnifiedAlertSeverity] ?? UNKNOWN_HEX;
+}
+
+/**
+ * State color. `anomaly` is not an alert state but appears in the same column of
+ * the alerts table, so it is resolved here too.
+ */
+export function getStateHex(state?: string | null): string {
+  if (!state) return UNKNOWN_HEX;
+  return STATE_HEX[state as UnifiedAlertState] ?? ALERT_KIND_HEX[state] ?? UNKNOWN_HEX;
+}

--- a/public/components/alerting/alert_colors.ts
+++ b/public/components/alerting/alert_colors.ts
@@ -4,7 +4,11 @@
  */
 
 import { euiThemeVars } from '@osd/ui-shared-deps/theme';
-import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../common/types/alerting';
+import type {
+  UnifiedAlertKind,
+  UnifiedAlertSeverity,
+  UnifiedAlertState,
+} from '../../../common/types/alerting';
 
 /**
  * Theme-derived colors for alert severity, state, and row kind.
@@ -42,7 +46,7 @@ export const STATE_HEX: Record<UnifiedAlertState, string> = {
  * Row kind → theme color. Anomaly rows use the darker warning tone so they read
  * as distinct from a `high`-severity alert rather than merely similar.
  */
-export const ALERT_KIND_HEX: Record<string, string> = {
+export const ALERT_KIND_HEX: Record<UnifiedAlertKind, string> = {
   alert: euiThemeVars.euiColorPrimary,
   anomaly: euiThemeVars.euiColorWarningText,
 };
@@ -62,5 +66,6 @@ export function getSeverityHex(severity?: string | null): string {
  */
 export function getStateHex(state?: string | null): string {
   if (!state) return UNKNOWN_HEX;
-  return STATE_HEX[state as UnifiedAlertState] ?? ALERT_KIND_HEX[state] ?? UNKNOWN_HEX;
+  const kindHex = ALERT_KIND_HEX[state as UnifiedAlertKind];
+  return STATE_HEX[state as UnifiedAlertState] ?? kindHex ?? UNKNOWN_HEX;
 }

--- a/public/components/alerting/enum_labels.ts
+++ b/public/components/alerting/enum_labels.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import type { UnifiedAlertSeverity, UnifiedAlertState } from '../../../common/types/alerting';
+
+/**
+ * Human-readable, translatable labels for the raw alert enums.
+ *
+ * The wire format uses lowercase machine values (`critical`, `at_risk`, …).
+ * Rendering those directly leaks the data model into the UI and cannot be
+ * localised, so every surface that shows a severity or state to a user should
+ * go through the getters below rather than interpolating the raw value.
+ */
+
+/**
+ * Single placeholder for an absent value. Kept here — alongside the other
+ * "how do we render a raw value as human text" rules — so surfaces stop
+ * drifting between `—`, `---`, and `N/A` for the same empty cell.
+ */
+export const EMPTY_VALUE = '—';
+
+export const SEVERITY_LABELS: Record<UnifiedAlertSeverity, string> = {
+  critical: i18n.translate('observability.alerting.severityLabel.critical', {
+    defaultMessage: 'Critical',
+  }),
+  high: i18n.translate('observability.alerting.severityLabel.high', {
+    defaultMessage: 'High',
+  }),
+  medium: i18n.translate('observability.alerting.severityLabel.medium', {
+    defaultMessage: 'Medium',
+  }),
+  low: i18n.translate('observability.alerting.severityLabel.low', {
+    defaultMessage: 'Low',
+  }),
+  info: i18n.translate('observability.alerting.severityLabel.info', {
+    defaultMessage: 'Info',
+  }),
+};
+
+export const STATE_LABELS: Record<UnifiedAlertState, string> = {
+  active: i18n.translate('observability.alerting.stateLabel.active', {
+    defaultMessage: 'Active',
+  }),
+  pending: i18n.translate('observability.alerting.stateLabel.pending', {
+    defaultMessage: 'Pending',
+  }),
+  acknowledged: i18n.translate('observability.alerting.stateLabel.acknowledged', {
+    defaultMessage: 'Acknowledged',
+  }),
+  silenced: i18n.translate('observability.alerting.stateLabel.silenced', {
+    defaultMessage: 'Silenced',
+  }),
+  resolved: i18n.translate('observability.alerting.stateLabel.resolved', {
+    defaultMessage: 'Resolved',
+  }),
+  error: i18n.translate('observability.alerting.stateLabel.error', {
+    defaultMessage: 'Error',
+  }),
+};
+
+/**
+ * Best-effort label for a value that isn't in the known enum — a backend may
+ * add a state before the UI knows about it. Turns `awaiting_data` into
+ * "Awaiting data" so an unrecognised value still reads as prose instead of
+ * disappearing behind a placeholder.
+ */
+function humanizeUnknown(value: string): string {
+  const spaced = value.replace(/[_-]+/g, ' ').trim();
+  if (!spaced) return EMPTY_VALUE;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/** Display label for an alert severity. Returns {@link EMPTY_VALUE} when absent. */
+export function getSeverityLabel(severity?: string | null): string {
+  if (!severity) return EMPTY_VALUE;
+  return SEVERITY_LABELS[severity as UnifiedAlertSeverity] ?? humanizeUnknown(severity);
+}
+
+/** Display label for an alert state. Returns {@link EMPTY_VALUE} when absent. */
+export function getStateLabel(state?: string | null): string {
+  if (!state) return EMPTY_VALUE;
+  return STATE_LABELS[state as UnifiedAlertState] ?? humanizeUnknown(state);
+}

--- a/public/components/alerting/enum_labels.ts
+++ b/public/components/alerting/enum_labels.ts
@@ -84,3 +84,44 @@ export function getStateLabel(state?: string | null): string {
   if (!state) return EMPTY_VALUE;
   return STATE_LABELS[state as UnifiedAlertState] ?? humanizeUnknown(state);
 }
+
+/**
+ * Rule/monitor status and health values, which are a different vocabulary from
+ * alert state. Only the OpenSearch-alerting side sends lowercase tokens; the
+ * AD/forecaster side already sends display-ready sentences ("Running",
+ * "Awaiting data to init"), which fall through {@link humanizeUnknown}
+ * unchanged. Only the tokens that actually need translating are mapped.
+ */
+const MONITOR_STATE_LABELS: Record<string, string> = {
+  active: i18n.translate('observability.alerting.monitorStateLabel.active', {
+    defaultMessage: 'Active',
+  }),
+  pending: i18n.translate('observability.alerting.monitorStateLabel.pending', {
+    defaultMessage: 'Pending',
+  }),
+  muted: i18n.translate('observability.alerting.monitorStateLabel.muted', {
+    defaultMessage: 'Muted',
+  }),
+  disabled: i18n.translate('observability.alerting.monitorStateLabel.disabled', {
+    defaultMessage: 'Disabled',
+  }),
+  healthy: i18n.translate('observability.alerting.monitorStateLabel.healthy', {
+    defaultMessage: 'Healthy',
+  }),
+  failing: i18n.translate('observability.alerting.monitorStateLabel.failing', {
+    defaultMessage: 'Failing',
+  }),
+  no_data: i18n.translate('observability.alerting.monitorStateLabel.noData', {
+    defaultMessage: 'No data',
+  }),
+};
+
+/**
+ * Display label for a rule/monitor `status` or `healthStatus`. Returns
+ * {@link EMPTY_VALUE} when absent. Unmapped values are humanized rather than
+ * dropped, so a status the UI doesn't know yet still reads as prose.
+ */
+export function getMonitorStateLabel(value?: string | null): string {
+  if (!value) return EMPTY_VALUE;
+  return MONITOR_STATE_LABELS[value] ?? humanizeUnknown(value);
+}

--- a/public/components/alerting/monitors_table/__tests__/monitors_filters_panel.test.tsx
+++ b/public/components/alerting/monitors_table/__tests__/monitors_filters_panel.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { MonitorsFiltersPanel } from '../monitors_filters_panel';
+import { emptyFilters } from '../monitors_table_filters';
+
+// Minimal-but-complete props so the pure-render panel mounts. Only the Status /
+// Severity / Health facet wiring is under test here; everything else is inert.
+const makeProps = (overrides = {}) => ({
+  rules: [],
+  datasources: [],
+  selectedDsIds: [],
+  onDatasourceChange: jest.fn(),
+  maxDatasources: 5,
+  onDatasourceCapReached: jest.fn(),
+  datasourceErrorMap: {},
+  filters: emptyFilters(),
+  activeFilterCount: 0,
+  clearAllFilters: jest.fn(),
+  updateFilter: jest.fn(),
+  updateLabelFilter: jest.fn(),
+  labelKeys: [],
+  datasourceEntries: [],
+  uniqueStatuses: ['active', 'muted'],
+  uniqueSeverities: ['critical', 'medium'],
+  uniqueTypes: [],
+  uniqueHealth: ['healthy', 'no_data'],
+  uniqueCreators: [],
+  facetCounts: {
+    counts: {
+      status: { active: 3, muted: 2 },
+      severity: { critical: 1, medium: 4 },
+      monitorType: {},
+      healthStatus: { healthy: 4, no_data: 1 },
+      createdBy: {},
+    },
+    labelCounts: {},
+  },
+  isFacetCollapsed: () => false,
+  toggleFacetCollapse: jest.fn(),
+  onToggleOpen: jest.fn(),
+  savedSearches: [],
+  setSavedSearches: jest.fn(),
+  loadSavedSearch: jest.fn(),
+  deleteSavedSearch: jest.fn(),
+  showSaveSearchInput: false,
+  setShowSaveSearchInput: jest.fn(),
+  saveSearchName: '',
+  setSaveSearchName: jest.fn(),
+  saveCurrentSearch: jest.fn(),
+  searchQuery: '',
+  ...overrides,
+});
+
+describe('MonitorsFiltersPanel — facet labels match the table', () => {
+  // Regression guard: the Status/Severity/Health facet labels must read the
+  // same humanized text as the table cells (PR labelled those cells). If the
+  // facet still showed the raw token while the table showed Title Case, the two
+  // halves of the same screen would disagree — the defect this fixes.
+  it('renders humanized Status / Severity / Health facet labels, not raw tokens', () => {
+    const { getByText, queryByText } = render(<MonitorsFiltersPanel {...makeProps()} />);
+    expect(getByText('Active')).toBeInTheDocument();
+    expect(getByText('Muted')).toBeInTheDocument();
+    expect(getByText('Critical')).toBeInTheDocument();
+    expect(getByText('Medium')).toBeInTheDocument();
+    expect(getByText('Healthy')).toBeInTheDocument();
+    // The underscore token must not leak; it reads "No data".
+    expect(getByText('No data')).toBeInTheDocument();
+    expect(queryByText('no_data')).toBeNull();
+    // No raw lowercase enum survives as a visible facet label.
+    expect(queryByText('active')).toBeNull();
+    expect(queryByText('medium')).toBeNull();
+  });
+
+  it('still filters on the RAW value when a humanized facet is clicked (display-only map)', () => {
+    // The crucial invariant: relabelling must not change which rows match.
+    // Clicking the "Active" label must call updateFilter('status', ['active']).
+    const updateFilter = jest.fn();
+    const { getByText } = render(<MonitorsFiltersPanel {...makeProps({ updateFilter })} />);
+    fireEvent.click(getByText('Active'));
+    expect(updateFilter).toHaveBeenCalledWith('status', ['active']);
+
+    fireEvent.click(getByText('No data'));
+    expect(updateFilter).toHaveBeenCalledWith('healthStatus', ['no_data']);
+  });
+});

--- a/public/components/alerting/monitors_table/__tests__/monitors_table_columns.test.tsx
+++ b/public/components/alerting/monitors_table/__tests__/monitors_table_columns.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { buildTableColumns } from '../monitors_table_columns';
+import type { UnifiedRuleSummary } from '../../../../../common/types/alerting';
+
+const baseParams = {
+  filtered: [] as UnifiedRuleSummary[],
+  selectedIds: new Set<string>(),
+  columnWidths: {},
+  dsNameMap: new Map<string, string>(),
+  toggleSelect: jest.fn(),
+  toggleSelectAll: jest.fn(),
+  setSelectedMonitor: jest.fn(),
+};
+
+// Pull a single column's `render` out of the built column set by field name so
+// the tests exercise the exact cell renderer the table uses.
+const renderCell = (field: string, value: unknown) => {
+  const cols = buildTableColumns({
+    ...baseParams,
+    visibleColumns: new Set([field]),
+  });
+  const col = cols.find((c) => c.field === field) as
+    | { render?: (v: unknown, item?: UnifiedRuleSummary) => React.ReactNode }
+    | undefined;
+  if (!col?.render) throw new Error(`no render for column "${field}"`);
+  return render(<div>{col.render(value)}</div>);
+};
+
+describe('monitors_table_columns cell labels', () => {
+  // The alerts table reads "Active"/"Medium"/"Healthy"; before this change the
+  // rules table rendered the raw lowercase backend tokens next to it, so the
+  // same vocabulary read two different ways on adjacent tabs.
+  it('title-cases the status cell instead of showing the raw token', () => {
+    const { getByText, queryByText } = renderCell('status', 'active');
+    expect(getByText('Active')).toBeInTheDocument();
+    expect(queryByText('active')).toBeNull();
+  });
+
+  it('title-cases the severity cell', () => {
+    const { getByText, queryByText } = renderCell('severity', 'medium');
+    expect(getByText('Medium')).toBeInTheDocument();
+    expect(queryByText('medium')).toBeNull();
+  });
+
+  it('renders the health cell without leaking the no_data underscore', () => {
+    const { getByText, queryByText } = renderCell('healthStatus', 'no_data');
+    expect(getByText('No data')).toBeInTheDocument();
+    expect(queryByText('no_data')).toBeNull();
+  });
+
+  it('passes AD/forecaster lifecycle statuses through unchanged', () => {
+    // These arrive already display-ready; re-casing them would corrupt the
+    // wording, so the label getter must leave them alone.
+    const { getByText } = renderCell('status', 'Awaiting data to init');
+    expect(getByText('Awaiting data to init')).toBeInTheDocument();
+  });
+});

--- a/public/components/alerting/monitors_table/__tests__/monitors_table_columns.test.tsx
+++ b/public/components/alerting/monitors_table/__tests__/monitors_table_columns.test.tsx
@@ -26,8 +26,7 @@ const renderCell = (field: string, value: unknown) => {
     visibleColumns: new Set([field]),
   });
   const col = cols.find((c) => c.field === field) as
-    | { render?: (v: unknown, item?: UnifiedRuleSummary) => React.ReactNode }
-    | undefined;
+    { render?: (v: unknown, item?: UnifiedRuleSummary) => React.ReactNode } | undefined;
   if (!col?.render) throw new Error(`no render for column "${field}"`);
   return render(<div>{col.render(value)}</div>);
 };

--- a/public/components/alerting/monitors_table/monitors_filters_panel.tsx
+++ b/public/components/alerting/monitors_table/monitors_filters_panel.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../../../common/types/alerting';
 import { FacetFilterGroup } from '../facet_filter_panel';
 import { HEALTH_COLORS, SEVERITY_COLORS, STATUS_COLORS, TYPE_LABELS } from '../shared_constants';
+import { getMonitorStateLabel, getSeverityLabel } from '../enum_labels';
 import { collectLabelValues, FilterState } from './monitors_table_filters';
 import { INTERNAL_LABEL_KEYS, SavedSearch } from './monitors_table_helpers';
 
@@ -141,6 +142,25 @@ export const MonitorsFiltersPanel: React.FC<MonitorsFiltersPanelProps> = ({
     }
     return map;
   }, [datasources]);
+
+  // Display maps so the Status / Severity / Health facet labels read the same
+  // as the table cells (e.g. "Active", "Medium", "No data") instead of the raw
+  // backend tokens. Only the *label* is mapped — the facet still filters on the
+  // raw value (FacetFilterGroup's onChange keeps the original option), so this
+  // is display-only and cannot change which rows match. Mirrors how the Type
+  // facet already uses TYPE_LABELS.
+  const statusDisplayMap = useMemo(
+    () => Object.fromEntries(uniqueStatuses.map((s) => [s, getMonitorStateLabel(s)])),
+    [uniqueStatuses]
+  );
+  const severityDisplayMap = useMemo(
+    () => Object.fromEntries(uniqueSeverities.map((s) => [s, getSeverityLabel(s)])),
+    [uniqueSeverities]
+  );
+  const healthDisplayMap = useMemo(
+    () => Object.fromEntries(uniqueHealth.map((h) => [h, getMonitorStateLabel(h)])),
+    [uniqueHealth]
+  );
 
   // Render a single facet group (delegates to shared component)
   const renderFacetGroup = (
@@ -253,7 +273,7 @@ export const MonitorsFiltersPanel: React.FC<MonitorsFiltersPanelProps> = ({
           filters.status,
           (v) => updateFilter('status', v as MonitorStatus[]),
           facetCounts.counts.status,
-          undefined,
+          statusDisplayMap,
           STATUS_COLORS
         )}
         {renderFacetGroup(
@@ -265,7 +285,7 @@ export const MonitorsFiltersPanel: React.FC<MonitorsFiltersPanelProps> = ({
           filters.severity,
           (v) => updateFilter('severity', v as UnifiedAlertSeverity[]),
           facetCounts.counts.severity,
-          undefined,
+          severityDisplayMap,
           SEVERITY_COLORS
         )}
         {renderFacetGroup(
@@ -288,7 +308,7 @@ export const MonitorsFiltersPanel: React.FC<MonitorsFiltersPanelProps> = ({
           filters.healthStatus,
           (v) => updateFilter('healthStatus', v as MonitorHealthStatus[]),
           facetCounts.counts.healthStatus,
-          undefined,
+          healthDisplayMap,
           HEALTH_COLORS
         )}
         {renderFacetGroup(

--- a/public/components/alerting/monitors_table/monitors_table_columns.tsx
+++ b/public/components/alerting/monitors_table/monitors_table_columns.tsx
@@ -41,6 +41,7 @@ import {
   STATUS_COLORS,
   TYPE_LABELS,
 } from '../shared_constants';
+import { getMonitorStateLabel, getSeverityLabel } from '../enum_labels';
 import { DEFAULT_WIDTHS } from './resizable_columns';
 
 // ============================================================================
@@ -200,7 +201,7 @@ export function buildTableColumns({
         sortable: true,
         width: w('status'),
         render: (s: MonitorStatus) => (
-          <EuiHealth color={STATUS_COLORS[s] || 'subdued'}>{s}</EuiHealth>
+          <EuiHealth color={STATUS_COLORS[s] || 'subdued'}>{getMonitorStateLabel(s)}</EuiHealth>
         ),
       });
     } else if (colId === 'severity') {
@@ -212,7 +213,7 @@ export function buildTableColumns({
         sortable: true,
         width: w('severity'),
         render: (s: UnifiedAlertSeverity) => (
-          <EuiBadge color={SEVERITY_COLORS[s] || 'default'}>{s}</EuiBadge>
+          <EuiBadge color={SEVERITY_COLORS[s] || 'default'}>{getSeverityLabel(s)}</EuiBadge>
         ),
       });
     } else if (colId === 'monitorType') {
@@ -234,7 +235,7 @@ export function buildTableColumns({
         sortable: true,
         width: w('healthStatus'),
         render: (h: MonitorHealthStatus) => (
-          <EuiHealth color={HEALTH_COLORS[h] || 'subdued'}>{h}</EuiHealth>
+          <EuiHealth color={HEALTH_COLORS[h] || 'subdued'}>{getMonitorStateLabel(h)}</EuiHealth>
         ),
       });
     } else if (colId === 'labels') {

--- a/public/components/alerting/time_format.ts
+++ b/public/components/alerting/time_format.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import moment from 'moment-timezone';
+import { uiSettingsService } from '../../../common/utils';
+import { EMPTY_VALUE } from './enum_labels';
+
+/**
+ * Timezone-explicit timestamp formatting for alert surfaces.
+ *
+ * `Date#toLocaleString()` renders in the browser's zone and never says which
+ * zone that was, so two engineers reading the same incident see two different
+ * "start" times with no way to tell them apart. Everything here honours the
+ * `dateFormat:tz` advanced setting and labels the zone it rendered in.
+ */
+
+const DEFAULT_TIMESTAMP_FORMAT = 'MMM D, YYYY @ HH:mm:ss';
+
+/**
+ * Resolve the timezone the user configured via `dateFormat:tz`, falling back to
+ * the browser's zone when the setting is unset or left at `Browser`. Mirrors the
+ * resolution Discover and APM use so one instant renders identically everywhere.
+ */
+export function resolveDisplayTz(): string {
+  const tz = uiSettingsService.get('dateFormat:tz');
+  if (!tz || tz === 'Browser') {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  }
+  return tz;
+}
+
+/**
+ * Short label for a zone at a given instant — `UTC`, `PDT`, or a numeric offset
+ * such as `+05:30` for zones without an abbreviation.
+ */
+export function getTimezoneLabel(
+  value: string | number | Date = Date.now(),
+  tz: string = resolveDisplayTz()
+): string {
+  return moment.tz(value, tz).format('z');
+}
+
+export interface FormatTimestampOptions {
+  /** Append the timezone label. Defaults to `true` — that's the point of this helper. */
+  withZone?: boolean;
+  /** moment format string. Defaults to `MMM D, YYYY @ HH:mm:ss`. */
+  format?: string;
+  /** Rendered when the input is missing or unparseable. Defaults to {@link EMPTY_VALUE}. */
+  fallback?: string;
+}
+
+/**
+ * Format an instant in the user's configured timezone, with that zone named.
+ * Returns the fallback (an em dash by default) for missing or unparseable input
+ * rather than the `Invalid date` string moment would otherwise produce.
+ */
+export function formatTimestamp(
+  value?: string | number | Date | null,
+  options: FormatTimestampOptions = {}
+): string {
+  const {
+    withZone = true,
+    format = DEFAULT_TIMESTAMP_FORMAT,
+    fallback = EMPTY_VALUE,
+  } = options;
+
+  if (value === null || value === undefined || value === '') return fallback;
+
+  // Normalise through `Date` first: handing moment an unparseable string makes it
+  // fall back to the `Date` constructor anyway, but with a deprecation warning
+  // that would fire on every malformed timestamp the backend hands us.
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+
+  const tz = resolveDisplayTz();
+  const instant = moment.tz(date, tz);
+  if (!instant.isValid()) return fallback;
+
+  return withZone ? `${instant.format(format)} ${instant.format('z')}` : instant.format(format);
+}

--- a/public/components/alerting/time_format.ts
+++ b/public/components/alerting/time_format.ts
@@ -60,11 +60,7 @@ export function formatTimestamp(
   value?: string | number | Date | null,
   options: FormatTimestampOptions = {}
 ): string {
-  const {
-    withZone = true,
-    format = DEFAULT_TIMESTAMP_FORMAT,
-    fallback = EMPTY_VALUE,
-  } = options;
+  const { withZone = true, format = DEFAULT_TIMESTAMP_FORMAT, fallback = EMPTY_VALUE } = options;
 
   if (value === null || value === undefined || value === '') return fallback;
 


### PR DESCRIPTION
## What & why
The Rules tab rendered raw backend tokens (`active`, `muted`, `medium`, `no_data`) next to an Alerts tab that reads 'Active'/'Medium'. Routes the Status/Severity/Health **table cells** *and* the left-rail **facet filters** through the shared label getters so the whole screen agrees. The facets still filter on the raw value (display-only map, exactly like the existing Type facet's `TYPE_LABELS`), so which rows match is unchanged. Colours, sort and widths untouched.

**Findings:** Enum-label parity across the Alerts/Rules tabs (table + facet filters).

## Before / after

**Before / after (table + filter rail both labelled)**

![Before / after (table + filter rail both labelled)](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR14/before-after.png)

**Flow**

![Flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/0cb85c96272133bceb00d47185d07d84db6eb62b/PR14/flow.gif)

## Testing
`monitors_table_columns.test.tsx` + `monitors_filters_panel.test.tsx` — the latter asserts the facet shows 'Active'/'No data' **and** that clicking it still calls `updateFilter('status', ['active'])` on the raw value. Existing `monitors_table_filters` + `facet_filter_panel` tests still pass (no filter regression). Centrally green.

## Review
Independent review flagged that the first pass labelled only the table cells, leaving the facet filters raw — the two halves of the screen disagreed. Fixed in a follow-up commit that labels the facets too (display-only), with a test guarding that filtering still matches the raw value.

## Regression check
The before/after above is a **full-viewport** capture, so adjacent components on the same surface are visible and unchanged — the diff is scoped to what's called out. Cross-component safety is also verified centrally: this change is file-disjoint from the other in-flight audit fixes (no file overlap, so it merges cleanly with them), and the affected plugin test suites pass with **0 new type errors** vs `main`. Aside from the merge-order note below, it can be reviewed, merged, and reverted independently.

## Dependency
Stacked on #2826 (shared primitives). This branch **includes** #2826's files so it builds and tests standalone in CI; merge #2826 first, then a rebase drops those files from this diff.

> Draft — see the merge-order note above.
