### PR TITLE
fix(observability): surface the missing permission on ruler 403 create failures

### DIFF
--- a/common/error/__tests__/classifiers.test.ts
+++ b/common/error/__tests__/classifiers.test.ts
@@ -110,11 +110,22 @@ describe('default classifiers — coverage table', () => {
       operation: 'rule.create.metric',
       upstreamCode: 'RULER_AUTH_FAILED',
       httpStatus: 403,
+      rawBody:
+        'no permissions for [cluster:admin/opensearch/directquery/write] and User [name=test] at https://host.internal:9090',
     });
     expect(forbidden.code).toBe('PERMISSION_DENIED');
 
-    // Auth failures carry no raw upstream detail.
+    // 401 re-auth carries no raw upstream detail.
     expect(unauthorized.details).toBeUndefined();
+
+    // 403 surfaces the missing permission (redacted) so the user can
+    // self-diagnose, while topology (host/URL) is still scrubbed.
+    const safe = forbidden.details?.find((d) => d.sensitivity === 'safe');
+    expect(safe?.value).toContain(
+      'no permissions for [cluster:admin/opensearch/directquery/write]'
+    );
+    expect(safe?.value).not.toContain('host.internal');
+    expect(safe?.value).toContain('<redacted-url>');
   });
 
   it('UNKNOWN: unmatched error still surfaces a redacted message + keeps raw sensitive', () => {

--- a/common/error/classifiers/ruler.ts
+++ b/common/error/classifiers/ruler.ts
@@ -31,20 +31,23 @@ export const rulerClassifier: ErrorClassifier = {
           details: rawDetails(ctx.rawBody),
         };
       case 'RULER_AUTH_FAILED':
-        // No raw details for auth failures — upstream auth errors can echo
-        // tokens/headers. Split 401 (re-auth) from 403 (lacks permission).
         return ctx.httpStatus === 401
-          ? {
+          ? // 401 carries no details. The fix is to re-authenticate.
+            {
               category: 'PERMISSION_DENIED',
               code: ErrorCode.AUTH_REQUIRED,
               retryable: false,
               httpStatus: ctx.httpStatus,
             }
-          : {
+          : // 403 keeps the redacted body so the caller sees the missing
+            // permission. Redaction leaves RBAC principal names (`User
+            // [name=...]`) intact, which is the caller's own identity.
+            {
               category: 'PERMISSION_DENIED',
               code: ErrorCode.PERMISSION_DENIED,
               retryable: false,
               httpStatus: ctx.httpStatus,
+              details: rawDetails(ctx.rawBody),
             };
       case 'RULER_UNREACHABLE':
       default:


### PR DESCRIPTION
### Description
The ruler `RULER_AUTH_FAILED` branch previously returned no `details` for either 401 or 403, so a 403 on metric rule / SLO create surfaced only a generic toast that never told the user which permission was missing.

This change attaches `rawDetails(ctx.rawBody)` to the 403 branch, the same redaction and sensitive-stripping path the `RULER_VALIDATION_FAILED` branch already uses. The redacted `safe` detail keeps the actionable permission string, for example `no permissions for [cluster:admin/opensearch/directquery/write]`, while URLs, hosts, IPs, and token-shaped content are scrubbed by `redactForDisplay`. The verbatim `sensitive` copy is dropped at the client boundary unless the operator sets `observability.errors.exposeSensitiveErrorDetail`, which defaults to `false`.

The 401 branch stays detail-free on purpose. A 401 means the credential itself was rejected, which is the response most likely to echo a bad token or header, so no upstream body is surfaced there.

### Issues Resolved
Fixes [#2814](https://github.com/opensearch-project/dashboards-observability/issues/2814)
Builds on [#2819](https://github.com/opensearch-project/dashboards-observability/pull/2819)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
