### PR TITLE
fix(apm): stop service graphs re-rendering on latency filter change #2626

### DIFF
--- a/public/components/apm/pages/service_details/service_dependencies.tsx
+++ b/public/components/apm/pages/service_details/service_dependencies.tsx
@@ -80,7 +80,6 @@ interface DependenciesTablePanelProps {
   filteredDependencies: GroupedDependency[];
   columns: Array<EuiBasicTableColumn<GroupedDependency>>;
   isLoading: boolean;
-  latencyPercentile: string;
   itemIdToExpandedRowMap: Record<string, React.ReactNode>;
   noDataMessage: string;
   noFilteredDataMessage: string;
@@ -91,7 +90,6 @@ const DependenciesTablePanelUI: React.FC<DependenciesTablePanelProps> = ({
   filteredDependencies,
   columns,
   isLoading,
-  latencyPercentile,
   itemIdToExpandedRowMap,
   noDataMessage,
   noFilteredDataMessage,
@@ -103,8 +101,10 @@ const DependenciesTablePanelUI: React.FC<DependenciesTablePanelProps> = ({
         <p>{dependenciesCount === 0 ? noDataMessage : noFilteredDataMessage}</p>
       </EuiText>
     ) : (
+      // Don't key the table on latencyPercentile
+      // Switching percentile only swaps the latency column
+      // Remounting would reset pagination and reload the row charts
       <EuiInMemoryTable
-        key={`dependencies-table-${latencyPercentile}`}
         items={filteredDependencies}
         columns={columns}
         loading={isLoading}
@@ -458,15 +458,17 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
     return textFilteredDependencies.filter((dep) => {
       // Latency range filter (only if range has been adjusted)
       const isLatencyFilterActive =
-        latencyRange[0] > latencyBounds.min || latencyRange[1] < latencyBounds.max;
+        // Gating on latencyUserModified avoids a false positive after a percentile switch
+        latencyUserModified.current &&
+        (latencyRange[0] > latencyBounds.min || latencyRange[1] < latencyBounds.max);
       if (isLatencyFilterActive) {
         // Use the selected percentile's duration for filtering
         const depLatency =
           latencyPercentile === 'p99'
             ? dep.p99Duration
             : latencyPercentile === 'p90'
-            ? dep.p90Duration
-            : dep.p50Duration;
+              ? dep.p90Duration
+              : dep.p50Duration;
         if (
           depLatency === undefined ||
           depLatency < latencyRange[0] ||
@@ -752,8 +754,8 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
           latencyPercentile === 'p99'
             ? 'p99Duration'
             : latencyPercentile === 'p90'
-            ? 'p90Duration'
-            : 'p50Duration',
+              ? 'p90Duration'
+              : 'p50Duration',
         name: (
           <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
@@ -979,15 +981,15 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
                 style={{ paddingTop: '8px', paddingRight: '8px' }}
               >
                 <DependencyFilterSidebar
-                  availabilityThresholds={(AVAILABILITY_THRESHOLD_OPTIONS as unknown) as string[]}
+                  availabilityThresholds={AVAILABILITY_THRESHOLD_OPTIONS as unknown as string[]}
                   selectedAvailabilityThresholds={
-                    (selectedAvailabilityThresholds as unknown) as string[]
+                    selectedAvailabilityThresholds as unknown as string[]
                   }
                   onAvailabilityThresholdsChange={
                     setSelectedAvailabilityThresholds as (selected: string[]) => void
                   }
-                  errorRateThresholds={(ERROR_RATE_THRESHOLD_OPTIONS as unknown) as string[]}
-                  selectedErrorRateThresholds={(selectedErrorRateThresholds as unknown) as string[]}
+                  errorRateThresholds={ERROR_RATE_THRESHOLD_OPTIONS as unknown as string[]}
+                  selectedErrorRateThresholds={selectedErrorRateThresholds as unknown as string[]}
                   onErrorRateThresholdsChange={
                     setSelectedErrorRateThresholds as (selected: string[]) => void
                   }
@@ -1026,7 +1028,6 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
                   filteredDependencies={filteredDependencies}
                   columns={columns}
                   isLoading={isLoading}
-                  latencyPercentile={latencyPercentile}
                   itemIdToExpandedRowMap={itemIdToExpandedRowMap}
                   noDataMessage={i18n.translate('observability.apm.dependencies.noData', {
                     defaultMessage:

--- a/public/components/apm/pages/service_details/service_operations.tsx
+++ b/public/components/apm/pages/service_details/service_operations.tsx
@@ -106,7 +106,6 @@ interface OperationsTablePanelProps {
   filteredOperations: OperationRow[];
   columns: Array<EuiBasicTableColumn<OperationRow>>;
   isLoading: boolean;
-  latencyPercentile: string;
   itemIdToExpandedRowMap: Record<string, React.ReactNode>;
   noDataMessage: string;
   noFilteredDataMessage: string;
@@ -117,7 +116,6 @@ const OperationsTablePanelUI: React.FC<OperationsTablePanelProps> = ({
   filteredOperations,
   columns,
   isLoading,
-  latencyPercentile,
   itemIdToExpandedRowMap,
   noDataMessage,
   noFilteredDataMessage,
@@ -129,8 +127,10 @@ const OperationsTablePanelUI: React.FC<OperationsTablePanelProps> = ({
         <p>{operationsCount === 0 ? noDataMessage : noFilteredDataMessage}</p>
       </EuiText>
     ) : (
+      // Don't key the table on latencyPercentile
+      // Switching percentile only swaps the latency column
+      // Remounting would reset pagination and reload the row charts
       <EuiInMemoryTable
-        key={`operations-table-${latencyPercentile}`}
         items={filteredOperations}
         columns={columns}
         loading={isLoading}
@@ -255,7 +255,11 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
   }, [timeRange]);
 
   // Fetch operations list from PPL
-  const { data: operationsData, isLoading: opsLoading, error: opsError } = useOperations({
+  const {
+    data: operationsData,
+    isLoading: opsLoading,
+    error: opsError,
+  } = useOperations({
     serviceName,
     environment,
     startTime: parsedTimeRange.startTime,
@@ -399,15 +403,17 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
     return textFilteredOperations.filter((op) => {
       // Latency range filter (only if range has been adjusted)
       const isLatencyFilterActive =
-        latencyRange[0] > latencyBounds.min || latencyRange[1] < latencyBounds.max;
+        // Gating on latencyUserModified avoids a false positive after a percentile switch
+        latencyUserModified.current &&
+        (latencyRange[0] > latencyBounds.min || latencyRange[1] < latencyBounds.max);
       if (isLatencyFilterActive) {
         // Use the selected percentile's duration for filtering
         const opLatency =
           latencyPercentile === 'p99'
             ? op.p99Duration
             : latencyPercentile === 'p90'
-            ? op.p90Duration
-            : op.p50Duration;
+              ? op.p90Duration
+              : op.p50Duration;
         if (opLatency < latencyRange[0] || opLatency > latencyRange[1]) {
           return false;
         }
@@ -700,8 +706,8 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
           latencyPercentile === 'p99'
             ? 'p99Duration'
             : latencyPercentile === 'p90'
-            ? 'p90Duration'
-            : 'p50Duration',
+              ? 'p90Duration'
+              : 'p50Duration',
         name: (
           <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
@@ -909,15 +915,15 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
                 style={{ paddingTop: '8px', paddingRight: '8px' }}
               >
                 <OperationFilterSidebar
-                  availabilityThresholds={(AVAILABILITY_THRESHOLD_OPTIONS as unknown) as string[]}
+                  availabilityThresholds={AVAILABILITY_THRESHOLD_OPTIONS as unknown as string[]}
                   selectedAvailabilityThresholds={
-                    (selectedAvailabilityThresholds as unknown) as string[]
+                    selectedAvailabilityThresholds as unknown as string[]
                   }
                   onAvailabilityThresholdsChange={
                     setSelectedAvailabilityThresholds as (selected: string[]) => void
                   }
-                  errorRateThresholds={(ERROR_RATE_THRESHOLD_OPTIONS as unknown) as string[]}
-                  selectedErrorRateThresholds={(selectedErrorRateThresholds as unknown) as string[]}
+                  errorRateThresholds={ERROR_RATE_THRESHOLD_OPTIONS as unknown as string[]}
+                  selectedErrorRateThresholds={selectedErrorRateThresholds as unknown as string[]}
                   onErrorRateThresholdsChange={
                     setSelectedErrorRateThresholds as (selected: string[]) => void
                   }
@@ -950,7 +956,6 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
                   filteredOperations={filteredOperations}
                   columns={columns}
                   isLoading={isLoading}
-                  latencyPercentile={latencyPercentile}
                   itemIdToExpandedRowMap={itemIdToExpandedRowMap}
                   noDataMessage={i18n.translate('observability.apm.operations.noData', {
                     defaultMessage:


### PR DESCRIPTION
### Description
Services detail Dependencies and Operations tabs remounted the whole table and re-fetched the three expanded-row charts whenever the latency percentile changed, because the table was keyed on latencyPercentile.

- Remove `latencyPercentile` from the table key so switching percentile updates the latency column in place via the memoized columns prop instead of remounting. Pagination and expanded-row charts are preserved.
- Gate the latency range filter on `latencyUserModified` so it only engages when the user actually adjusts the slider. This avoids a false positive on the render right after a percentile switch, where the stale range was compared against the new larger bounds and briefly filtered out rows.

#### Before

https://github.com/user-attachments/assets/ea29701a-d4ca-4cde-9eb2-23a9ebdf6b71

#### After

https://github.com/user-attachments/assets/5bcde003-c1fa-4d1c-80e7-a8964f289723


### Issues Resolved
[#2626](https://github.com/opensearch-project/dashboards-observability/issues/2626)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
