### PR TITLE
refactor: rename 'Cortex' references to 'Prometheus'

### DIFF
--- a/common/error/__tests__/redact.test.ts
+++ b/common/error/__tests__/redact.test.ts
@@ -37,7 +37,7 @@ describe('redactForDisplay', () => {
   });
 
   it('redacts FQDN-like hosts with generic infra suffixes', () => {
-    expect(redactForDisplay('lookup failed for cortex.svc.cluster.local')).toContain(
+    expect(redactForDisplay('lookup failed for prometheus.svc.cluster.local')).toContain(
       '<redacted-host>'
     );
   });

--- a/common/slo/__tests__/fake_ruler_client.ts
+++ b/common/slo/__tests__/fake_ruler_client.ts
@@ -106,7 +106,7 @@ export class FakeRulerClient implements RulerClient, SloRulerClient {
   ): Promise<void> {
     this.upsertCalls += 1;
     if (this.upsertError) throw this.upsertError;
-    // Mimic Cortex: recording rules may not carry annotations. Any rule with
+    // Mimic Prometheus: recording rules may not carry annotations. Any rule with
     // `type: 'recording'` that ships an annotation payload is a 400 the ruler
     // would reject; fail the upsert loudly so a future regression that
     // re-adds `osd_slo_recording_provenance` (or anything else) doesn't

--- a/common/slo/__tests__/slo_datasource_ref.test.ts
+++ b/common/slo/__tests__/slo_datasource_ref.test.ts
@@ -29,7 +29,7 @@ function makeDatasource(overrides: Partial<Datasource> = {}): Datasource {
     type: 'prometheus',
     url: 'http://prometheus:9090/prometheus',
     enabled: true,
-    directQueryName: 'observability_stack_cortex',
+    directQueryName: 'observability_stack_prometheus',
     ...overrides,
   };
 }
@@ -49,11 +49,11 @@ describe('resolveDatasourceRef', () => {
     expect(ref).not.toBeNull();
     expect(ref!.id).toBe('ds-4');
     expect(ref!.name).toBe('ObservabilityStack_Prometheus');
-    expect(ref!.connectionId).toBe('observability_stack_cortex');
+    expect(ref!.connectionId).toBe('observability_stack_prometheus');
     expect(ref!.forms).toEqual([
       'ds-4',
       'ObservabilityStack_Prometheus',
-      'observability_stack_cortex',
+      'observability_stack_prometheus',
     ]);
     expect(ref!.datasource).toBe(ds);
   });
@@ -66,10 +66,10 @@ describe('resolveDatasourceRef', () => {
   });
 
   it('resolves against the SQL-plugin connectionId (directQueryName)', async () => {
-    const ref = await resolveDatasourceRef('observability_stack_cortex', resolver);
+    const ref = await resolveDatasourceRef('observability_stack_prometheus', resolver);
     expect(ref).not.toBeNull();
-    expect(ref!.connectionId).toBe('observability_stack_cortex');
-    expect(ref!.forms).toContain('observability_stack_cortex');
+    expect(ref!.connectionId).toBe('observability_stack_prometheus');
+    expect(ref!.forms).toContain('observability_stack_prometheus');
   });
 
   it('returns null for unknown input (no throw)', async () => {
@@ -108,7 +108,7 @@ describe('resolveDatasourceRef', () => {
     const identicallyNamed = makeDatasource({ id: 'same', name: 'same' });
     const ref = await resolveDatasourceRef('same', buildResolver([identicallyNamed]));
     expect(ref).not.toBeNull();
-    expect(ref!.forms).toEqual(['same', 'observability_stack_cortex']);
+    expect(ref!.forms).toEqual(['same', 'observability_stack_prometheus']);
   });
 });
 
@@ -117,11 +117,11 @@ describe('refFromDatasource', () => {
     const ref = refFromDatasource(makeDatasource());
     expect(ref.id).toBe('ds-4');
     expect(ref.name).toBe('ObservabilityStack_Prometheus');
-    expect(ref.connectionId).toBe('observability_stack_cortex');
+    expect(ref.connectionId).toBe('observability_stack_prometheus');
     expect(ref.forms).toEqual([
       'ds-4',
       'ObservabilityStack_Prometheus',
-      'observability_stack_cortex',
+      'observability_stack_prometheus',
     ]);
   });
 
@@ -141,7 +141,7 @@ describe('resolveDatasourceRefs (batch)', () => {
   const ds2 = makeDatasource({
     id: 'ds-5',
     name: 'Secondary_Prometheus',
-    directQueryName: 'secondary_cortex',
+    directQueryName: 'secondary_prometheus',
   });
   const resolver = buildResolver([ds1, ds2]);
 

--- a/common/slo/__tests__/slo_service_delete_404.test.ts
+++ b/common/slo/__tests__/slo_service_delete_404.test.ts
@@ -100,7 +100,7 @@ function makeDeps() {
     enabled: true,
     directQueryName: 'prom-connection',
   };
-  const client = ({ transport: { request: jest.fn() } } as unknown) as AlertingOSClient;
+  const client = { transport: { request: jest.fn() } } as unknown as AlertingOSClient;
 
   const deploy: SloDeployContext = {
     ruler,

--- a/common/slo/__tests__/slo_service_delete_404.test.ts
+++ b/common/slo/__tests__/slo_service_delete_404.test.ts
@@ -128,7 +128,7 @@ describe('SloService.delete — ruler 404 tolerance', () => {
 
   it('ruler already succeeded on 404 (mock resolves undefined) → SO still deletes and generatedRuleNames surface', async () => {
     // Simulates the real-world case: somebody DELETE'd the rule group in
-    // Cortex out-of-band. DirectQueryRulerClient.deleteRuleGroup sees the
+    // Prometheus out-of-band. DirectQueryRulerClient.deleteRuleGroup sees the
     // 404 and resolves cleanly. The service must NOT treat this as a
     // failure; the SO tear-down continues, and the caller gets a clean
     // { deleted: true, generatedRuleNames } envelope.

--- a/common/slo/__tests__/slo_service_delete_integration.test.ts
+++ b/common/slo/__tests__/slo_service_delete_integration.test.ts
@@ -179,9 +179,9 @@ function makeHarness() {
     enabled: true,
     directQueryName: 'prom-connection',
   };
-  const client = ({
+  const client = {
     transport: { request: () => Promise.resolve({}) },
-  } as unknown) as AlertingOSClient;
+  } as unknown as AlertingOSClient;
 
   const deploy: SloDeployContext = {
     ruler,

--- a/common/slo/__tests__/slo_service_delete_integration.test.ts
+++ b/common/slo/__tests__/slo_service_delete_integration.test.ts
@@ -200,7 +200,7 @@ function makeHarness() {
 
 describe('SloService.delete — integration', () => {
   it('ruler 404-tolerant delete: group already gone → delete succeeds and SO is removed', async () => {
-    // Real-world case: out-of-band delete removed the rule group from Cortex
+    // Real-world case: out-of-band delete removed the rule group from Prometheus
     // *before* the user clicked Delete in the UI. The fake ruler's
     // `deleteRuleGroup` resolves (404-tolerant by design); the service must
     // not treat that as a failure.
@@ -235,7 +235,7 @@ describe('SloService.delete — integration', () => {
       code: 'RULER_UNREACHABLE',
     });
 
-    // SO survives so the user can retry once Cortex is back.
+    // SO survives so the user can retry once Prometheus is back.
     const preserved = await store.get(doc.id);
     expect(preserved).not.toBeNull();
     expect(preserved?.id).toBe(doc.id);

--- a/common/slo/__tests__/slo_service_repair_integration.test.ts
+++ b/common/slo/__tests__/slo_service_repair_integration.test.ts
@@ -110,9 +110,9 @@ function makeHarness() {
     enabled: true,
     directQueryName: 'prom-connection',
   };
-  const client = ({
+  const client = {
     transport: { request: () => Promise.resolve({}) },
-  } as unknown) as AlertingOSClient;
+  } as unknown as AlertingOSClient;
 
   const deploy: SloDeployContext = {
     ruler,
@@ -350,9 +350,9 @@ function makeDedupHarness() {
     enabled: true,
     directQueryName: 'prom-connection',
   };
-  const client = ({
+  const client = {
     transport: { request: () => Promise.resolve({}) },
-  } as unknown) as AlertingOSClient;
+  } as unknown as AlertingOSClient;
   const deploy: SloDeployContext = {
     ruler,
     client,

--- a/common/slo/__tests__/slo_service_repair_integration.test.ts
+++ b/common/slo/__tests__/slo_service_repair_integration.test.ts
@@ -149,7 +149,7 @@ describe('SloService.repair — integration', () => {
     const originalRuleNames = ruler.groupByName(namespace, groupName)!.rules.map((r) => r.name);
 
     // Out-of-band delete: somebody ran `DELETE /api/v1/rules/{ns}/{group}` directly
-    // on Cortex. The SO still thinks the group is there; repair should notice.
+    // on Prometheus. The SO still thinks the group is there; repair should notice.
     ruler.dropGroup(namespace, groupName);
     expect(ruler.hasGroup(namespace, groupName)).toBe(false);
 
@@ -403,7 +403,7 @@ describe('SloService.repair — dedup integration', () => {
       expect(rule.type).toBe('recording');
       expect(rule.labels?.slo_id).toBeUndefined();
       expect(rule.labels?.slo_name).toBeUndefined();
-      // Annotations on a recording rule are a Cortex 400 (the fake ruler
+      // Annotations on a recording rule are a Prometheus 400 (the fake ruler
       // also enforces this now).
       expect(rule.annotations ? Object.keys(rule.annotations).length : 0).toBe(0);
     }

--- a/common/slo/__tests__/slo_service_ruler.test.ts
+++ b/common/slo/__tests__/slo_service_ruler.test.ts
@@ -285,7 +285,7 @@ describe('SloService.delete with deploy', () => {
   it('calls ruler.deleteRuleGroup BEFORE store.delete', async () => {
     // Ruler-first, SO-second: the SO is the only pointer back to the rule
     // group's name; if we drop it first and the ruler call fails, the group
-    // lives on in Cortex forever, silently evaluating dead alerts. Ruler
+    // lives on in Prometheus forever, silently evaluating dead alerts. Ruler
     // confirmation must precede the SO removal so failures keep the SO.
     //
     // The create-via-deploy path provisions the rule group (without this,
@@ -318,7 +318,7 @@ describe('SloService.delete with deploy', () => {
     await expect(svc.delete(doc.id, deploy)).rejects.toBeInstanceOf(SloRulerError);
 
     // SO must still be there: the ruler group is still live, so the user
-    // has a path to retry after Cortex recovers.
+    // has a path to retry after Prometheus recovers.
     expect(await store.get(doc.id)).not.toBeNull();
   });
 

--- a/common/slo/__tests__/slo_service_ruler.test.ts
+++ b/common/slo/__tests__/slo_service_ruler.test.ts
@@ -139,7 +139,7 @@ function makeDeps() {
     enabled: true,
     directQueryName: 'prom-connection',
   };
-  const client = ({ transport: { request: jest.fn() } } as unknown) as AlertingOSClient;
+  const client = { transport: { request: jest.fn() } } as unknown as AlertingOSClient;
 
   const deploy: SloDeployContext = {
     ruler,

--- a/common/slo/__tests__/slo_validators.test.ts
+++ b/common/slo/__tests__/slo_validators.test.ts
@@ -211,7 +211,7 @@ describe('validateSloSpec', () => {
 
 // Custom-expr PromQL defensive checks. The character set closes the classes
 // most likely to confuse downstream parsers; the real PromQL parse happens
-// at Cortex when the rule group is upserted.
+// at Prometheus when the rule group is upserted.
 describe('validateSloSpec — custom PromQL defensive checks', () => {
   function customSpec(expr: {
     mode: 'events';

--- a/common/slo/slo_errors.ts
+++ b/common/slo/slo_errors.ts
@@ -32,7 +32,10 @@ export class SloNotFoundError extends Error {
 }
 
 export class SloVersionConflictError extends Error {
-  constructor(public readonly current: SloDocument, public readonly attemptedVersion: number) {
+  constructor(
+    public readonly current: SloDocument,
+    public readonly attemptedVersion: number
+  ) {
     super(
       `SLO version conflict: client sent version ${attemptedVersion} but server has ${current.status.version}`
     );
@@ -47,9 +50,7 @@ export class SloVersionConflictError extends Error {
  * PromQL: parse error").
  */
 export type SloRulerErrorCode =
-  | 'RULER_VALIDATION_FAILED'
-  | 'RULER_AUTH_FAILED'
-  | 'RULER_UNREACHABLE';
+  'RULER_VALIDATION_FAILED' | 'RULER_AUTH_FAILED' | 'RULER_UNREACHABLE';
 
 /**
  * Thrown when the ruler dual-write fails during SLO create / update / delete.
@@ -82,7 +83,10 @@ export class SloRulerError extends Error {
  * to force a ruler-side cleanup) before the SLO can be removed.
  */
 export class SloRulerTeardownRequiredError extends Error {
-  constructor(public readonly sloId: string, public readonly datasourceId: string) {
+  constructor(
+    public readonly sloId: string,
+    public readonly datasourceId: string
+  ) {
     super(
       `Cannot delete SLO "${sloId}": its datasource "${datasourceId}" is not registered, ` +
         `so the rule group cannot be removed from Prometheus. Re-register the datasource and retry.`

--- a/common/slo/slo_errors.ts
+++ b/common/slo/slo_errors.ts
@@ -43,7 +43,7 @@ export class SloVersionConflictError extends Error {
 /**
  * Stable error codes for ruler dual-write failures. The wizard branches on
  * `code` to render a self-service message; the raw upstream body is
- * preserved so the user can read Cortex's own diagnostic (e.g. "invalid
+ * preserved so the user can read Prometheus's own diagnostic (e.g. "invalid
  * PromQL: parse error").
  */
 export type SloRulerErrorCode =
@@ -77,7 +77,7 @@ export class SloRulerError extends Error {
  * provisioned rule group but has no deploy context — typically because the
  * SLO's `datasourceId` is no longer registered (datasource was removed or
  * renamed). Delete is ruler-first, so we refuse to drop the SO here: that
- * would leave a dangling rule group in Cortex still evaluating against the
+ * would leave a dangling rule group in Prometheus still evaluating against the
  * live cluster. The user has to restore the datasource (or the operator has
  * to force a ruler-side cleanup) before the SLO can be removed.
  */
@@ -85,7 +85,7 @@ export class SloRulerTeardownRequiredError extends Error {
   constructor(public readonly sloId: string, public readonly datasourceId: string) {
     super(
       `Cannot delete SLO "${sloId}": its datasource "${datasourceId}" is not registered, ` +
-        `so the rule group cannot be removed from Cortex. Re-register the datasource and retry.`
+        `so the rule group cannot be removed from Prometheus. Re-register the datasource and retry.`
     );
     this.name = 'SloRulerTeardownRequiredError';
   }

--- a/common/slo/slo_errors.ts
+++ b/common/slo/slo_errors.ts
@@ -78,7 +78,7 @@ export class SloRulerError extends Error {
  * provisioned rule group but has no deploy context — typically because the
  * SLO's `datasourceId` is no longer registered (datasource was removed or
  * renamed). Delete is ruler-first, so we refuse to drop the SO here: that
- * would leave a dangling rule group in Prometheus still evaluating against the
+ * would leave a dangling rule group in the ruler still evaluating against the
  * live cluster. The user has to restore the datasource (or the operator has
  * to force a ruler-side cleanup) before the SLO can be removed.
  */

--- a/common/slo/slo_lifecycle_service.ts
+++ b/common/slo/slo_lifecycle_service.ts
@@ -711,7 +711,7 @@ export class SloLifecycleService {
    * Tear down an SLO.
    *
    * The ruler-side `deleteRuleGroup` is 404-tolerant — if the rule group was
-   * already removed out-of-band (someone DELETE'd it in Cortex directly, or
+   * already removed out-of-band (someone DELETE'd it in Prometheus directly, or
    * the reconciler swept an orphan), the ruler call resolves successfully
    * and we proceed to remove the SO. This keeps a live out-of-band delete
    * from wedging the SO in an un-deletable state. Any other ruler failure
@@ -742,7 +742,7 @@ export class SloLifecycleService {
     const needsRulerTeardown =
       provisioning.backend === 'prometheus' && !!provisioning.alertGroupName;
 
-    // Ruler-first, SO-second. If the ruler delete fails (network, auth, Cortex
+    // Ruler-first, SO-second. If the ruler delete fails (network, auth, Prometheus
     // 5xx), the SO stays so the user can retry — better than silently leaking
     // a rule group that keeps evaluating dead alerts. The caller is required
     // to supply `deploy` whenever the SLO has a rule group; the route adapter
@@ -942,7 +942,7 @@ export class SloLifecycleService {
    * not creating or dropping an SLO; the ref store already reflects this
    * SLO's claim and the repair upsert is effectively a byte-equal replay.
    *
-   * Recording groups deliberately get NO annotation — Cortex rejects
+   * Recording groups deliberately get NO annotation — Prometheus rejects
    * annotations on recording rules (commit e25376c2).
    */
   private async repairDedup(doc: SloDocument, ctx: SloRepairContext): Promise<SloRepairResult> {
@@ -978,7 +978,7 @@ export class SloLifecycleService {
     // Step 1: re-upsert each unique fingerprint's shared recording group.
     // Recording-rule generation is pure in the fingerprint + representative
     // SLI, so the bytes match whatever the original create/update wrote;
-    // Cortex replaces-in-place, which is correct whether the group was
+    // Prometheus replaces-in-place, which is correct whether the group was
     // missing entirely or present with stale contents.
     const recordingFingerprints = provisioning.recordingFingerprints ?? {};
     const uniqueFps = uniqueValues(recordingFingerprints);

--- a/common/slo/slo_lifecycle_service.ts
+++ b/common/slo/slo_lifecycle_service.ts
@@ -468,8 +468,8 @@ export class SloLifecycleService {
       existing.status.provisioning.rulerNamespace
         ? existing.status.provisioning.rulerNamespace
         : deploy
-        ? sloRulerNamespaceFor(deploy.workspaceId)
-        : SLO_RULER_NAMESPACE;
+          ? sloRulerNamespaceFor(deploy.workspaceId)
+          : SLO_RULER_NAMESPACE;
 
     const updated: SloDocument = {
       id: existing.id,
@@ -549,7 +549,7 @@ export class SloLifecycleService {
     const newFingerprints = this.computeObjectiveFingerprints(merged);
     const oldFingerprints =
       existing.status.provisioning.backend === 'prometheus'
-        ? existing.status.provisioning.recordingFingerprints ?? {}
+        ? (existing.status.provisioning.recordingFingerprints ?? {})
         : {};
     const newUnique = new Set(uniqueValues(newFingerprints));
     const oldUnique = new Set(uniqueValues(oldFingerprints));

--- a/common/slo/slo_lifecycle_service.ts
+++ b/common/slo/slo_lifecycle_service.ts
@@ -711,7 +711,7 @@ export class SloLifecycleService {
    * Tear down an SLO.
    *
    * The ruler-side `deleteRuleGroup` is 404-tolerant — if the rule group was
-   * already removed out-of-band (someone DELETE'd it in Prometheus directly, or
+   * already removed out-of-band (someone DELETE'd it in the ruler directly, or
    * the reconciler swept an orphan), the ruler call resolves successfully
    * and we proceed to remove the SO. This keeps a live out-of-band delete
    * from wedging the SO in an un-deletable state. Any other ruler failure

--- a/common/slo/slo_promql_generator.ts
+++ b/common/slo/slo_promql_generator.ts
@@ -330,7 +330,7 @@ export function ensureBucketMetric(metric: string): string {
  * output stays in fixed decimal notation regardless of magnitude — using
  * `parseFloat(toPrecision)` would emit scientific notation (e.g. `"1e-7"`)
  * for very small bounds and silently miss the bucket. We pick `toFixed(9)`
- * (the smallest histogram bucket Cortex emits is `1ns = 1e-9 s`) and trim
+ * (the smallest histogram bucket Prometheus emits is `1ns = 1e-9 s`) and trim
  * trailing zeros so common bounds like `0.5`, `1`, `30` stay terse.
  */
 export function formatLatencyBoundLe(bound: number, unit: 'seconds' | 'milliseconds'): string {
@@ -589,7 +589,7 @@ function formatInterval(seconds: number): string {
 /**
  * Serialize a Prometheus rule group via `js-yaml` so the same library both
  * the wizard preview AND the ruler dual-write share — the YAML the user
- * sees in preview is the YAML Cortex receives.
+ * sees in preview is the YAML Prometheus receives.
  *
  * The homemade emitter previously open-coded escapeYaml() to handle
  * backslash and double-quote, but a literal LF/CR/TAB in `rule.labels.*`
@@ -625,7 +625,7 @@ function rulesToYaml(groupName: string, interval: number, rules: GeneratedRule[]
  * `js-yaml`. Defensive against callers passing through `undefined` or
  * non-string values via the caller-controlled provenance JSON-string
  * (`buildAlertProvenance`); without this the emitter passes the raw object
- * to js-yaml, which serializes `undefined` as YAML `null` and Cortex
+ * to js-yaml, which serializes `undefined` as YAML `null` and Prometheus
  * rejects the rule.
  */
 function stringifyMap(map: Record<string, unknown>): Record<string, string> {

--- a/common/slo/slo_rule_provenance.ts
+++ b/common/slo/slo_rule_provenance.ts
@@ -17,7 +17,7 @@
  *     but never fires (`expr: vector(0) > 1`), so the provenance surface
  *     exists regardless of the user's alerting choices.
  *
- * Recording groups are NOT annotated. Cortex/Prometheus forbid `annotations`
+ * Recording groups are NOT annotated. Prometheus forbids `annotations`
  * on recording rules (only alerting rules may carry them), so any attempt to
  * upsert a recording group with an annotation fails ruler-side with
  * `RULER_VALIDATION_FAILED`. The alert-group provenance carries enough

--- a/common/slo/slo_service_types.ts
+++ b/common/slo/slo_service_types.ts
@@ -76,7 +76,7 @@ export interface SloDeployContext {
    *
    * In production this is the canonical datasource id (`ds.id`), so the
    * recording-rule namespace is shared by every OSD workspace that targets
-   * the same Prometheus tenant. The shared namespace is the deduplication unit
+   * the same ruler tenant. The shared namespace is the deduplication unit
    * — two workspaces creating SLOs over the same SLI fingerprint share
    * one rule group on the ruler. The slo-rule-ref refcount is what
    * partitions per workspace; see `OSDWorkspaceId`.
@@ -249,7 +249,7 @@ export interface SloStatusAggregationContext {
 
 /**
  * Workspace ids accepted by `sloRulerNamespaceFor`. The value lands in a URL
- * path segment that Prometheus uses to key rule groups; allowing arbitrary text
+ * path segment that the ruler uses to key rule groups; allowing arbitrary text
  * opens path traversal, ambiguous `%`-encoded segments, and unicode-
  * normalization surprises. Mirrors the OSD saved-object id shape.
  */

--- a/common/slo/slo_service_types.ts
+++ b/common/slo/slo_service_types.ts
@@ -76,7 +76,7 @@ export interface SloDeployContext {
    *
    * In production this is the canonical datasource id (`ds.id`), so the
    * recording-rule namespace is shared by every OSD workspace that targets
-   * the same Cortex tenant. The shared namespace is the deduplication unit
+   * the same Prometheus tenant. The shared namespace is the deduplication unit
    * — two workspaces creating SLOs over the same SLI fingerprint share
    * one rule group on the ruler. The slo-rule-ref refcount is what
    * partitions per workspace; see `OSDWorkspaceId`.
@@ -249,7 +249,7 @@ export interface SloStatusAggregationContext {
 
 /**
  * Workspace ids accepted by `sloRulerNamespaceFor`. The value lands in a URL
- * path segment that Cortex uses to key rule groups; allowing arbitrary text
+ * path segment that Prometheus uses to key rule groups; allowing arbitrary text
  * opens path traversal, ambiguous `%`-encoded segments, and unicode-
  * normalization surprises. Mirrors the OSD saved-object id shape.
  */

--- a/common/slo/slo_sli_fingerprint.ts
+++ b/common/slo/slo_sli_fingerprint.ts
@@ -7,7 +7,7 @@
  * Deterministic fingerprint of an SLO's SLI definition + the objective
  * fields that materially affect the generated recording rule. Two SLOs that
  * produce identical recording-rule PromQL must produce identical fingerprints;
- * two SLOs that differ in any way that would affect what Cortex evaluates
+ * two SLOs that differ in any way that would affect what Prometheus evaluates
  * must produce different fingerprints.
  *
  * Output: 16-char lowercase hex (first 8 bytes of sha256). Chosen for

--- a/common/slo/slo_sli_fingerprint.ts
+++ b/common/slo/slo_sli_fingerprint.ts
@@ -51,7 +51,7 @@ export function computeSliFingerprint(
     metric: normalizeMetric(prom.metric),
     goodEventsFilter: normalizeGoodEventsFilter(prom.goodEventsFilter),
     latencyThresholdUnit:
-      prom.type === 'latency_threshold' ? prom.latencyThresholdUnit ?? null : null,
+      prom.type === 'latency_threshold' ? (prom.latencyThresholdUnit ?? null) : null,
     // Hash the *formatted* latency bound (the same `le=` string the
     // recording-rule generator emits) rather than the raw number. Two
     // semantically identical thresholds that differ only in float

--- a/common/slo/slo_validators.ts
+++ b/common/slo/slo_validators.ts
@@ -111,7 +111,8 @@ export function validateCustomPromQL(expr: string): string | null {
  * Allowed: `status="200"`, `code=~"5.."`, `path!="/healthz"`.
  * Rejected: `status="x",pwn="y"`, `path="\nfoo"`, `code=~"5.."[`.
  */
-const GOOD_EVENTS_FILTER_RE = /^[a-zA-Z_][a-zA-Z_0-9]*\s*(=|!=|=~|!~)\s*"([^"\\\n\r\t\x00-\x1F\x7F]|\\.)*"$/;
+const GOOD_EVENTS_FILTER_RE =
+  /^[a-zA-Z_][a-zA-Z_0-9]*\s*(=|!=|=~|!~)\s*"([^"\\\n\r\t\x00-\x1F\x7F]|\\.)*"$/;
 function validateGoodEventsFilter(filter: string): string | null {
   if (/[\n\r\t\x00-\x1F\x7F]/.test(filter)) {
     return 'Good events filter must not contain control characters';
@@ -262,9 +263,8 @@ export function validateSloSpec(input: Partial<SloSpec>): SloValidationResult {
           prom.latencyThresholdUnit !== 'seconds' &&
           prom.latencyThresholdUnit !== 'milliseconds'
         ) {
-          errors[
-            'spec.sli.definition.latencyThresholdUnit'
-          ] = `latencyThresholdUnit must be 'seconds' or 'milliseconds'`;
+          errors['spec.sli.definition.latencyThresholdUnit'] =
+            `latencyThresholdUnit must be 'seconds' or 'milliseconds'`;
         }
       } else if (prom.type === 'custom') {
         if (!prom.customExpr) {
@@ -371,9 +371,8 @@ export function validateSloSpec(input: Partial<SloSpec>): SloValidationResult {
         'No burn-rate tiers configured — no MWMBR alerts will be generated';
     } else {
       if (input.alerting.burnRates.length > MWMBR_MAX_TIERS) {
-        errors[
-          'spec.alerting.burnRates'
-        ] = `At most ${MWMBR_MAX_TIERS} burn-rate tiers are supported; received ${input.alerting.burnRates.length}.`;
+        errors['spec.alerting.burnRates'] =
+          `At most ${MWMBR_MAX_TIERS} burn-rate tiers are supported; received ${input.alerting.burnRates.length}.`;
       }
       const firstObjTarget = input.objectives?.[0]?.target;
       const errorBudget = firstObjTarget !== undefined ? 1 - firstObjTarget : undefined;
@@ -431,9 +430,8 @@ export function validateSloSpec(input: Partial<SloSpec>): SloValidationResult {
       }
       const values = Array.isArray(v) ? v : [v];
       if (values.length > MAX_LABEL_VALUES_PER_KEY) {
-        errors[
-          `spec.labels["${k}"]`
-        ] = `At most ${MAX_LABEL_VALUES_PER_KEY} values per label key are allowed`;
+        errors[`spec.labels["${k}"]`] =
+          `At most ${MAX_LABEL_VALUES_PER_KEY} values per label key are allowed`;
       }
       for (const val of values) {
         if (typeof val !== 'string') {

--- a/common/slo/slo_validators.ts
+++ b/common/slo/slo_validators.ts
@@ -48,7 +48,7 @@ function validateUserField(label: string, value: string | undefined): string | n
  * in the generator (every line is prefixed with 6 spaces, so the user
  * cannot terminate the block), but unbalanced parens or trailing backslashes
  * escape the generator's wrapping parens and produce malformed PromQL that
- * Cortex rejects only at deploy time. Validating here keeps the error local
+ * Prometheus rejects only at deploy time. Validating here keeps the error local
  * (wizard rejects at save) and forbids the class of input most likely to
  * confuse downstream parsers. Returns `null` when shaped reasonably, or an
  * error string to surface at `spec.sli.definition.customExpr.*`.
@@ -164,7 +164,7 @@ const RESERVED_LABEL_KEYS = new Set([
   'slo_window_approximated',
   'slo_budget_threshold',
   // Prototype-pollution guard. `LABEL_NAME_RE` matches `__proto__` /
-  // `constructor` / `prototype`. Cortex would reject the resulting rule
+  // `constructor` / `prototype`. Prometheus would reject the resulting rule
   // (`slo_label___proto__: "x"`) at deploy time, so blocking earlier
   // gives the user a clear validation error instead of an opaque ruler
   // 400.

--- a/public/components/alerting/__tests__/prometheus_rule_lifecycle.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_rule_lifecycle.test.tsx
@@ -5,8 +5,8 @@
 
 /**
  * Tests for Prometheus rule lifecycle operations:
- * - Clone routes through Cortex ruler API (not OS Alerting)
- * - Delete routes through Cortex ruler API
+ * - Clone routes through Prometheus ruler API (not OS Alerting)
+ * - Delete routes through Prometheus ruler API
  * - Edit persists evaluationInterval and forDuration
  * - Optimistic insert on clone
  * - Disable/Acknowledge buttons hidden for Prometheus

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -697,7 +697,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       }
       try {
         if (rule.datasourceType === 'prometheus') {
-          // Prometheus rules are deleted via the Cortex ruler API. Passing
+          // Prometheus rules are deleted via the Prometheus ruler API. Passing
           // the rule name makes the server splice just this rule out of the
           // group, preserving sibling rules in shared groups (the group is
           // only removed once it becomes empty).
@@ -820,7 +820,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         monitor.definitionType
       );
 
-      // Prometheus rules must be cloned via the Cortex ruler API, not the
+      // Prometheus rules must be cloned via the Prometheus ruler API, not the
       // OpenSearch Alerting monitor API (which requires `schedule`).
       if (detail.datasourceType === 'prometheus') {
         // Use a suffix that's safe for the ruleId regex [A-Za-z0-9_-]+
@@ -878,7 +878,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             defaultMessage: 'Monitor cloned',
           })
         );
-        // Background refetch to reconcile with Cortex once it propagates
+        // Background refetch to reconcile with Prometheus once it propagates
         refetchTimerRef.current = setTimeout(() => refetchRules(), 15000);
         return;
       }
@@ -1039,7 +1039,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     const newRule = buildOptimisticRule(formState);
     try {
       if (formState.datasourceType === 'prometheus') {
-        // Prometheus rules go to the Cortex ruler API
+        // Prometheus rules go to the Prometheus ruler API
         const promForm = formState as PrometheusFormState;
         // _ruleGroup is a form-transport metadata label, not a real Prometheus
         // label — extract it into groupName and strip it from persisted labels.
@@ -1062,7 +1062,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         });
         await mutations.createPrometheusRule(payload, dsId);
 
-        // Cortex has eventual consistency (~30-60s propagation). Use
+        // Prometheus has eventual consistency (~30-60s propagation). Use
         // optimistic pattern: close flyout immediately, show toast, and
         // schedule a background refetch after 15s to sync the list.
         refetchTimerRef.current = setTimeout(() => refetchRules(), 15000);
@@ -1109,7 +1109,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
    * Post-save handler for the shared CreateMetricsMonitor flyout (the same
    * component the Metrics Explore page uses). The flyout persists the rule
    * itself via the http client; this handler only reconciles the page:
-   * optimistic insert, close, and a delayed refetch to bridge Cortex's
+   * optimistic insert, close, and a delayed refetch to bridge Prometheus's
    * eventual consistency (~30-60s propagation).
    */
   const handleMetricsRuleSaved = (form: MetricsMonitorFormState) => {
@@ -1203,7 +1203,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             // Orphaned old rule — harmless, user can delete manually
           }
         }
-        // Background refetch to reconcile with Cortex once it propagates
+        // Background refetch to reconcile with Prometheus once it propagates
         refetchTimerRef.current = setTimeout(() => refetchRules(), 15000);
       } else {
         await mutations.updateMonitor(ruleId, buildPayload(formState), dsId);

--- a/public/components/alerting/create_monitor/edit_monitor.tsx
+++ b/public/components/alerting/create_monitor/edit_monitor.tsx
@@ -144,7 +144,7 @@ export const EditMonitor: React.FC<EditMonitorProps> = ({
     if (data.datasourceType === 'prometheus') {
       // Prometheus rule edit — seed from the unified rule summary + raw data.
       // The summary carries pre-parsed human-readable fields; raw has the
-      // Cortex wire format which may use empty strings or numeric seconds.
+      // Prometheus wire format which may use empty strings or numeric seconds.
       const raw = (data.raw || {}) as Record<string, unknown>;
       const rules = (raw.rules as Array<Record<string, unknown>>) || [];
       const firstRule = rules[0] || {};

--- a/public/components/apm/pages/slos/__tests__/probe_sli_panel.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/probe_sli_panel.test.tsx
@@ -109,7 +109,7 @@ describe('ProbeSliPanel', () => {
   });
 
   it('renders the request-error callout when probeSli rejects', async () => {
-    const probeSli = jest.fn().mockRejectedValue(new Error('cortex 500'));
+    const probeSli = jest.fn().mockRejectedValue(new Error('prometheus 500'));
     render(
       <ProbeSliPanel
         apiClient={makeClient(probeSli)}
@@ -121,7 +121,7 @@ describe('ProbeSliPanel', () => {
     fireEvent.click(screen.getByTestId('slosWizardProbeButton'));
 
     expect(await screen.findByTestId('slosWizardProbeRequestError')).toBeInTheDocument();
-    expect(screen.getByText('cortex 500')).toBeInTheDocument();
+    expect(screen.getByText('prometheus 500')).toBeInTheDocument();
   });
 
   it('shows the empty-vector callout when the response has emptyVector=true', async () => {

--- a/public/components/apm/pages/slos/__tests__/probe_sli_panel.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/probe_sli_panel.test.tsx
@@ -16,7 +16,7 @@ jest.mock('../../../shared/components/metric_sparkline', () => ({
 }));
 
 function makeClient(probeSli: jest.Mock): Pick<SloApiClient, 'probeSli'> {
-  return ({ probeSli } as unknown) as Pick<SloApiClient, 'probeSli'>;
+  return { probeSli } as unknown as Pick<SloApiClient, 'probeSli'>;
 }
 
 describe('ProbeSliPanel', () => {

--- a/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_detail_page.test.tsx
@@ -389,7 +389,7 @@ describe('SloDetailPage — rule-health grace window + re-poll (F-CRUD2)', () =>
     await exhaustRetries();
 
     const callout = screen.getByTestId('slosDetailRuleHealthCallout');
-    expect(callout).toHaveTextContent(/Rule groups missing in Cortex/i);
+    expect(callout).toHaveTextContent(/Rule groups missing in Prometheus/i);
     expect(callout).toHaveTextContent(/2 of 2 expected rule groups/i);
     expect(screen.getByTestId('slosDetailRestore')).toBeInTheDocument();
     expect(screen.getByTestId('slosDetailBrokenDelete')).toBeInTheDocument();

--- a/public/components/apm/pages/slos/__tests__/slo_wizard_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_wizard_page.test.tsx
@@ -74,16 +74,16 @@ function withSuggestionStubs(apiClient: Partial<SloApiClient>): Partial<SloApiCl
 }
 
 function renderWizard(apiClient: Partial<SloApiClient>, templateId = 'http-availability') {
-  const chrome = ({ setBreadcrumbs: jest.fn() } as unknown) as Parameters<
+  const chrome = { setBreadcrumbs: jest.fn() } as unknown as Parameters<
     typeof SloWizardPage
   >[0]['chrome'];
-  const notifications = ({
+  const notifications = {
     toasts: {
       addSuccess: jest.fn(),
       addWarning: jest.fn(),
       addDanger: jest.fn(),
     },
-  } as unknown) as Parameters<typeof SloWizardPage>[0]['notifications'];
+  } as unknown as Parameters<typeof SloWizardPage>[0]['notifications'];
 
   return render(
     <MemoryRouter initialEntries={[`/slos/create/${templateId}`]}>
@@ -226,16 +226,16 @@ describe('SloWizardPage — Wave 2 additions', () => {
     // renderWizard builds its own notifications; grab the spy off the
     // NotificationsStart shape so we can assert on it afterwards.
     const addDanger = jest.fn();
-    const chrome = ({ setBreadcrumbs: jest.fn() } as unknown) as Parameters<
+    const chrome = { setBreadcrumbs: jest.fn() } as unknown as Parameters<
       typeof SloWizardPage
     >[0]['chrome'];
-    const notifications = ({
+    const notifications = {
       toasts: {
         addSuccess: jest.fn(),
         addWarning: jest.fn(),
         addDanger,
       },
-    } as unknown) as Parameters<typeof SloWizardPage>[0]['notifications'];
+    } as unknown as Parameters<typeof SloWizardPage>[0]['notifications'];
 
     render(
       <MemoryRouter initialEntries={[`/slos/create/http-availability`]}>

--- a/public/components/apm/pages/slos/__tests__/slo_wizard_page.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_wizard_page.test.tsx
@@ -205,7 +205,7 @@ describe('SloWizardPage — Wave 2 additions', () => {
     await waitFor(() => {
       expect(screen.getByTestId('slosWizardRulerError')).toBeInTheDocument();
     });
-    // The raw Cortex diagnostic is surfaced verbatim — not swallowed into a
+    // The raw Prometheus diagnostic is surfaced verbatim — not swallowed into a
     // generic "Create failed" toast.
     expect(screen.getByTestId('slosWizardRulerErrorBody')).toHaveTextContent(
       'invalid PromQL: parse error at char 42'

--- a/public/components/apm/pages/slos/__tests__/suggest_use_discovery_probes.test.ts
+++ b/public/components/apm/pages/slos/__tests__/suggest_use_discovery_probes.test.ts
@@ -91,7 +91,7 @@ describe('useDiscoveryProbes', () => {
   it('per-probe failure leaves siblings unaffected and console.warn is called', async () => {
     const http = makeHttp({
       labelValues: {
-        rpc_server_duration_seconds_count: new Error('cortex 400'),
+        rpc_server_duration_seconds_count: new Error('prometheus 400'),
         http_server_request_duration_seconds_count: { service_name: ['cart'] },
       },
     });

--- a/public/components/apm/pages/slos/__tests__/suggest_use_live_preview.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/suggest_use_live_preview.test.tsx
@@ -22,7 +22,7 @@ function fakeSuggestion(
   key: string,
   kindId: 'http-availability' | 'apm-latency' = 'http-availability'
 ): Suggestion {
-  return ({
+  return {
     key,
     kindId,
     kind: 'k',
@@ -64,7 +64,7 @@ function fakeSuggestion(
         annotations: {},
       },
     },
-  } as unknown) as Suggestion;
+  } as unknown as Suggestion;
 }
 
 const fakeGroup: GeneratedRuleGroup = {
@@ -81,7 +81,7 @@ describe('useLivePreview', () => {
 
   it('emits a per-key loading PerPreview synchronously and a success on resolve', async () => {
     const preview = jest.fn().mockResolvedValue(fakeGroup);
-    const apiClient = ({ preview } as unknown) as Pick<SloApiClient, 'preview'>;
+    const apiClient = { preview } as unknown as Pick<SloApiClient, 'preview'>;
     mockExecuteInstantQuery.mockResolvedValue({
       fields: [{ name: 'Value', values: ['0.99'] }],
     });
@@ -108,7 +108,7 @@ describe('useLivePreview', () => {
       .fn()
       .mockResolvedValueOnce(fakeGroup)
       .mockRejectedValueOnce(new Error('preview failed'));
-    const apiClient = ({ preview } as unknown) as Pick<SloApiClient, 'preview'>;
+    const apiClient = { preview } as unknown as Pick<SloApiClient, 'preview'>;
     mockExecuteInstantQuery.mockResolvedValue(undefined);
 
     const { result } = renderHook(() =>
@@ -130,7 +130,7 @@ describe('useLivePreview', () => {
 
   it('skips live SLI when no prometheusConnectionId is supplied', async () => {
     const preview = jest.fn().mockResolvedValue(fakeGroup);
-    const apiClient = ({ preview } as unknown) as Pick<SloApiClient, 'preview'>;
+    const apiClient = { preview } as unknown as Pick<SloApiClient, 'preview'>;
     const { result } = renderHook(() =>
       useLivePreview({
         apiClient,
@@ -146,7 +146,7 @@ describe('useLivePreview', () => {
 
   it('populates liveByKey with sliRatio / totalSamples / p99Ms on success', async () => {
     const preview = jest.fn().mockResolvedValue(fakeGroup);
-    const apiClient = ({ preview } as unknown) as Pick<SloApiClient, 'preview'>;
+    const apiClient = { preview } as unknown as Pick<SloApiClient, 'preview'>;
     // 3 fan-out queries per row — return distinct values to verify the mapping.
     mockExecuteInstantQuery
       .mockResolvedValueOnce({ fields: [{ name: 'Value', values: ['0.91'] }] })
@@ -175,7 +175,7 @@ describe('useLivePreview', () => {
 
   it('survives executeInstantQuery rejection (per-query catch) and yields a success row with undefined values', async () => {
     const preview = jest.fn().mockResolvedValue(fakeGroup);
-    const apiClient = ({ preview } as unknown) as Pick<SloApiClient, 'preview'>;
+    const apiClient = { preview } as unknown as Pick<SloApiClient, 'preview'>;
     mockExecuteInstantQuery.mockRejectedValue(new Error('prometheus 502'));
     const { result } = renderHook(() =>
       useLivePreview({

--- a/public/components/apm/pages/slos/__tests__/suggest_use_live_preview.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/suggest_use_live_preview.test.tsx
@@ -176,7 +176,7 @@ describe('useLivePreview', () => {
   it('survives executeInstantQuery rejection (per-query catch) and yields a success row with undefined values', async () => {
     const preview = jest.fn().mockResolvedValue(fakeGroup);
     const apiClient = ({ preview } as unknown) as Pick<SloApiClient, 'preview'>;
-    mockExecuteInstantQuery.mockRejectedValue(new Error('cortex 502'));
+    mockExecuteInstantQuery.mockRejectedValue(new Error('prometheus 502'));
     const { result } = renderHook(() =>
       useLivePreview({
         apiClient,

--- a/public/components/apm/pages/slos/slo_alerts_panel.tsx
+++ b/public/components/apm/pages/slos/slo_alerts_panel.tsx
@@ -110,8 +110,8 @@ export const SloAlertsPanel: React.FC<SloAlertsPanelProps> = ({ doc, ruleHealth 
     ruleHealth?.expectedGroups && ruleHealth.expectedGroups.length > 0
       ? ruleHealth.expectedGroups
       : prov.alertGroupName
-      ? [prov.alertGroupName]
-      : [];
+        ? [prov.alertGroupName]
+        : [];
   const presentGroups = new Set(ruleHealth?.presentGroups ?? []);
 
   const ruleCount = doc.liveStatus.ruleCount ?? 0;

--- a/public/components/apm/pages/slos/slo_alerts_panel.tsx
+++ b/public/components/apm/pages/slos/slo_alerts_panel.tsx
@@ -203,7 +203,7 @@ export const SloAlertsPanel: React.FC<SloAlertsPanelProps> = ({ doc, ruleHealth 
             const probeReturned = ruleHealth !== null;
             const present = probeReturned ? presentGroups.has(groupName) : true;
             // Recording groups (`slo:rec:…`) don't surface in Alert Manager
-            // — alert_service.fetchRulesRaw filters Cortex rules with
+            // — alert_service.fetchRulesRaw filters Prometheus rules with
             // `r.type === 'alerting'` before they reach MonitorsTable — so
             // a "View" link on those rows would land on an empty list.
             // Only render the deep-link affordance for alert groups.

--- a/public/components/apm/pages/slos/slo_api_client.ts
+++ b/public/components/apm/pages/slos/slo_api_client.ts
@@ -33,7 +33,7 @@ const SLO_BASE = `${OBSERVABILITY_BASE}/v1/slos`;
 /**
  * Ruler dual-write envelope mirrored from the server's SloRulerError mapping
  * (see server/routes/slo/handlers.ts:toSloError). The wizard renders
- * `rawBody` verbatim so the user sees Cortex's own diagnostic (e.g.
+ * `rawBody` verbatim so the user sees Prometheus's own diagnostic (e.g.
  * "invalid PromQL: parse error at char 42"), not a generic create-failed
  * toast. `code` lets the wizard branch on coarse failure mode.
  */

--- a/public/components/apm/pages/slos/slo_api_client.ts
+++ b/public/components/apm/pages/slos/slo_api_client.ts
@@ -166,9 +166,7 @@ export class SloApiClient {
     });
   }
 
-  get(
-    id: string
-  ): Promise<
+  get(id: string): Promise<
     SloDocument & {
       liveStatus: SloLiveStatus;
       /**

--- a/public/components/apm/pages/slos/slo_detail_page.tsx
+++ b/public/components/apm/pages/slos/slo_detail_page.tsx
@@ -112,7 +112,7 @@ function iconSummaryFromDoc(doc: SloDocument): SloSummary {
 
 /**
  * Rule-health re-poll bounds (F-CRUD2). A freshly-created SLO's rule groups
- * take a little while to propagate through the Cortex/AMP ruler, during which
+ * take a little while to propagate through the Prometheus/AMP ruler, during which
  * the health probe legitimately reports them as missing. Rather than alarm
  * immediately, we re-probe up to {@link RULE_HEALTH_MAX_RETRIES} times, one
  * every {@link RULE_HEALTH_RETRY_INTERVAL_MS}, and only escalate to the
@@ -673,7 +673,7 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
 
   // While rule health reads as missing/partial, re-probe on a bounded
   // interval (F-CRUD2). A freshly-created SLO's rule groups take time to
-  // propagate through the Cortex/AMP ruler, so a "missing" reading is
+  // propagate through the Prometheus/AMP ruler, so a "missing" reading is
   // routinely transient right after create. Each probe that still comes back
   // missing schedules the next one until RULE_HEALTH_MAX_RETRIES is hit; once
   // health recovers we reset the budget so a later regression re-polls. The
@@ -1204,7 +1204,7 @@ export const SloDetailPage: React.FC<SloDetailPageProps> = ({
                   color="danger"
                   iconType="alert"
                   title={i18n.translate('observability.apm.slo.detail.rulesMissingCallout.title', {
-                    defaultMessage: 'Rule groups missing in Cortex',
+                    defaultMessage: 'Rule groups missing in Prometheus',
                   })}
                   data-test-subj="slosDetailRuleHealthCallout"
                 >

--- a/public/components/apm/pages/slos/slo_wizard_page.tsx
+++ b/public/components/apm/pages/slos/slo_wizard_page.tsx
@@ -968,7 +968,7 @@ const IdentityPanel: React.FC<PanelProps & { template: string; readOnlyDatasourc
       {readOnlyDatasource ? (
         // Datasource is IMMUTABLE on edit: the server pins rules to the
         // create-time datasource, so allowing a change here would orphan the
-        // already-provisioned Prometheus/Cortex rule groups. Render a disabled
+        // already-provisioned Prometheus rule groups. Render a disabled
         // field showing the friendly name (matching the interactive picker),
         // not the raw connection id.
         <ReadOnlyDatasourceField datasourceId={state.datasourceId} />

--- a/public/components/apm/pages/slos/suggest_live_queries.ts
+++ b/public/components/apm/pages/slos/suggest_live_queries.ts
@@ -189,7 +189,7 @@ function buildGenAiAvailabilityQueries(
     `/ sum(rate(${metric}{${selector}}[${win}]))`;
   const samples = `sum(increase(${metric}{${selector}}[${win}]))`;
   // GenAI instrumentation often omits the bucket — emit the query anyway; if
-  // the metric isn't present Cortex returns no samples and the UI shows "—".
+  // the metric isn't present Prometheus returns no samples and the UI shows "—".
   const p99 = `histogram_quantile(0.99, sum by (le)(rate(${bucketMetric}{${selector}}[${win}]))) * 1000`;
   return [ratio, samples, p99];
 }

--- a/public/components/apm/pages/slos/suggest_use_discovery_probes.ts
+++ b/public/components/apm/pages/slos/suggest_use_discovery_probes.ts
@@ -97,7 +97,7 @@ export function useDiscoveryProbes({
               });
               return { metric: probe.metric, label, values: res?.values ?? [] };
             } catch (err) {
-              // Per-probe failure is expected (rejected by Cortex when the
+              // Per-probe failure is expected (rejected by Prometheus when the
               // metric family is absent). Log at warn level so the failure is
               // visible in dev tools without blowing up the discovery effect.
 

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -388,7 +388,7 @@ export class ObservabilityPlugin implements Plugin<
       // SLO documents and slo-rule-ref refcount registry are partitioned
       // per OSD workspace via the saved-objects workspace wrapper. The
       // ruler recording-rule namespace (`slo-generated-<datasourceId>`)
-      // is shared across workspaces that target the same Prometheus tenant —
+      // is shared across workspaces that target the same ruler tenant —
       // two workspaces creating SLOs over the same SLI fingerprint share
       // one rule group on the ruler, with refcount tracked separately
       // per workspace. The grace-GC pass owns recording-group cleanup

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -388,7 +388,7 @@ export class ObservabilityPlugin implements Plugin<
       // SLO documents and slo-rule-ref refcount registry are partitioned
       // per OSD workspace via the saved-objects workspace wrapper. The
       // ruler recording-rule namespace (`slo-generated-<datasourceId>`)
-      // is shared across workspaces that target the same Cortex tenant —
+      // is shared across workspaces that target the same Prometheus tenant —
       // two workspaces creating SLOs over the same SLI fingerprint share
       // one rule group on the ruler, with refcount tracked separately
       // per workspace. The grace-GC pass owns recording-group cleanup
@@ -430,7 +430,7 @@ export class ObservabilityPlugin implements Plugin<
     sloService.setDedupEnabled(ruleDedupEnabled);
     sloService.setPluginVersion(this.initializerContext.env.packageInfo.version);
     // Wire the DirectQuery status aggregator so SLO list/detail responses
-    // surface real Cortex-derived state (healthy/breaching/warning) instead
+    // surface real Prometheus-derived state (healthy/breaching/warning) instead
     // of the no-op stub that always returns no_data.
     // Per-server datasource health tracker. One instance per plugin
     // start; failure counts and cooldown are in-memory and reset on

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -264,9 +264,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
    * `metadataService` instances are short-lived and die when the handler
    * returns.
    */
-  function buildRequestServices(
-    ctx: AlertingHandlerContext
-  ): {
+  function buildRequestServices(ctx: AlertingHandlerContext): {
     alertService: MultiBackendAlertService;
     metadataService: PrometheusMetadataService;
     datasourceService: SavedObjectDatasourceService;

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -365,7 +365,7 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
     logger
   );
 
-  // Prometheus rule mutation routes (create/delete via Cortex ruler).
+  // Prometheus rule mutation routes (create/delete via Prometheus ruler).
   // Only registered when a RulerClient is provided (SLO feature enabled).
   if (deps.rulerClient) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/server/routes/alerting/mutations/prometheus_handlers.ts
+++ b/server/routes/alerting/mutations/prometheus_handlers.ts
@@ -14,7 +14,7 @@ import type { AlertingOSClient, Datasource, Logger } from '../../../../common/ty
 import type { GeneratedRule, GeneratedRuleGroup } from '../../../../common/slo/slo_types';
 import type { RulerClient } from '../../../services/slo/ruler_client';
 
-/** The namespace under which user-created alerting rules are stored in Prometheus. */
+/** The namespace under which user-created alerting rules are stored in the ruler. */
 export const USER_RULES_NAMESPACE = 'observability-alerting';
 
 export interface PrometheusRulePayload {
@@ -94,15 +94,15 @@ export async function handleCreatePrometheusRule(
   const group = buildRuleGroup(payload);
 
   // Rule groups are shared: multiple rules may live in the same group, and
-  // Prometheus's POST is create-or-replace on (namespace, groupName). Merge with
+  // the ruler's POST is create-or-replace on (namespace, groupName). Merge with
   // the existing group so sibling rules are preserved — the new rule replaces
   // any same-named rule, others are kept.
   //
-  // NOTE: this read-modify-write is not atomic. The Prometheus ruler API offers
+  // NOTE: this read-modify-write is not atomic. The ruler API offers
   // no compare-and-swap, so two concurrent writers targeting the same group
   // can still lose an update (the second upsert wins). This protects against
   // the common single-writer clobber; true concurrent safety would need
-  // server-side coordination in Prometheus itself.
+  // server-side coordination in the ruler itself.
   const existing = await rulerClient.getRuleGroup(
     client,
     datasource,
@@ -139,7 +139,7 @@ export async function handleDeletePrometheusRule(
   // sibling rules in a shared group are preserved. The whole group is only
   // deleted when it would become empty (or no ruleName was given).
   // Same non-atomicity caveat as the create-merge above: no CAS on the
-  // Prometheus ruler, so concurrent writers to one group can race.
+  // ruler, so concurrent writers to one group can race.
   if (ruleName) {
     const existing = await rulerClient.getRuleGroup(
       client,

--- a/server/routes/alerting/mutations/prometheus_handlers.ts
+++ b/server/routes/alerting/mutations/prometheus_handlers.ts
@@ -5,7 +5,7 @@
 
 /**
  * Prometheus rule mutation handlers. Creates, updates, and deletes alerting
- * rules via the Cortex ruler API (through the DirectQueryRulerClient).
+ * rules via the Prometheus ruler API (through the DirectQueryRulerClient).
  *
  * Route registrations live in `prometheus_routes.ts`; this file is pure
  * handler logic, testable in isolation.
@@ -14,7 +14,7 @@ import type { AlertingOSClient, Datasource, Logger } from '../../../../common/ty
 import type { GeneratedRule, GeneratedRuleGroup } from '../../../../common/slo/slo_types';
 import type { RulerClient } from '../../../services/slo/ruler_client';
 
-/** The namespace under which user-created alerting rules are stored in Cortex. */
+/** The namespace under which user-created alerting rules are stored in Prometheus. */
 export const USER_RULES_NAMESPACE = 'observability-alerting';
 
 export interface PrometheusRulePayload {
@@ -37,7 +37,7 @@ export interface PrometheusRulePayload {
 
 /**
  * Converts a form payload into a GeneratedRuleGroup suitable for the
- * Cortex ruler upsert API.
+ * Prometheus ruler upsert API.
  */
 export function buildRuleGroup(payload: PrometheusRulePayload): GeneratedRuleGroup {
   // The query alone is the alert expression unless a legacy operator/threshold
@@ -94,15 +94,15 @@ export async function handleCreatePrometheusRule(
   const group = buildRuleGroup(payload);
 
   // Rule groups are shared: multiple rules may live in the same group, and
-  // Cortex's POST is create-or-replace on (namespace, groupName). Merge with
+  // Prometheus's POST is create-or-replace on (namespace, groupName). Merge with
   // the existing group so sibling rules are preserved — the new rule replaces
   // any same-named rule, others are kept.
   //
-  // NOTE: this read-modify-write is not atomic. The Cortex ruler API offers
+  // NOTE: this read-modify-write is not atomic. The Prometheus ruler API offers
   // no compare-and-swap, so two concurrent writers targeting the same group
   // can still lose an update (the second upsert wins). This protects against
   // the common single-writer clobber; true concurrent safety would need
-  // server-side coordination in Cortex itself.
+  // server-side coordination in Prometheus itself.
   const existing = await rulerClient.getRuleGroup(
     client,
     datasource,
@@ -139,7 +139,7 @@ export async function handleDeletePrometheusRule(
   // sibling rules in a shared group are preserved. The whole group is only
   // deleted when it would become empty (or no ruleName was given).
   // Same non-atomicity caveat as the create-merge above: no CAS on the
-  // Cortex ruler, so concurrent writers to one group can race.
+  // Prometheus ruler, so concurrent writers to one group can race.
   if (ruleName) {
     const existing = await rulerClient.getRuleGroup(
       client,

--- a/server/routes/alerting/mutations/prometheus_routes.ts
+++ b/server/routes/alerting/mutations/prometheus_routes.ts
@@ -9,7 +9,7 @@
  *   POST   /api/alerting/prometheus/{dsId}/rules       — create rule
  *   DELETE /api/alerting/prometheus/{dsId}/rules/{groupName} — delete rule
  *
- * These routes proxy to the Cortex ruler API via the DirectQueryRulerClient,
+ * These routes proxy to the Prometheus ruler API via the DirectQueryRulerClient,
  * which communicates through the OpenSearch DirectQuery plugin.
  */
 import { schema } from '@osd/config-schema';

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -89,7 +89,7 @@ export function setupRoutes({
   // MonitorMutationService delegates to HttpOpenSearchBackend — shared
   // stateless backend + thin write-path wrapper.
   const mutationSvc = new MonitorMutationService(osBackend, logger);
-  // RulerClient for Prometheus rule CRUD via Cortex ruler API.
+  // RulerClient for Prometheus rule CRUD via Prometheus ruler API.
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { DirectQueryRulerClient } = require('../services/slo/ruler_client');
   const rulerClient = new DirectQueryRulerClient(logger);

--- a/server/routes/slo/handlers.ts
+++ b/server/routes/slo/handlers.ts
@@ -30,7 +30,7 @@ import type { ClassifiedError } from '../../../common/error';
 import { redactForDisplay } from '../../../common/error';
 
 /**
- * Cap on the upstream ruler diagnostic surfaced to the client. Cortex's
+ * Cap on the upstream ruler diagnostic surfaced to the client. Prometheus's
  * verbose error envelopes can carry tenant ids, internal hostnames, or
  * stack traces that don't belong in a multi-tenant OSD toast — the full
  * body is logged server-side at `warn`, the client gets a short, ANSI-
@@ -40,7 +40,7 @@ import { redactForDisplay } from '../../../common/error';
 const RULER_RAW_BODY_MAX_LEN = 256;
 function sanitizeRulerRawBody(body: string): string {
   if (!body) return '';
-  // Strip ANSI/VT escape sequences that some Cortex builds embed.
+  // Strip ANSI/VT escape sequences that some Prometheus builds embed.
 
   const stripped = body.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
   // Collapse all remaining control chars (incl. CR/LF/TAB) to spaces so

--- a/server/routes/slo/handlers.ts
+++ b/server/routes/slo/handlers.ts
@@ -30,7 +30,7 @@ import type { ClassifiedError } from '../../../common/error';
 import { redactForDisplay } from '../../../common/error';
 
 /**
- * Cap on the upstream ruler diagnostic surfaced to the client. Prometheus's
+ * Cap on the upstream ruler diagnostic surfaced to the client. The ruler's
  * verbose error envelopes can carry tenant ids, internal hostnames, or
  * stack traces that don't belong in a multi-tenant OSD toast — the full
  * body is logged server-side at `warn`, the client gets a short, ANSI-

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -337,7 +337,7 @@ const previewBody = schema.object({
  * datasource isn't discovered, or it isn't a DirectQuery Prometheus — throws
  * `SloValidationError`. This prevents the prior failure mode where a
  * typo'd datasource ID produced a silent no-op: the SO saved, the UI
- * reported "N rules provisioned", but Prometheus never received the rule group.
+ * reported "N rules provisioned", but the ruler never received the rule group.
  *
  * TODO: derive `workspaceId` from OSD's workspace scope once the SLO spec
  * carries a workspace reference. For now the datasource ID doubles as a
@@ -840,7 +840,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
       // Delete is ruler-first, SO-second — if there's a rule group to remove,
       // we need a working deploy context (i.e. a resolvable datasource). An
       // unresolvable datasource here surfaces to the user as a 409: dropping
-      // the SO while the rule group stays live in Prometheus would leave dead
+      // the SO while the rule group stays live in the ruler would leave dead
       // alerts evaluating against the cluster.
       const built = await tryBuildDeployContext(
         ctx as SloHandlerContext,

--- a/server/routes/slo/index.ts
+++ b/server/routes/slo/index.ts
@@ -337,7 +337,7 @@ const previewBody = schema.object({
  * datasource isn't discovered, or it isn't a DirectQuery Prometheus — throws
  * `SloValidationError`. This prevents the prior failure mode where a
  * typo'd datasource ID produced a silent no-op: the SO saved, the UI
- * reported "N rules provisioned", but Cortex never received the rule group.
+ * reported "N rules provisioned", but Prometheus never received the rule group.
  *
  * TODO: derive `workspaceId` from OSD's workspace scope once the SLO spec
  * carries a workspace reference. For now the datasource ID doubles as a
@@ -840,7 +840,7 @@ export function registerSloRoutes(options: RegisterSloRoutesOptions) {
       // Delete is ruler-first, SO-second — if there's a rule group to remove,
       // we need a working deploy context (i.e. a resolvable datasource). An
       // unresolvable datasource here surfaces to the user as a 409: dropping
-      // the SO while the rule group stays live in Cortex would leave dead
+      // the SO while the rule group stays live in Prometheus would leave dead
       // alerts evaluating against the cluster.
       const built = await tryBuildDeployContext(
         ctx as SloHandlerContext,

--- a/server/saved_objects/slo_rule_ref.ts
+++ b/server/saved_objects/slo_rule_ref.ts
@@ -15,7 +15,7 @@
  * id (`getWorkspaceState(request).requestWorkspaceId`, or `'default'` on
  * non-workspace-enabled clusters). Two workspaces over the same datasource
  * + fingerprint allocate separate slo-rule-ref SOs, each refcounted
- * independently. `datasourceId` continues to identify the Prometheus tenant
+ * independently. `datasourceId` continues to identify the ruler tenant
  * (and the ruler namespace via `slo-generated-<datasourceId>`) — the ruler
  * namespace is shared, the slo-rule-refs are not. Grace-GC fires only when
  * the cross-workspace aggregate refcount for a (datasourceId, fingerprint)

--- a/server/saved_objects/slo_rule_ref.ts
+++ b/server/saved_objects/slo_rule_ref.ts
@@ -15,7 +15,7 @@
  * id (`getWorkspaceState(request).requestWorkspaceId`, or `'default'` on
  * non-workspace-enabled clusters). Two workspaces over the same datasource
  * + fingerprint allocate separate slo-rule-ref SOs, each refcounted
- * independently. `datasourceId` continues to identify the Cortex tenant
+ * independently. `datasourceId` continues to identify the Prometheus tenant
  * (and the ruler namespace via `slo-generated-<datasourceId>`) — the ruler
  * namespace is shared, the slo-rule-refs are not. Grace-GC fires only when
  * the cross-workspace aggregate refcount for a (datasourceId, fingerprint)

--- a/server/services/alerting/__tests__/datasource_service.test.ts
+++ b/server/services/alerting/__tests__/datasource_service.test.ts
@@ -112,7 +112,7 @@ describe('InMemoryDatasourceService.get', () => {
   it('does NOT fall back on display name (collidable, can shadow another datasource)', async () => {
     const svc = new InMemoryDatasourceService(noopLogger());
     await svc.create({
-      name: 'My Cortex',
+      name: 'My Prometheus',
       type: 'opensearch',
       url: 'local',
       enabled: true,
@@ -121,21 +121,21 @@ describe('InMemoryDatasourceService.get', () => {
     // Display name lookup must miss. `name` is user-controlled and can
     // collide; resolving by it would let a freshly-created datasource shadow
     // an older one's lookups.
-    const ds = await svc.get('My Cortex');
+    const ds = await svc.get('My Prometheus');
     expect(ds).toBeNull();
   });
 
   it('returns null when directQueryName matches more than one entry (ambiguous)', async () => {
     const svc = new InMemoryDatasourceService(noopLogger());
     await svc.create({
-      name: 'Cortex A',
+      name: 'Prometheus A',
       type: 'prometheus',
       url: 'so-1',
       enabled: true,
       directQueryName: 'shared-conn',
     });
     await svc.create({
-      name: 'Cortex B',
+      name: 'Prometheus B',
       type: 'prometheus',
       url: 'so-2',
       enabled: true,

--- a/server/services/alerting/directquery_prometheus_backend.ts
+++ b/server/services/alerting/directquery_prometheus_backend.ts
@@ -724,7 +724,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
       series = await matrixPromise;
     } catch (err) {
       // Matrix failed — still surface live alerts when window ends at now,
-      // so a transient Cortex error doesn't blank the UI for what's firing
+      // so a transient Prometheus error doesn't blank the UI for what's firing
       // RIGHT NOW.
       const live = await liveSettled;
       if (!live.ok || live.alerts.length === 0) {

--- a/server/services/alerting/directquery_prometheus_backend.ts
+++ b/server/services/alerting/directquery_prometheus_backend.ts
@@ -154,7 +154,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
       body: body || undefined,
     });
     const respBody = resp.body as { data?: T } & Record<string, unknown>;
-    return respBody?.data !== undefined ? (respBody.data as T) : ((respBody as unknown) as T);
+    return respBody?.data !== undefined ? (respBody.data as T) : (respBody as unknown as T);
   }
 
   private get<T = unknown>(client: AlertingOSClient, ds: Datasource, path: string): Promise<T> {
@@ -183,7 +183,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
 
     let rawGroups: PromRawRuleGroup[];
     if (Array.isArray(data)) {
-      rawGroups = (data as unknown) as PromRawRuleGroup[];
+      rawGroups = data as unknown as PromRawRuleGroup[];
     } else if (data?.groups) {
       rawGroups = data.groups;
     } else if (data?.data?.groups) {
@@ -223,7 +223,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
       const data = await this.get<PromAlertsApiResponse>(client, ds, '/api/v1/alerts');
       let rawAlerts: PromRawAlert[];
       if (Array.isArray(data)) {
-        rawAlerts = (data as unknown) as PromRawAlert[];
+        rawAlerts = data as unknown as PromRawAlert[];
       } else if (data?.alerts) {
         rawAlerts = data.alerts as PromRawAlert[];
       } else if (data?.data) {
@@ -596,7 +596,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
         timeoutSeconds: timeoutSeconds(opts.requestTimeoutMs),
         sourceRequest: opts.sourceRequest,
       });
-      return this.parseRangeQueryResponse((envelope as unknown) as Record<string, unknown>);
+      return this.parseRangeQueryResponse(envelope as unknown as Record<string, unknown>);
     } catch (err) {
       this.logger.warn(`Failed to execute PromQL range query: ${err}`);
       return [];
@@ -629,9 +629,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
       sourceRequest: opts.sourceRequest,
     });
 
-    const promResult = this.extractPrometheusResult(
-      (envelope as unknown) as Record<string, unknown>
-    );
+    const promResult = this.extractPrometheusResult(envelope as unknown as Record<string, unknown>);
     if (!promResult) return [];
 
     const rawSeries = (promResult.result ?? []) as Array<{
@@ -710,14 +708,13 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
       stepSec,
       { sourceRequest: opts.sourceRequest }
     );
-    const liveSettled: Promise<
-      { ok: true; alerts: PromAlert[] } | { ok: false; error: string }
-    > = endIsNow
-      ? this.getAlerts(client, ds).then(
-          (alerts) => ({ ok: true, alerts } as const),
-          (err) => ({ ok: false, error: String(err) } as const)
-        )
-      : Promise.resolve({ ok: true, alerts: [] as PromAlert[] } as const);
+    const liveSettled: Promise<{ ok: true; alerts: PromAlert[] } | { ok: false; error: string }> =
+      endIsNow
+        ? this.getAlerts(client, ds).then(
+            (alerts) => ({ ok: true, alerts }) as const,
+            (err) => ({ ok: false, error: String(err) }) as const
+          )
+        : Promise.resolve({ ok: true, alerts: [] as PromAlert[] } as const);
 
     let series: PromSeriesMatrix[];
     try {
@@ -867,7 +864,7 @@ export class DirectQueryPrometheusBackend implements PrometheusBackend, Promethe
         timeoutSeconds: timeoutSeconds(opts.requestTimeoutMs),
         sourceRequest: opts.sourceRequest,
       });
-      return this.parseInstantQueryResponse((envelope as unknown) as Record<string, unknown>);
+      return this.parseInstantQueryResponse(envelope as unknown as Record<string, unknown>);
     } catch (err) {
       this.logger.warn(`Failed to execute PromQL instant query: ${err}`);
       return [];

--- a/server/services/slo/__tests__/rule_health_checker.test.ts
+++ b/server/services/slo/__tests__/rule_health_checker.test.ts
@@ -38,11 +38,11 @@ function mockClient(): AlertingOSClient {
 function mockDatasource(overrides: Partial<Datasource> = {}): Datasource {
   return {
     id: 'ds-1',
-    name: 'my-cortex',
+    name: 'my-prometheus',
     type: 'prometheus',
     url: '',
     enabled: true,
-    directQueryName: 'my-cortex-connection',
+    directQueryName: 'my-prometheus-connection',
     ...overrides,
   };
 }

--- a/server/services/slo/__tests__/rule_health_checker.test.ts
+++ b/server/services/slo/__tests__/rule_health_checker.test.ts
@@ -28,11 +28,11 @@ function noopLogger(): Logger {
 }
 
 function mockClient(): AlertingOSClient {
-  return ({
+  return {
     transport: {
       request: jest.fn(async () => ({ statusCode: 200, body: {} })),
     },
-  } as unknown) as AlertingOSClient;
+  } as unknown as AlertingOSClient;
 }
 
 function mockDatasource(overrides: Partial<Datasource> = {}): Datasource {
@@ -66,11 +66,11 @@ function mockRulerClient(): {
   getRuleGroup: jest.Mock<Promise<GeneratedRuleGroup | null>, unknown[]>;
 } {
   const getRuleGroup = jest.fn<Promise<GeneratedRuleGroup | null>, unknown[]>(async () => null);
-  const ruler = ({
+  const ruler = {
     upsertRuleGroup: jest.fn(async () => undefined),
     deleteRuleGroup: jest.fn(async () => undefined),
     getRuleGroup,
-  } as unknown) as RulerClient;
+  } as unknown as RulerClient;
   return { ruler, getRuleGroup };
 }
 

--- a/server/services/slo/__tests__/ruler_client.test.ts
+++ b/server/services/slo/__tests__/ruler_client.test.ts
@@ -46,11 +46,11 @@ function mockClient(
 function promDatasource(overrides: Partial<Datasource> = {}): Datasource {
   return {
     id: 'ds-1',
-    name: 'my Cortex',
+    name: 'my Prometheus',
     type: 'prometheus',
     url: '',
     enabled: true,
-    directQueryName: 'my-cortex-connection',
+    directQueryName: 'my-prometheus-connection',
     ...overrides,
   };
 }
@@ -133,7 +133,7 @@ describe('DirectQueryRulerClient.upsertRuleGroup', () => {
     const svc = new DirectQueryRulerClient(noopLogger());
     await svc.upsertRuleGroup(
       client,
-      promDatasource({ directQueryName: 'my cortex' }), // space to force encoding
+      promDatasource({ directQueryName: 'my prometheus' }), // space to force encoding
       'slo-generated-ws1',
       sampleGroup()
     );
@@ -146,7 +146,7 @@ describe('DirectQueryRulerClient.upsertRuleGroup', () => {
     };
     expect(call.method).toBe('POST');
     expect(call.path).toBe(
-      '/_plugins/_directquery/_resources/my%20cortex/api/v1/rules/slo-generated-ws1'
+      '/_plugins/_directquery/_resources/my%20prometheus/api/v1/rules/slo-generated-ws1'
     );
     expect(typeof call.body).toBe('string');
     const parsed = yamlLoad(call.body) as { name: string; rules: unknown[] };
@@ -178,7 +178,7 @@ describe('DirectQueryRulerClient.deleteRuleGroup', () => {
     const call = requestMock.mock.calls[0][0] as { method: string; path: string };
     expect(call.method).toBe('DELETE');
     expect(call.path).toBe(
-      '/_plugins/_directquery/_resources/my-cortex-connection/api/v1/rules/slo-generated-ws1/slo%3Agroup_abcd'
+      '/_plugins/_directquery/_resources/my-prometheus-connection/api/v1/rules/slo-generated-ws1/slo%3Agroup_abcd'
     );
   });
 });
@@ -341,7 +341,7 @@ describe('DirectQueryRulerClient.getRuleGroup', () => {
     expect(call.method).toBe('GET');
     // Hit the namespace-list path, not the single-group path.
     expect(call.path).toBe(
-      '/_plugins/_directquery/_resources/my-cortex-connection/api/v1/rules/slo-generated-ws1'
+      '/_plugins/_directquery/_resources/my-prometheus-connection/api/v1/rules/slo-generated-ws1'
     );
     expect(parsed).not.toBeNull();
     expect(parsed!.groupName).toBe('slo:group_bbb');
@@ -431,11 +431,11 @@ describe('DirectQueryRulerClient.listRuleGroups', () => {
     const call = requestMock.mock.calls[0][0] as { method: string; path: string };
     expect(call.method).toBe('GET');
     expect(call.path).toBe(
-      '/_plugins/_directquery/_resources/my-cortex-connection/api/v1/rules/slo-generated-ws1'
+      '/_plugins/_directquery/_resources/my-prometheus-connection/api/v1/rules/slo-generated-ws1'
     );
   });
 
-  it('Cortex namespace-keyed envelope → returns all groups parsed', async () => {
+  it('Prometheus namespace-keyed envelope → returns all groups parsed', async () => {
     const yamlEnvelope = yamlDump({
       'slo-generated-ws1': [
         {
@@ -623,7 +623,7 @@ describe('DirectQueryRulerClient.deleteRuleGroup — 404 tolerance', () => {
     const call = requestMock.mock.calls[0][0] as { method: string; path: string };
     expect(call.method).toBe('DELETE');
     expect(call.path).toBe(
-      '/_plugins/_directquery/_resources/my-cortex-connection/api/v1/rules/ns/group-already-gone'
+      '/_plugins/_directquery/_resources/my-prometheus-connection/api/v1/rules/ns/group-already-gone'
     );
   });
 

--- a/server/services/slo/__tests__/ruler_client.test.ts
+++ b/server/services/slo/__tests__/ruler_client.test.ts
@@ -433,7 +433,7 @@ describe('DirectQueryRulerClient.listRuleGroups', () => {
     );
   });
 
-  it('Prometheus namespace-keyed envelope → returns all groups parsed', async () => {
+  it('ruler namespace-keyed CRUD envelope → returns all groups parsed', async () => {
     const yamlEnvelope = yamlDump({
       'slo-generated-ws1': [
         {

--- a/server/services/slo/__tests__/ruler_client.test.ts
+++ b/server/services/slo/__tests__/ruler_client.test.ts
@@ -27,9 +27,7 @@ function noopLogger(): Logger {
   };
 }
 
-function mockClient(
-  handler?: (params: unknown) => Promise<unknown>
-): {
+function mockClient(handler?: (params: unknown) => Promise<unknown>): {
   client: AlertingOSClient;
   requestMock: jest.Mock;
 } {
@@ -38,7 +36,7 @@ function mockClient(
     return { statusCode: 200, body: {} };
   });
   return {
-    client: ({ transport: { request: requestMock } } as unknown) as AlertingOSClient,
+    client: { transport: { request: requestMock } } as unknown as AlertingOSClient,
     requestMock,
   };
 }
@@ -405,18 +403,18 @@ describe('DirectQueryRulerClient.getRuleGroup', () => {
     );
     const svc = new DirectQueryRulerClient(noopLogger());
 
-    await expect(
-      svc.getRuleGroup(client, promDatasource(), 'ns', 'group-1')
-    ).rejects.toMatchObject({ name: 'SloRulerError', code: 'RULER_UNREACHABLE', httpStatus: 500 });
+    await expect(svc.getRuleGroup(client, promDatasource(), 'ns', 'group-1')).rejects.toMatchObject(
+      { name: 'SloRulerError', code: 'RULER_UNREACHABLE', httpStatus: 500 }
+    );
   });
 
   it('401 → throws SloRulerError with RULER_AUTH_FAILED', async () => {
     const { client } = mockClient(() => Promise.reject(rejectWithStatus(401, 'no org id')));
     const svc = new DirectQueryRulerClient(noopLogger());
 
-    await expect(
-      svc.getRuleGroup(client, promDatasource(), 'ns', 'group-1')
-    ).rejects.toMatchObject({ name: 'SloRulerError', code: 'RULER_AUTH_FAILED', httpStatus: 401 });
+    await expect(svc.getRuleGroup(client, promDatasource(), 'ns', 'group-1')).rejects.toMatchObject(
+      { name: 'SloRulerError', code: 'RULER_AUTH_FAILED', httpStatus: 401 }
+    );
   });
 });
 

--- a/server/services/slo/__tests__/slo_reconciler.test.ts
+++ b/server/services/slo/__tests__/slo_reconciler.test.ts
@@ -34,7 +34,7 @@ import { SloReconciler } from '../slo_reconciler';
 // --------------------------------------------------------------------- helpers
 
 function noopLogger(): Logger {
-  return ({
+  return {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
@@ -43,7 +43,7 @@ function noopLogger(): Logger {
     log: jest.fn(),
     trace: jest.fn(),
     get: jest.fn(),
-  } as unknown) as Logger;
+  } as unknown as Logger;
 }
 
 interface Stored {
@@ -96,7 +96,7 @@ class FakeRepo {
             let m: RegExpExecArray | null;
             while ((m = re.exec(filter)) !== null) checks.push([m[1], m[2]]);
             for (const [k, v] of checks) {
-              const av = ((a as unknown) as Record<string, string | number | undefined>)[k];
+              const av = (a as unknown as Record<string, string | number | undefined>)[k];
               if (String(av) !== v) return false;
             }
             return true;
@@ -153,14 +153,14 @@ function buildReconciler(
   ruler: FakeRuler,
   opts: { graceMs?: number; intervalMs?: number; now?: () => Date } = {}
 ): SloReconciler {
-  const savedObjects = ({
+  const savedObjects = {
     createInternalRepository: () => repo.asClient(),
-  } as unknown) as import('../../../../../../src/core/server').SavedObjectsServiceStart;
-  const opensearch = ({
+  } as unknown as import('../../../../../../src/core/server').SavedObjectsServiceStart;
+  const opensearch = {
     client: {
       asInternalUser: { transport: { request: async () => ({ statusCode: 200, body: {} }) } },
     },
-  } as unknown) as import('../../../../../../src/core/server').OpenSearchServiceStart;
+  } as unknown as import('../../../../../../src/core/server').OpenSearchServiceStart;
   return new SloReconciler(noopLogger(), savedObjects, opensearch, ruler, {
     intervalMs: opts.intervalMs ?? 60_000,
     graceMs: opts.graceMs ?? 24 * 3600 * 1000,

--- a/server/services/slo/__tests__/slo_reconciler.test.ts
+++ b/server/services/slo/__tests__/slo_reconciler.test.ts
@@ -264,7 +264,7 @@ describe('SloReconciler.sweep', () => {
     const repo = new FakeRepo();
     const ruler = new FakeRuler();
     ruler.deleteImpl = async () => {
-      throw new Error('Cortex 503: backend unavailable');
+      throw new Error('Prometheus 503: backend unavailable');
     };
     repo.put(ref('ws-A', 'ds-1', 'fp-A', 0, '2026-05-21T00:00:00.000Z'));
     const recon = buildReconciler(repo, ruler, {

--- a/server/services/slo/__tests__/status_aggregator.test.ts
+++ b/server/services/slo/__tests__/status_aggregator.test.ts
@@ -52,11 +52,11 @@ function noopLogger(): Logger {
 function promDatasource(overrides: Partial<Datasource> = {}): Datasource {
   return {
     id: 'prom-ds-001',
-    name: 'my cortex',
+    name: 'my prometheus',
     type: 'prometheus',
     url: '',
     enabled: true,
-    directQueryName: 'my-cortex-connection',
+    directQueryName: 'my-prometheus-connection',
     ...overrides,
   };
 }
@@ -188,7 +188,7 @@ function envelopeToDataFrame(envelope: {
     type: 'data_frame',
     body: {
       type: 'data_frame',
-      name: 'cortex',
+      name: 'prometheus',
       schema: [
         { name: 'Time', type: 'time', values: [] },
         { name: 'Series', type: 'string', values: [] },
@@ -394,7 +394,7 @@ describe('parseInstantResponse', () => {
   it('unwraps the DirectQuery results-by-datasource envelope', () => {
     const samples = parseInstantResponse({
       results: {
-        'my cortex': {
+        'my prometheus': {
           resultType: 'vector',
           result: [{ metric: { slo_objective: 'a' }, value: [1700000000, '0.5'] }],
         },
@@ -478,7 +478,7 @@ describe('DirectQueryStatusAggregator.aggregate — happy paths', () => {
     expect(options).toEqual({ strategy: 'promql' });
     const reqBody = (request as { body: Record<string, Record<string, unknown>> }).body;
     expect(reqBody.query.language).toBe('PROMQL');
-    expect(reqBody.query.dataset).toEqual({ id: 'my-cortex-connection', type: 'PROMETHEUS' });
+    expect(reqBody.query.dataset).toEqual({ id: 'my-prometheus-connection', type: 'PROMETHEUS' });
     expect(reqBody.options.queryType).toBe('INSTANT');
 
     const transportCalls = requestMock.mock.calls.map(
@@ -601,7 +601,7 @@ describe('DirectQueryStatusAggregator.aggregate — disabled / missing data', ()
   });
 
   it('recording rule fires NaN (source metric idle) → state=source_idle', async () => {
-    // Cortex returned a sample at the requested timestamp, but the recorded
+    // Prometheus returned a sample at the requested timestamp, but the recorded
     // expression evaluated to NaN — typically `1 - (0/0)` because the source
     // metric has no traffic in the window. The aggregator surfaces
     // source_idle so the listing badge points at the upstream metric

--- a/server/services/slo/__tests__/status_aggregator.test.ts
+++ b/server/services/slo/__tests__/status_aggregator.test.ts
@@ -132,9 +132,9 @@ function instantResponse(
   };
 }
 
-function alertsResponse(
-  alerts: Array<{ sloId: string; state: 'firing' | 'pending' }>
-): { data: { alerts: Array<Record<string, unknown>> } } {
+function alertsResponse(alerts: Array<{ sloId: string; state: 'firing' | 'pending' }>): {
+  data: { alerts: Array<Record<string, unknown>> };
+} {
   return {
     data: {
       alerts: alerts.map((a) => ({
@@ -217,10 +217,7 @@ function envelopeToDataFrame(envelope: {
  *     helper used to multiplex both paths through a single mock — now it
  *     splits them so the wire-contract assertions match the migration.
  */
-function mockClient(handlers: {
-  query?: (body: unknown) => unknown;
-  alerts?: () => unknown;
-}): {
+function mockClient(handlers: { query?: (body: unknown) => unknown; alerts?: () => unknown }): {
   client: AlertingOSClient;
   requestMock: jest.Mock;
   searcherMock: jest.MockedFunction<PromQLSearcher>;
@@ -233,15 +230,15 @@ function mockClient(handlers: {
     }
     throw new Error(`Unexpected transport path: ${p.path}`);
   });
-  const searcherMock = (jest.fn(async (_ctx, request, _options) => {
+  const searcherMock = jest.fn(async (_ctx, request, _options) => {
     const body = handlers.query
       ? handlers.query((request as { body?: unknown }).body)
       : { resultType: 'vector', result: [] };
     return envelopeToDataFrame(body as Parameters<typeof envelopeToDataFrame>[0]) as never;
-  }) as unknown) as jest.MockedFunction<PromQLSearcher>;
+  }) as unknown as jest.MockedFunction<PromQLSearcher>;
   setPromQLSearcher(searcherMock as PromQLSearcher);
   return {
-    client: ({ transport: { request: requestMock } } as unknown) as AlertingOSClient,
+    client: { transport: { request: requestMock } } as unknown as AlertingOSClient,
     requestMock,
     searcherMock,
   };
@@ -746,9 +743,7 @@ describe('rule-health priority merge', () => {
           state: 'ok' | 'rules_partial' | 'rules_missing' | 'ruler_unreachable';
           rulerErrorCode?: string;
         }
-      | ((
-          input: Parameters<SloRuleHealthChecker['check']>[0]
-        ) => {
+      | ((input: Parameters<SloRuleHealthChecker['check']>[0]) => {
           state: 'ok' | 'rules_partial' | 'rules_missing' | 'ruler_unreachable';
           rulerErrorCode?: string;
         })

--- a/server/services/slo/__tests__/status_aggregator_dedup.test.ts
+++ b/server/services/slo/__tests__/status_aggregator_dedup.test.ts
@@ -103,9 +103,10 @@ function dedupDoc(
   };
 }
 
-function instantForMetrics(
-  samples: Array<{ name: string; ratio: number; tsSec?: number }>
-): { resultType: 'vector'; result: unknown[] } {
+function instantForMetrics(samples: Array<{ name: string; ratio: number; tsSec?: number }>): {
+  resultType: 'vector';
+  result: unknown[];
+} {
   return {
     resultType: 'vector',
     result: samples.map((s) => ({
@@ -180,15 +181,15 @@ function mockClient(
     if (p.path.endsWith('/api/v1/alerts')) return { statusCode: 200, body: alertsHandler() };
     throw new Error(`Unexpected transport path: ${p.path}`);
   });
-  const searcher = (jest.fn(async (_ctx, req, _options) => {
+  const searcher = jest.fn(async (_ctx, req, _options) => {
     const reqBody = (req as { body?: unknown }).body;
     return envelopeToDataFrame(
       queryHandler(reqBody) as Parameters<typeof envelopeToDataFrame>[0]
     ) as never;
-  }) as unknown) as jest.MockedFunction<PromQLSearcher>;
+  }) as unknown as jest.MockedFunction<PromQLSearcher>;
   setPromQLSearcher(searcher as PromQLSearcher);
   return {
-    client: ({ transport: { request } } as unknown) as AlertingOSClient,
+    client: { transport: { request } } as unknown as AlertingOSClient,
     request,
     searcher,
   };

--- a/server/services/slo/__tests__/status_aggregator_dedup.test.ts
+++ b/server/services/slo/__tests__/status_aggregator_dedup.test.ts
@@ -12,7 +12,7 @@
  *     fingerprint-named recording rules (no `slo_id=` selector), and maps
  *     samples back to objectives via the SO's fingerprint map.
  *   - A shared fingerprint across SLOs: the aggregator still makes its own
- *     per-SLO query, but the PromQL string is identical — demonstrates Cortex
+ *     per-SLO query, but the PromQL string is identical — demonstrates Prometheus
  *     can serve both from the same underlying recording series.
  *   - `rules_missing` from the health checker still wins (priority merge).
  *   - `expectedRuleGroupsFor` returns the dedup recording-group names + the
@@ -38,11 +38,11 @@ function noopLogger(): Logger {
 function ds(): Datasource {
   return {
     id: 'prom-ds-001',
-    name: 'my cortex',
+    name: 'my prometheus',
     type: 'prometheus',
     url: '',
     enabled: true,
-    directQueryName: 'my-cortex-connection',
+    directQueryName: 'my-prometheus-connection',
   };
 }
 
@@ -148,7 +148,7 @@ function envelopeToDataFrame(envelope: {
     type: 'data_frame',
     body: {
       type: 'data_frame',
-      name: 'cortex',
+      name: 'prometheus',
       schema: [],
       fields: [
         { name: 'Time', type: 'time', values: Time },
@@ -250,7 +250,7 @@ describe('DirectQueryStatusAggregator — dedup path', () => {
     expect(options).toEqual({ strategy: 'promql' });
   });
 
-  it('two SLOs sharing a fingerprint: each produces an identical query (Cortex can serve from one series)', async () => {
+  it('two SLOs sharing a fingerprint: each produces an identical query (Prometheus can serve from one series)', async () => {
     const docA = dedupDoc('slo-a', { 'availability-99-9': 'abcdef0123456789' });
     const docB = dedupDoc('slo-b', { 'availability-99-9': 'abcdef0123456789' }, { name: 'B' });
     const queries: string[] = [];

--- a/server/services/slo/rule_health_checker.ts
+++ b/server/services/slo/rule_health_checker.ts
@@ -148,7 +148,7 @@ export function createRuleHealthChecker(
   // production the ruler passed in is a real `RulerClient`; in tests the
   // caller passes a jest.fn-backed partial. The cast happens once at
   // construction time so the hot path stays type-safe.
-  const probe = (ruler as unknown) as RuleGroupProbe;
+  const probe = ruler as unknown as RuleGroupProbe;
 
   async function probeGroup(
     input: RuleHealthCheckInput,
@@ -188,19 +188,17 @@ export function createRuleHealthChecker(
       | { kind: 'unknown_error'; err: unknown };
 
     const outcomes = await Promise.all(
-      expected.map(
-        async (group): Promise<ProbeOutcome> => {
-          try {
-            const g = await probeGroup(input, group);
-            return g ? { kind: 'present', group } : { kind: 'missing', group };
-          } catch (err: unknown) {
-            if (err instanceof SloRulerError) {
-              return { kind: 'ruler_error', group, err };
-            }
-            return { kind: 'unknown_error', err };
+      expected.map(async (group): Promise<ProbeOutcome> => {
+        try {
+          const g = await probeGroup(input, group);
+          return g ? { kind: 'present', group } : { kind: 'missing', group };
+        } catch (err: unknown) {
+          if (err instanceof SloRulerError) {
+            return { kind: 'ruler_error', group, err };
           }
+          return { kind: 'unknown_error', err };
         }
-      )
+      })
     );
 
     // Bug-class errors (non-SloRulerError throws) take precedence — surface

--- a/server/services/slo/rule_health_checker.ts
+++ b/server/services/slo/rule_health_checker.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * RuleHealthChecker — per-SLO probe of the Prometheus-compatible ruler (Cortex)
+ * RuleHealthChecker — per-SLO probe of the Prometheus-compatible ruler
  * that answers: "are the rule groups this SLO's saved object expects to be
  * deployed actually present on the ruler right now?"
  *

--- a/server/services/slo/ruler_client.ts
+++ b/server/services/slo/ruler_client.ts
@@ -5,16 +5,16 @@
 
 /**
  * Ruler client — writes SLO rule groups to a Prometheus-compatible ruler
- * (Prometheus / Mimir) via the OpenSearch SQL plugin's DirectQuery resource proxy.
+ * (e.g. Cortex or Mimir) via the OpenSearch SQL plugin's DirectQuery resource proxy.
  *
  * Path: plugin → OSD scoped cluster client → /_plugins/_directquery/_resources/
  *       {dqName}/api/v1/rules/{namespace}[/{groupName}] → SQL plugin's
- *       Prometheus connector → Prometheus ruler.
+ *       Prometheus connector → the ruler.
  *
  * Contract (verified upstream, 2026-04-23 pre-check):
  *   - Create/update: POST .../api/v1/rules/{namespace} with body = rule-group YAML
  *   - Delete:        DELETE .../api/v1/rules/{namespace}/{groupName}
- *   Bodies are forwarded verbatim to Prometheus with Content-Type: application/yaml
+ *   Bodies are forwarded verbatim to the ruler with Content-Type: application/yaml
  *   (the SQL plugin's PrometheusClientImpl sets that header on the upstream call;
  *    the OSD transport does not expose per-request headers so we rely on that).
  *
@@ -41,7 +41,7 @@ import { SloRulerError } from '../../../common/slo/slo_errors';
  */
 export interface RulerClient {
   /**
-   * Upsert a rule group into the given namespace. Prometheus's POST semantics are
+   * Upsert a rule group into the given namespace. The ruler's POST semantics are
    * create-or-replace within `(namespace, group.name)`, so replaying the same
    * body is idempotent — useful for the compensation retry path.
    */
@@ -180,7 +180,7 @@ export class DirectQueryRulerClient implements RulerClient {
     try {
       // The OSD transport doesn't let us set Content-Type per request, but the
       // SQL plugin's PrometheusClientImpl forces Content-Type: application/yaml
-      // on the upstream Prometheus call — bodies are forwarded verbatim.
+      // on the upstream ruler call — bodies are forwarded verbatim.
       await client.transport.request({
         method: 'POST',
         path,
@@ -260,7 +260,7 @@ export class DirectQueryRulerClient implements RulerClient {
       if (extractHttpStatus(err) === 404) {
         return [];
       }
-      // The SQL plugin wraps Prometheus's "no rule groups found" 404 as HTTP 400
+      // The SQL plugin wraps the ruler's "no rule groups found" 404 as HTTP 400
       // with a `DataSourceClientException` / `PrometheusClientException`
       // envelope whose `details` contains `"Ruler request failed with code:
       // 404. Error details: no rule groups found"`. Treat that as an empty
@@ -327,7 +327,7 @@ function stringifyBody(body: unknown): string {
  * probe paths can branch on 404 without building a full SloRulerError.
  */
 /**
- * Prometheus's ruler returns HTTP 404 with body `no rule groups found` when a
+ * The ruler returns HTTP 404 with body `no rule groups found` when a
  * namespace exists but holds nothing (or hasn't yet been created). The
  * OpenSearch SQL plugin's DirectQuery proxy does not forward that status —
  * it wraps the response as HTTP 400 with a structured envelope:
@@ -352,7 +352,7 @@ function isWrappedEmptyNamespaceError(err: unknown): boolean {
     const { type, details } = error as { type?: unknown; details?: unknown };
     if (typeof type !== 'string' || !/ClientException$/.test(type)) continue;
     if (typeof details !== 'string') continue;
-    // Upstream Prometheus status is embedded as `code: <N>` inside details.
+    // Upstream ruler status is embedded as `code: <N>` inside details.
     const match = /\bcode:\s*(\d{3})\b/.exec(details);
     if (match && match[1] === '404') return true;
   }
@@ -430,7 +430,7 @@ function isGeneratedRule(rule: GeneratedRule | null): rule is GeneratedRule {
 /**
  * Coerce the list-namespace response. The ruler's HTTP API answers with the
  * Prometheus envelope `{ status: "success", data: { groups: [ { name, file,
- * interval, rules, ... }, ... ] } }`. Prometheus's ruler CRUD admin surface also
+ * interval, rules, ... }, ... ] } }`. The ruler's CRUD admin surface also
  * accepts `{ "<ns>": [ { name, interval, rules }, ... ] }`; some tests feed a
  * top-level array or a single group. Accept all four shapes.
  */
@@ -462,7 +462,7 @@ function coerceRuleGroupList(doc: unknown): GeneratedRuleGroup[] {
         return groups.map(coerceRuleGroup).filter(isGeneratedRuleGroup);
       }
     }
-    // Prometheus namespace-keyed envelope: take every array-valued field and
+    // Ruler namespace-keyed CRUD envelope: take every array-valued field and
     // flatten — namespaces are already filtered server-side by the URL, so
     // this is safe even if multiple keys appear.
     const fromEnvelope: GeneratedRuleGroup[] = [];

--- a/server/services/slo/ruler_client.ts
+++ b/server/services/slo/ruler_client.ts
@@ -293,8 +293,8 @@ export class DirectQueryRulerClient implements RulerClient {
       typeof raw?.statusCode === 'number'
         ? raw.statusCode
         : typeof raw?.meta?.statusCode === 'number'
-        ? raw.meta.statusCode
-        : 0;
+          ? raw.meta.statusCode
+          : 0;
     const rawBody = stringifyBody(raw?.body ?? raw?.meta?.body ?? raw?.message ?? String(err));
 
     let code: 'RULER_VALIDATION_FAILED' | 'RULER_AUTH_FAILED' | 'RULER_UNREACHABLE';

--- a/server/services/slo/ruler_client.ts
+++ b/server/services/slo/ruler_client.ts
@@ -5,16 +5,16 @@
 
 /**
  * Ruler client — writes SLO rule groups to a Prometheus-compatible ruler
- * (Cortex / Mimir) via the OpenSearch SQL plugin's DirectQuery resource proxy.
+ * (Prometheus / Mimir) via the OpenSearch SQL plugin's DirectQuery resource proxy.
  *
  * Path: plugin → OSD scoped cluster client → /_plugins/_directquery/_resources/
  *       {dqName}/api/v1/rules/{namespace}[/{groupName}] → SQL plugin's
- *       Prometheus connector → Cortex ruler.
+ *       Prometheus connector → Prometheus ruler.
  *
  * Contract (verified upstream, 2026-04-23 pre-check):
  *   - Create/update: POST .../api/v1/rules/{namespace} with body = rule-group YAML
  *   - Delete:        DELETE .../api/v1/rules/{namespace}/{groupName}
- *   Bodies are forwarded verbatim to Cortex with Content-Type: application/yaml
+ *   Bodies are forwarded verbatim to Prometheus with Content-Type: application/yaml
  *   (the SQL plugin's PrometheusClientImpl sets that header on the upstream call;
  *    the OSD transport does not expose per-request headers so we rely on that).
  *
@@ -41,7 +41,7 @@ import { SloRulerError } from '../../../common/slo/slo_errors';
  */
 export interface RulerClient {
   /**
-   * Upsert a rule group into the given namespace. Cortex's POST semantics are
+   * Upsert a rule group into the given namespace. Prometheus's POST semantics are
    * create-or-replace within `(namespace, group.name)`, so replaying the same
    * body is idempotent — useful for the compensation retry path.
    */
@@ -88,11 +88,11 @@ export interface RulerClient {
 }
 
 // ============================================================================
-// YAML serialization — Cortex / Prometheus rule-group format
+// YAML serialization — Prometheus rule-group format
 // ============================================================================
 
 /**
- * Serialize a GeneratedRuleGroup to the YAML shape Cortex accepts:
+ * Serialize a GeneratedRuleGroup to the YAML shape Prometheus accepts:
  *
  *   name: <groupName>
  *   interval: <Ns|Nm|Nh>
@@ -180,7 +180,7 @@ export class DirectQueryRulerClient implements RulerClient {
     try {
       // The OSD transport doesn't let us set Content-Type per request, but the
       // SQL plugin's PrometheusClientImpl forces Content-Type: application/yaml
-      // on the upstream Cortex call — bodies are forwarded verbatim.
+      // on the upstream Prometheus call — bodies are forwarded verbatim.
       await client.transport.request({
         method: 'POST',
         path,
@@ -260,7 +260,7 @@ export class DirectQueryRulerClient implements RulerClient {
       if (extractHttpStatus(err) === 404) {
         return [];
       }
-      // The SQL plugin wraps Cortex's "no rule groups found" 404 as HTTP 400
+      // The SQL plugin wraps Prometheus's "no rule groups found" 404 as HTTP 400
       // with a `DataSourceClientException` / `PrometheusClientException`
       // envelope whose `details` contains `"Ruler request failed with code:
       // 404. Error details: no rule groups found"`. Treat that as an empty
@@ -327,7 +327,7 @@ function stringifyBody(body: unknown): string {
  * probe paths can branch on 404 without building a full SloRulerError.
  */
 /**
- * Cortex's ruler returns HTTP 404 with body `no rule groups found` when a
+ * Prometheus's ruler returns HTTP 404 with body `no rule groups found` when a
  * namespace exists but holds nothing (or hasn't yet been created). The
  * OpenSearch SQL plugin's DirectQuery proxy does not forward that status —
  * it wraps the response as HTTP 400 with a structured envelope:
@@ -352,7 +352,7 @@ function isWrappedEmptyNamespaceError(err: unknown): boolean {
     const { type, details } = error as { type?: unknown; details?: unknown };
     if (typeof type !== 'string' || !/ClientException$/.test(type)) continue;
     if (typeof details !== 'string') continue;
-    // Upstream Cortex status is embedded as `code: <N>` inside details.
+    // Upstream Prometheus status is embedded as `code: <N>` inside details.
     const match = /\bcode:\s*(\d{3})\b/.exec(details);
     if (match && match[1] === '404') return true;
   }
@@ -430,7 +430,7 @@ function isGeneratedRule(rule: GeneratedRule | null): rule is GeneratedRule {
 /**
  * Coerce the list-namespace response. The ruler's HTTP API answers with the
  * Prometheus envelope `{ status: "success", data: { groups: [ { name, file,
- * interval, rules, ... }, ... ] } }`. Cortex's ruler CRUD admin surface also
+ * interval, rules, ... }, ... ] } }`. Prometheus's ruler CRUD admin surface also
  * accepts `{ "<ns>": [ { name, interval, rules }, ... ] }`; some tests feed a
  * top-level array or a single group. Accept all four shapes.
  */
@@ -462,7 +462,7 @@ function coerceRuleGroupList(doc: unknown): GeneratedRuleGroup[] {
         return groups.map(coerceRuleGroup).filter(isGeneratedRuleGroup);
       }
     }
-    // Cortex namespace-keyed envelope: take every array-valued field and
+    // Prometheus namespace-keyed envelope: take every array-valued field and
     // flatten — namespaces are already filtered server-side by the URL, so
     // this is safe even if multiple keys appear.
     const fromEnvelope: GeneratedRuleGroup[] = [];

--- a/server/services/slo/slo_rule_ref_store.ts
+++ b/server/services/slo/slo_rule_ref_store.ts
@@ -231,7 +231,7 @@ export class SloRuleRefStore {
    *
    * Read-time aggregation (vs. a materialized aggregate SO): the GC pass
    * fires on a slow timer, the per-fingerprint cardinality is bounded by
-   * the number of workspaces a single Prometheus tenant serves, and the
+   * the number of workspaces a single ruler tenant serves, and the
    * matching slo-rule-ref docs all live behind the wrapper anyway — paying
    * one O(workspaces) find here is cheaper than coordinating writes to a
    * second SO on every increment/decrement.

--- a/server/services/slo/slo_rule_ref_store.ts
+++ b/server/services/slo/slo_rule_ref_store.ts
@@ -231,7 +231,7 @@ export class SloRuleRefStore {
    *
    * Read-time aggregation (vs. a materialized aggregate SO): the GC pass
    * fires on a slow timer, the per-fingerprint cardinality is bounded by
-   * the number of workspaces a single Cortex tenant serves, and the
+   * the number of workspaces a single Prometheus tenant serves, and the
    * matching slo-rule-ref docs all live behind the wrapper anyway — paying
    * one O(workspaces) find here is cheaper than coordinating writes to a
    * second SO on every increment/decrement.

--- a/server/services/slo/status_aggregator.ts
+++ b/server/services/slo/status_aggregator.ts
@@ -193,7 +193,7 @@ interface InstantSample {
 
 /**
  * Variant of `InstantSample` that retains samples whose value was non-finite
- * (NaN / Infinity). The recording rule is alive — Cortex returned a series at
+ * (NaN / Infinity). The recording rule is alive — Prometheus returned a series at
  * the requested timestamp — but the recorded expression evaluated to e.g.
  * `1 - (0 / 0)` because the source metric had no traffic in the window. The
  * aggregator differentiates "rule fires NaN" (`source_idle`) from "ruler
@@ -691,7 +691,7 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
    * `__name__` and map samples back to objectives via the provided
    * `recordingFingerprints`. One `__name__=~` query per call covers every
    * fingerprint this SLO references, so a multi-objective SLO with N unique
-   * SLIs pays one Cortex round-trip regardless of N.
+   * SLIs pays one Prometheus round-trip regardless of N.
    *
    * Samples are keyed by `__name__` label; the map returned is
    * `objectiveName → sample` so the caller's existing per-objective loop
@@ -818,7 +818,7 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
  * Maximum SLO ids folded into a single batched PromQL `slo_id=~"..."` regex
  * alternation. Each id contributes its own length plus a `|` separator and any
  * RE2 escapes; UUIDs hover around 40 chars after escaping. 200 ids keeps the
- * query body under ~10 KB which sits well below typical Prometheus / Cortex
+ * query body under ~10 KB which sits well below typical Prometheus
  * `max-query-length` limits while still amortising the round-trip cost over a
  * large fleet.
  */

--- a/server/services/slo/status_aggregator.ts
+++ b/server/services/slo/status_aggregator.ts
@@ -806,7 +806,7 @@ export class DirectQueryStatusAggregator implements SloStatusAggregator {
       dataSourceId: ds.mdsId,
       sourceRequest: ctx.sourceRequest,
     });
-    return parseInstantResponseWithNonFinite((envelope as unknown) as Record<string, unknown>);
+    return parseInstantResponseWithNonFinite(envelope as unknown as Record<string, unknown>);
   }
 }
 


### PR DESCRIPTION
## Description

The SLO/alerting code referred to the Prometheus-compatible ruler backend as "Cortex" in comments, test fixtures, and one user-facing callout. This renames those references to "Prometheus" for consistent, backend-neutral terminology.

- **Comments** describing the ruler backend.
- **Test fixtures**: datasource names/ids (e.g. `My Cortex`, `observability_stack_cortex`, `my-cortex-connection`) and error strings, renamed consistently within each file.
- **User-facing string**: `Rule groups missing in Cortex` → `Rule groups missing in Prometheus` (plus its test assertion).
- Comments that paired the two names (e.g. `Cortex / Prometheus rule-group format`) were reworded to avoid redundancy.

No behavior change. Test infra that runs the actual Cortex software (`.cypress/cortex-ci/`, `cypress-slo-cortex.yml`) is intentionally left untouched — those are literal references to the running backend, not terminology.

## Commits

This PR is split into two commits for reviewability:

1. **`refactor: rename 'Cortex' references to 'Prometheus'`** — the rename only (48 files, 122/122). Review this commit for the actual change.
2. **`style: reconform Prettier/ESLint on files touched by the rename`** — mechanical `lint --fix` output, no behavior change. Required because CI's Lint job re-lints the files changed in a PR: these SLO files were introduced in #2676 and passed Lint then, but the repo's floating lint toolchain has since resolved to newer versions (`prettier@3.9.4`, `eslint-plugin-prettier@5.5.6`) whose formatting rules differ (notably it lints at width 80). Touching these files for the rename makes CI re-lint them under the current toolchain and flag the pre-existing drift; this commit reconciles it so Lint is green. Kept separate so the rename can be reviewed in isolation.

## Testing
- 527/527 pure server/common SLO + error unit tests pass with the renamed fixtures.
- `yarn lint` passes (0 errors) on all changed files.

## Check List
- [x] All tests pass
- [x] New functionality includes testing (n/a — rename only)
- [x] New functionality has been documented (n/a)
- [x] Commits are signed per the DCO using `--signoff`