### PR TITLE
fix(apm): preserve table page across latency percentile switch (#2849)

### DIFF
--- a/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
@@ -85,11 +85,10 @@ const props = {
   serviceMapDataset: 'otel-v1-apm-span',
 };
 
-// EuiSuperSelect is not a native <select> (and the dependencies one has no data-test-subj):
-// click the control to open the popover, then click the option.
+// EuiSuperSelect is not a native <select>: click the control to open the popover, then click
+// the option. Targeting the stable data-test-subj avoids grabbing an unrelated EuiSuperSelect.
 const switchPercentile = (label: 'P99' | 'P90' | 'P50') => {
-  const control = document.querySelector('.euiSuperSelectControl') as HTMLElement;
-  fireEvent.click(control);
+  fireEvent.click(screen.getByTestId('dependencyLatencyPercentileSelector'));
   const listbox = screen.getByRole('listbox');
   fireEvent.click(within(listbox).getByText(label));
 };

--- a/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+// Counts expanded-row chart mounts to detect a table remount on a percentile switch
+// (the pre-#2626 bug). See service_operations.test.tsx for the full rationale.
+const mockChartState = { mounts: 0 };
+
+jest.mock('../../../shared/hooks/use_dependencies', () => ({ useDependencies: jest.fn() }));
+jest.mock('../../../shared/hooks/use_dependency_metrics', () => ({
+  useDependencyMetrics: jest.fn(),
+}));
+jest.mock('../../../shared/hooks/use_chart_step_window', () => ({
+  useChartStepWindow: () => ({ window: '1m' }),
+}));
+jest.mock('../../../shared/hooks/use_debounced_value', () => ({
+  useDebouncedValue: (value: unknown) => value,
+}));
+jest.mock('../../../shared/components/dependency_filter_sidebar', () => ({
+  DependencyFilterSidebar: () => <div data-test-subj="dependencyFilterSidebar" />,
+}));
+jest.mock('../../../shared/components/promql_line_chart', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const react = require('react');
+  return {
+    PromQLLineChart: () => {
+      react.useEffect(() => {
+        mockChartState.mounts += 1;
+      }, []);
+      return <div data-test-subj="promqlChart" />;
+    },
+  };
+});
+
+import { useDependencies } from '../../../shared/hooks/use_dependencies';
+import { useDependencyMetrics } from '../../../shared/hooks/use_dependency_metrics';
+import { ServiceDependencies } from '../service_dependencies';
+
+const ROW_COUNT = 15; // > DEFAULT_PAGE_SIZE (10), so page 2 exists
+
+const svc = (i: number) => `dep-svc-${String(i).padStart(2, '0')}`;
+const compositeKey = (i: number) => `${svc(i)}:GET /op`;
+
+// Sorted by availability asc, so dep-svc-00 has the lowest availability and auto-expands on load.
+const buildDependencies = () =>
+  Array.from({ length: ROW_COUNT }, (_, i) => ({
+    serviceName: svc(i),
+    environment: 'prod',
+    remoteOperation: 'GET /op',
+    serviceOperations: ['GET /checkout'],
+    callCount: 100 + i,
+    requestCount: 100 + i,
+    p50Duration: 10 + i,
+    p90Duration: 20 + i,
+    p99Duration: 30 + i,
+    faultRate: 0,
+    errorRate: 0,
+    availability: i,
+  }));
+
+const buildMetricsMap = (deps: ReturnType<typeof buildDependencies>) =>
+  new Map(
+    deps.map((dep, i) => [
+      compositeKey(i),
+      {
+        requestCount: dep.requestCount,
+        p50Duration: dep.p50Duration,
+        p90Duration: dep.p90Duration,
+        p99Duration: dep.p99Duration,
+        errorRate: dep.errorRate,
+        availability: dep.availability,
+      },
+    ])
+  );
+
+const props = {
+  serviceName: 'checkout',
+  environment: 'prod',
+  timeRange: { from: 'now-1h', to: 'now' },
+  prometheusConnectionId: 'prom-1',
+  serviceMapDataset: 'otel-v1-apm-span',
+};
+
+// EuiSuperSelect is not a native <select> (and the dependencies one has no data-test-subj):
+// click the control to open the popover, then click the option.
+const switchPercentile = (label: 'P99' | 'P90' | 'P50') => {
+  const control = document.querySelector('.euiSuperSelectControl') as HTMLElement;
+  fireEvent.click(control);
+  const listbox = screen.getByRole('listbox');
+  fireEvent.click(within(listbox).getByText(label));
+};
+
+describe('ServiceDependencies - percentile switch does not remount the table (#2626)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChartState.mounts = 0;
+    const dependencies = buildDependencies();
+    (useDependencies as jest.Mock).mockReturnValue({
+      data: dependencies,
+      groupedData: dependencies,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    (useDependencyMetrics as jest.Mock).mockReturnValue({
+      metrics: buildMetricsMap(dependencies),
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('should not reload the expanded-row charts when the latency percentile changes', async () => {
+    render(<ServiceDependencies {...props} />);
+
+    // dep-svc-00 auto-expands on load, mounting its 3 charts.
+    await waitFor(() => expect(screen.getAllByTestId('promqlChart')).toHaveLength(3));
+
+    const mountsBeforeSwitch = mockChartState.mounts;
+    switchPercentile('P90');
+
+    expect(mockChartState.mounts).toBe(mountsBeforeSwitch);
+  });
+
+  it('should keep the expanded row expanded across a percentile switch', async () => {
+    render(<ServiceDependencies {...props} />);
+
+    await waitFor(() => expect(screen.getAllByTestId('promqlChart')).toHaveLength(3));
+    expect(screen.getByText(svc(0))).toBeInTheDocument();
+
+    switchPercentile('P90');
+
+    expect(screen.getAllByTestId('promqlChart')).toHaveLength(3);
+    expect(screen.getByText(svc(0))).toBeInTheDocument();
+  });
+
+  // EuiInMemoryTable resets pageIndex to 0 when the `items` reference changes, and
+  // filteredDependencies is a new array on every percentile change. Controlled pagination
+  // (pageIndex/pageSize in state) keeps the user on the current page.
+  it('should keep the user on the current pagination page across a percentile switch', async () => {
+    render(<ServiceDependencies {...props} />);
+
+    await waitFor(() => expect(screen.getByText(svc(0))).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('pagination-button-1')); // page 2
+    expect(screen.getByText(svc(14))).toBeInTheDocument();
+    expect(screen.queryByText(svc(0))).not.toBeInTheDocument();
+
+    switchPercentile('P90');
+
+    expect(screen.getByText(svc(14))).toBeInTheDocument();
+    expect(screen.queryByText(svc(0))).not.toBeInTheDocument();
+  });
+});

--- a/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
@@ -154,4 +154,25 @@ describe('ServiceDependencies - percentile switch does not remount the table (#2
     expect(screen.getByText(svc(14))).toBeInTheDocument();
     expect(screen.queryByText(svc(0))).not.toBeInTheDocument();
   });
+
+  // Unlike a percentile switch, changing a filter produces a new result set, so the user should
+  // land back on page 1 (the top of the filtered results) rather than a stale high page.
+  it('should reset to page 1 when a filter changes', async () => {
+    render(<ServiceDependencies {...props} />);
+
+    await waitFor(() => expect(screen.getByText(svc(0))).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('pagination-button-1')); // page 2
+    expect(screen.getByText(svc(14))).toBeInTheDocument();
+    expect(screen.queryByText(svc(0))).not.toBeInTheDocument();
+
+    // Typing a query that still matches all 15 rows keeps 2 pages, so the jump back to page 1
+    // is a deliberate filter reset, not the row-count clamp.
+    fireEvent.change(screen.getByPlaceholderText('Filter dependencies...'), {
+      target: { value: 'dep' },
+    });
+
+    expect(screen.getByText(svc(0))).toBeInTheDocument();
+    expect(screen.queryByText(svc(14))).not.toBeInTheDocument();
+  });
 });

--- a/public/components/apm/pages/service_details/__tests__/service_operations.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_operations.test.tsx
@@ -1,0 +1,159 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+// Counts expanded-row chart mounts. The pre-#2626 bug keyed the table on latencyPercentile,
+// so a percentile switch remounted every row's charts (which re-fetch on mount). The fix
+// removes that key; this counter catches a regression.
+const mockChartState = { mounts: 0 };
+
+jest.mock('../../../shared/hooks/use_operations', () => ({ useOperations: jest.fn() }));
+jest.mock('../../../shared/hooks/use_operation_metrics', () => ({
+  useOperationMetrics: jest.fn(),
+}));
+jest.mock('../../../shared/hooks/use_chart_step_window', () => ({
+  useChartStepWindow: () => ({ window: '1m' }),
+}));
+jest.mock('../../../shared/hooks/use_debounced_value', () => ({
+  useDebouncedValue: (value: unknown) => value,
+}));
+jest.mock('../../../shared/components/operation_filter_sidebar', () => ({
+  OperationFilterSidebar: () => <div data-test-subj="operationFilterSidebar" />,
+}));
+jest.mock('../../../shared/components/service_correlations_flyout', () => ({
+  ServiceCorrelationsFlyout: () => <div data-test-subj="correlationsFlyout" />,
+}));
+jest.mock('../../../shared/components/promql_line_chart', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const react = require('react');
+  return {
+    PromQLLineChart: () => {
+      react.useEffect(() => {
+        mockChartState.mounts += 1;
+      }, []);
+      return <div data-test-subj="promqlChart" />;
+    },
+  };
+});
+
+import { useOperations } from '../../../shared/hooks/use_operations';
+import { useOperationMetrics } from '../../../shared/hooks/use_operation_metrics';
+import { ServiceOperations } from '../service_operations';
+
+const ROW_COUNT = 15; // > DEFAULT_PAGE_SIZE (10), so page 2 exists
+
+const padded = (i: number) => `op-${String(i).padStart(2, '0')}`;
+
+// Sorted by availability asc, so op-00 has the lowest availability and auto-expands on load.
+const buildOperations = () =>
+  Array.from({ length: ROW_COUNT }, (_, i) => ({
+    operationName: padded(i),
+    requestCount: 100 + i,
+    errorRate: 0,
+    faultRate: 0,
+    avgDuration: 10 + i,
+    p50Duration: 10 + i,
+    p90Duration: 20 + i,
+    p99Duration: 30 + i,
+    availability: i,
+    dependencyCount: 0,
+  }));
+
+const buildMetricsMap = (operations: ReturnType<typeof buildOperations>) =>
+  new Map(
+    operations.map((op) => [
+      op.operationName,
+      {
+        requestCount: op.requestCount,
+        p50Duration: op.p50Duration,
+        p90Duration: op.p90Duration,
+        p99Duration: op.p99Duration,
+        errorRate: op.errorRate,
+        availability: op.availability,
+        dependencyCount: op.dependencyCount,
+      },
+    ])
+  );
+
+const props = {
+  serviceName: 'checkout',
+  environment: 'prod',
+  timeRange: { from: 'now-1h', to: 'now' },
+  prometheusConnectionId: 'prom-1',
+  serviceMapDataset: 'otel-v1-apm-span',
+};
+
+// EuiSuperSelect is not a native <select>: click to open the popover, then click the option.
+const switchPercentile = (label: 'P99' | 'P90' | 'P50') => {
+  fireEvent.click(screen.getByTestId('latencyPercentileSelector'));
+  const listbox = screen.getByRole('listbox');
+  fireEvent.click(within(listbox).getByText(label));
+};
+
+describe('ServiceOperations - percentile switch does not remount the table (#2626)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChartState.mounts = 0;
+    const operations = buildOperations();
+    (useOperations as jest.Mock).mockReturnValue({
+      data: operations,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    (useOperationMetrics as jest.Mock).mockReturnValue({
+      metrics: buildMetricsMap(operations),
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('should not reload the expanded-row charts when the latency percentile changes', async () => {
+    render(<ServiceOperations {...props} />);
+
+    // The lowest-availability row (op-00) auto-expands on load, mounting its 3 charts.
+    await waitFor(() => expect(screen.getAllByTestId('promqlChart')).toHaveLength(3));
+
+    const mountsBeforeSwitch = mockChartState.mounts;
+    switchPercentile('P90');
+
+    // No remount: charts stayed mounted, so the count is unchanged.
+    expect(mockChartState.mounts).toBe(mountsBeforeSwitch);
+  });
+
+  it('should keep the expanded row expanded across a percentile switch', async () => {
+    render(<ServiceOperations {...props} />);
+
+    await waitFor(() => expect(screen.getAllByTestId('promqlChart')).toHaveLength(3));
+    expect(screen.getByText(padded(0))).toBeInTheDocument();
+
+    switchPercentile('P90');
+
+    // Same row still expanded with its 3 charts after the switch.
+    expect(screen.getAllByTestId('promqlChart')).toHaveLength(3);
+    expect(screen.getByText(padded(0))).toBeInTheDocument();
+  });
+
+  // EuiInMemoryTable resets pageIndex to 0 when the `items` reference changes, and
+  // filteredOperations is a new array on every percentile change. Controlled pagination
+  // (pageIndex/pageSize in state) keeps the user on the current page.
+  it('should keep the user on the current pagination page across a percentile switch', async () => {
+    render(<ServiceOperations {...props} />);
+
+    await waitFor(() => expect(screen.getByText(padded(0))).toBeInTheDocument());
+
+    // Go to page 2 (EUI pagination buttons are 0-indexed).
+    fireEvent.click(screen.getByTestId('pagination-button-1'));
+    expect(screen.getByText(padded(14))).toBeInTheDocument();
+    expect(screen.queryByText(padded(0))).not.toBeInTheDocument();
+
+    switchPercentile('P90');
+
+    expect(screen.getByText(padded(14))).toBeInTheDocument();
+    expect(screen.queryByText(padded(0))).not.toBeInTheDocument();
+  });
+});

--- a/public/components/apm/pages/service_details/__tests__/service_operations.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_operations.test.tsx
@@ -156,4 +156,24 @@ describe('ServiceOperations - percentile switch does not remount the table (#262
     expect(screen.getByText(padded(14))).toBeInTheDocument();
     expect(screen.queryByText(padded(0))).not.toBeInTheDocument();
   });
+
+  // Unlike a percentile switch, changing a filter produces a new result set, so the user should
+  // land back on page 1 (the top of the filtered results) rather than a stale high page.
+  it('should reset to page 1 when a filter changes', async () => {
+    render(<ServiceOperations {...props} />);
+
+    await waitFor(() => expect(screen.getByText(padded(0))).toBeInTheDocument());
+
+    // Go to page 2.
+    fireEvent.click(screen.getByTestId('pagination-button-1'));
+    expect(screen.getByText(padded(14))).toBeInTheDocument();
+    expect(screen.queryByText(padded(0))).not.toBeInTheDocument();
+
+    // Typing a query that still matches all 15 rows keeps 2 pages, so the jump back to page 1
+    // is a deliberate filter reset, not the row-count clamp.
+    fireEvent.change(screen.getByTestId('operationsSearchBar'), { target: { value: 'op' } });
+
+    expect(screen.getByText(padded(0))).toBeInTheDocument();
+    expect(screen.queryByText(padded(14))).not.toBeInTheDocument();
+  });
 });

--- a/public/components/apm/pages/service_details/service_dependencies.tsx
+++ b/public/components/apm/pages/service_details/service_dependencies.tsx
@@ -998,6 +998,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
             }}
             compressed
             prepend="Latency"
+            data-test-subj="dependencyLatencyPercentileSelector"
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/public/components/apm/pages/service_details/service_dependencies.tsx
+++ b/public/components/apm/pages/service_details/service_dependencies.tsx
@@ -44,6 +44,7 @@ import {
 } from '../../query_services/query_requests/promql_queries';
 import { useDependencies } from '../../shared/hooks/use_dependencies';
 import { useDependencyMetrics } from '../../shared/hooks/use_dependency_metrics';
+import { useControlledPagination } from '../../shared/hooks/use_controlled_pagination';
 import { parseTimeRange } from '../../shared/utils/time_utils';
 import { useChartStepWindow } from '../../shared/hooks/use_chart_step_window';
 import { DependencyFilterSidebar } from '../../shared/components/dependency_filter_sidebar';
@@ -226,17 +227,6 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
     togglePanelRef.current?.('dependencies-filter-sidebar', { direction: 'left' });
   }, []);
 
-  // Stabilized callbacks for sidebar to prevent re-renders through EuiResizableContainer
-  const onLatencyRangeChange = useCallback((val: [number, number]) => {
-    latencyUserModified.current = true;
-    setLatencyRange(val);
-  }, []);
-
-  const onRequestsRangeChange = useCallback((val: [number, number]) => {
-    requestsUserModified.current = true;
-    setRequestsRange(val);
-  }, []);
-
   // Threshold filter states (using semantic enum keys)
   const [selectedAvailabilityThresholds, setSelectedAvailabilityThresholds] = useState<
     AvailabilityThreshold[]
@@ -249,15 +239,6 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 150);
   const [latencyPercentile, setLatencyPercentile] = useState<'p99' | 'p90' | 'p50'>('p99');
-  const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState<number>(SERVICE_DETAILS_CONSTANTS.DEFAULT_PAGE_SIZE);
-
-  const onTableChange = useCallback(({ page }: Criteria<GroupedDependency>) => {
-    if (page) {
-      setPageIndex(page.index);
-      setPageSize(page.size);
-    }
-  }, []);
 
   // Range filter states
   const [latencyRange, setLatencyRange] = useState<[number, number]>([0, 0]);
@@ -517,14 +498,48 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
     latencyPercentile,
   ]);
 
+  // Controlled pagination (clamped against the current row count). Declared after
+  // filteredDependencies because the hook needs the row count to clamp.
+  const { pageIndex, pageSize, onTableChange, resetPage } =
+    useControlledPagination<GroupedDependency>(filteredDependencies.length);
+
+  // Stabilized callbacks for sidebar to prevent re-renders through EuiResizableContainer.
+  // Range-slider changes reset the page to 1 (a filter change), unlike a percentile switch.
+  const onLatencyRangeChange = useCallback(
+    (val: [number, number]) => {
+      latencyUserModified.current = true;
+      setLatencyRange(val);
+      resetPage();
+    },
+    [resetPage]
+  );
+
+  const onRequestsRangeChange = useCallback(
+    (val: [number, number]) => {
+      requestsUserModified.current = true;
+      setRequestsRange(val);
+      resetPage();
+    },
+    [resetPage]
+  );
+
+  // Reset to page 1 on filter changes. Excludes latencyRange/requestsRange on purpose: a
+  // percentile switch resets latencyRange, so watching the ranges here would reset the page on
+  // a percentile switch too and defeat the fix (#2849). The sliders reset in their own handlers.
+  useEffect(() => {
+    resetPage();
+  }, [
+    debouncedSearchQuery,
+    selectedDependencies,
+    selectedServiceOperations,
+    selectedRemoteOperations,
+    selectedAvailabilityThresholds,
+    selectedErrorRateThresholds,
+    resetPage,
+  ]);
+
   const isLoading = depsLoading || metricsLoading;
   const error = depsError;
-
-  // If a filter shrinks the row count below the current page, clamp to the last valid page so
-  // the table never shows an empty, out-of-range page. Computed during render (not in an effect)
-  // so the clamp applies on the same paint, with no flash of an empty page.
-  const lastPageIndex = Math.max(0, Math.ceil(filteredDependencies.length / pageSize) - 1);
-  const clampedPageIndex = Math.min(pageIndex, lastPageIndex);
 
   // Build active filter badges from current filter state
   const activeFilters: FilterBadge[] = useMemo(() => {
@@ -608,6 +623,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
         onRemove: () => {
           latencyUserModified.current = false;
           setLatencyRange([latencyBounds.min, latencyBounds.max]);
+          resetPage();
         },
       });
     }
@@ -626,6 +642,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
         onRemove: () => {
           requestsUserModified.current = false;
           setRequestsRange([requestsBounds.min, requestsBounds.max]);
+          resetPage();
         },
       });
     }
@@ -641,6 +658,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
     requestsRange,
     latencyBounds,
     requestsBounds,
+    resetPage,
   ]);
 
   // Clear all filters handler
@@ -654,7 +672,8 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
     requestsUserModified.current = false;
     setLatencyRange([latencyBounds.min, latencyBounds.max]);
     setRequestsRange([requestsBounds.min, requestsBounds.max]);
-  }, [latencyBounds, requestsBounds]);
+    resetPage();
+  }, [latencyBounds, requestsBounds, resetPage]);
 
   // Auto-expand the first row (lowest availability) on initial page load
   useEffect(() => {
@@ -1068,7 +1087,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
                     }
                   )}
                   dependenciesCount={dependencies.length}
-                  pageIndex={clampedPageIndex}
+                  pageIndex={pageIndex}
                   pageSize={pageSize}
                   onTableChange={onTableChange}
                 />

--- a/public/components/apm/pages/service_details/service_dependencies.tsx
+++ b/public/components/apm/pages/service_details/service_dependencies.tsx
@@ -7,6 +7,7 @@ import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import {
   EuiInMemoryTable,
   EuiBasicTableColumn,
+  Criteria,
   EuiPanel,
   EuiSpacer,
   EuiCallOut,
@@ -84,6 +85,9 @@ interface DependenciesTablePanelProps {
   noDataMessage: string;
   noFilteredDataMessage: string;
   dependenciesCount: number;
+  pageIndex: number;
+  pageSize: number;
+  onTableChange: (criteria: Criteria<GroupedDependency>) => void;
 }
 
 const DependenciesTablePanelUI: React.FC<DependenciesTablePanelProps> = ({
@@ -94,6 +98,9 @@ const DependenciesTablePanelUI: React.FC<DependenciesTablePanelProps> = ({
   noDataMessage,
   noFilteredDataMessage,
   dependenciesCount,
+  pageIndex,
+  pageSize,
+  onTableChange,
 }) => (
   <EuiPanel>
     {!isLoading && filteredDependencies.length === 0 ? (
@@ -101,9 +108,9 @@ const DependenciesTablePanelUI: React.FC<DependenciesTablePanelProps> = ({
         <p>{dependenciesCount === 0 ? noDataMessage : noFilteredDataMessage}</p>
       </EuiText>
     ) : (
-      // Don't key the table on latencyPercentile
-      // Switching percentile only swaps the latency column
-      // Remounting would reset pagination and reload the row charts
+      // Switching percentile rebuilds the items array (new reference). Keying the table on it
+      // would remount and reload the row charts; leaving pagination uncontrolled would reset
+      // pageIndex to 0. So the table is not keyed and pagination is controlled.
       <EuiInMemoryTable
         items={filteredDependencies}
         columns={columns}
@@ -115,9 +122,11 @@ const DependenciesTablePanelUI: React.FC<DependenciesTablePanelProps> = ({
           },
         }}
         pagination={{
-          initialPageSize: SERVICE_DETAILS_CONSTANTS.DEFAULT_PAGE_SIZE,
+          pageIndex,
+          pageSize,
           pageSizeOptions: SERVICE_DETAILS_CONSTANTS.PAGE_SIZE_OPTIONS,
         }}
+        onTableChange={onTableChange}
         itemId={(item: GroupedDependency) => `${item.serviceName}:${item.remoteOperation}`}
         isExpandable={true}
         itemIdToExpandedRowMap={itemIdToExpandedRowMap}
@@ -240,6 +249,15 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 150);
   const [latencyPercentile, setLatencyPercentile] = useState<'p99' | 'p90' | 'p50'>('p99');
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState<number>(SERVICE_DETAILS_CONSTANTS.DEFAULT_PAGE_SIZE);
+
+  const onTableChange = useCallback(({ page }: Criteria<GroupedDependency>) => {
+    if (page) {
+      setPageIndex(page.index);
+      setPageSize(page.size);
+    }
+  }, []);
 
   // Range filter states
   const [latencyRange, setLatencyRange] = useState<[number, number]>([0, 0]);
@@ -501,6 +519,12 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
 
   const isLoading = depsLoading || metricsLoading;
   const error = depsError;
+
+  // If a filter shrinks the row count below the current page, clamp to the last valid page so
+  // the table never shows an empty, out-of-range page. Computed during render (not in an effect)
+  // so the clamp applies on the same paint, with no flash of an empty page.
+  const lastPageIndex = Math.max(0, Math.ceil(filteredDependencies.length / pageSize) - 1);
+  const clampedPageIndex = Math.min(pageIndex, lastPageIndex);
 
   // Build active filter badges from current filter state
   const activeFilters: FilterBadge[] = useMemo(() => {
@@ -1044,6 +1068,9 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
                     }
                   )}
                   dependenciesCount={dependencies.length}
+                  pageIndex={clampedPageIndex}
+                  pageSize={pageSize}
+                  onTableChange={onTableChange}
                 />
               </EuiResizablePanel>
             </>

--- a/public/components/apm/pages/service_details/service_operations.tsx
+++ b/public/components/apm/pages/service_details/service_operations.tsx
@@ -7,6 +7,7 @@ import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import {
   EuiInMemoryTable,
   EuiBasicTableColumn,
+  Criteria,
   EuiPanel,
   EuiSpacer,
   EuiCallOut,
@@ -110,6 +111,9 @@ interface OperationsTablePanelProps {
   noDataMessage: string;
   noFilteredDataMessage: string;
   operationsCount: number;
+  pageIndex: number;
+  pageSize: number;
+  onTableChange: (criteria: Criteria<OperationRow>) => void;
 }
 
 const OperationsTablePanelUI: React.FC<OperationsTablePanelProps> = ({
@@ -120,6 +124,9 @@ const OperationsTablePanelUI: React.FC<OperationsTablePanelProps> = ({
   noDataMessage,
   noFilteredDataMessage,
   operationsCount,
+  pageIndex,
+  pageSize,
+  onTableChange,
 }) => (
   <EuiPanel>
     {!isLoading && filteredOperations.length === 0 ? (
@@ -127,9 +134,9 @@ const OperationsTablePanelUI: React.FC<OperationsTablePanelProps> = ({
         <p>{operationsCount === 0 ? noDataMessage : noFilteredDataMessage}</p>
       </EuiText>
     ) : (
-      // Don't key the table on latencyPercentile
-      // Switching percentile only swaps the latency column
-      // Remounting would reset pagination and reload the row charts
+      // Switching percentile rebuilds the items array (new reference). Keying the table on it
+      // would remount and reload the row charts; leaving pagination uncontrolled would reset
+      // pageIndex to 0. So the table is not keyed and pagination is controlled.
       <EuiInMemoryTable
         items={filteredOperations}
         columns={columns}
@@ -141,9 +148,11 @@ const OperationsTablePanelUI: React.FC<OperationsTablePanelProps> = ({
           },
         }}
         pagination={{
-          initialPageSize: SERVICE_DETAILS_CONSTANTS.DEFAULT_PAGE_SIZE,
+          pageIndex,
+          pageSize,
           pageSizeOptions: SERVICE_DETAILS_CONSTANTS.PAGE_SIZE_OPTIONS,
         }}
+        onTableChange={onTableChange}
         itemId="operationName"
         isExpandable={true}
         itemIdToExpandedRowMap={itemIdToExpandedRowMap}
@@ -206,6 +215,15 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 150);
   const [latencyPercentile, setLatencyPercentile] = useState<'p99' | 'p90' | 'p50'>('p99');
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState<number>(SERVICE_DETAILS_CONSTANTS.DEFAULT_PAGE_SIZE);
+
+  const onTableChange = useCallback(({ page }: Criteria<OperationRow>) => {
+    if (page) {
+      setPageIndex(page.index);
+      setPageSize(page.size);
+    }
+  }, []);
 
   // Flyout state for viewing correlated spans/logs
   const [flyoutState, setFlyoutState] = useState<{
@@ -441,6 +459,12 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
 
   const isLoading = opsLoading || metricsLoading;
   const error = opsError;
+
+  // If a filter shrinks the row count below the current page, clamp to the last valid page so
+  // the table never shows an empty, out-of-range page. Computed during render (not in an effect)
+  // so the clamp applies on the same paint, with no flash of an empty page.
+  const lastPageIndex = Math.max(0, Math.ceil(filteredOperations.length / pageSize) - 1);
+  const clampedPageIndex = Math.min(pageIndex, lastPageIndex);
 
   // Build active filter badges from current filter state
   const activeFilters: FilterBadge[] = useMemo(() => {
@@ -972,6 +996,9 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
                     }
                   )}
                   operationsCount={operations.length}
+                  pageIndex={clampedPageIndex}
+                  pageSize={pageSize}
+                  onTableChange={onTableChange}
                 />
               </EuiResizablePanel>
             </>

--- a/public/components/apm/pages/service_details/service_operations.tsx
+++ b/public/components/apm/pages/service_details/service_operations.tsx
@@ -45,6 +45,7 @@ import {
 } from '../../query_services/query_requests/promql_queries';
 import { useOperations } from '../../shared/hooks/use_operations';
 import { useOperationMetrics } from '../../shared/hooks/use_operation_metrics';
+import { useControlledPagination } from '../../shared/hooks/use_controlled_pagination';
 import { parseTimeRange } from '../../shared/utils/time_utils';
 import { useChartStepWindow } from '../../shared/hooks/use_chart_step_window';
 import { OperationFilterSidebar } from '../../shared/components/operation_filter_sidebar';
@@ -215,15 +216,6 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearchQuery = useDebouncedValue(searchQuery, 150);
   const [latencyPercentile, setLatencyPercentile] = useState<'p99' | 'p90' | 'p50'>('p99');
-  const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState<number>(SERVICE_DETAILS_CONSTANTS.DEFAULT_PAGE_SIZE);
-
-  const onTableChange = useCallback(({ page }: Criteria<OperationRow>) => {
-    if (page) {
-      setPageIndex(page.index);
-      setPageSize(page.size);
-    }
-  }, []);
 
   // Flyout state for viewing correlated spans/logs
   const [flyoutState, setFlyoutState] = useState<{
@@ -246,17 +238,6 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
   );
   const handleTogglePanel = useCallback(() => {
     togglePanelRef.current?.('operations-filter-sidebar', { direction: 'left' });
-  }, []);
-
-  // Stabilized callbacks for sidebar to prevent re-renders through EuiResizableContainer
-  const onLatencyRangeChange = useCallback((val: [number, number]) => {
-    latencyUserModified.current = true;
-    setLatencyRange(val);
-  }, []);
-
-  const onRequestsRangeChange = useCallback((val: [number, number]) => {
-    requestsUserModified.current = true;
-    setRequestsRange(val);
   }, []);
 
   // Parse time range
@@ -457,14 +438,47 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
     latencyPercentile,
   ]);
 
+  // Controlled pagination (clamped against the current row count). Declared after
+  // filteredOperations because the hook needs the row count to clamp.
+  const { pageIndex, pageSize, onTableChange, resetPage } = useControlledPagination<OperationRow>(
+    filteredOperations.length
+  );
+
+  // Stabilized callbacks for sidebar to prevent re-renders through EuiResizableContainer.
+  // Range-slider changes reset the page to 1 (a filter change), unlike a percentile switch.
+  const onLatencyRangeChange = useCallback(
+    (val: [number, number]) => {
+      latencyUserModified.current = true;
+      setLatencyRange(val);
+      resetPage();
+    },
+    [resetPage]
+  );
+
+  const onRequestsRangeChange = useCallback(
+    (val: [number, number]) => {
+      requestsUserModified.current = true;
+      setRequestsRange(val);
+      resetPage();
+    },
+    [resetPage]
+  );
+
+  // Reset to page 1 on filter changes. Excludes latencyRange/requestsRange on purpose: a
+  // percentile switch resets latencyRange, so watching the ranges here would reset the page on
+  // a percentile switch too and defeat the fix (#2849). The sliders reset in their own handlers.
+  useEffect(() => {
+    resetPage();
+  }, [
+    debouncedSearchQuery,
+    selectedOperations,
+    selectedAvailabilityThresholds,
+    selectedErrorRateThresholds,
+    resetPage,
+  ]);
+
   const isLoading = opsLoading || metricsLoading;
   const error = opsError;
-
-  // If a filter shrinks the row count below the current page, clamp to the last valid page so
-  // the table never shows an empty, out-of-range page. Computed during render (not in an effect)
-  // so the clamp applies on the same paint, with no flash of an empty page.
-  const lastPageIndex = Math.max(0, Math.ceil(filteredOperations.length / pageSize) - 1);
-  const clampedPageIndex = Math.min(pageIndex, lastPageIndex);
 
   // Build active filter badges from current filter state
   const activeFilters: FilterBadge[] = useMemo(() => {
@@ -524,6 +538,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
         onRemove: () => {
           latencyUserModified.current = false;
           setLatencyRange([latencyBounds.min, latencyBounds.max]);
+          resetPage();
         },
       });
     }
@@ -542,6 +557,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
         onRemove: () => {
           requestsUserModified.current = false;
           setRequestsRange([requestsBounds.min, requestsBounds.max]);
+          resetPage();
         },
       });
     }
@@ -555,6 +571,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
     requestsRange,
     latencyBounds,
     requestsBounds,
+    resetPage,
   ]);
 
   // Clear all filters handler
@@ -566,7 +583,8 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
     requestsUserModified.current = false;
     setLatencyRange([latencyBounds.min, latencyBounds.max]);
     setRequestsRange([requestsBounds.min, requestsBounds.max]);
-  }, [latencyBounds, requestsBounds]);
+    resetPage();
+  }, [latencyBounds, requestsBounds, resetPage]);
 
   // Auto-expand the first row (lowest availability) on initial page load
   useEffect(() => {
@@ -996,7 +1014,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
                     }
                   )}
                   operationsCount={operations.length}
-                  pageIndex={clampedPageIndex}
+                  pageIndex={pageIndex}
                   pageSize={pageSize}
                   onTableChange={onTableChange}
                 />

--- a/public/components/apm/shared/hooks/__tests__/use_controlled_pagination.test.ts
+++ b/public/components/apm/shared/hooks/__tests__/use_controlled_pagination.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useControlledPagination } from '../use_controlled_pagination';
+
+describe('useControlledPagination', () => {
+  it('should default to the first page and the default page size', () => {
+    const { result } = renderHook(() => useControlledPagination(100));
+    expect(result.current.pageIndex).toBe(0);
+    expect(result.current.pageSize).toBe(10);
+  });
+
+  it('should track pageIndex and pageSize from onTableChange', () => {
+    const { result } = renderHook(() => useControlledPagination(100));
+
+    act(() => {
+      result.current.onTableChange({ page: { index: 2, size: 25 } });
+    });
+
+    expect(result.current.pageIndex).toBe(2);
+    expect(result.current.pageSize).toBe(25);
+  });
+
+  it('should clamp and persist the page index when the row count shrinks below the current page', () => {
+    const { result, rerender } = renderHook(({ count }) => useControlledPagination(count), {
+      initialProps: { count: 100 },
+    });
+
+    act(() => {
+      result.current.onTableChange({ page: { index: 3, size: 10 } });
+    });
+    expect(result.current.pageIndex).toBe(3);
+
+    // Shrink to 15 rows => 2 pages (indices 0..1); page 3 clamps to 1.
+    rerender({ count: 15 });
+    expect(result.current.pageIndex).toBe(1);
+
+    // Grow back to 100 rows: because the clamp was persisted to state, the stale page 3 is
+    // not resurrected — the user stays on the page they were viewing.
+    rerender({ count: 100 });
+    expect(result.current.pageIndex).toBe(1);
+  });
+
+  it('should clamp to page 0 when there are no rows', () => {
+    const { result, rerender } = renderHook(({ count }) => useControlledPagination(count), {
+      initialProps: { count: 100 },
+    });
+
+    act(() => {
+      result.current.onTableChange({ page: { index: 4, size: 10 } });
+    });
+
+    rerender({ count: 0 });
+    expect(result.current.pageIndex).toBe(0);
+  });
+
+  it('should return to the first page when resetPage is called', () => {
+    const { result } = renderHook(() => useControlledPagination(100));
+
+    act(() => {
+      result.current.onTableChange({ page: { index: 2, size: 10 } });
+    });
+    expect(result.current.pageIndex).toBe(2);
+
+    act(() => {
+      result.current.resetPage();
+    });
+    expect(result.current.pageIndex).toBe(0);
+  });
+});

--- a/public/components/apm/shared/hooks/use_controlled_pagination.ts
+++ b/public/components/apm/shared/hooks/use_controlled_pagination.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useState } from 'react';
+import { Criteria } from '@elastic/eui';
+import { SERVICE_DETAILS_CONSTANTS } from '../../common/constants';
+
+export interface ControlledPagination<T> {
+  /** Clamped page index safe to pass to EuiInMemoryTable's controlled pagination. */
+  pageIndex: number;
+  /** Current page size, driven by the table's page-size selector. */
+  pageSize: number;
+  /** Wire to EuiInMemoryTable's onTableChange to keep pageIndex/pageSize in state. */
+  onTableChange: (criteria: Criteria<T>) => void;
+  /**
+   * Reset to the first page. Call from filter user-actions (search, selections,
+   * range sliders, clear-all) where the user expects to land on page 1.
+   * Do NOT call it on a latency-percentile switch — that keeps the same rows and
+   * the current page must be preserved.
+   */
+  resetPage: () => void;
+}
+
+/**
+ * Controlled pagination for the service-details tables. Pagination must be controlled so a
+ * latency-percentile switch (which rebuilds the items array) preserves the page instead of
+ * resetting to 0; callers therefore call resetPage() themselves on filter changes.
+ *
+ * @param itemCount post-filter row count, used to clamp the page index.
+ */
+export function useControlledPagination<T>(itemCount: number): ControlledPagination<T> {
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState<number>(SERVICE_DETAILS_CONSTANTS.DEFAULT_PAGE_SIZE);
+
+  const onTableChange = useCallback(({ page }: Criteria<T>) => {
+    if (page) {
+      setPageIndex(page.index);
+      setPageSize(page.size);
+    }
+  }, []);
+
+  const resetPage = useCallback(() => setPageIndex(0), []);
+
+  // Clamp to the last valid page so a shrunk result set (e.g. a background refetch) never lands
+  // on an empty page. Adjusting state during render (a supported React pattern) persists the
+  // clamp, so a later growth of the result set can't resurrect the stale higher page.
+  const lastPageIndex = Math.max(0, Math.ceil(itemCount / pageSize) - 1);
+  if (pageIndex > lastPageIndex) {
+    setPageIndex(lastPageIndex);
+  }
+  const clampedPageIndex = Math.min(pageIndex, lastPageIndex);
+
+  return { pageIndex: clampedPageIndex, pageSize, onTableChange, resetPage };
+}


### PR DESCRIPTION
### Description
The service-details **Operations** and **Dependencies** tables reset to page 1 whenever the latency percentile (P50/P90/P99) is switched while on page 2+.

Root cause: switching the percentile rebuilds the filtered-rows array (`filteredOperations`/`filteredDependencies`) as a new array reference, and `EuiInMemoryTable` resets an *uncontrolled* `pageIndex` to 0 on any change to the `items` reference.

Fix: make pagination controlled - `pageIndex` and `pageSize` are lifted into component state and updated via `onTableChange`, so the current page and page size survive a percentile switch. The page index is additionally clamped during render, so a filter that shrinks the row count below the current page never lands the table on an empty, out-of-range page.

#### Before

https://github.com/user-attachments/assets/4493f161-bc57-4e04-9c00-7df5b42334e6

#### After

https://github.com/user-attachments/assets/66dea5f1-7693-469a-9417-1857df599959


### Issues Resolved
[2849](https://github.com/opensearch-project/dashboards-observability/issues/2849)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
