### PR TITLE
fix link checker: replace nonexistent PR #2674 link with commit link

### DIFF
--- a/release-notes/opensearch-dashboards-observability.release-notes-3.7.0.0.md
+++ b/release-notes/opensearch-dashboards-observability.release-notes-3.7.0.0.md
@@ -31,7 +31,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.7.0
 
 ### Maintenance
 
-* Fix typo in application deletion error toast: "occured" → "occurred" ([#2674](https://github.com/opensearch-project/dashboards-observability/pull/2674))
+* Fix typo in application deletion error toast: "occured" → "occurred" ([0f223f5](https://github.com/opensearch-project/dashboards-observability/commit/0f223f546c6cc9f55172253bf1bdbfb7af3cafb7))
 * Bump uuid to 3.4.0 to resolve CVE-2026-41907 in transitive dependency ([#2679](https://github.com/opensearch-project/dashboards-observability/pull/2679))
 * Improve Alerts empty state with primary Rules button and updated layout ([#2686](https://github.com/opensearch-project/dashboards-observability/pull/2686))
 * Migrate plugin to TypeScript 6.0.2 compatibility by removing conflicting dependencies ([#2652](https://github.com/opensearch-project/dashboards-observability/pull/2652))


### PR DESCRIPTION
### Description
Fixes the link-checker failure in `release-notes/opensearch-dashboards-observability.release-notes-3.7.0.0.md:34`

The release note cited [PR#2674](https://github.com/opensearch-project/dashboards-observability/issues/2674) which was deleted upstream and now returns 404, failing the link checker. The underlying commit [0f223f5](https://github.com/opensearch-project/dashboards-observability/commit/0f223f546c6cc9f55172253bf1bdbfb7af3cafb7) still exists in the repo, so I repointed the link to that commit. The checker passes and the citation is preserved. Same approach as #2688.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
