### PR TITLE
fix(apm): promote range-filter gate flags from refs to state + add re-render regression tests

### DIFF
--- a/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
@@ -24,10 +24,12 @@ jest.mock('../../../shared/components/dependency_filter_sidebar', () => ({
   // Expose the latency slider callback so tests can activate the range filter. Narrowing to
   // [latencyMax, latencyMax] leaves only the single highest-latency row.
   DependencyFilterSidebar: (props: {
+    latencyRange: [number, number];
     latencyMax: number;
     onLatencyRangeChange: (range: [number, number]) => void;
   }) => (
     <div data-test-subj="dependencyFilterSidebar">
+      <span data-test-subj="mockLatencyRange">{JSON.stringify(props.latencyRange)}</span>
       <button
         type="button"
         data-test-subj="mockNarrowLatencyRange"
@@ -89,6 +91,13 @@ const buildMetricsMap = (deps: ReturnType<typeof buildDependencies>) =>
       },
     ])
   );
+
+// Every percentile here floors/ceils to {30, 31}, so latencyBounds is unchanged across a switch
+// and the bounds effect (keyed on those bounds) never fires to reset the range.
+const tiedBounds = (items: ReturnType<typeof buildDependencies>) =>
+  items.map((dep, i) => ({ ...dep, p99Duration: 30.1 + i * 0.05, p90Duration: 30.2 + i * 0.04 }));
+
+const latencyRangeText = () => screen.getByTestId('mockLatencyRange').textContent;
 
 const props = {
   serviceName: 'checkout',
@@ -209,6 +218,35 @@ describe('ServiceDependencies - percentile switch does not remount the table (#2
     fireEvent.click(screen.getByTestId('mockNarrowLatencyRange'));
     expect(screen.getByText(svc(14))).toBeInTheDocument();
     expect(screen.queryByText(svc(0))).not.toBeInTheDocument();
+  });
+
+  // The percentile handler resets latencyRange itself rather than relying on the bounds effect,
+  // which does not fire when the new percentile rounds to the same bounds. The stale range is
+  // invisible in the table (the gate is off), so assert on the range the sidebar receives.
+  it('should reset the latency range on a percentile switch when the rounded bounds are unchanged', () => {
+    const dependencies = tiedBounds(buildDependencies());
+    (useDependencies as jest.Mock).mockReturnValue({
+      data: dependencies,
+      groupedData: dependencies,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    (useDependencyMetrics as jest.Mock).mockReturnValue({
+      metrics: buildMetricsMap(dependencies),
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ServiceDependencies {...props} />);
+    expect(latencyRangeText()).toBe('[30,31]');
+
+    fireEvent.click(screen.getByTestId('mockNarrowLatencyRange'));
+    expect(latencyRangeText()).toBe('[31,31]');
+
+    switchPercentile('P90');
+
+    expect(latencyRangeText()).toBe('[30,31]');
   });
 });
 

--- a/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
@@ -21,7 +21,20 @@ jest.mock('../../../shared/hooks/use_debounced_value', () => ({
   useDebouncedValue: (value: unknown) => value,
 }));
 jest.mock('../../../shared/components/dependency_filter_sidebar', () => ({
-  DependencyFilterSidebar: () => <div data-test-subj="dependencyFilterSidebar" />,
+  // Expose the latency slider callback so tests can activate the range filter. Narrowing to
+  // [latencyMax, latencyMax] leaves only the single highest-latency row.
+  DependencyFilterSidebar: (props: {
+    latencyMax: number;
+    onLatencyRangeChange: (range: [number, number]) => void;
+  }) => (
+    <div data-test-subj="dependencyFilterSidebar">
+      <button
+        type="button"
+        data-test-subj="mockNarrowLatencyRange"
+        onClick={() => props.onLatencyRangeChange([props.latencyMax, props.latencyMax])}
+      />
+    </div>
+  ),
 }));
 jest.mock('../../../shared/components/promql_line_chart', () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -173,5 +186,28 @@ describe('ServiceDependencies - percentile switch does not remount the table (#2
 
     expect(screen.getByText(svc(0))).toBeInTheDocument();
     expect(screen.queryByText(svc(14))).not.toBeInTheDocument();
+  });
+
+  // A percentile switch resets the latency gate, so a range filter set under one percentile does
+  // not carry over to the next; moving the slider again re-engages it. This locks the gate's
+  // user-facing behavior and is not sensitive to the ref-vs-state implementation of the flag.
+  it('should clear the latency filter on a percentile switch and re-engage it when the slider moves again', async () => {
+    render(<ServiceDependencies {...props} />);
+
+    await waitFor(() => expect(screen.getByText(svc(0))).toBeInTheDocument());
+
+    // Move the slider to the top of the range: only the highest-latency row (dep-svc-14) survives.
+    fireEvent.click(screen.getByTestId('mockNarrowLatencyRange'));
+    expect(screen.getByText(svc(14))).toBeInTheDocument();
+    expect(screen.queryByText(svc(0))).not.toBeInTheDocument();
+
+    // Switching percentile clears the filter: every row returns.
+    switchPercentile('P90');
+    expect(screen.getByText(svc(0))).toBeInTheDocument();
+
+    // Moving the slider again re-engages the filter under the new percentile.
+    fireEvent.click(screen.getByTestId('mockNarrowLatencyRange'));
+    expect(screen.getByText(svc(14))).toBeInTheDocument();
+    expect(screen.queryByText(svc(0))).not.toBeInTheDocument();
   });
 });

--- a/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_dependencies.test.tsx
@@ -211,3 +211,42 @@ describe('ServiceDependencies - percentile switch does not remount the table (#2
     expect(screen.queryByText(svc(0))).not.toBeInTheDocument();
   });
 });
+
+describe('ServiceDependencies - requests filter does not blank the table on load', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const dependencies = buildDependencies();
+    (useDependencies as jest.Mock).mockReturnValue({
+      data: dependencies,
+      groupedData: dependencies,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    (useDependencyMetrics as jest.Mock).mockReturnValue({
+      metrics: buildMetricsMap(dependencies),
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  // requestsRange starts at [0,0] while requestsBounds derives from the data, so an ungated filter
+  // reads active and blanks the table for the one commit before the bounds effect resets the range.
+  // The profiler is needed because render() flushes that effect before returning, hiding the transient.
+  it('should show rows on every commit while bounds and range settle', () => {
+    const rowVisiblePerCommit: boolean[] = [];
+    render(
+      <React.Profiler
+        id="dependencies"
+        onRender={() => {
+          rowVisiblePerCommit.push(document.body.textContent?.includes(svc(0)) ?? false);
+        }}
+      >
+        <ServiceDependencies {...props} />
+      </React.Profiler>
+    );
+
+    expect(rowVisiblePerCommit.length).toBeGreaterThan(0);
+    expect(rowVisiblePerCommit.every(Boolean)).toBe(true);
+  });
+});

--- a/public/components/apm/pages/service_details/__tests__/service_operations.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_operations.test.tsx
@@ -25,10 +25,12 @@ jest.mock('../../../shared/components/operation_filter_sidebar', () => ({
   // Expose the latency slider callback so tests can activate the range filter. Narrowing to
   // [latencyMax, latencyMax] leaves only the single highest-latency row.
   OperationFilterSidebar: (props: {
+    latencyRange: [number, number];
     latencyMax: number;
     onLatencyRangeChange: (range: [number, number]) => void;
   }) => (
     <div data-test-subj="operationFilterSidebar">
+      <span data-test-subj="mockLatencyRange">{JSON.stringify(props.latencyRange)}</span>
       <button
         type="button"
         data-test-subj="mockNarrowLatencyRange"
@@ -91,6 +93,13 @@ const buildMetricsMap = (operations: ReturnType<typeof buildOperations>) =>
       },
     ])
   );
+
+// Every percentile here floors/ceils to {30, 31}, so latencyBounds is unchanged across a switch
+// and the bounds effect (keyed on those bounds) never fires to reset the range.
+const tiedBounds = (items: ReturnType<typeof buildOperations>) =>
+  items.map((op, i) => ({ ...op, p99Duration: 30.1 + i * 0.05, p90Duration: 30.2 + i * 0.04 }));
+
+const latencyRangeText = () => screen.getByTestId('mockLatencyRange').textContent;
 
 const props = {
   serviceName: 'checkout',
@@ -211,6 +220,34 @@ describe('ServiceOperations - percentile switch does not remount the table (#262
     fireEvent.click(screen.getByTestId('mockNarrowLatencyRange'));
     expect(screen.getByText(padded(14))).toBeInTheDocument();
     expect(screen.queryByText(padded(0))).not.toBeInTheDocument();
+  });
+
+  // The percentile handler resets latencyRange itself rather than relying on the bounds effect,
+  // which does not fire when the new percentile rounds to the same bounds. The stale range is
+  // invisible in the table (the gate is off), so assert on the range the sidebar receives.
+  it('should reset the latency range on a percentile switch when the rounded bounds are unchanged', () => {
+    const operations = tiedBounds(buildOperations());
+    (useOperations as jest.Mock).mockReturnValue({
+      data: operations,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    (useOperationMetrics as jest.Mock).mockReturnValue({
+      metrics: buildMetricsMap(operations),
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ServiceOperations {...props} />);
+    expect(latencyRangeText()).toBe('[30,31]');
+
+    fireEvent.click(screen.getByTestId('mockNarrowLatencyRange'));
+    expect(latencyRangeText()).toBe('[31,31]');
+
+    switchPercentile('P90');
+
+    expect(latencyRangeText()).toBe('[30,31]');
   });
 });
 

--- a/public/components/apm/pages/service_details/__tests__/service_operations.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_operations.test.tsx
@@ -213,3 +213,41 @@ describe('ServiceOperations - percentile switch does not remount the table (#262
     expect(screen.queryByText(padded(0))).not.toBeInTheDocument();
   });
 });
+
+describe('ServiceOperations - requests filter does not blank the table on load', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const operations = buildOperations();
+    (useOperations as jest.Mock).mockReturnValue({
+      data: operations,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    (useOperationMetrics as jest.Mock).mockReturnValue({
+      metrics: buildMetricsMap(operations),
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  // requestsRange starts at [0,0] while requestsBounds derives from the data, so an ungated filter
+  // reads active and blanks the table for the one commit before the bounds effect resets the range.
+  // The profiler is needed because render() flushes that effect before returning, hiding the transient.
+  it('should show rows on every commit while bounds and range settle', () => {
+    const rowVisiblePerCommit: boolean[] = [];
+    render(
+      <React.Profiler
+        id="operations"
+        onRender={() => {
+          rowVisiblePerCommit.push(document.body.textContent?.includes(padded(0)) ?? false);
+        }}
+      >
+        <ServiceOperations {...props} />
+      </React.Profiler>
+    );
+
+    expect(rowVisiblePerCommit.length).toBeGreaterThan(0);
+    expect(rowVisiblePerCommit.every(Boolean)).toBe(true);
+  });
+});

--- a/public/components/apm/pages/service_details/__tests__/service_operations.test.tsx
+++ b/public/components/apm/pages/service_details/__tests__/service_operations.test.tsx
@@ -22,7 +22,20 @@ jest.mock('../../../shared/hooks/use_debounced_value', () => ({
   useDebouncedValue: (value: unknown) => value,
 }));
 jest.mock('../../../shared/components/operation_filter_sidebar', () => ({
-  OperationFilterSidebar: () => <div data-test-subj="operationFilterSidebar" />,
+  // Expose the latency slider callback so tests can activate the range filter. Narrowing to
+  // [latencyMax, latencyMax] leaves only the single highest-latency row.
+  OperationFilterSidebar: (props: {
+    latencyMax: number;
+    onLatencyRangeChange: (range: [number, number]) => void;
+  }) => (
+    <div data-test-subj="operationFilterSidebar">
+      <button
+        type="button"
+        data-test-subj="mockNarrowLatencyRange"
+        onClick={() => props.onLatencyRangeChange([props.latencyMax, props.latencyMax])}
+      />
+    </div>
+  ),
 }));
 jest.mock('../../../shared/components/service_correlations_flyout', () => ({
   ServiceCorrelationsFlyout: () => <div data-test-subj="correlationsFlyout" />,
@@ -175,5 +188,28 @@ describe('ServiceOperations - percentile switch does not remount the table (#262
 
     expect(screen.getByText(padded(0))).toBeInTheDocument();
     expect(screen.queryByText(padded(14))).not.toBeInTheDocument();
+  });
+
+  // A percentile switch resets the latency gate, so a range filter set under one percentile does
+  // not carry over to the next; moving the slider again re-engages it. This locks the gate's
+  // user-facing behavior and is not sensitive to the ref-vs-state implementation of the flag.
+  it('should clear the latency filter on a percentile switch and re-engage it when the slider moves again', async () => {
+    render(<ServiceOperations {...props} />);
+
+    await waitFor(() => expect(screen.getByText(padded(0))).toBeInTheDocument());
+
+    // Move the slider to the top of the range: only the highest-latency row (op-14) survives.
+    fireEvent.click(screen.getByTestId('mockNarrowLatencyRange'));
+    expect(screen.getByText(padded(14))).toBeInTheDocument();
+    expect(screen.queryByText(padded(0))).not.toBeInTheDocument();
+
+    // Switching percentile clears the filter: every row returns.
+    switchPercentile('P90');
+    expect(screen.getByText(padded(0))).toBeInTheDocument();
+
+    // Moving the slider again re-engages the filter under the new percentile.
+    fireEvent.click(screen.getByTestId('mockNarrowLatencyRange'));
+    expect(screen.getByText(padded(14))).toBeInTheDocument();
+    expect(screen.queryByText(padded(0))).not.toBeInTheDocument();
   });
 });

--- a/public/components/apm/pages/service_details/service_dependencies.tsx
+++ b/public/components/apm/pages/service_details/service_dependencies.tsx
@@ -243,8 +243,10 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
   // Range filter states
   const [latencyRange, setLatencyRange] = useState<[number, number]>([0, 0]);
   const [requestsRange, setRequestsRange] = useState<[number, number]>([0, 0]);
-  const latencyUserModified = useRef(false);
-  const requestsUserModified = useRef(false);
+  // Track whether the user has explicitly interacted with range filters.
+  // Use as state, so the memos that read them re-run when a flag flips.
+  const [latencyUserModified, setLatencyUserModified] = useState(false);
+  const [requestsUserModified, setRequestsUserModified] = useState(false);
 
   // Parse time range
   const parsedTimeRange = useMemo(() => {
@@ -421,7 +423,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
   // Step 3: Reset slider ranges when bounds change
   // Use functional update to prevent unnecessary re-renders when values haven't changed
   useEffect(() => {
-    latencyUserModified.current = false;
+    setLatencyUserModified(false);
     setLatencyRange((prev) => {
       if (prev[0] === latencyBounds.min && prev[1] === latencyBounds.max) {
         return prev; // Return same reference to avoid re-render
@@ -431,7 +433,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
   }, [latencyBounds.min, latencyBounds.max]);
 
   useEffect(() => {
-    requestsUserModified.current = false;
+    setRequestsUserModified(false);
     setRequestsRange((prev) => {
       if (prev[0] === requestsBounds.min && prev[1] === requestsBounds.max) {
         return prev; // Return same reference to avoid re-render
@@ -458,7 +460,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
       // Latency range filter (only if range has been adjusted)
       const isLatencyFilterActive =
         // Gating on latencyUserModified avoids a false positive after a percentile switch
-        latencyUserModified.current &&
+        latencyUserModified &&
         (latencyRange[0] > latencyBounds.min || latencyRange[1] < latencyBounds.max);
       if (isLatencyFilterActive) {
         // Use the selected percentile's duration for filtering
@@ -491,6 +493,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
     });
   }, [
     textFilteredDependencies,
+    latencyUserModified,
     latencyRange,
     requestsRange,
     latencyBounds,
@@ -507,7 +510,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
   // Range-slider changes reset the page to 1 (a filter change), unlike a percentile switch.
   const onLatencyRangeChange = useCallback(
     (val: [number, number]) => {
-      latencyUserModified.current = true;
+      setLatencyUserModified(true);
       setLatencyRange(val);
       resetPage();
     },
@@ -516,7 +519,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
 
   const onRequestsRangeChange = useCallback(
     (val: [number, number]) => {
-      requestsUserModified.current = true;
+      setRequestsUserModified(true);
       setRequestsRange(val);
       resetPage();
     },
@@ -611,7 +614,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
 
     // Latency range filter badge (only if user has interacted and modified from default bounds)
     const isLatencyModified =
-      latencyUserModified.current &&
+      latencyUserModified &&
       (latencyRange[0] > latencyBounds.min || latencyRange[1] < latencyBounds.max);
     if (isLatencyModified) {
       badges.push({
@@ -621,7 +624,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
         }),
         values: [`${latencyRange[0].toFixed(0)}-${latencyRange[1].toFixed(0)}ms`],
         onRemove: () => {
-          latencyUserModified.current = false;
+          setLatencyUserModified(false);
           setLatencyRange([latencyBounds.min, latencyBounds.max]);
           resetPage();
         },
@@ -630,7 +633,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
 
     // Requests range filter badge (only if user has interacted and modified from default bounds)
     const isRequestsModified =
-      requestsUserModified.current &&
+      requestsUserModified &&
       (requestsRange[0] > requestsBounds.min || requestsRange[1] < requestsBounds.max);
     if (isRequestsModified) {
       badges.push({
@@ -640,7 +643,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
         }),
         values: [`${requestsRange[0].toFixed(0)}-${requestsRange[1].toFixed(0)}`],
         onRemove: () => {
-          requestsUserModified.current = false;
+          setRequestsUserModified(false);
           setRequestsRange([requestsBounds.min, requestsBounds.max]);
           resetPage();
         },
@@ -654,6 +657,8 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
     selectedRemoteOperations,
     selectedAvailabilityThresholds,
     selectedErrorRateThresholds,
+    latencyUserModified,
+    requestsUserModified,
     latencyRange,
     requestsRange,
     latencyBounds,
@@ -668,8 +673,8 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
     setSelectedRemoteOperations([]);
     setSelectedAvailabilityThresholds([]);
     setSelectedErrorRateThresholds([]);
-    latencyUserModified.current = false;
-    requestsUserModified.current = false;
+    setLatencyUserModified(false);
+    setRequestsUserModified(false);
     setLatencyRange([latencyBounds.min, latencyBounds.max]);
     setRequestsRange([requestsBounds.min, requestsBounds.max]);
     resetPage();
@@ -993,7 +998,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
             options={LATENCY_OPTIONS}
             valueOfSelected={latencyPercentile}
             onChange={(value) => {
-              latencyUserModified.current = false;
+              setLatencyUserModified(false);
               setLatencyPercentile(value as 'p99' | 'p90' | 'p50');
             }}
             compressed

--- a/public/components/apm/pages/service_details/service_dependencies.tsx
+++ b/public/components/apm/pages/service_details/service_dependencies.tsx
@@ -481,7 +481,8 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
 
       // Requests range filter (only if range has been adjusted)
       const isRequestsFilterActive =
-        requestsRange[0] > requestsBounds.min || requestsRange[1] < requestsBounds.max;
+        requestsUserModified &&
+        (requestsRange[0] > requestsBounds.min || requestsRange[1] < requestsBounds.max);
       if (isRequestsFilterActive) {
         const depRequestCount = dep.requestCount ?? 0;
         if (depRequestCount < requestsRange[0] || depRequestCount > requestsRange[1]) {
@@ -494,6 +495,7 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
   }, [
     textFilteredDependencies,
     latencyUserModified,
+    requestsUserModified,
     latencyRange,
     requestsRange,
     latencyBounds,

--- a/public/components/apm/pages/service_details/service_dependencies.tsx
+++ b/public/components/apm/pages/service_details/service_dependencies.tsx
@@ -1000,7 +1000,9 @@ export const ServiceDependencies: React.FC<ServiceDependenciesProps> = ({
             options={LATENCY_OPTIONS}
             valueOfSelected={latencyPercentile}
             onChange={(value) => {
+              // Reset the range: the bounds effect will not fire if the bounds round the same.
               setLatencyUserModified(false);
+              setLatencyRange([latencyBounds.min, latencyBounds.max]);
               setLatencyPercentile(value as 'p99' | 'p90' | 'p50');
             }}
             compressed

--- a/public/components/apm/pages/service_details/service_operations.tsx
+++ b/public/components/apm/pages/service_details/service_operations.tsx
@@ -932,7 +932,9 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
             options={LATENCY_OPTIONS}
             valueOfSelected={latencyPercentile}
             onChange={(value) => {
+              // Reset the range: the bounds effect will not fire if the bounds round the same.
               setLatencyUserModified(false);
+              setLatencyRange([latencyBounds.min, latencyBounds.max]);
               setLatencyPercentile(value as 'p99' | 'p90' | 'p50');
             }}
             compressed

--- a/public/components/apm/pages/service_details/service_operations.tsx
+++ b/public/components/apm/pages/service_details/service_operations.tsx
@@ -209,8 +209,10 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
   // Range filter states
   const [latencyRange, setLatencyRange] = useState<[number, number]>([0, 0]);
   const [requestsRange, setRequestsRange] = useState<[number, number]>([0, 0]);
-  const latencyUserModified = useRef(false);
-  const requestsUserModified = useRef(false);
+  // Track whether the user has explicitly interacted with range filters.
+  // Use as state, so the memos that read them re-run when a flag flips.
+  const [latencyUserModified, setLatencyUserModified] = useState(false);
+  const [requestsUserModified, setRequestsUserModified] = useState(false);
 
   // Search and latency selector states
   const [searchQuery, setSearchQuery] = useState('');
@@ -368,7 +370,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
   // Step 3: Reset slider ranges when bounds change
   // Use functional update to prevent unnecessary re-renders when values haven't changed
   useEffect(() => {
-    latencyUserModified.current = false;
+    setLatencyUserModified(false);
     setLatencyRange((prev) => {
       if (prev[0] === latencyBounds.min && prev[1] === latencyBounds.max) {
         return prev; // Return same reference to avoid re-render
@@ -378,7 +380,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
   }, [latencyBounds.min, latencyBounds.max]);
 
   useEffect(() => {
-    requestsUserModified.current = false;
+    setRequestsUserModified(false);
     setRequestsRange((prev) => {
       if (prev[0] === requestsBounds.min && prev[1] === requestsBounds.max) {
         return prev; // Return same reference to avoid re-render
@@ -403,7 +405,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
       // Latency range filter (only if range has been adjusted)
       const isLatencyFilterActive =
         // Gating on latencyUserModified avoids a false positive after a percentile switch
-        latencyUserModified.current &&
+        latencyUserModified &&
         (latencyRange[0] > latencyBounds.min || latencyRange[1] < latencyBounds.max);
       if (isLatencyFilterActive) {
         // Use the selected percentile's duration for filtering
@@ -431,6 +433,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
     });
   }, [
     textFilteredOperations,
+    latencyUserModified,
     latencyRange,
     requestsRange,
     latencyBounds,
@@ -448,7 +451,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
   // Range-slider changes reset the page to 1 (a filter change), unlike a percentile switch.
   const onLatencyRangeChange = useCallback(
     (val: [number, number]) => {
-      latencyUserModified.current = true;
+      setLatencyUserModified(true);
       setLatencyRange(val);
       resetPage();
     },
@@ -457,7 +460,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
 
   const onRequestsRangeChange = useCallback(
     (val: [number, number]) => {
-      requestsUserModified.current = true;
+      setRequestsUserModified(true);
       setRequestsRange(val);
       resetPage();
     },
@@ -526,7 +529,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
 
     // Latency range filter badge (only if user has interacted and modified from default bounds)
     const isLatencyModified =
-      latencyUserModified.current &&
+      latencyUserModified &&
       (latencyRange[0] > latencyBounds.min || latencyRange[1] < latencyBounds.max);
     if (isLatencyModified) {
       badges.push({
@@ -536,7 +539,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
         }),
         values: [`${latencyRange[0].toFixed(0)}-${latencyRange[1].toFixed(0)}ms`],
         onRemove: () => {
-          latencyUserModified.current = false;
+          setLatencyUserModified(false);
           setLatencyRange([latencyBounds.min, latencyBounds.max]);
           resetPage();
         },
@@ -545,7 +548,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
 
     // Requests range filter badge (only if user has interacted and modified from default bounds)
     const isRequestsModified =
-      requestsUserModified.current &&
+      requestsUserModified &&
       (requestsRange[0] > requestsBounds.min || requestsRange[1] < requestsBounds.max);
     if (isRequestsModified) {
       badges.push({
@@ -555,7 +558,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
         }),
         values: [`${requestsRange[0].toFixed(0)}-${requestsRange[1].toFixed(0)}`],
         onRemove: () => {
-          requestsUserModified.current = false;
+          setRequestsUserModified(false);
           setRequestsRange([requestsBounds.min, requestsBounds.max]);
           resetPage();
         },
@@ -567,6 +570,8 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
     selectedOperations,
     selectedAvailabilityThresholds,
     selectedErrorRateThresholds,
+    latencyUserModified,
+    requestsUserModified,
     latencyRange,
     requestsRange,
     latencyBounds,
@@ -579,8 +584,8 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
     setSelectedOperations([]);
     setSelectedAvailabilityThresholds([]);
     setSelectedErrorRateThresholds([]);
-    latencyUserModified.current = false;
-    requestsUserModified.current = false;
+    setLatencyUserModified(false);
+    setRequestsUserModified(false);
     setLatencyRange([latencyBounds.min, latencyBounds.max]);
     setRequestsRange([requestsBounds.min, requestsBounds.max]);
     resetPage();
@@ -925,7 +930,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
             options={LATENCY_OPTIONS}
             valueOfSelected={latencyPercentile}
             onChange={(value) => {
-              latencyUserModified.current = false;
+              setLatencyUserModified(false);
               setLatencyPercentile(value as 'p99' | 'p90' | 'p50');
             }}
             compressed

--- a/public/components/apm/pages/service_details/service_operations.tsx
+++ b/public/components/apm/pages/service_details/service_operations.tsx
@@ -422,7 +422,8 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
 
       // Requests range filter (only if range has been adjusted)
       const isRequestsFilterActive =
-        requestsRange[0] > requestsBounds.min || requestsRange[1] < requestsBounds.max;
+        requestsUserModified &&
+        (requestsRange[0] > requestsBounds.min || requestsRange[1] < requestsBounds.max);
       if (isRequestsFilterActive) {
         if (op.requestCount < requestsRange[0] || op.requestCount > requestsRange[1]) {
           return false;
@@ -434,6 +435,7 @@ export const ServiceOperations: React.FC<ServiceOperationsProps> = ({
   }, [
     textFilteredOperations,
     latencyUserModified,
+    requestsUserModified,
     latencyRange,
     requestsRange,
     latencyBounds,

--- a/public/components/apm/pages/services_home/services_home.tsx
+++ b/public/components/apm/pages/services_home/services_home.tsx
@@ -668,7 +668,8 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
 
     // Filter by latency range (only if range has been adjusted from full range)
     const isLatencyFilterActive =
-      latencyRange[0] > metricRanges.latencyMin || latencyRange[1] < metricRanges.latencyMax;
+      latencyUserModified &&
+      (latencyRange[0] > metricRanges.latencyMin || latencyRange[1] < metricRanges.latencyMax);
     if (isLatencyFilterActive) {
       filtered = filtered.filter((service) => {
         const metrics = metricsMap.get(service.serviceName);
@@ -681,8 +682,9 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
 
     // Filter by throughput range (only if range has been adjusted from full range)
     const isThroughputFilterActive =
-      throughputRange[0] > metricRanges.throughputMin ||
-      throughputRange[1] < metricRanges.throughputMax;
+      throughputUserModified &&
+      (throughputRange[0] > metricRanges.throughputMin ||
+        throughputRange[1] < metricRanges.throughputMax);
     if (isThroughputFilterActive) {
       filtered = filtered.filter((service) => {
         const metrics = metricsMap.get(service.serviceName);
@@ -711,6 +713,8 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
     fullyFilteredItems,
     metricsMap,
     metricRanges,
+    latencyUserModified,
+    throughputUserModified,
     latencyRange,
     throughputRange,
     selectedFailureRateThresholds,

--- a/public/components/apm/pages/services_home/services_home.tsx
+++ b/public/components/apm/pages/services_home/services_home.tsx
@@ -309,9 +309,10 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
   // Latency percentile selector state
   const [latencyPercentile, setLatencyPercentile] = useState<'p99' | 'p90' | 'p50'>('p99');
 
-  // Track whether user has explicitly interacted with range filters (prevents badge flicker on hydration)
-  const latencyUserModified = useRef(false);
-  const throughputUserModified = useRef(false);
+  // Track whether the user has explicitly interacted with range filters.
+  // Use as state, so the activeFilters memo re-runs when a flag flips.
+  const [latencyUserModified, setLatencyUserModified] = useState(false);
+  const [throughputUserModified, setThroughputUserModified] = useState(false);
 
   // EuiResizableContainer togglePanel ref — captured inside render-prop, never passed as a prop
   const togglePanelRef = useRef<((id: string, options: { direction: string }) => void) | null>(
@@ -323,12 +324,12 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
 
   // Stabilized callbacks for sidebar to prevent re-renders through EuiResizableContainer
   const onLatencyRangeChange = useCallback((val: [number, number]) => {
-    latencyUserModified.current = true;
+    setLatencyUserModified(true);
     setLatencyRange(val);
   }, []);
 
   const onThroughputRangeChange = useCallback((val: [number, number]) => {
-    throughputUserModified.current = true;
+    setThroughputUserModified(true);
     setThroughputRange(val);
   }, []);
 
@@ -652,8 +653,8 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
   useEffect(() => {
     setLatencyRange([metricRanges.latencyMin, metricRanges.latencyMax]);
     setThroughputRange([metricRanges.throughputMin, metricRanges.throughputMax]);
-    latencyUserModified.current = false;
-    throughputUserModified.current = false;
+    setLatencyUserModified(false);
+    setThroughputUserModified(false);
   }, [metricRanges]);
 
   // Apply metric filters for display (on top of already filtered items)
@@ -734,7 +735,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
 
     // Latency range filter badge (only if user explicitly modified)
     const isLatencyModified =
-      latencyUserModified.current &&
+      latencyUserModified &&
       (latencyRange[0] > metricRanges.latencyMin || latencyRange[1] < metricRanges.latencyMax);
     if (isLatencyModified) {
       badges.push({
@@ -742,7 +743,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
         category: i18nTexts.filters.latency,
         values: [`${latencyRange[0].toFixed(0)}-${latencyRange[1].toFixed(0)}ms`],
         onRemove: () => {
-          latencyUserModified.current = false;
+          setLatencyUserModified(false);
           setLatencyRange([metricRanges.latencyMin, metricRanges.latencyMax]);
         },
       });
@@ -750,7 +751,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
 
     // Throughput range filter badge (only if user explicitly modified)
     const isThroughputModified =
-      throughputUserModified.current &&
+      throughputUserModified &&
       (throughputRange[0] > metricRanges.throughputMin ||
         throughputRange[1] < metricRanges.throughputMax);
     if (isThroughputModified) {
@@ -761,7 +762,7 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
           `${formatThroughput(throughputRange[0])} - ${formatThroughput(throughputRange[1])}`,
         ],
         onRemove: () => {
-          throughputUserModified.current = false;
+          setThroughputUserModified(false);
           setThroughputRange([metricRanges.throughputMin, metricRanges.throughputMax]);
         },
       });
@@ -801,6 +802,8 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
     return badges;
   }, [
     selectedEnvironments,
+    latencyUserModified,
+    throughputUserModified,
     latencyRange,
     throughputRange,
     selectedFailureRateThresholds,
@@ -815,8 +818,8 @@ export const ServicesHome: React.FC<ServicesHomeProps> = ({
     setThroughputRange([metricRanges.throughputMin, metricRanges.throughputMax]);
     setSelectedFailureRateThresholds([]);
     setSelectedGroupByAttributes({});
-    latencyUserModified.current = false;
-    throughputUserModified.current = false;
+    setLatencyUserModified(false);
+    setThroughputUserModified(false);
   }, [metricRanges]);
 
   const columns: Array<EuiBasicTableColumn<ServiceTableItem>> = useMemo(


### PR DESCRIPTION
### Description

Follow up to the review on [#2842 ](https://github.com/opensearch-project/dashboards-observability/pull/2842) after it merged. 

- Promote the range-filter gate flags from refs to state. `latencyUserModified` and `requestsUserModified` on the operations and dependencies tabs, and `latencyUserModified` and `throughputUserModified` on the services home page, were refs read inside the filter and `activeFilters` `useMemo` bodies. A ref is not a valid memo dependency, so the gate could desync from the flag. They are now `useState` and listed in the relevant memo dependency arrays. Behavior is unchanged, since every write was already paired with a `setState` in the same handler. This removes the ref-in-memo anti-pattern so the gate cannot desync if a dependency's memoization changes later.
- Add regression tests for the percentile re-render fix. The tests assert that switching the latency percentile does not remount the operations and dependencies tables, so pagination and expanded-row charts are preserved and not re-fetched, and that a percentile switch clears the latency range filter and re-engages it when the slider moves again.


### Issues Resolved
Follow up to review comments on [#2842](https://github.com/opensearch-project/dashboards-observability/pull/2842). Related to [#2626](https://github.com/opensearch-project/dashboards-observability/issue/2626) 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
