### PR TITLE
Fix/notification channel picker get configs

### DIFF
--- a/public/components/alerting/hooks/__tests__/use_destinations.test.ts
+++ b/public/components/alerting/hooks/__tests__/use_destinations.test.ts
@@ -9,11 +9,11 @@
  */
 import { renderHook, waitFor, act } from '@testing-library/react';
 
-const mockListDestinations = jest.fn();
+const mockGetNotificationConfigs = jest.fn();
 
 jest.mock('../../query_services/alerting_opensearch_service', () => ({
   AlertingOpenSearchService: jest.fn().mockImplementation(() => ({
-    listDestinations: mockListDestinations,
+    getNotificationConfigs: mockGetNotificationConfigs,
   })),
 }));
 
@@ -22,22 +22,22 @@ import { useDestinations } from '../use_destinations';
 const emptyResult = { destinations: [], totalDestinations: 0, truncated: false };
 
 beforeEach(() => {
-  mockListDestinations.mockReset();
-  mockListDestinations.mockResolvedValue(emptyResult);
+  mockGetNotificationConfigs.mockReset();
+  mockGetNotificationConfigs.mockResolvedValue(emptyResult);
 });
 
 describe('useDestinations', () => {
   it('does not call the service when dsId is empty', async () => {
     const { result } = renderHook(() => useDestinations({ dsId: '' }));
     await Promise.resolve();
-    expect(mockListDestinations).not.toHaveBeenCalled();
+    expect(mockGetNotificationConfigs).not.toHaveBeenCalled();
     expect(result.current.destinations).toEqual([]);
     expect(result.current.totalDestinations).toBe(0);
     expect(result.current.truncated).toBe(false);
   });
 
   it('returns destinations + total + truncated from the service', async () => {
-    mockListDestinations.mockResolvedValueOnce({
+    mockGetNotificationConfigs.mockResolvedValueOnce({
       destinations: [
         { id: 'd-1', name: 'ops', type: 'slack' },
         { id: 'd-2', name: 'pager', type: 'pagerduty' },
@@ -50,11 +50,11 @@ describe('useDestinations', () => {
     expect(result.current.totalDestinations).toBe(2);
     expect(result.current.truncated).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(mockListDestinations).toHaveBeenCalledWith('ds-1');
+    expect(mockGetNotificationConfigs).toHaveBeenCalledWith('ds-1');
   });
 
   it('propagates truncated=true and the cluster-side total', async () => {
-    mockListDestinations.mockResolvedValueOnce({
+    mockGetNotificationConfigs.mockResolvedValueOnce({
       destinations: Array.from({ length: 200 }, (_, i) => ({
         id: `d-${i}`,
         name: `n-${i}`,
@@ -70,7 +70,7 @@ describe('useDestinations', () => {
   });
 
   it('captures errors thrown by the service', async () => {
-    mockListDestinations.mockRejectedValueOnce(new Error('forbidden'));
+    mockGetNotificationConfigs.mockRejectedValueOnce(new Error('forbidden'));
     const { result } = renderHook(() => useDestinations({ dsId: 'ds-1' }));
     await waitFor(() => expect(result.current.error?.message).toBe('forbidden'));
     expect(result.current.isLoading).toBe(false);
@@ -82,21 +82,21 @@ describe('useDestinations', () => {
       ({ token }: { token: number }) => useDestinations({ dsId: 'ds-1', refreshToken: token }),
       { initialProps: { token: 0 } }
     );
-    await waitFor(() => expect(mockListDestinations).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockGetNotificationConfigs).toHaveBeenCalledTimes(1));
     rerender({ token: 1 });
-    await waitFor(() => expect(mockListDestinations).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockGetNotificationConfigs).toHaveBeenCalledTimes(2));
   });
 
   it('refetches when refetch() is called', async () => {
     const { result } = renderHook(() => useDestinations({ dsId: 'ds-1' }));
-    await waitFor(() => expect(mockListDestinations).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockGetNotificationConfigs).toHaveBeenCalledTimes(1));
     act(() => result.current.refetch());
-    await waitFor(() => expect(mockListDestinations).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockGetNotificationConfigs).toHaveBeenCalledTimes(2));
   });
 
   it('does not write the resolved value into state after unmount', async () => {
     let resolveCall: (v: unknown) => void = () => undefined;
-    mockListDestinations.mockImplementationOnce(() => new Promise((r) => (resolveCall = r)));
+    mockGetNotificationConfigs.mockImplementationOnce(() => new Promise((r) => (resolveCall = r)));
     const { result, unmount } = renderHook(() => useDestinations({ dsId: 'ds-1' }));
     unmount();
     resolveCall({

--- a/public/components/alerting/hooks/use_destinations.ts
+++ b/public/components/alerting/hooks/use_destinations.ts
@@ -54,7 +54,7 @@ export function useDestinations({
     setError(null);
     (async () => {
       try {
-        const result = await service.listDestinations(dsId);
+        const result = await service.getNotificationConfigs(dsId);
         if (!cancelled) {
           setDestinations(result.destinations);
           setTotalDestinations(result.totalDestinations);

--- a/public/components/alerting/query_services/__tests__/alerting_opensearch_service.test.ts
+++ b/public/components/alerting/query_services/__tests__/alerting_opensearch_service.test.ts
@@ -116,4 +116,47 @@ describe('AlertingOpenSearchService', () => {
       });
     });
   });
+
+  describe('getNotificationConfigs', () => {
+    it('calls /api/notifications/get_configs with channel-type filters', async () => {
+      mockGet.mockResolvedValueOnce({
+        config_list: [
+          {
+            config_id: 'ch-1',
+            config: { name: 'channel-1', config_type: 'sns', is_enabled: true },
+          },
+        ],
+        total_hits: 1,
+      });
+      const svc = new AlertingOpenSearchService();
+      const result = await svc.getNotificationConfigs('ds-1');
+
+      expect(mockGet).toHaveBeenCalledTimes(1);
+      expect(mockGet.mock.calls[0][0]).toBe('/api/notifications/get_configs');
+      const query = mockGet.mock.calls[0][1].query;
+      expect(query.dataSourceId).toBe('ds-1');
+      expect(query.config_type).toContain('slack');
+      expect(query.config_type).toContain('sns');
+      expect(result.destinations).toEqual([{ id: 'ch-1', name: 'channel-1', type: 'sns' }]);
+      expect(result.totalDestinations).toBe(1);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('omits dataSourceId for the synthetic local-cluster id', async () => {
+      mockGet.mockResolvedValueOnce({ config_list: [], total_hits: 0 });
+      const svc = new AlertingOpenSearchService();
+      await svc.getNotificationConfigs('local-cluster');
+
+      const query = mockGet.mock.calls[0][1].query;
+      expect(query).not.toHaveProperty('dataSourceId');
+    });
+
+    it('does not fall back to the legacy alerting destinations route on failure', async () => {
+      mockGet.mockRejectedValueOnce(new Error('get_configs failed'));
+      const svc = new AlertingOpenSearchService();
+
+      await expect(svc.getNotificationConfigs('ds-1')).rejects.toThrow('get_configs failed');
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/public/components/alerting/query_services/alerting_opensearch_service.ts
+++ b/public/components/alerting/query_services/alerting_opensearch_service.ts
@@ -103,27 +103,48 @@ export class AlertingOpenSearchService {
   }
 
   /**
-   * List notification destinations for a datasource. Used by the create/edit
-   * flyout to populate the action destination picker. Returns a thin
+   * List notification channel configs for a datasource. Used by the
+   * create/edit flyout to populate the action channel picker. Returns a thin
    * summary — id, name, and type are all the picker needs.
    *
-   * The upstream alerting API isn't paginated; the server caps at size=200
-   * and surfaces `truncated`/`totalDestinations` so the UI can hint when
-   * older entries are unreachable.
+   * Calls `/api/notifications/get_configs` — the notifications-dashboards
+   * plugin's own route (the same one alerting-dashboards-plugin uses for its
+   * channel picker). It carries the correct per-environment client routing
+   * (MDS-aware). The legacy alerting destinations APIs were removed in the
+   * 3.0 release and are intentionally not used here.
    */
-  async listDestinations(dsId: string): Promise<DestinationsListResult> {
-    const resp = (await this.requireHttp().get(
-      `/api/alerting/opensearch/${encodeURIComponent(dsId)}/destinations`
-    )) as {
-      destinations: DestinationSummary[];
-      totalDestinations?: number;
-      truncated?: boolean;
+  async getNotificationConfigs(dsId: string): Promise<DestinationsListResult> {
+    const configTypes = ['slack', 'chime', 'webhook', 'email', 'sns', 'microsoft_teams'];
+    // The synthetic local-cluster ids aren't MDS data-source saved objects;
+    // the notifications route addresses the local cluster by omitting the
+    // dataSourceId param entirely.
+    const isLocalCluster = dsId === 'local-cluster' || dsId === 'local_cluster';
+    const query: Record<string, string | string[]> = {
+      ...(isLocalCluster ? {} : { dataSourceId: dsId }),
+      from_index: '0',
+      max_items: '5000',
+      sort_field: 'name',
+      sort_order: 'asc',
+      config_type: configTypes,
     };
-    const destinations = resp.destinations || [];
+    const resp = (await this.requireHttp().get('/api/notifications/get_configs', {
+      query,
+    })) as {
+      config_list?: Array<{
+        config_id: string;
+        config?: { name?: string; config_type?: string; is_enabled?: boolean };
+      }>;
+      total_hits?: number;
+    };
+    const destinations: DestinationSummary[] = (resp.config_list || []).map((item) => ({
+      id: item.config_id || '',
+      name: item.config?.name || '',
+      type: item.config?.config_type || 'custom_webhook',
+    }));
     return {
       destinations,
-      totalDestinations: resp.totalDestinations ?? destinations.length,
-      truncated: resp.truncated ?? false,
+      totalDestinations: resp.total_hits ?? destinations.length,
+      truncated: (resp.total_hits ?? 0) > destinations.length,
     };
   }
 


### PR DESCRIPTION
### Description

Fixes the notification channel picker in the PPL alerting rule flyout (Create/Edit logs rule) showing no channels even when channels exist on the datasource.

**Root cause**

The picker's service method only called the plugin's backend route (`/api/alerting/opensearch/{dsId}/destinations`), which relies on the OSD server-side client reaching the Notifications plugin REST API directly. In some deployments that call fails or returns empty, leaving the picker permanently blank — the browser never issues a `get_configs` request at all. The route also lives under the legacy alerting "destinations" naming; the alerting destinations APIs were removed in the 3.0 release, so nothing should be built on that path.

**Fix**

- Renamed `listDestinations` → `getNotificationConfigs` to reflect what it actually fetches.
- It now calls only `GET /api/notifications/get_configs` — the notifications-dashboards plugin's own route (the same one alerting-dashboards-plugin uses for its channel picker), which carries the correct per-environment (MDS-aware) client routing. There is no fallback to the alerting destinations route.
- The synthetic `local-cluster` / `local_cluster` ids omit the `dataSourceId` query param, matching how the notifications route addresses the local cluster.
- Errors from `get_configs` propagate directly to the picker's inline error state.

**Before:** channel dropdown empty, no `get_configs` call in the network tab.
**After:** channels load via `get_configs` (`config_type=slack|chime|webhook|email|sns|microsoft_teams`, sorted by name), same as the classic alerting UI.

Note: the now-unused server-side `/api/alerting/opensearch/{dsId}/destinations` route and `osBackend.getDestinations` are left in place to keep this diff focused; happy to remove them here or in a follow-up.

### Testing

- Unit tests for `getNotificationConfigs`: request shape and channel-type filters, `dataSourceId` omission for local-cluster ids, and that a `get_configs` failure propagates without any call to the legacy destinations route.
- Updated `use_destinations` hook tests to the renamed method; 17 tests pass across both suites.
- Verified manually against a managed OpenSearch domain: the picker now lists the configured SNS channel that previously did not appear.
<img width="3456" height="2234" alt="Image 8-27-26 at 4 55 PM" src="https://github.com/user-attachments/assets/8d228d4f-03da-40a6-a69e-afefea96d71b" />


### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] All tests pass, including unit test, integration test and doctest
- [x] Commits are signed per the DCO using `--signoff`



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
