### PR TITLE
Add Riya Saxena (riysaxen-amzn) as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
 
-- @ps48 @joshuali925 @dai-chen @mengweieric @vamsi-amazon @swiddis @penghuo @anirudha @sumukhswamy @sejli @TackAdam @RyanL1997 @lezzago @riysaxen-amzn
+* @ps48 @joshuali925 @dai-chen @mengweieric @vamsimanohar @swiddis @penghuo @anirudha @sumukhswamy @sejli @TackAdam @RyanL1997 @lezzago @riysaxen-amzn

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
 
-- @ps48 @joshuali925 @dai-chen @mengweieric @vamsi-amazon @swiddis @penghuo @anirudha @sumukhswamy @sejli @TackAdam @RyanL1997 @lezzago
+- @ps48 @joshuali925 @dai-chen @mengweieric @vamsi-amazon @swiddis @penghuo @anirudha @sumukhswamy @sejli @TackAdam @RyanL1997 @lezzago @riysaxen-amzn

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,6 +19,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Adam Tackett            | [TackAdam](https://github.com/TackAdam)         | Amazon      |
 | Jialiang Liang          | [RyanL1997](https://github.com/RyanL1997)       | Amazon      |
 | Ashish Agrawal          | [lezzago](https://github.com/lezzago)           | Amazon      |
+| Riya Saxena             | [riysaxen-amzn](https://github.com/riysaxen-amzn) | Amazon    |
 
 ## Emeritus Maintainers
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Shenoy Pratik           | [ps48](https://github.com/ps48)                 | Amazon      |
 | Simeon Widdis           | [swiddis](https://github.com/swiddis)           | Amazon      |
 | Chen Dai                | [dai-chen](https://github.com/dai-chen)         | Amazon      |
-| Vamsi Manohar           | [vamsi-amazon](https://github.com/vamsimanohar) | Amazon      |
+| Vamsi Manohar           | [vamsimanohar](https://github.com/vamsimanohar) | Amazon      |
 | Peng Huo                | [penghuo](https://github.com/penghuo)           | Amazon      |
 | Anirudha Jadhav         | [anirudha](https://github.com/anirudha)         | Amazon      |
 | Sumukh Hanumantha Swamy | [sumukhswamy](https://github.com/sumukhswamy)   | Amazon      |


### PR DESCRIPTION
### Description

Following the nomination process at https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#nomination, I nominated and the other maintainers of dashboards-observability have voted to invite @riysaxen-amzn (Riya Saxena) to be a maintainer, and she has graciously accepted the invitation.

Riya has been an active contributor to the repository, with 11 closed PRs authored:
- https://github.com/opensearch-project/dashboards-observability/pulls?q=is%3Apr+author%3Ariysaxen-amzn

She has also participated in repository maintenance by reviewing PRs (7 PRs reviewed):
- https://github.com/opensearch-project/dashboards-observability/pulls?q=is%3Aclosed+reviewed-by%3A%40riysaxen-amzn

The maintainers have voted and agreed to this nomination (+1 from @sumukhswamy, @TackAdam, @joshuali925, @ps48, and @mengweieric; no vetoes).

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/dashboards-observability/blob/main/CONTRIBUTING.md).
