### PR TITLE
fix(notebooks): gate sample visualization title suffix on data source id

### DIFF
--- a/public/components/notebooks/components/main.tsx
+++ b/public/components/notebooks/components/main.tsx
@@ -337,6 +337,7 @@ export class Main extends React.Component<MainProps, MainState> {
         });
       }
       const visIds: string[] = [];
+      // Sample data only suffixes titles when installed against a data source, so gate on the id.
       await this.props.http
         .get('../api/saved_objects/_find', {
           query: {
@@ -344,18 +345,21 @@ export class Main extends React.Component<MainProps, MainState> {
             search_fields: 'title',
             search:
               `[Logs] Response Codes Over Time + Annotations` +
-              (dataSourceMDSLabel ? `_${dataSourceMDSLabel}` : ''),
+              (dataSourceMDSId ? `_${dataSourceMDSLabel}` : ''),
           },
         })
         .then((resp) => {
           if (this.props.dataSourceEnabled) {
-            const searchTitle = `[Logs] Response Codes Over Time + Annotations_${dataSourceMDSLabel}`;
+            const searchTitle =
+              `[Logs] Response Codes Over Time + Annotations` +
+              (dataSourceMDSId ? `_${dataSourceMDSLabel}` : '');
             const savedObjects = resp.saved_objects;
 
             const foundObject = savedObjects.find((obj) => obj.attributes.title === searchTitle);
-            if (foundObject) {
-              visIds.push(foundObject.id);
+            if (!foundObject) {
+              throw new Error(`Unable to locate sample visualization "${searchTitle}"`);
             }
+            visIds.push(foundObject.id);
           } else {
             visIds.push(resp.saved_objects[0].id);
           }
@@ -367,18 +371,21 @@ export class Main extends React.Component<MainProps, MainState> {
             search_fields: 'title',
             search:
               `[Logs] Unique Visitors vs. Average Bytes` +
-              (dataSourceMDSLabel ? `_${dataSourceMDSLabel}` : ''),
+              (dataSourceMDSId ? `_${dataSourceMDSLabel}` : ''),
           },
         })
         .then((resp) => {
           if (this.props.dataSourceEnabled) {
-            const searchTitle = `[Logs] Unique Visitors vs. Average Bytes_${dataSourceMDSLabel}`;
+            const searchTitle =
+              `[Logs] Unique Visitors vs. Average Bytes` +
+              (dataSourceMDSId ? `_${dataSourceMDSLabel}` : '');
             const savedObjects = resp.saved_objects;
 
             const foundObject = savedObjects.find((obj) => obj.attributes.title === searchTitle);
-            if (foundObject) {
-              visIds.push(foundObject.id);
+            if (!foundObject) {
+              throw new Error(`Unable to locate sample visualization "${searchTitle}"`);
             }
+            visIds.push(foundObject.id);
           } else {
             visIds.push(resp.saved_objects[0].id);
           }
@@ -390,18 +397,21 @@ export class Main extends React.Component<MainProps, MainState> {
             search_fields: 'title',
             search:
               `[Flights] Flight Count and Average Ticket Price` +
-              (dataSourceMDSLabel ? `_${dataSourceMDSLabel}` : ''),
+              (dataSourceMDSId ? `_${dataSourceMDSLabel}` : ''),
           },
         })
         .then((resp) => {
           if (this.props.dataSourceEnabled) {
-            const searchTitle = `[Flights] Flight Count and Average Ticket Price_${dataSourceMDSLabel}`;
+            const searchTitle =
+              `[Flights] Flight Count and Average Ticket Price` +
+              (dataSourceMDSId ? `_${dataSourceMDSLabel}` : '');
             const savedObjects = resp.saved_objects;
 
             const foundObject = savedObjects.find((obj) => obj.attributes.title === searchTitle);
-            if (foundObject) {
-              visIds.push(foundObject.id);
+            if (!foundObject) {
+              throw new Error(`Unable to locate sample visualization "${searchTitle}"`);
             }
+            visIds.push(foundObject.id);
           } else {
             visIds.push(resp.saved_objects[0].id);
           }
@@ -423,8 +433,9 @@ export class Main extends React.Component<MainProps, MainState> {
         });
       this.setToast(`Sample notebooks successfully added.`);
     } catch (err: any) {
-      this.setToast('Error adding sample notebooks.', 'danger');
-      console.error(err.body.message);
+      const message = err.body?.message ?? err.message;
+      this.setToast('Error adding sample notebooks.', 'danger', message);
+      console.error(message);
     } finally {
       this.setState({ loading: false });
     }


### PR DESCRIPTION
### Description

Sample notebook visualization paragraphs fail to render, showing `Could not locate that visualization (id: undefined)`.

**Root cause.** `addSampleNotebooks` decided whether to append the `_${dataSourceTitle}` title suffix from the selector **label** rather than the data source **id**:

```ts
(dataSourceMDSLabel ? `_${dataSourceMDSLabel}` : '')
```

The selector defaults to **Local cluster**, which reports the label `Local cluster` but an **empty id**, while sample data only suffixes titles when installed against a data source, since `sample_data/data_sets/util.ts` gates the suffix on `dataSourceId`. So it searched for `..._Local cluster`, a title never written. All three lookups missed, and `if (foundObject)` skipped each miss silently, leaving `visIds` empty.

`getSampleNotebooks` then interpolates `visIds[0..2]` into a JSON template string, so `${visId}` stringified to the literal text `undefined`:

```json
"explicitInput": { "id": "1", "savedObjectId": "undefined" }
```

That it is a string rather than nullish is confirmed by `SavedObjectNotFound`, which builds its id clause as `const idMsg = id ? ...` and so would print no `(id: ...)` clause at all for a real `undefined`.

**Fix.** Gate the suffix on the data source id, and throw instead of skipping a miss silently.

**Notes for reviewers**

1. **Existing broken notebooks are not repaired**, the bad id is already persisted. Delete and re-add them, since re-adding creates duplicates rather than replacing.
2. **No unit test, verified manually instead**, with a before and after recording below. A unit test is current not existing, can add if necessary.
3. **The fix repeats in three blocks** to match the existing structure and keep backports clean. Can dedupe separately.

**Testing.** Verified against a local cluster with MDS enabled. Selected Local cluster in the modal, deleted the existing sample notebooks, and re-added them. Querying the stored `observability-notebook` saved objects confirms each visualization paragraph now holds a real `savedObjectId` rather than the string `undefined`, and the paragraphs render. 

**Before**

https://github.com/user-attachments/assets/d6295bd4-37fb-4018-b246-a354e219c50e

**After**

https://github.com/user-attachments/assets/912b4eef-d057-4825-ae26-085d2728702f


### Issues Resolved

Fixes #2455


### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).