### PR TITLE
fix(ci): pin Cypress to 13.17.0 in FTR e2e workflow

### DIFF
--- a/.github/workflows/ftr-e2e-dashboards-observability-test.yml
+++ b/.github/workflows/ftr-e2e-dashboards-observability-test.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Install Cypress
         run: |
-          npm install cypress --save-dev
+          npm install cypress@13.17.0 --save-dev
         shell: bash
         working-directory: opensearch-dashboards-functional-test
 


### PR DESCRIPTION
## Description

The FTR E2E workflow installed Cypress with an **unpinned** command:

```yaml
- name: Install Cypress
  run: |
    npm install cypress --save-dev
```

Because no version was specified, this recently began resolving to **Cypress 16.0.0**, which overrode the `13.17.0` version pinned by the [`opensearch-dashboards-functional-test`](https://github.com/opensearch-project/opensearch-dashboards-functional-test) repo that the workflow checks out and runs.

Cypress 16 **removed the `Cypress.env()` API**:

> `Cypress.env()` was removed in Cypress version 16.0.0. Please update to use `Cypress.expose()` for non-sensitive values, or `cy.env()` for sensitive values.

The functional-test suite calls `Cypress.env()` at **module import time** (`cypress/utils/base_constants.js`), which is loaded transitively by every spec via `constants.js → commands.js → support/index.js`. As a result **all 9 observability specs failed identically** with `An uncaught error was detected outside of a test` — 0 passing / 1 failing each — before any test body executed. Cypress 16 also removed `experimentalMemoryManagement`, producing an additional warning.

This is not caused by any plugin code change — it is CI toolchain version drift, so it affects every observability FTR run (and any PR) until pinned.

## Fix

Pin the install to the version the functional-test repo uses:

```yaml
npm install cypress@13.17.0 --save-dev
```

This aligns with:
- The `opensearch-dashboards-functional-test` repo, pinned to `13.17.0`.
- `OpenSearch-Dashboards`, pinned to `^13.6.0`.
- This repo's other Cypress workflows (`integration-tests-workflow.yml`, `cypress-slo-cortex.yml`), which use `npx cypress install` and already respect the declared version.

Migrating the functional-test suite to the Cypress 16 API (`Cypress.env` is used in ~107 files there) is a separate, larger effort that should follow OpenSearch-Dashboards upgrading Cypress, not be forced by this CI break.

## Check List
- [x] All tests pass
- [x] New functionality does not break existing functionality
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
