### PR TITLE
feat(alerting): copy Explore query into metrics rule flyout + real preview

### DIFF
--- a/.cypress/integration/alerting_test/metrics_rule_preview_api.spec.js
+++ b/.cypress/integration/alerting_test/metrics_rule_preview_api.spec.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="cypress" />
+
+/*
+ * Prometheus alert-rule PREVIEW route API contract.
+ *
+ * Runs against the real Cortex + Prometheus DirectQuery datasource stood up by
+ * the `cypress-slo-cortex` workflow (`.cypress/cortex-ci/`). Locally:
+ *   yarn cypress:run --spec \
+ *     .cypress/integration/alerting_test/metrics_rule_preview_api.spec.js \
+ *     --env "sloDatasourceId=ObservabilityStack_Prometheus[,workspaceId=<id>]"
+ *
+ * Pins the SERVER-SIDE contract of POST /api/alerting/prometheus/{dsId}/preview
+ * that backs the metrics "Create alert rule" flyout's live preview chart:
+ *   1. A bare metric returns a `{points, query}` envelope (200).
+ *   2. A trailing comparison is stripped from the effective (plotted) query.
+ *   3. An oversized range/step is rejected (400) — resolution is capped.
+ *   4. start >= end is rejected (400).
+ *   5. An unknown datasource returns 404.
+ * Each test sends a single request and asserts the failure/success mode —
+ * fast and deterministic, no UI.
+ */
+
+const WORKSPACE_PREFIX = Cypress.env('workspaceId') ? `/w/${Cypress.env('workspaceId')}` : '';
+const datasourceId = Cypress.env('sloDatasourceId') || 'prom_integ_test';
+const PREVIEW_URL = `${WORKSPACE_PREFIX}/api/alerting/prometheus/${encodeURIComponent(
+  datasourceId
+)}/preview`;
+
+const preview = (body) =>
+  cy.request({
+    method: 'POST',
+    url: PREVIEW_URL,
+    headers: { 'osd-xsrf': 'true' },
+    body,
+    failOnStatusCode: false,
+  });
+
+describe('Prometheus preview route contract', () => {
+  // Skip the whole suite if the datasource/route isn't reachable (e.g. the
+  // Cortex sidecar didn't come up), matching the SLO specs' degrade behavior.
+  before(function () {
+    preview({ query: 'up' }).then((resp) => {
+      if (resp.status !== 200) {
+        Cypress.log({
+          name: 'preview',
+          message: `preview probe failed (${resp.status}); skipping suite`,
+        });
+        this.skip();
+      }
+    });
+  });
+
+  it('returns a {points, query} envelope for a bare metric', () => {
+    preview({ query: 'up' }).then((resp) => {
+      expect(resp.status).to.eq(200);
+      expect(resp.body).to.have.property('points');
+      expect(resp.body.points).to.be.an('array');
+      // The effective query echoes the (unchanged) input for a bare metric.
+      expect(resp.body.query).to.eq('up');
+      if (resp.body.points.length > 0) {
+        expect(resp.body.points[0]).to.have.all.keys('timestamp', 'value');
+      }
+    });
+  });
+
+  it('strips a trailing comparison from the effective plotted query', () => {
+    preview({ query: 'up > 0.5' }).then((resp) => {
+      expect(resp.status).to.eq(200);
+      // The chart plots the metric series, not the boolean condition.
+      expect(resp.body.query).to.eq('up');
+    });
+  });
+
+  it('rejects an oversized range/step with 400 (resolution capped)', () => {
+    preview({ query: 'up', start: 0, end: 4000000000, step: 1 }).then((resp) => {
+      expect(resp.status).to.eq(400);
+      expect(String(resp.body.message || '')).to.match(/too large|points/i);
+    });
+  });
+
+  it('rejects start >= end with 400', () => {
+    preview({ query: 'up', start: 100, end: 50 }).then((resp) => {
+      expect(resp.status).to.eq(400);
+      expect(String(resp.body.message || '')).to.match(/earlier than end/i);
+    });
+  });
+
+  it('returns 404 for an unknown datasource', () => {
+    cy.request({
+      method: 'POST',
+      url: `${WORKSPACE_PREFIX}/api/alerting/prometheus/does-not-exist-ds/preview`,
+      headers: { 'osd-xsrf': 'true' },
+      body: { query: 'up' },
+      failOnStatusCode: false,
+    }).then((resp) => {
+      expect(resp.status).to.eq(404);
+    });
+  });
+});

--- a/.github/workflows/cypress-slo-cortex.yml
+++ b/.github/workflows/cypress-slo-cortex.yml
@@ -395,10 +395,10 @@ jobs:
       # -----------------------------------------------------------------------
       # 4. Run Cypress
       # -----------------------------------------------------------------------
-      - name: Run Cypress SLO specs
+      - name: Run Cypress SLO + Prometheus alerting specs
         run: |
           cd ./OpenSearch-Dashboards/plugins/dashboards-observability
-          yarn cypress:run --headless --spec '.cypress/integration/slo_test/*.spec.js'
+          yarn cypress:run --headless --spec '.cypress/integration/slo_test/*.spec.js,.cypress/integration/alerting_test/metrics_rule_preview_api.spec.js'
         env:
           CYPRESS_sloDatasourceId: ${{ steps.register-ds.outputs.ds_name }}
           CYPRESS_cortexBaseUrl: 'http://localhost:9090'

--- a/public/components/alerting/__tests__/alarms_page.test.tsx
+++ b/public/components/alerting/__tests__/alarms_page.test.tsx
@@ -63,6 +63,15 @@ jest.mock('../notification_routing_panel', () => ({
   NotificationRoutingPanel: () => <div data-test-subj="routingPanel" />,
 }));
 jest.mock('../create_monitor', () => ({ CreateMonitor: () => null }));
+// The Alert Manager "Create metrics rule" path renders CreateMetricsMonitor;
+// capture its props so we can assert the group-scoped duplicate-name checker.
+const mockMetricsFlyout = jest.fn();
+jest.mock('../create_metrics_monitor', () => ({
+  CreateMetricsMonitor: (props: unknown) => {
+    mockMetricsFlyout(props);
+    return null;
+  },
+}));
 jest.mock('../create_monitor/edit_monitor', () => ({ EditMonitor: () => null }));
 jest.mock('../alert_detail_flyout', () => ({ AlertDetailFlyout: () => null }));
 
@@ -169,6 +178,57 @@ describe('AlarmsPage', () => {
     });
     fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
     expect(screen.getByTestId('monitorsTable')).toBeInTheDocument();
+  });
+
+  it('scopes the duplicate-name check to the rule group', async () => {
+    mockMetricsFlyout.mockClear();
+    mockUseRulesData.mockReturnValue({
+      ...emptyRulesHookResult,
+      rules: [
+        { id: 'r1', name: 'HighLatency', datasourceId: 'prom-1', group: 'payments' },
+        { id: 'r2', name: 'OtherRule', datasourceId: 'prom-1', group: 'payments' },
+      ] as unknown as never,
+    });
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    // MonitorsTable only renders on the Rules tab — switch to it first.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+    });
+    // Open the metrics create flyout via the MonitorsTable's onCreateMonitor callback.
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0];
+    await act(async () => {
+      tableProps.onCreateMonitor('metrics');
+    });
+    const flyoutProps = mockMetricsFlyout.mock.calls[mockMetricsFlyout.mock.calls.length - 1][0];
+    const isNameTaken = flyoutProps.isNameTaken as (n: string, d: string, g?: string) => boolean;
+
+    // Same name in the SAME group → duplicate.
+    expect(isNameTaken('HighLatency', 'prom-1', 'payments')).toBe(true);
+    // Same name in a DIFFERENT group → allowed (valid distinct rule).
+    expect(isNameTaken('HighLatency', 'prom-1', 'checkout')).toBe(false);
+    // No group supplied → datasource-wide (back-compat for PPL monitors).
+    expect(isNameTaken('HighLatency', 'prom-1')).toBe(true);
+  });
+
+  it('refetches rules when switching into the Rules tab and forwards a Refresh handler', async () => {
+    // Fresh spy so we count only calls made after mount (the mount fetch is
+    // owned by useRulesData, which is mocked out here).
+    (emptyRulesHookResult.refetch as jest.Mock).mockClear();
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+    });
+    // Switching INTO the Rules tab triggers a refetch so a rule created
+    // elsewhere (e.g. the Metrics page flyout) appears without a manual reload.
+    expect(emptyRulesHookResult.refetch).toHaveBeenCalled();
+    // MonitorsTable receives a manual Refresh handler + spinner flag.
+    const last = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0];
+    expect(typeof last.onRefresh).toBe('function');
+    expect('refreshing' in last).toBe(true);
   });
 
   it('forwards picker state + handlers to the AlertsDashboard (picker now lives in the timeline panel)', async () => {

--- a/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 
 jest.mock('echarts', () => ({
   init: jest.fn(() => ({ setOption: jest.fn(), resize: jest.fn(), dispose: jest.fn() })),
@@ -31,6 +31,13 @@ jest.mock('../create_monitor/prom_query_builder', () => ({
   PromQueryBuilder: ({ onQueryChange }: { onQueryChange: (q: string) => void }) => (
     <button data-test-subj="mockBuilderSetQuery" onClick={() => onQueryChange('up{job="api"}')} />
   ),
+  // Lightweight stand-in: builder-representable = a bare metric or metric{...};
+  // anything else (rates, comparisons) returns null. Used by the Query section
+  // to decide the "builder will overwrite your expression" warning.
+  parseBuilderQuery: (q: string) => {
+    const m = (q || '').trim().match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?$/);
+    return m ? { metric: m[1] } : null;
+  },
 }));
 
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
@@ -39,7 +46,47 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   unobserve: jest.fn(),
 }));
 
-import { CreateMetricsMonitor } from '../create_metrics_monitor';
+import {
+  CreateMetricsMonitor,
+  materializeLabels,
+  materializeAnnotations,
+  startsWithComparison,
+} from '../create_metrics_monitor';
+
+describe('CreateMetricsMonitor materialize/validate helpers', () => {
+  it('materializeLabels drops empty-key/value entries and trims keys', () => {
+    expect(
+      materializeLabels([
+        { key: 'severity', value: 'warning', isDynamic: false },
+        { key: 'team', value: '', isDynamic: false }, // empty value → dropped
+        { key: '', value: 'x', isDynamic: false }, // empty key → dropped
+        { key: '  region  ', value: 'us', isDynamic: false }, // key trimmed
+      ])
+    ).toEqual([
+      { key: 'severity', value: 'warning', isDynamic: false },
+      { key: 'region', value: 'us', isDynamic: false },
+    ]);
+  });
+
+  it('materializeAnnotations drops empties and folds the description field (description wins)', () => {
+    const annotations = [
+      { key: 'summary', value: 'high' },
+      { key: 'runbook', value: '' }, // dropped
+      { key: 'description', value: 'manual' }, // overridden by the field
+    ];
+    expect(materializeAnnotations(annotations, 'from field')).toEqual([
+      { key: 'summary', value: 'high' },
+      { key: 'description', value: 'from field' },
+    ]);
+  });
+
+  it('startsWithComparison flags a leading comparison (invalid alert expression)', () => {
+    expect(startsWithComparison('> 0.5')).toBe(true);
+    expect(startsWithComparison('  >= 1')).toBe(true);
+    expect(startsWithComparison('rate(x[5m]) > 0.5')).toBe(false);
+    expect(startsWithComparison('up')).toBe(false);
+  });
+});
 
 describe('CreateMetricsMonitor', () => {
   it('renders flyout with form title', () => {
@@ -102,6 +149,141 @@ describe('CreateMetricsMonitor', () => {
       'button[class*="euiButton--fill"]'
     ) as HTMLButtonElement;
     expect(createBtn.disabled).toBe(true);
+  });
+
+  it('seeds the query from initialQuery copied off the Explore Metrics page', () => {
+    render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasourceId="prom-1"
+        initialQuery="rate(http_requests_total[5m])"
+      />
+    );
+
+    // The pre-filled expression is visible/editable (not hidden), so a complex
+    // expression the builder can't represent is never hidden-yet-submittable.
+    const expr = document.querySelector(
+      '[data-test-subj="metricsMonitorPromQlExpression"]'
+    ) as HTMLTextAreaElement;
+    expect(expr).not.toBeNull();
+    expect(expr.value).toBe('rate(http_requests_total[5m])');
+
+    // With the query seeded, Create enables as soon as a name is entered — no
+    // separate builder selection required.
+    const nameInput = document.querySelector('input[aria-label="Rule name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'r' } });
+    const createBtn = document.querySelector(
+      'button[class*="euiButton--fill"]'
+    ) as HTMLButtonElement;
+    expect(createBtn.disabled).toBe(false);
+  });
+
+  it('defaults to Code mode when a query is copied in, Builder mode when empty', () => {
+    // Copied query -> Code mode: raw expression shown, builder hidden.
+    const { unmount } = render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasourceId="prom-1"
+        initialQuery="rate(http_requests_total[5m]) > 0.5"
+      />
+    );
+    expect(
+      document.querySelector('[data-test-subj="metricsMonitorPromQlExpression"]')
+    ).not.toBeNull();
+    expect(document.querySelector('[data-test-subj="mockBuilderSetQuery"]')).toBeNull();
+    unmount();
+
+    // Empty flyout -> Builder mode: builder shown, raw expression hidden.
+    render(<CreateMetricsMonitor onCancel={jest.fn()} onSave={jest.fn()} datasourceId="prom-1" />);
+    expect(document.querySelector('[data-test-subj="mockBuilderSetQuery"]')).not.toBeNull();
+    expect(document.querySelector('[data-test-subj="metricsMonitorPromQlExpression"]')).toBeNull();
+  });
+
+  it('warns before the builder overwrites a copied complex expression (finding #7)', () => {
+    render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasourceId="prom-1"
+        initialQuery="rate(http_requests_total[5m]) > 0.5"
+      />
+    );
+    // Starts in Code mode — no overwrite warning yet.
+    expect(
+      document.querySelector('[data-test-subj="metricsMonitorBuilderOverwriteWarning"]')
+    ).toBeNull();
+    // Switch to Builder — the copied expression isn't builder-representable, so
+    // the warning appears instead of silently clobbering it.
+    fireEvent.click(screen.getByText('Builder'));
+    expect(
+      document.querySelector('[data-test-subj="metricsMonitorBuilderOverwriteWarning"]')
+    ).not.toBeNull();
+  });
+
+  it('keeps Create disabled for a comparison-only expression', () => {
+    render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasourceId="prom-1"
+        initialQuery="> 0.5"
+      />
+    );
+    const nameInput = document.querySelector('input[aria-label="Rule name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'bad-rule' } });
+    const createBtn = document.querySelector(
+      'button[class*="euiButton--fill"]'
+    ) as HTMLButtonElement;
+    // Name + query present, but the expression is only a comparison → blocked.
+    expect(createBtn.disabled).toBe(true);
+  });
+
+  it('trims the rule name and group name in the save payload', async () => {
+    const mockPost = jest.fn().mockResolvedValue({});
+    render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasourceId="test-ds-123"
+        initialQuery="up"
+        http={{ post: mockPost }}
+        addToast={jest.fn()}
+      />
+    );
+    const nameInput = document.querySelector('input[aria-label="Rule name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: '  spaced-rule  ' } });
+    fireEvent.click(document.querySelector('button[class*="euiButton--fill"]')!);
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalled());
+    const body = JSON.parse(mockPost.mock.calls[0][1].body);
+    expect(body.name).toBe('spaced-rule');
+    expect(body.groupName).toBe('spaced-rule');
+  });
+
+  it('shows namespace, rule group, and evaluation interval in the YAML preview (finding #10)', () => {
+    render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasourceId="prom-1"
+        initialQuery="up"
+      />
+    );
+    const nameInput = document.querySelector('input[aria-label="Rule name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'my-rule' } });
+
+    // The Rule Preview (YAML) block renders its content even while collapsed.
+    const body = document.body.textContent || '';
+    // Namespace comment + the rule-group wrapper (group name defaults to the
+    // rule name) + the group-level evaluation interval — all part of what the
+    // save payload actually writes, so the preview now reflects it.
+    expect(body).toContain('# namespace: observability-alerting');
+    expect(body).toContain('name: "my-rule"');
+    expect(body).toContain('interval: 1m');
+    expect(body).toContain('rules:');
+    expect(body).toContain('- alert: "my-rule"');
   });
 
   it('shows the "Build query in metrics" link only when requested (Alert Manager)', () => {

--- a/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
@@ -286,6 +286,38 @@ describe('CreateMetricsMonitor', () => {
     expect(body).toContain('- alert: "my-rule"');
   });
 
+  it('disables Run preview until there is an expression and a datasource', () => {
+    // Empty flyout (no initialQuery) → no expression yet → Run preview disabled.
+    const { unmount } = render(
+      <CreateMetricsMonitor onCancel={jest.fn()} onSave={jest.fn()} datasourceId="prom-1" />
+    );
+    expect(
+      (
+        document.querySelector(
+          '[data-test-subj="metricsMonitorRunPreviewButton"]'
+        ) as HTMLButtonElement
+      ).disabled
+    ).toBe(true);
+    unmount();
+
+    // With a copied expression it enables.
+    render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasourceId="prom-1"
+        initialQuery="up > 0"
+      />
+    );
+    expect(
+      (
+        document.querySelector(
+          '[data-test-subj="metricsMonitorRunPreviewButton"]'
+        ) as HTMLButtonElement
+      ).disabled
+    ).toBe(false);
+  });
+
   it('shows the "Build query in metrics" link only when requested (Alert Manager)', () => {
     const { unmount } = render(
       <CreateMetricsMonitor

--- a/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
@@ -145,6 +145,45 @@ describe('PrometheusFormSection — simplified layout', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('notes when the expression matched multiple series (only the first is charted)', async () => {
+    // Reconfigure the mocked resources service so the preview reports 3 matching
+    // series — the chart still plots one line, but the UI must say so.
+    const { AlertingPromResourcesService } = jest.requireMock(
+      '../query_services/alerting_prom_resources_service'
+    );
+    // Save the file-level default so overriding it here doesn't leak into
+    // later tests that rely on the original metric/label/group fixtures.
+    const original = AlertingPromResourcesService.getMockImplementation();
+    AlertingPromResourcesService.mockImplementation(() => ({
+      listMetricNames: jest.fn().mockResolvedValue({ metrics: ['up'] }),
+      listLabelNames: jest.fn().mockResolvedValue({ labels: [] }),
+      listLabelValues: jest.fn().mockResolvedValue({ values: [] }),
+      listRuleGroupNames: jest.fn().mockResolvedValue({ groups: [] }),
+      runQueryPreview: jest.fn().mockResolvedValue({
+        points: [{ timestamp: 1_700_000_000_000, value: 1 }],
+        query: 'up',
+        seriesCount: 3,
+      }),
+    }));
+
+    try {
+      render(
+        <PrometheusFormSection
+          form={baseForm}
+          onUpdate={jest.fn()}
+          validationErrors={{}}
+          hasSubmitted={false}
+          datasourceId="ds-1"
+        />
+      );
+      fireEvent.click(screen.getByTestId('prometheusRunPreviewButton'));
+
+      expect(await screen.findByText(/Matched 3 series/)).toBeInTheDocument();
+    } finally {
+      AlertingPromResourcesService.mockImplementation(original);
+    }
+  });
+
   it('renders the "Build query in metrics" link in the query panel header', () => {
     render(
       <PrometheusFormSection

--- a/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
@@ -35,6 +35,12 @@ jest.mock('../query_services/alerting_prom_resources_service', () => ({
     listLabelNames: jest.fn().mockResolvedValue({ labels: ['job', 'instance'] }),
     listLabelValues: jest.fn().mockResolvedValue({ values: ['node-exporter'] }),
     listRuleGroupNames: jest.fn().mockResolvedValue({ groups: ['team-a-rules', 'team-b-rules'] }),
+    runQueryPreview: jest.fn().mockResolvedValue({
+      points: [
+        { timestamp: 1_700_000_000_000, value: 0.02 },
+        { timestamp: 1_700_000_060_000, value: 0.05 },
+      ],
+    }),
   })),
 }));
 
@@ -115,13 +121,14 @@ describe('PrometheusFormSection — simplified layout', () => {
     );
   });
 
-  it('shows preview results after clicking Run preview', () => {
+  it('runs a real range query and renders the results chart after clicking Run preview', async () => {
     render(
       <PrometheusFormSection
         form={baseForm}
         onUpdate={jest.fn()}
         validationErrors={{}}
         hasSubmitted={false}
+        datasourceId="ds-1"
       />
     );
 
@@ -130,8 +137,12 @@ describe('PrometheusFormSection — simplified layout', () => {
 
     fireEvent.click(screen.getByTestId('prometheusRunPreviewButton'));
 
-    expect(screen.getByTestId('echarts-render')).toBeInTheDocument();
-    expect(screen.getByText('Sample data — run the rule to see real results')).toBeInTheDocument();
+    // The chart renders once the live range query resolves (no more hardcoded
+    // "sample data" callout).
+    expect(await screen.findByTestId('echarts-render')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Sample data — run the rule to see real results')
+    ).not.toBeInTheDocument();
   });
 
   it('renders the "Build query in metrics" link in the query panel header', () => {
@@ -402,6 +413,23 @@ describe('PrometheusFormSection — edit mode seeding', () => {
     fireEvent.click(clearButtons[0]);
 
     expect(onUpdate).toHaveBeenCalledWith('query', '');
+  });
+
+  it('does not re-emit / rewrite a non-canonically-spaced seeded query on mount', () => {
+    const onUpdate = jest.fn();
+    render(
+      <PrometheusFormSection
+        form={{ ...baseForm, query: 'up{ job = "api" }' }}
+        onUpdate={onUpdate}
+        validationErrors={{}}
+        hasSubmitted={false}
+      />
+    );
+
+    // The builder seeds its fields from the query but must NOT rewrite it on
+    // mount — re-emitting would normalize the whitespace the user never touched
+    // (`up{ job = "api" }` → `up{job="api"}`) and spuriously mark the form dirty.
+    expect(onUpdate).not.toHaveBeenCalledWith('query', expect.anything());
   });
 
   it('does not clobber a complex seeded query on mount', () => {

--- a/public/components/alerting/__tests__/query_preview_results.test.tsx
+++ b/public/components/alerting/__tests__/query_preview_results.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for QueryPreviewResults — specifically that a not-run / no-input state
+ * is distinguished from a genuine empty result, so the "returned no data"
+ * warning never blames a valid metric for missing input (review finding p2).
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryPreviewResults } from '../query_preview_results';
+
+jest.mock('../echarts_render', () => ({
+  EchartsRender: () => <div data-test-subj="echarts-render" />,
+}));
+
+const mockRunQueryPreview = jest.fn();
+jest.mock('../query_services/alerting_prom_resources_service', () => ({
+  AlertingPromResourcesService: jest
+    .fn()
+    .mockImplementation(() => ({ runQueryPreview: mockRunQueryPreview })),
+}));
+
+describe('QueryPreviewResults — not-run vs. empty result', () => {
+  beforeEach(() => mockRunQueryPreview.mockReset());
+
+  it('shows a neutral prompt (not the empty-result warning) when there is no expression', () => {
+    render(<QueryPreviewResults query="" datasourceId="ds-1" />);
+    expect(screen.getByText('Nothing to preview yet')).toBeInTheDocument();
+    expect(screen.queryByText('No results for this time range')).not.toBeInTheDocument();
+    expect(mockRunQueryPreview).not.toHaveBeenCalled();
+  });
+
+  it('shows a neutral prompt when no datasource is selected', () => {
+    render(<QueryPreviewResults query="up" datasourceId={undefined} />);
+    expect(screen.getByText('Nothing to preview yet')).toBeInTheDocument();
+    expect(mockRunQueryPreview).not.toHaveBeenCalled();
+  });
+
+  it('shows the empty-result warning only after a real run returns zero rows', async () => {
+    mockRunQueryPreview.mockResolvedValue({ points: [], query: 'up', seriesCount: 0 });
+    render(<QueryPreviewResults query="up" datasourceId="ds-1" runToken={1} />);
+    expect(await screen.findByText('No results for this time range')).toBeInTheDocument();
+    expect(screen.queryByText('Nothing to preview yet')).not.toBeInTheDocument();
+  });
+
+  it('notes when more than one series matched', async () => {
+    mockRunQueryPreview.mockResolvedValue({
+      points: [{ timestamp: 1, value: 1 }],
+      query: 'up',
+      seriesCount: 4,
+    });
+    render(<QueryPreviewResults query="up" datasourceId="ds-1" runToken={1} />);
+    await waitFor(() => expect(screen.getByText(/Matched 4 series/)).toBeInTheDocument());
+    expect(screen.getByTestId('echarts-render')).toBeInTheDocument();
+  });
+});

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -172,6 +172,12 @@ function buildPrometheusRulePayload(opts: {
   annotations: Record<string, string>;
   enabled: boolean;
   groupName?: string;
+  /**
+   * Allow replacing an existing same-named rule in the group. Edit flows set
+   * this; create flows leave it false so the server rejects a name collision
+   * (409) instead of silently overwriting.
+   */
+  overwrite?: boolean;
 }) {
   return {
     name: opts.name,
@@ -182,6 +188,7 @@ function buildPrometheusRulePayload(opts: {
     annotations: opts.annotations,
     enabled: opts.enabled,
     ...(opts.groupName ? { groupName: opts.groupName } : {}),
+    ...(opts.overwrite ? { overwrite: true } : {}),
   };
 }
 
@@ -407,7 +414,57 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     setRules,
     setRulesTotal,
     refetch: refetchRules,
+    backgroundRefetch: backgroundRefetchRules,
   } = useRulesData({ selectedDsIds });
+
+  // Keep the rules list fresh without a manual reload. A rule created
+  // elsewhere (e.g. the Metrics page "Create alert rule" flyout) only lands
+  // in the unified list once Cortex's querier has loaded and first-evaluated
+  // it, which can lag the create by up to the rule's evaluation interval — so
+  // the initial mount fetch can miss it and the list would otherwise stay
+  // stale until a filter toggle. Refetch when the user switches INTO the Rules
+  // tab so a freshly-created rule shows up on navigation.
+  const prevTabRef = useRef(activeTab);
+  useEffect(() => {
+    if (activeTab === 'rules' && prevTabRef.current !== 'rules') {
+      refetchRules();
+    }
+    prevTabRef.current = activeTab;
+  }, [activeTab, refetchRules]);
+
+  // Also refetch when the window/tab regains focus, so returning to an
+  // already-open Alerts app re-syncs (e.g. after creating a rule in another
+  // browser tab). Cheap: only re-runs the rules query. `focus` and
+  // `visibilitychange` both fire when refocusing a window, so throttle to
+  // one refetch per second to avoid a redundant double request.
+  const lastFocusRefetchRef = useRef(0);
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState !== 'visible') return;
+      const nowMs = Date.now();
+      if (nowMs - lastFocusRefetchRef.current < 1000) return;
+      lastFocusRefetchRef.current = nowMs;
+      refetchRules();
+    };
+    window.addEventListener('focus', onVisible);
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      window.removeEventListener('focus', onVisible);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [refetchRules]);
+
+  // While the Rules tab is open and visible, poll silently every 15s so a rule
+  // that was just created — here or from the Metrics page — shows on its own
+  // once Cortex's querier has loaded it, without the user clicking Refresh.
+  // Background refetch = no spinner / no error-banner clobber.
+  useEffect(() => {
+    if (activeTab !== 'rules') return undefined;
+    const intervalId = window.setInterval(() => {
+      if (document.visibilityState === 'visible') backgroundRefetchRules();
+    }, 15000);
+    return () => window.clearInterval(intervalId);
+  }, [activeTab, backgroundRefetchRules]);
 
   const [deletedRuleIds, setDeletedRuleIds] = useState<Set<string>>(new Set());
   const [showCreateMonitor, setShowCreateMonitor] = useState(false);
@@ -425,40 +482,37 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   // datasource filter has surfaced — saving against an unselected DS could
   // still create a same-name monitor on that DS, but that's a much narrower
   // footgun than the original "two identical names on the same cluster".
-  const rulesByDsName = useMemo(() => {
-    const map = new Map<string, Set<string>>();
-    rules.forEach((r) => {
-      if (deletedRuleIds.has(r.id)) return;
-      const dsKey = r.datasourceId;
-      const names = map.get(dsKey) ?? new Set<string>();
-      names.add(r.name.trim().toLowerCase());
-      map.set(dsKey, names);
-    });
-    return map;
-  }, [rules, deletedRuleIds]);
-
-  const isNameTakenForCreate = useCallback(
-    (name: string, dsId: string) => {
-      const set = rulesByDsName.get(dsId);
-      return !!set?.has(name.trim().toLowerCase());
-    },
-    [rulesByDsName]
-  );
-
-  const buildIsNameTakenForEdit = useCallback(
-    (excludeRuleId: string) => (name: string, dsId: string) => {
+  // Duplicate-rule detection. Prometheus rule identity is (datasource, group,
+  // name), so when a `group` is supplied the collision is scoped to that group
+  // — this lets a user legitimately keep `HighLatency` in two different groups
+  // without a false "already exists". When no group is supplied (OpenSearch/PPL
+  // monitors, which have no group) the check falls back to datasource-wide.
+  const isRuleNameTaken = useCallback(
+    (name: string, dsId: string, group: string | undefined, excludeRuleId?: string) => {
       const trimmed = name.trim().toLowerCase();
-      // Walk the rule list directly so we can exclude the monitor being
-      // edited; the cached map doesn't carry id information.
+      if (!trimmed) return false;
+      const g = group?.trim().toLowerCase();
       return rules.some(
         (r) =>
           r.id !== excludeRuleId &&
           !deletedRuleIds.has(r.id) &&
           r.datasourceId === dsId &&
-          r.name.trim().toLowerCase() === trimmed
+          r.name.trim().toLowerCase() === trimmed &&
+          (g === undefined || g === '' || (r.group ?? '').trim().toLowerCase() === g)
       );
     },
     [rules, deletedRuleIds]
+  );
+
+  const isNameTakenForCreate = useCallback(
+    (name: string, dsId: string, group?: string) => isRuleNameTaken(name, dsId, group),
+    [isRuleNameTaken]
+  );
+
+  const buildIsNameTakenForEdit = useCallback(
+    (excludeRuleId: string) => (name: string, dsId: string, group?: string) =>
+      isRuleNameTaken(name, dsId, group, excludeRuleId),
+    [isRuleNameTaken]
   );
   // The popover's "Logs" entry maps to an OpenSearch monitor and "Metrics"
   // maps to a Prometheus rule. When the user picks Logs the flyout is forced
@@ -1184,6 +1238,9 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           ),
           enabled: promForm.enabled,
           groupName: ruleGroupLabel || promForm.name,
+          // Edit intends to replace the existing rule (same name+group) —
+          // opt into overwrite so the server's create-collision guard allows it.
+          overwrite: true,
         });
         // Create new rule first, then delete old on success (prevents data loss
         // if create fails — worst case is a harmless duplicate).
@@ -1339,6 +1396,8 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           rules={visibleRules}
           datasources={datasources}
           loading={dataLoading}
+          onRefresh={refetchRules}
+          refreshing={dataLoading}
           onDelete={handleDeleteRules}
           onClone={handleCloneRule}
           onEdit={(monitor) => setEditTarget({ dsId: monitor.datasourceId, ruleId: monitor.id })}

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -434,9 +434,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
 
   // Also refetch when the window/tab regains focus, so returning to an
   // already-open Alerts app re-syncs (e.g. after creating a rule in another
-  // browser tab). Cheap: only re-runs the rules query. `focus` and
-  // `visibilitychange` both fire when refocusing a window, so throttle to
-  // one refetch per second to avoid a redundant double request.
+  // browser tab). Uses the BACKGROUND refetch (no spinner, no error/warning
+  // banner clobber) — a silent refocus re-sync, matching the 15s poll's
+  // intent. `focus` and `visibilitychange` both fire when refocusing a
+  // window, so throttle to one refetch per second to avoid a double request.
   const lastFocusRefetchRef = useRef(0);
   useEffect(() => {
     const onVisible = () => {
@@ -444,7 +445,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       const nowMs = Date.now();
       if (nowMs - lastFocusRefetchRef.current < 1000) return;
       lastFocusRefetchRef.current = nowMs;
-      refetchRules();
+      backgroundRefetchRules();
     };
     window.addEventListener('focus', onVisible);
     document.addEventListener('visibilitychange', onVisible);
@@ -452,7 +453,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       window.removeEventListener('focus', onVisible);
       document.removeEventListener('visibilitychange', onVisible);
     };
-  }, [refetchRules]);
+  }, [backgroundRefetchRules]);
 
   // While the Rules tab is open and visible, poll silently every 15s so a rule
   // that was just created — here or from the Metrics page — shows on its own

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -450,6 +450,10 @@ const QuerySection = React.memo<{
               <EuiButton
                 size="s"
                 onClick={onRunPreview}
+                // A preview needs both an expression and a datasource; disabling
+                // avoids running an empty query that would surface a misleading
+                // "returned no data" message for missing input.
+                isDisabled={form.query.trim() === '' || !form.datasourceId}
                 data-test-subj="metricsMonitorRunPreviewButton"
                 aria-label={i18n.translate(
                   'observability.alerting.createMetricsMonitor.runPreviewAriaLabel',
@@ -574,7 +578,7 @@ const QuerySection = React.memo<{
                 'observability.alerting.createMetricsMonitor.expressionHelpText',
                 {
                   defaultMessage:
-                    'The complete alert condition. Switch to Builder to construct a simple metric/label query.',
+                    'The complete alert condition — it fires for every series the expression returns. A bare series (e.g. "up") is always-firing; add a comparison/threshold (e.g. "> 0.5") for a conditional alert. Switch to Builder to construct a simple metric/label query.',
                 }
               )}
               fullWidth

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -27,7 +27,9 @@ import {
   EuiSelect,
   EuiButton,
   EuiButtonEmpty,
+  EuiButtonGroup,
   EuiButtonIcon,
+  EuiCallOut,
   EuiText,
   EuiBadge,
   EuiAccordion,
@@ -47,7 +49,7 @@ import {
 import { i18n } from '@osd/i18n';
 import { coreRefs } from '../../framework/core_refs';
 import { classifiedToastColor, classifiedToastText, extractClassifiedError } from '../common/error';
-import { PromQueryBuilder } from './create_monitor/prom_query_builder';
+import { PromQueryBuilder, parseBuilderQuery } from './create_monitor/prom_query_builder';
 import { RuleGroupSelector } from './create_monitor/rule_group_selector';
 import { QueryPreviewResults } from './query_preview_results';
 // Shared label editor + entry types keep both flyouts' Labels sections in sync
@@ -74,6 +76,9 @@ export interface MetricsMonitorFormState {
   annotations: AnnotationEntry[];
 }
 
+/** Which query editor the Query section shows. */
+export type QueryMode = 'code' | 'builder';
+
 export interface CreateMetricsMonitorProps {
   onCancel: () => void;
   onSave: (form: MetricsMonitorFormState) => void;
@@ -81,6 +86,21 @@ export interface CreateMetricsMonitorProps {
   datasourceId?: string;
   /** Datasource display name from the current Explore page context */
   datasourceName?: string;
+  /**
+   * PromQL the user had in the Explore Metrics editor, used to pre-fill the
+   * flyout's query. The builder seeds its fields from this when the expression
+   * is builder-representable; complex expressions stay in the visible
+   * expression field (and drive the preview) without the builder clobbering
+   * them.
+   */
+  initialQuery?: string;
+  /**
+   * Time window (epoch seconds) the preview should run over — typically the
+   * Explore time picker the user came from, so the flyout's Run preview
+   * reflects the same range they were just looking at. When omitted the
+   * preview defaults to the last hour.
+   */
+  initialTimeRange?: { start: number; end: number };
   /**
    * Selectable Prometheus datasources. Provided by the Alert Manager Rules
    * page (no page context there); when absent, the flyout is pinned to the
@@ -91,7 +111,7 @@ export interface CreateMetricsMonitorProps {
    * Duplicate-name guard, checked against the selected datasource. Provided
    * by the Alert Manager Rules page which knows the existing rules.
    */
-  isNameTaken?: (name: string, dsId: string) => boolean;
+  isNameTaken?: (name: string, dsId: string, group?: string) => boolean;
   /**
    * Show the "Build query in metrics →" round-trip link in the Query
    * section header. Set by the Alert Manager Rules page; must stay off on
@@ -157,6 +177,46 @@ const FOR_DURATION_OPTIONS = [
 
 /** The namespace all rules created from this flyout are stored under. */
 const USER_RULES_NAMESPACE = 'observability-alerting';
+
+/**
+ * The label entries that will actually be persisted: both key AND value must be
+ * non-empty (a key with a blank value is dropped). Shared by the Rule Preview
+ * (YAML) and the save payload so the preview can never advertise a different
+ * set than what is written. Keys are trimmed to match server-side storage.
+ */
+export function materializeLabels(labels: LabelEntry[]): LabelEntry[] {
+  return labels
+    .filter((l) => l.key.trim() !== '' && l.value.trim() !== '')
+    .map((l) => ({ ...l, key: l.key.trim() }));
+}
+
+/**
+ * The annotation entries that will be persisted. Drops empty key/value pairs and
+ * folds the Rule details Description field into the standard `description`
+ * annotation (which wins over a manually-typed one). Shared by preview + save so
+ * the two cannot drift.
+ */
+export function materializeAnnotations(
+  annotations: AnnotationEntry[],
+  descriptionField: string
+): AnnotationEntry[] {
+  const description = descriptionField.trim();
+  const manual = annotations
+    .filter((a) => a.key.trim() !== '' && a.value.trim() !== '')
+    .filter((a) => !(description && a.key.trim() === 'description'))
+    .map((a) => ({ ...a, key: a.key.trim() }));
+  return description ? [...manual, { key: 'description', value: description }] : manual;
+}
+
+/**
+ * A PromQL expression that starts with a comparison operator (`> 0.5`) is not a
+ * valid alert condition — the metric/series to the left is missing. Cheap guard
+ * to block obviously-malformed input at submit time (full validation happens
+ * server-side / on preview).
+ */
+export function startsWithComparison(query: string): boolean {
+  return /^\s*(>=|<=|==|!=|>|<)/.test(query);
+}
 
 // ============================================================================
 // Sub-components
@@ -230,6 +290,7 @@ const MonitorDetailsSection = React.memo<{
         onChange={(e) => onUpdate({ monitorName: e.target.value })}
         fullWidth
         compressed
+        data-test-subj="metricsMonitorNameField"
         aria-label={i18n.translate(
           'observability.alerting.createMetricsMonitor.monitorNameAriaLabel',
           { defaultMessage: 'Rule name' }
@@ -282,12 +343,19 @@ const MonitorDetailsSection = React.memo<{
   </EuiAccordion>
 ));
 
-/** Section 2: Query — shared PromQL builder with datasource picker */
+/** Section 2: Query — Code (raw PromQL) or point-and-click Builder */
 const QuerySection = React.memo<{
   form: MetricsMonitorFormState;
   onUpdate: (patch: Partial<MetricsMonitorFormState>) => void;
   showPreview: boolean;
   onRunPreview: () => void;
+  /** Bumped on each "Run preview" click so the results block re-fetches. */
+  previewToken: number;
+  /** Time window (epoch seconds) the preview runs over; undefined = last hour. */
+  previewTimeRange?: { start: number; end: number };
+  /** 'code' shows the raw PromQL editor; 'builder' shows the metric picker. */
+  queryMode: QueryMode;
+  onQueryModeChange: (mode: QueryMode) => void;
   contextDatasourceName?: string;
   /** Selectable datasources (Alert Manager); absent = pinned context ds. */
   datasources?: Array<{ id: string; name: string; type: string }>;
@@ -299,11 +367,20 @@ const QuerySection = React.memo<{
     onUpdate,
     showPreview,
     onRunPreview,
+    previewToken,
+    previewTimeRange,
+    queryMode,
+    onQueryModeChange,
     contextDatasourceName,
     datasources,
     showBuildInMetricsLink,
   }) => {
     const [showDatasourcePicker, setShowDatasourcePicker] = useState(false);
+    // A non-empty expression the builder cannot represent (e.g. a copied
+    // `rate(...) > 0.5`). Switching to the builder and picking a metric would
+    // replace it — warn instead of silently clobbering (audit finding #7).
+    const builderWouldOverwrite =
+      form.query.trim() !== '' && parseBuilderQuery(form.query) === null;
 
     // With an explicit datasource list (Alert Manager) the picker offers all
     // Prometheus datasources; otherwise it is pinned to the Explore page's
@@ -373,6 +450,7 @@ const QuerySection = React.memo<{
               <EuiButton
                 size="s"
                 onClick={onRunPreview}
+                data-test-subj="metricsMonitorRunPreviewButton"
                 aria-label={i18n.translate(
                   'observability.alerting.createMetricsMonitor.runPreviewAriaLabel',
                   { defaultMessage: 'Run preview' }
@@ -424,34 +502,128 @@ const QuerySection = React.memo<{
                 closePopover={() => setShowDatasourcePicker(false)}
                 panelPaddingSize="s"
               >
-                {datasourceOptions.map((ds) => (
-                  <EuiButtonEmpty
-                    key={ds.id}
-                    size="xs"
-                    onClick={() => {
-                      onUpdate({ datasourceId: ds.id });
-                      setShowDatasourcePicker(false);
-                    }}
-                    style={{ display: 'block', width: '100%', textAlign: 'left' }}
-                  >
-                    {ds.name}
-                  </EuiButtonEmpty>
-                ))}
+                {datasourceOptions.map((ds) => {
+                  const isSelected = ds.id === form.datasourceId;
+                  return (
+                    <EuiButtonEmpty
+                      key={ds.id}
+                      size="xs"
+                      // Show which datasource is active: a check on the selected
+                      // row (empty icon keeps the others aligned) plus aria-current
+                      // so assistive tech announces the selection.
+                      iconType={isSelected ? 'check' : 'empty'}
+                      iconSide="left"
+                      color={isSelected ? 'primary' : 'text'}
+                      aria-current={isSelected}
+                      onClick={() => {
+                        onUpdate({ datasourceId: ds.id });
+                        setShowDatasourcePicker(false);
+                      }}
+                      style={{ display: 'block', width: '100%', textAlign: 'left' }}
+                    >
+                      {ds.name}
+                    </EuiButtonEmpty>
+                  );
+                })}
               </EuiPopover>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false} style={{ marginLeft: 'auto' }}>
+              {/* Builder ⇄ Code toggle. Only one editor shows at a time, so a
+                copied PromQL expression (Code) is never silently overwritten by
+                the builder's output — the two no longer share a visible field. */}
+              <EuiButtonGroup
+                legend={i18n.translate(
+                  'observability.alerting.createMetricsMonitor.queryModeLegend',
+                  { defaultMessage: 'Query editor mode' }
+                )}
+                buttonSize="compressed"
+                options={[
+                  {
+                    id: 'builder',
+                    label: i18n.translate(
+                      'observability.alerting.createMetricsMonitor.queryModeBuilder',
+                      { defaultMessage: 'Builder' }
+                    ),
+                  },
+                  {
+                    id: 'code',
+                    label: i18n.translate(
+                      'observability.alerting.createMetricsMonitor.queryModeCode',
+                      { defaultMessage: 'Code' }
+                    ),
+                  },
+                ]}
+                idSelected={queryMode}
+                onChange={(id) => onQueryModeChange(id as QueryMode)}
+                data-test-subj="metricsMonitorQueryModeToggle"
+              />
             </EuiFlexItem>
           </EuiFlexGroup>
 
           <EuiSpacer size="m" />
 
-          {/* Point-and-click builder — same component as the Alert Manager
-            "Create metrics rule" flyout. Seeds from the pre-filled Explore
-            query when it is builder-representable; complex expressions leave
-            the builder inert so the seeded query is preserved. */}
-          <PromQueryBuilder
-            datasourceId={form.datasourceId}
-            query={form.query}
-            onQueryChange={(q) => onUpdate({ query: q })}
-          />
+          {queryMode === 'code' ? (
+            /* Code mode: raw PromQL expression. A query copied from Explore
+              lands here as-is (including complex expressions the builder can't
+              represent), editable directly. */
+            <EuiFormRow
+              label={i18n.translate('observability.alerting.createMetricsMonitor.expressionLabel', {
+                defaultMessage: 'PromQL expression',
+              })}
+              helpText={i18n.translate(
+                'observability.alerting.createMetricsMonitor.expressionHelpText',
+                {
+                  defaultMessage:
+                    'The complete alert condition. Switch to Builder to construct a simple metric/label query.',
+                }
+              )}
+              fullWidth
+            >
+              <EuiTextArea
+                value={form.query}
+                onChange={(e) => onUpdate({ query: e.target.value })}
+                placeholder={i18n.translate(
+                  'observability.alerting.createMetricsMonitor.expressionPlaceholder',
+                  { defaultMessage: 'e.g. rate(http_requests_total[5m]) > 0.5' }
+                )}
+                rows={2}
+                fullWidth
+                compressed
+                aria-label={i18n.translate(
+                  'observability.alerting.createMetricsMonitor.expressionAriaLabel',
+                  { defaultMessage: 'PromQL expression' }
+                )}
+                data-test-subj="metricsMonitorPromQlExpression"
+              />
+            </EuiFormRow>
+          ) : (
+            /* Builder mode: point-and-click metric/label picker. */
+            <>
+              {builderWouldOverwrite && (
+                <>
+                  <EuiCallOut
+                    size="s"
+                    color="warning"
+                    iconType="alert"
+                    title={i18n.translate(
+                      'observability.alerting.createMetricsMonitor.builderOverwriteWarning',
+                      {
+                        defaultMessage:
+                          'Your current PromQL expression can’t be represented by the builder. Selecting a metric here will replace it — switch to Code to keep editing it directly.',
+                      }
+                    )}
+                    data-test-subj="metricsMonitorBuilderOverwriteWarning"
+                  />
+                  <EuiSpacer size="s" />
+                </>
+              )}
+              <PromQueryBuilder
+                datasourceId={form.datasourceId}
+                query={form.query}
+                onQueryChange={(q) => onUpdate({ query: q })}
+              />
+            </>
+          )}
 
           <EuiSpacer size="m" />
 
@@ -489,7 +661,13 @@ const QuerySection = React.memo<{
         {showPreview && (
           <>
             <EuiSpacer size="m" />
-            <QueryPreviewResults id="cmm-preview-results" query={form.query} />
+            <QueryPreviewResults
+              id="cmm-preview-results"
+              query={form.query}
+              datasourceId={form.datasourceId}
+              timeRange={previewTimeRange}
+              runToken={previewToken}
+            />
           </>
         )}
       </EuiAccordion>
@@ -632,39 +810,45 @@ const RulePreviewSection = React.memo<{
 }>(({ form }) => {
   const yaml = useMemo(() => {
     const esc = (s: string) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
-    const labels = form.labels.filter((l) => l.key && l.value);
-    // Mirror the save path: the Rule details Description field persists as
-    // the `description` annotation (and wins over a manually-typed one), so
-    // the preview must show exactly what will be saved
-    const annotations = [
-      ...form.annotations.filter(
-        (a) => a.key && a.value && !(form.description.trim() && a.key === 'description')
-      ),
-      ...(form.description.trim() ? [{ key: 'description', value: form.description.trim() }] : []),
-    ];
-    let out = `- alert: "${esc(form.monitorName || '<monitor-name>')}"\n`;
+    // Use the exact same materialization as the save path so the previewed
+    // YAML is guaranteed to match the rule that gets written (WYSIWYG).
+    const labels = materializeLabels(form.labels);
+    const annotations = materializeAnnotations(form.annotations, form.description);
+    // Mirror the full rule-group the save payload creates: rules are stored
+    // under (namespace → group → rule), and the group carries the evaluation
+    // interval. Previewing only the rule body hid where it lands and how often
+    // it runs; show the whole structure so the preview matches what's written.
+    const groupName = (form.groupName || form.monitorName || '<group-name>').trim();
+    let out = `# namespace: ${form.namespace}\n`;
+    out += `name: "${esc(groupName)}"\n`;
+    out += `interval: ${form.evalInterval}\n`;
+    out += `rules:\n`;
+    out += `  - alert: "${esc(form.monitorName || '<monitor-name>')}"\n`;
     // The PromQL expression is the complete alert condition
-    out += `  expr: "${esc(form.query || '<promql-expression>')}"\n`;
-    out += `  for: ${form.forDuration}\n`;
+    out += `    expr: "${esc(form.query || '<promql-expression>')}"\n`;
+    out += `    for: ${form.forDuration}\n`;
     if (labels.length > 0) {
-      out += `  labels:\n`;
+      out += `    labels:\n`;
       // Template values are single-quoted, matching the server's js-yaml
       // serialization (unquoted `{{ ... }}` would be invalid YAML)
       for (const l of labels) {
-        out += `    "${esc(l.key)}": ${l.isDynamic ? `'${l.value}'` : `"${esc(l.value)}"`}\n`;
+        out += `      "${esc(l.key)}": ${l.isDynamic ? `'${l.value}'` : `"${esc(l.value)}"`}\n`;
       }
     }
     if (annotations.length > 0) {
-      out += `  annotations:\n`;
+      out += `    annotations:\n`;
       // Annotations lack the isDynamic flag — detect template syntax to
       // single-quote like the server's js-yaml serialization does
       for (const a of annotations) {
         const value = /\{\{.*\}\}/.test(a.value) ? `'${a.value}'` : `"${esc(a.value)}"`;
-        out += `    "${esc(a.key)}": ${value}\n`;
+        out += `      "${esc(a.key)}": ${value}\n`;
       }
     }
     return out;
   }, [
+    form.namespace,
+    form.groupName,
+    form.evalInterval,
     form.monitorName,
     form.query,
     form.forDuration,
@@ -731,6 +915,8 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
   onSave,
   datasourceId: contextDatasourceId,
   datasourceName: contextDatasourceName,
+  initialQuery,
+  initialTimeRange,
   datasources,
   isNameTaken,
   showBuildInMetricsLink,
@@ -746,11 +932,11 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
     description: '',
     namespace: USER_RULES_NAMESPACE,
     groupName: '',
-    // Empty on purpose: the query must come from an explicit builder
-    // selection. A pre-seeded expression would be submittable while the
-    // builder renders empty (it cannot represent complex expressions),
-    // silently creating a rule for a metric the user never chose.
-    query: '',
+    // Pre-filled from the Explore Metrics editor when opened from that page.
+    // Safe to seed now that the expression is shown in a visible, editable
+    // field (see QuerySection) — a complex expression the builder can't
+    // represent is no longer hidden-yet-submittable.
+    query: initialQuery ?? '',
     datasourceId: defaultDatasourceId,
     forDuration: '5m',
     evalInterval: '1m',
@@ -759,7 +945,15 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
     labels: [{ key: 'severity', value: 'warning', isDynamic: false }],
     annotations: [],
   });
+  // Default to Code mode when a query was copied in (so it shows as-is and the
+  // builder can't overwrite it); an empty flyout starts in Builder mode.
+  const [queryMode, setQueryMode] = useState<QueryMode>(() =>
+    (initialQuery ?? '').trim() ? 'code' : 'builder'
+  );
   const [showPreview, setShowPreview] = useState(false);
+  // Bumped on each "Run preview" click so QueryPreviewResults re-runs the
+  // range query even when the panel is already open.
+  const [previewToken, setPreviewToken] = useState(0);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   // JSON snapshot so ANY field edit (description, group, duration,
   // datasource, label/annotation content) arms the discard-confirm modal —
@@ -792,13 +986,20 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
 
   const handleRunPreview = useCallback(() => {
     setShowPreview(true);
+    setPreviewToken((t) => t + 1);
   }, []);
 
   const duplicateName = !!(
     isNameTaken &&
     form.monitorName.trim() !== '' &&
     form.datasourceId !== '' &&
-    isNameTaken(form.monitorName.trim(), form.datasourceId)
+    // Scope the collision to the effective rule group (defaults to the rule
+    // name), matching Prometheus's (group, name) identity.
+    isNameTaken(
+      form.monitorName.trim(),
+      form.datasourceId,
+      (form.groupName || form.monitorName).trim()
+    )
   );
   const nameError = duplicateName
     ? i18n.translate('observability.alerting.createMetricsMonitor.nameDuplicate', {
@@ -809,6 +1010,8 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
   const isValid =
     form.monitorName.trim() !== '' &&
     form.query.trim() !== '' &&
+    // Reject an expression that is only/starts-with a comparison (no series).
+    !startsWithComparison(form.query) &&
     form.datasourceId !== '' &&
     !duplicateName;
 
@@ -828,25 +1031,19 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
       // The PromQL expression is the complete alert condition — no
       // operator/threshold appended server-side.
       const payload = {
-        name: form.monitorName,
+        name: form.monitorName.trim(),
         query: form.query,
         forDuration: form.forDuration,
         evaluationInterval: form.evalInterval,
-        labels: Object.fromEntries(
-          form.labels.filter((l) => l.key.trim()).map((l) => [l.key, l.value])
+        // Same materialization the Rule Preview (YAML) shows — no drift.
+        labels: Object.fromEntries(materializeLabels(form.labels).map((l) => [l.key, l.value])),
+        annotations: Object.fromEntries(
+          materializeAnnotations(form.annotations, form.description).map(
+            (a) => [a.key, a.value] as [string, string]
+          )
         ),
-        annotations: Object.fromEntries([
-          ...form.annotations
-            .filter((a) => a.key.trim())
-            .map((a) => [a.key, a.value] as [string, string]),
-          // The Rule details Description field persists as the standard
-          // `description` annotation (the server's rule builder reads it)
-          ...(form.description.trim()
-            ? [['description', form.description.trim()] as [string, string]]
-            : []),
-        ]),
         enabled: true,
-        groupName: form.groupName || form.monitorName,
+        groupName: (form.groupName || form.monitorName).trim(),
       };
       await http.post(`/api/alerting/prometheus/${encodeURIComponent(form.datasourceId)}/rules`, {
         body: JSON.stringify(payload),
@@ -913,6 +1110,10 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
           onUpdate={updateForm}
           showPreview={showPreview}
           onRunPreview={handleRunPreview}
+          previewToken={previewToken}
+          previewTimeRange={initialTimeRange}
+          queryMode={queryMode}
+          onQueryModeChange={setQueryMode}
           contextDatasourceName={contextDatasourceName}
           datasources={datasources}
           showBuildInMetricsLink={showBuildInMetricsLink}
@@ -943,14 +1144,20 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
       <EuiFlyoutFooter>
         <EuiFlexGroup justifyContent="flexEnd" responsive={false} gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiButtonEmpty onClick={handleClose}>
+            <EuiButtonEmpty onClick={handleClose} data-test-subj="metricsMonitorCancelButton">
               {i18n.translate('observability.alerting.createMetricsMonitor.cancelButton', {
                 defaultMessage: 'Cancel',
               })}
             </EuiButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton fill onClick={handleSave} isLoading={isSaving} isDisabled={!isValid}>
+            <EuiButton
+              fill
+              onClick={handleSave}
+              isLoading={isSaving}
+              isDisabled={!isValid}
+              data-test-subj="metricsMonitorCreateButton"
+            >
               {i18n.translate('observability.alerting.createMetricsMonitor.createButton', {
                 defaultMessage: 'Create',
               })}

--- a/public/components/alerting/create_monitor/index.tsx
+++ b/public/components/alerting/create_monitor/index.tsx
@@ -121,7 +121,7 @@ export interface CreateMonitorProps {
    * up against the loaded rules list (excluding `initialForm`'s own id in
    * edit mode so renaming back to the current name passes).
    */
-  isNameTaken?: (trimmedName: string, dsId: string) => boolean;
+  isNameTaken?: (trimmedName: string, dsId: string, group?: string) => boolean;
   /**
    * Server-side error from the most recent save attempt, routed by the
    * parent to whichever form field it belongs under so the user sees it
@@ -311,11 +311,18 @@ export const CreateMonitor: React.FC<CreateMonitorProps> = ({
   // page didn't supply a checker.
   const trimmedName = activeForm.name.trim();
   const dsForCheck = activeForm.datasourceId;
+  // For Prometheus the collision is scoped to the target rule group (the
+  // `_ruleGroup` transport label, defaulting to the rule name); OpenSearch
+  // monitors have no group so the check stays datasource-wide (group=undefined).
+  const groupForCheck =
+    backendType === 'prometheus'
+      ? (promForm.labels.find((l) => l.key === '_ruleGroup')?.value || '').trim() || trimmedName
+      : undefined;
   const duplicateName = !!(
     isNameTaken &&
     trimmedName !== '' &&
     dsForCheck !== '' &&
-    isNameTaken(trimmedName, dsForCheck)
+    isNameTaken(trimmedName, dsForCheck, groupForCheck)
   );
   const duplicateNameError = duplicateName
     ? i18n.translate('observability.alerting.createMonitor.nameDuplicate', {

--- a/public/components/alerting/create_monitor/prom_query_builder.tsx
+++ b/public/components/alerting/create_monitor/prom_query_builder.tsx
@@ -165,8 +165,18 @@ export const PromQueryBuilder: React.FC<{
   }, [selectedMetric, selectedLabelName, selectedLabelValue, labelOperator, onQueryChange]);
 
   // Sync when builder field selections change; clearing the metric clears a
-  // builder-authored query so the two stay consistent
+  // builder-authored query so the two stay consistent.
+  const didMountRef = useRef(false);
   useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      // Seeded FROM the query on mount: mark ownership so a later clear can
+      // reset it, but do NOT re-emit — re-emitting would normalize whitespace
+      // the user never touched (e.g. `foo{ bar = "x" }` → `foo{bar="x"}`) and
+      // spuriously mark the form dirty / pop the discard-changes modal.
+      if (seededBuilder) builderOwnsQuery.current = true;
+      return;
+    }
     if (selectedMetric.length > 0) {
       syncBuilderToQuery();
     } else if (builderOwnsQuery.current) {
@@ -193,7 +203,15 @@ export const PromQueryBuilder: React.FC<{
               )}
               options={metricOptions}
               selectedOptions={selectedMetric}
-              onChange={(opts) => setSelectedMetric(opts)}
+              onChange={(opts) => {
+                setSelectedMetric(opts);
+                // Reset the label filter when the metric changes — a label
+                // name/value valid for the old metric can be invalid (or mean
+                // something different) for the new one, which would build an
+                // incorrect `newMetric{staleLabel="staleValue"}` query.
+                setSelectedLabelName([]);
+                setSelectedLabelValue([]);
+              }}
               singleSelection={{ asPlainText: true }}
               compressed
               isClearable

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -84,6 +84,8 @@ export const PrometheusFormSection: React.FC<{
     () => form.labels.find((l) => l.key === '_ruleGroup')?.value || ''
   );
   const [showPreview, setShowPreview] = useState(false);
+  // Bumped on each "Run preview" click so QueryPreviewResults re-runs the query.
+  const [previewToken, setPreviewToken] = useState(0);
 
   // Use a ref for form.labels to avoid circular dependency:
   // handleRuleGroupChange → onUpdate('labels') → parent re-renders → new form.labels → new callback
@@ -328,7 +330,10 @@ export const PrometheusFormSection: React.FC<{
               <EuiFlexItem grow={false}>
                 <EuiButton
                   size="s"
-                  onClick={() => setShowPreview(true)}
+                  onClick={() => {
+                    setShowPreview(true);
+                    setPreviewToken((t) => t + 1);
+                  }}
                   data-test-subj="prometheusRunPreviewButton"
                   aria-label={i18n.translate(
                     'observability.alerting.prometheusFormSection.runPreviewAriaLabel',
@@ -415,7 +420,11 @@ export const PrometheusFormSection: React.FC<{
           {showPreview && (
             <>
               <EuiSpacer size="m" />
-              <QueryPreviewResults query={form.query} />
+              <QueryPreviewResults
+                query={form.query}
+                datasourceId={datasourceId}
+                runToken={previewToken}
+              />
             </>
           )}
         </EuiAccordion>

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -334,6 +334,9 @@ export const PrometheusFormSection: React.FC<{
                     setShowPreview(true);
                     setPreviewToken((t) => t + 1);
                   }}
+                  // Needs an expression and a datasource; disabling avoids an
+                  // empty run surfacing a misleading "returned no data" message.
+                  isDisabled={form.query.trim() === '' || !datasourceId}
                   data-test-subj="prometheusRunPreviewButton"
                   aria-label={i18n.translate(
                     'observability.alerting.prometheusFormSection.runPreviewAriaLabel',

--- a/public/components/alerting/hooks/use_rules_data.ts
+++ b/public/components/alerting/hooks/use_rules_data.ts
@@ -41,8 +41,12 @@ export interface UseRulesDataResult {
   /** Imperatively set the rules array — used for optimistic insert / clear-on-delete. */
   setRules: React.Dispatch<React.SetStateAction<UnifiedRuleSummary[]>>;
   setRulesTotal: React.Dispatch<React.SetStateAction<number>>;
-  /** Imperative refetch; equivalent to bumping `refreshToken`. */
+  /** Imperative refetch; equivalent to bumping `refreshToken`. Shows the
+   * loading state (spinner) — use for explicit user actions. */
   refetch: () => void;
+  /** Silent refetch that does NOT toggle the loading state — use for periodic
+   * background polling so the table doesn't flash while it re-syncs. */
+  backgroundRefetch: () => void;
 }
 
 export function useRulesData({ selectedDsIds }: UseRulesDataParams): UseRulesDataResult {
@@ -57,15 +61,19 @@ export function useRulesData({ selectedDsIds }: UseRulesDataParams): UseRulesDat
   const refetch = useCallback(() => setInternalRefresh((t) => t + 1), []);
 
   const fetchRules = useCallback(
-    async (dsIds: string[]) => {
+    async (dsIds: string[], background = false) => {
       if (dsIds.length === 0) {
         setRules([]);
         setRulesTotal(0);
         return;
       }
-      setIsLoading(true);
-      setError(null);
-      setWarnings([]);
+      // A background poll re-syncs silently: no spinner, and it leaves the
+      // current error/warning surface in place until it has a fresh answer.
+      if (!background) {
+        setIsLoading(true);
+        setError(null);
+        setWarnings([]);
+      }
       try {
         const res = await osService.listRules({ dsIds });
         setRules(res.results || []);
@@ -86,19 +94,28 @@ export function useRulesData({ selectedDsIds }: UseRulesDataParams): UseRulesDat
           );
         }
       } catch (e: unknown) {
-        setError(
-          e instanceof Error
-            ? e.message
-            : i18n.translate('observability.alerting.alarmsPage.fetchRulesError', {
-                defaultMessage: 'Failed to fetch rules',
-              })
-        );
+        // A failed background poll must not blow away the currently-displayed
+        // rules with an error banner — keep the last good state and try again
+        // on the next tick. Foreground fetches still surface the error.
+        if (!background) {
+          setError(
+            e instanceof Error
+              ? e.message
+              : i18n.translate('observability.alerting.alarmsPage.fetchRulesError', {
+                  defaultMessage: 'Failed to fetch rules',
+                })
+          );
+        }
       } finally {
-        setIsLoading(false);
+        if (!background) setIsLoading(false);
       }
     },
     [osService]
   );
+
+  const backgroundRefetch = useCallback(() => {
+    if (selectedDsIds.length > 0) fetchRules(selectedDsIds, true);
+  }, [selectedDsIds, fetchRules]);
 
   useEffect(() => {
     if (selectedDsIds.length === 0) {
@@ -110,5 +127,15 @@ export function useRulesData({ selectedDsIds }: UseRulesDataParams): UseRulesDat
     // Imperative refetch via `refetch()` bumps `internalRefresh`.
   }, [selectedDsIds, internalRefresh, fetchRules]);
 
-  return { rules, rulesTotal, isLoading, error, warnings, setRules, setRulesTotal, refetch };
+  return {
+    rules,
+    rulesTotal,
+    isLoading,
+    error,
+    warnings,
+    setRules,
+    setRulesTotal,
+    refetch,
+    backgroundRefetch,
+  };
 }

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -58,6 +58,10 @@ interface MonitorsTableProps {
   onCreateMonitor?: (
     type: 'logs' | 'prometheus' | 'metrics' | 'slo' | 'detector' | 'forecaster'
   ) => void;
+  /** Manually refetch the rules list (e.g. to pick up a just-created rule). */
+  onRefresh?: () => void;
+  /** True while a refetch is in flight — drives the Refresh button spinner. */
+  refreshing?: boolean;
   /** Currently selected datasource IDs */
   selectedDsIds: string[];
   /** Callback when datasource selection changes */
@@ -98,6 +102,8 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
   onStopResources,
   onToggleEnabled,
   onCreateMonitor,
+  onRefresh,
+  refreshing,
   selectedDsIds,
   onDatasourceChange,
   maxDatasources,
@@ -485,6 +491,8 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
                 selectedIds={selectedIds}
                 setSelectedIds={setSelectedIds}
                 onCreateMonitor={onCreateMonitor}
+                onRefresh={onRefresh}
+                refreshing={refreshing}
                 logsCreateDisabled={logsCreateDisabled}
                 metricsCreateDisabled={metricsCreateDisabled}
                 detectorCreateDisabled={adCreateDisabled}

--- a/public/components/alerting/monitors_table/monitors_main_panel.tsx
+++ b/public/components/alerting/monitors_table/monitors_main_panel.tsx
@@ -67,6 +67,10 @@ export interface MonitorsMainPanelProps {
 
   // Create
   onCreateMonitor?: (type: 'logs' | 'prometheus' | 'metrics' | 'detector' | 'forecaster') => void;
+  /** Manually refetch the rules list. Renders a Refresh button when provided. */
+  onRefresh?: () => void;
+  /** True while a refetch is in flight — shows the Refresh button spinner. */
+  refreshing?: boolean;
   /**
    * When true, the "Logs" popover entry is disabled with a hint that an
    * OpenSearch datasource is needed. Triggered when the parent's selection
@@ -150,6 +154,8 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
   detectorCreateDisabled = false,
   forecasterCreateDisabled = false,
   noDatasourceSelected = false,
+  onRefresh,
+  refreshing = false,
   showCreatePopover,
   setShowCreatePopover,
   showDeleteConfirm,
@@ -193,6 +199,22 @@ export const MonitorsMainPanel: React.FC<MonitorsMainPanelProps> = ({
               gutterSize="s"
               style={{ marginBottom: 8 }}
             >
+              {onRefresh && (
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    iconType="refresh"
+                    size="s"
+                    isLoading={refreshing}
+                    onClick={() => onRefresh()}
+                    data-test-subj="alertManagerRefreshRulesButton"
+                  >
+                    <FormattedMessage
+                      id="observability.alerting.monitorsTable.mainPanel.refresh"
+                      defaultMessage="Refresh"
+                    />
+                  </EuiButton>
+                </EuiFlexItem>
+              )}
               <EuiFlexItem grow={false}>
                 <EuiPopover
                   button={

--- a/public/components/alerting/query_preview_results.tsx
+++ b/public/components/alerting/query_preview_results.tsx
@@ -70,6 +70,12 @@ interface PreviewState {
   plottedQuery: string;
   /** How many series the expression matched (only the first is charted). */
   seriesCount: number;
+  /**
+   * True before any query has been run, or when Run preview was clicked with no
+   * expression / datasource. Distinguishes "nothing ran" from "ran and got zero
+   * rows" so the empty-result warning isn't shown for missing input.
+   */
+  noInput: boolean;
 }
 
 const EMPTY_STATE: PreviewState = {
@@ -79,6 +85,7 @@ const EMPTY_STATE: PreviewState = {
   requestedQuery: '',
   plottedQuery: '',
   seriesCount: 0,
+  noInput: true,
 };
 
 /**
@@ -134,7 +141,7 @@ export const QueryPreviewResults: React.FC<{
       return;
     }
     let stale = false;
-    setState({ ...EMPTY_STATE, loading: true, requestedQuery: trimmed });
+    setState({ ...EMPTY_STATE, loading: true, requestedQuery: trimmed, noInput: false });
     const range = timeRangeRef.current;
     const previewRange = range
       ? { start: range.start, end: range.end, step: deriveStep(range) }
@@ -150,6 +157,7 @@ export const QueryPreviewResults: React.FC<{
             requestedQuery: trimmed,
             plottedQuery: plotted || trimmed,
             seriesCount: seriesCount ?? (points && points.length ? 1 : 0),
+            noInput: false,
           });
         }
       })
@@ -159,6 +167,7 @@ export const QueryPreviewResults: React.FC<{
             ...EMPTY_STATE,
             error: err instanceof Error ? err.message : String(err),
             requestedQuery: trimmed,
+            noInput: false,
           });
         }
       });
@@ -193,31 +202,57 @@ export const QueryPreviewResults: React.FC<{
       initialIsOpen
       paddingSize="s"
     >
-      <EuiText size="xs" color="subdued">
-        {state.plottedQuery || query}
-      </EuiText>
-      {state.seriesCount > 1 && (
-        <EuiText size="xs" color="subdued">
-          <em>
-            {i18n.translate('observability.alerting.queryPreviewResults.multiSeriesNote', {
-              defaultMessage:
-                'Matched {count} series — charting the first. The alert evaluates every matching series.',
-              values: { count: state.seriesCount },
-            })}
-          </em>
-        </EuiText>
-      )}
-      {comparisonStripped && (
-        <EuiText size="xs" color="subdued">
-          <em>
-            {i18n.translate('observability.alerting.queryPreviewResults.comparisonStrippedNote', {
-              defaultMessage: 'Comparison removed to plot the underlying metric series.',
-            })}
-          </em>
-        </EuiText>
+      {!state.noInput && (
+        <>
+          <EuiText size="xs" color="subdued">
+            {state.plottedQuery || query}
+          </EuiText>
+          {state.seriesCount > 1 && (
+            <EuiText size="xs" color="subdued">
+              <em>
+                {i18n.translate('observability.alerting.queryPreviewResults.multiSeriesNote', {
+                  defaultMessage:
+                    'Matched {count} series — charting the first. The alert evaluates every matching series.',
+                  values: { count: state.seriesCount },
+                })}
+              </em>
+            </EuiText>
+          )}
+          {comparisonStripped && (
+            <EuiText size="xs" color="subdued">
+              <em>
+                {i18n.translate(
+                  'observability.alerting.queryPreviewResults.comparisonStrippedNote',
+                  {
+                    defaultMessage: 'Comparison removed to plot the underlying metric series.',
+                  }
+                )}
+              </em>
+            </EuiText>
+          )}
+        </>
       )}
       <EuiSpacer size="s" />
-      {state.loading ? (
+      {state.noInput ? (
+        // Nothing has been run (or Run preview was clicked with no expression /
+        // datasource). Neutral prompt — NOT the "returned no data" warning,
+        // which would wrongly blame a valid metric for missing input.
+        <EuiCallOut
+          size="s"
+          color="primary"
+          iconType="iInCircle"
+          title={i18n.translate('observability.alerting.queryPreviewResults.notRunTitle', {
+            defaultMessage: 'Nothing to preview yet',
+          })}
+        >
+          <EuiText size="xs">
+            {i18n.translate('observability.alerting.queryPreviewResults.notRunBody', {
+              defaultMessage:
+                'Enter a PromQL expression and select a datasource, then click Run preview.',
+            })}
+          </EuiText>
+        </EuiCallOut>
+      ) : state.loading ? (
         <EuiFlexGroup justifyContent="center" alignItems="center" style={{ height: 200 }}>
           <EuiFlexItem grow={false}>
             <EuiLoadingChart size="l" mono />

--- a/public/components/alerting/query_preview_results.tsx
+++ b/public/components/alerting/query_preview_results.tsx
@@ -68,6 +68,8 @@ interface PreviewState {
   requestedQuery: string;
   /** The effective expression the server plotted (comparison stripped). */
   plottedQuery: string;
+  /** How many series the expression matched (only the first is charted). */
+  seriesCount: number;
 }
 
 const EMPTY_STATE: PreviewState = {
@@ -76,6 +78,7 @@ const EMPTY_STATE: PreviewState = {
   points: [],
   requestedQuery: '',
   plottedQuery: '',
+  seriesCount: 0,
 };
 
 /**
@@ -138,7 +141,7 @@ export const QueryPreviewResults: React.FC<{
       : undefined;
     new AlertingPromResourcesService(datasourceId)
       .runQueryPreview(trimmed, previewRange)
-      .then(({ points, query: plotted }) => {
+      .then(({ points, query: plotted, seriesCount }) => {
         if (!stale) {
           setState({
             loading: false,
@@ -146,6 +149,7 @@ export const QueryPreviewResults: React.FC<{
             points: points || [],
             requestedQuery: trimmed,
             plottedQuery: plotted || trimmed,
+            seriesCount: seriesCount ?? (points && points.length ? 1 : 0),
           });
         }
       })
@@ -179,7 +183,7 @@ export const QueryPreviewResults: React.FC<{
             <strong>
               <FormattedMessage
                 id="observability.alerting.queryPreviewResults.resultsTitle"
-                defaultMessage="Results ({count})"
+                defaultMessage="Samples ({count})"
                 values={{ count: resultCount }}
               />
             </strong>
@@ -192,6 +196,17 @@ export const QueryPreviewResults: React.FC<{
       <EuiText size="xs" color="subdued">
         {state.plottedQuery || query}
       </EuiText>
+      {state.seriesCount > 1 && (
+        <EuiText size="xs" color="subdued">
+          <em>
+            {i18n.translate('observability.alerting.queryPreviewResults.multiSeriesNote', {
+              defaultMessage:
+                'Matched {count} series — charting the first. The alert evaluates every matching series.',
+              values: { count: state.seriesCount },
+            })}
+          </em>
+        </EuiText>
+      )}
       {comparisonStripped && (
         <EuiText size="xs" color="subdued">
           <em>

--- a/public/components/alerting/query_preview_results.tsx
+++ b/public/components/alerting/query_preview_results.tsx
@@ -8,77 +8,241 @@
  * Metrics page "Create alert rule" flyout and the Alert Manager
  * "Create metrics rule" flyout.
  *
- * Currently renders representative sample data (line chart) with a callout
- * making that explicit; a follow-up wires it to a live range query.
+ * Runs the current PromQL expression as a live range query via
+ * `AlertingPromResourcesService.runQueryPreview` and renders the returned time
+ * series. When a `timeRange` is supplied (e.g. the Explore time picker the user
+ * came from) the query runs over that window; otherwise it defaults to the last
+ * hour at a 60s step. Shows a loading spinner while the query runs, an error
+ * callout on failure, and an empty-state when the query returns no data.
+ * `runToken` changes on each "Run preview" click to force a re-fetch.
  */
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   EuiAccordion,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLoadingChart,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { i18n } from '@osd/i18n';
 import { EchartsRender } from './echarts_render';
+import { AlertingPromResourcesService } from './query_services/alerting_prom_resources_service';
 
-const PREVIEW_TIMESTAMPS = ['04:00', '06:00', '08:00', '10:00', '12:00', '14:00', '16:00', '17:00'];
-const PREVIEW_VALUES = [0.02, 0.03, 0.01, 0.06, 0.04, 0.07, 0.05, 0.08];
+interface PreviewPoint {
+  timestamp: number;
+  value: number;
+}
 
-const PREVIEW_CHART_OPTION: Record<string, unknown> = {
-  grid: { left: 48, right: 16, top: 16, bottom: 32 },
-  tooltip: { trigger: 'axis' },
-  xAxis: { type: 'category', data: PREVIEW_TIMESTAMPS },
-  yAxis: { type: 'value' },
-  series: [
-    {
-      type: 'line',
-      data: PREVIEW_VALUES,
-      smooth: true,
-      itemStyle: { color: '#006BB4' },
-      areaStyle: { color: 'rgba(0,107,180,0.1)' },
-    },
-  ],
+/** Build the echarts line-chart spec from live range-query points. */
+function buildChartOption(points: PreviewPoint[]): Record<string, unknown> {
+  const timeLabels = points.map((p) =>
+    new Date(p.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  );
+  const values = points.map((p) => p.value);
+  return {
+    grid: { left: 48, right: 16, top: 16, bottom: 32 },
+    tooltip: { trigger: 'axis' },
+    xAxis: { type: 'category', data: timeLabels },
+    yAxis: { type: 'value' },
+    series: [
+      {
+        type: 'line',
+        data: values,
+        smooth: true,
+        showSymbol: false,
+        itemStyle: { color: '#006BB4' },
+        areaStyle: { color: 'rgba(0,107,180,0.1)' },
+      },
+    ],
+  };
+}
+
+interface PreviewState {
+  loading: boolean;
+  error: string | null;
+  points: PreviewPoint[];
+  /** The query that was actually previewed (snapshot at fetch time). */
+  requestedQuery: string;
+  /** The effective expression the server plotted (comparison stripped). */
+  plottedQuery: string;
+}
+
+const EMPTY_STATE: PreviewState = {
+  loading: false,
+  error: null,
+  points: [],
+  requestedQuery: '',
+  plottedQuery: '',
 };
 
+/**
+ * Preview range in epoch seconds. When present the query runs over
+ * `[start, end]`; the step is derived to target a readable point count.
+ */
+export interface PreviewTimeRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Derive a range-query step (seconds) that keeps the preview under the route's
+ * point budget while staying readable — ~500 points, floored at 15s.
+ */
+function deriveStep(range: PreviewTimeRange): number {
+  const span = Math.max(1, range.end - range.start);
+  return Math.max(15, Math.ceil(span / 500));
+}
+
 export const QueryPreviewResults: React.FC<{
-  /** The query being previewed — shown as the series caption. */
+  /** The PromQL expression to preview. */
   query: string;
+  /** Datasource the query runs against; without it no preview can run. */
+  datasourceId?: string;
+  /**
+   * Time window to preview over (epoch seconds). When omitted the server
+   * defaults to the last hour at a 60s step.
+   */
+  timeRange?: PreviewTimeRange;
+  /** Bumped on each "Run preview" click to re-run the query. */
+  runToken?: number;
   /** Unique accordion id — pass a distinct one per mount point. */
   id?: string;
-}> = ({ query, id = 'prom-preview-results' }) => (
-  <EuiAccordion
-    id={id}
-    buttonContent={
-      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
-        <EuiFlexItem grow={false}>
-          <strong>
-            <FormattedMessage
-              id="observability.alerting.queryPreviewResults.resultsTitle"
-              defaultMessage="Results ({count})"
-              values={{ count: PREVIEW_VALUES.length }}
-            />
-          </strong>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+}> = ({ query, datasourceId, timeRange, runToken, id = 'prom-preview-results' }) => {
+  const [state, setState] = useState<PreviewState>(EMPTY_STATE);
+
+  // Snapshot the live query in a ref so editing it does NOT re-fire the range
+  // query on every keystroke. The fetch is deliberately keyed on `runToken`
+  // (bumped by the "Run preview" button) and the datasource, so a preview
+  // reflects the query as of the last explicit Run preview click.
+  const queryRef = useRef(query);
+  queryRef.current = query;
+  // Same treatment for the range: read it at fetch time so a re-render with a
+  // new object identity doesn't re-fire the query (only runToken/ds do).
+  const timeRangeRef = useRef(timeRange);
+  timeRangeRef.current = timeRange;
+
+  useEffect(() => {
+    const trimmed = (queryRef.current || '').trim();
+    if (!datasourceId || !trimmed) {
+      setState(EMPTY_STATE);
+      return;
     }
-    initialIsOpen
-    paddingSize="s"
-  >
-    <EuiCallOut size="s" color="warning" iconType="iInCircle">
-      <EuiText size="xs">
-        {i18n.translate('observability.alerting.queryPreviewResults.sampleDataCallout', {
-          defaultMessage: 'Sample data — run the rule to see real results',
-        })}
+    let stale = false;
+    setState({ ...EMPTY_STATE, loading: true, requestedQuery: trimmed });
+    const range = timeRangeRef.current;
+    const previewRange = range
+      ? { start: range.start, end: range.end, step: deriveStep(range) }
+      : undefined;
+    new AlertingPromResourcesService(datasourceId)
+      .runQueryPreview(trimmed, previewRange)
+      .then(({ points, query: plotted }) => {
+        if (!stale) {
+          setState({
+            loading: false,
+            error: null,
+            points: points || [],
+            requestedQuery: trimmed,
+            plottedQuery: plotted || trimmed,
+          });
+        }
+      })
+      .catch((err) => {
+        if (!stale) {
+          setState({
+            ...EMPTY_STATE,
+            error: err instanceof Error ? err.message : String(err),
+            requestedQuery: trimmed,
+          });
+        }
+      });
+    return () => {
+      stale = true;
+    };
+    // `query` is intentionally read from a ref (not a dep) — see note above.
+  }, [datasourceId, runToken]);
+
+  const resultCount = state.points.length;
+  // A trailing comparison (e.g. `> 0.5`) is stripped server-side so the chart
+  // plots the metric series rather than a 0/1 boolean. Surface that so the
+  // caption isn't mistaken for a threshold-applied series.
+  const comparisonStripped = !!state.plottedQuery && state.plottedQuery !== state.requestedQuery;
+
+  return (
+    <EuiAccordion
+      id={id}
+      buttonContent={
+        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <strong>
+              <FormattedMessage
+                id="observability.alerting.queryPreviewResults.resultsTitle"
+                defaultMessage="Results ({count})"
+                values={{ count: resultCount }}
+              />
+            </strong>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      }
+      initialIsOpen
+      paddingSize="s"
+    >
+      <EuiText size="xs" color="subdued">
+        {state.plottedQuery || query}
       </EuiText>
-    </EuiCallOut>
-    <EuiSpacer size="s" />
-    <EuiText size="xs" color="subdued">
-      {query || 'http_requests_total'}
-    </EuiText>
-    <EuiSpacer size="s" />
-    <EchartsRender spec={PREVIEW_CHART_OPTION} height={200} />
-  </EuiAccordion>
-);
+      {comparisonStripped && (
+        <EuiText size="xs" color="subdued">
+          <em>
+            {i18n.translate('observability.alerting.queryPreviewResults.comparisonStrippedNote', {
+              defaultMessage: 'Comparison removed to plot the underlying metric series.',
+            })}
+          </em>
+        </EuiText>
+      )}
+      <EuiSpacer size="s" />
+      {state.loading ? (
+        <EuiFlexGroup justifyContent="center" alignItems="center" style={{ height: 200 }}>
+          <EuiFlexItem grow={false}>
+            <EuiLoadingChart size="l" mono />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ) : state.error ? (
+        <EuiCallOut
+          size="s"
+          color="danger"
+          iconType="alert"
+          title={i18n.translate('observability.alerting.queryPreviewResults.errorTitle', {
+            defaultMessage: 'Could not run preview',
+          })}
+        >
+          <EuiText size="xs">{state.error}</EuiText>
+        </EuiCallOut>
+      ) : resultCount === 0 ? (
+        // An empty result is ambiguous: the range genuinely had no data, OR the
+        // datasource degraded a query it couldn't evaluate to an empty response
+        // (the PromQL strategy doesn't always throw on a rejected query). Word
+        // this so the user doesn't wrongly conclude the metric has no data and
+        // build a rule on a broken expression.
+        <EuiCallOut
+          size="s"
+          color="warning"
+          iconType="iInCircle"
+          title={i18n.translate('observability.alerting.queryPreviewResults.noDataTitle', {
+            defaultMessage: 'No results for this time range',
+          })}
+        >
+          <EuiText size="xs">
+            {i18n.translate('observability.alerting.queryPreviewResults.noDataBody', {
+              defaultMessage:
+                'The query returned no data for this time range, or the data source could not evaluate it. Double-check the expression before saving.',
+            })}
+          </EuiText>
+        </EuiCallOut>
+      ) : (
+        <EchartsRender spec={buildChartOption(state.points)} height={200} />
+      )}
+    </EuiAccordion>
+  );
+};

--- a/public/components/alerting/query_services/alerting_prom_resources_service.ts
+++ b/public/components/alerting/query_services/alerting_prom_resources_service.ts
@@ -82,10 +82,18 @@ export class AlertingPromResourcesService {
   async runQueryPreview(
     query: string,
     range?: { start?: number; end?: number; step?: number }
-  ): Promise<{ points: Array<{ timestamp: number; value: number }>; query?: string }> {
+  ): Promise<{
+    points: Array<{ timestamp: number; value: number }>;
+    query?: string;
+    seriesCount?: number;
+  }> {
     return (await this.requireHttp().post(
       `/api/alerting/prometheus/${encodeURIComponent(this.datasourceId)}/preview`,
       { body: JSON.stringify({ query, ...(range || {}) }) }
-    )) as { points: Array<{ timestamp: number; value: number }>; query?: string };
+    )) as {
+      points: Array<{ timestamp: number; value: number }>;
+      query?: string;
+      seriesCount?: number;
+    };
   }
 }

--- a/public/components/alerting/query_services/alerting_prom_resources_service.ts
+++ b/public/components/alerting/query_services/alerting_prom_resources_service.ts
@@ -72,4 +72,20 @@ export class AlertingPromResourcesService {
       `/api/alerting/prometheus/${encodeURIComponent(this.datasourceId)}/metadata/metric-metadata`
     )) as { metadata: PrometheusMetricMetadata[] };
   }
+
+  /**
+   * Run an ad-hoc PromQL range query for the "Create alert rule" flyout preview.
+   * Returns a single flattened `{timestamp (ms), value}[]` series (empty when
+   * the query yields no data). `range` is epoch seconds; the server defaults to
+   * the last hour at a 60s step when omitted.
+   */
+  async runQueryPreview(
+    query: string,
+    range?: { start?: number; end?: number; step?: number }
+  ): Promise<{ points: Array<{ timestamp: number; value: number }>; query?: string }> {
+    return (await this.requireHttp().post(
+      `/api/alerting/prometheus/${encodeURIComponent(this.datasourceId)}/preview`,
+      { body: JSON.stringify({ query, ...(range || {}) }) }
+    )) as { points: Array<{ timestamp: number; value: number }>; query?: string };
+  }
 }

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -749,6 +749,62 @@ export class ObservabilityPlugin implements Plugin<
               const dsId = dataset?.dataSource?.id || dataset?.id;
               const dsName =
                 dataset?.dataSource?.title ?? dataset?.dataSource?.name ?? dataset?.title;
+              // The live PromQL the user has in the Explore editor. Prefer the
+              // action dependency's `queryInEditor` (the shared code editor's
+              // live buffer), then the last-executed query. On the Metrics
+              // page the query is authored in a per-row builder/code editor
+              // that is NOT wired into the shared editor, so `queryInEditor`
+              // is empty there before submit — fall back to the live value the
+              // metrics panel mirrors into the data plugin's QueryStringManager
+              // on every keystroke, so a not-yet-run query still copies over.
+              const liveQueryStringValue = (() => {
+                try {
+                  const services = props.services as {
+                    data?: { query?: { queryString?: { getQuery?: () => { query?: unknown } } } };
+                  };
+                  const q = services?.data?.query?.queryString?.getQuery?.()?.query;
+                  return typeof q === 'string' ? q : '';
+                } catch {
+                  return '';
+                }
+              })();
+              const initialQuery =
+                props.dependencies.queryInEditor ||
+                (props.dependencies.query as { query?: string })?.query ||
+                liveQueryStringValue ||
+                '';
+              // The Explore time picker the user is currently viewing. Pass it
+              // through so the flyout's "Run preview" charts the same window
+              // (rather than a fixed last-hour), resolving `now`-relative
+              // ranges to concrete epoch-second bounds. Falls back to the
+              // server default (last hour) if the timefilter isn't available.
+              const initialTimeRange = (() => {
+                try {
+                  const services = props.services as {
+                    data?: {
+                      query?: {
+                        timefilter?: {
+                          timefilter?: {
+                            getBounds?: () => {
+                              min?: { valueOf?: () => number };
+                              max?: { valueOf?: () => number };
+                            };
+                          };
+                        };
+                      };
+                    };
+                  };
+                  const bounds = services?.data?.query?.timefilter?.timefilter?.getBounds?.();
+                  const min = bounds?.min?.valueOf?.();
+                  const max = bounds?.max?.valueOf?.();
+                  if (typeof min === 'number' && typeof max === 'number' && max > min) {
+                    return { start: Math.floor(min / 1000), end: Math.floor(max / 1000) };
+                  }
+                } catch {
+                  // fall through to server default
+                }
+                return undefined;
+              })();
               return (
                 <React.Suspense fallback={null}>
                   <LazyCreateMetricsMonitor
@@ -758,6 +814,8 @@ export class ObservabilityPlugin implements Plugin<
                     }}
                     datasourceId={dsId}
                     datasourceName={dsName}
+                    initialQuery={initialQuery}
+                    initialTimeRange={initialTimeRange}
                     http={props.services.http}
                     addToast={(title, color, text) => {
                       // Forward the classified error body (`text`) and honor

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -797,7 +797,10 @@ export class ObservabilityPlugin implements Plugin<
                   const bounds = services?.data?.query?.timefilter?.timefilter?.getBounds?.();
                   const min = bounds?.min?.valueOf?.();
                   const max = bounds?.max?.valueOf?.();
-                  if (typeof min === 'number' && typeof max === 'number' && max > min) {
+                  // Require at least a 1s span so the floor-to-seconds below can't
+                  // collapse to start === end (which the preview route rejects as
+                  // 400). Sub-second Explore windows fall back to the last-hour default.
+                  if (typeof min === 'number' && typeof max === 'number' && max - min >= 1000) {
                     return { start: Math.floor(min / 1000), end: Math.floor(max / 1000) };
                   }
                 } catch {

--- a/server/routes/alerting/__tests__/index.test.ts
+++ b/server/routes/alerting/__tests__/index.test.ts
@@ -19,6 +19,7 @@
  *     admin route registered inline (14 GETs)
  *   - 1 mappings POST route (POSTs index list in body to avoid URL limits)
  *   - 4 Prometheus metadata routes inside `if (enableMetadataRoutes)` (4 GETs)
+ *     + 1 Prometheus preview POST route inside the same block
  *
  * Datasource CRUD routes have been deleted — these tests also assert none
  * of them sneak back in.
@@ -55,7 +56,7 @@ describe('registerAlertingRoutes', () => {
     mockRouter.delete.mockClear();
   });
 
-  it('registers all runtime routes when metadata routes are enabled (18 GET + 3 POST + 1 PUT + 1 DELETE = 23)', () => {
+  it('registers all runtime routes when metadata routes are enabled (18 GET + 4 POST + 1 PUT + 1 DELETE = 24)', () => {
     registerAlertingRoutes(mockRouter as never, {
       osBackend: mockOsBackend,
       promBackend: mockPromBackend,
@@ -69,8 +70,8 @@ describe('registerAlertingRoutes', () => {
       mockRouter.put.mock.calls.length +
       mockRouter.delete.mock.calls.length;
     // 14 inline GETs (incl. probe + destinations + indices + aliases) + 4 metadata GETs = 18 GETs
-    // 2 monitor POSTs + 1 PUT + 1 DELETE + 1 mappings POST = 5 non-GET routes
-    expect(total).toBe(23);
+    // 2 monitor POSTs + 1 PUT + 1 DELETE + 1 mappings POST + 1 prometheus preview POST = 6 non-GET routes
+    expect(total).toBe(24);
     expect(mockRouter.get.mock.calls.length).toBe(18);
   });
 

--- a/server/routes/alerting/__tests__/prometheus_handlers.test.ts
+++ b/server/routes/alerting/__tests__/prometheus_handlers.test.ts
@@ -116,7 +116,7 @@ describe('handleCreatePrometheusRule — shared group merge', () => {
     expect(upserted.interval).toBe(300);
   });
 
-  it('replaces a same-named rule instead of duplicating it (edit upsert)', async () => {
+  it('replaces a same-named rule when overwrite is set (edit upsert)', async () => {
     const ruler = makeRulerClient({
       groupName: 'team-rules',
       interval: 60,
@@ -128,6 +128,7 @@ describe('handleCreatePrometheusRule — shared group merge', () => {
     await handleCreatePrometheusRule(ruler as any, mockClient, mockDatasource, {
       ...basePayload,
       groupName: 'team-rules',
+      overwrite: true,
     });
 
     const upserted = ruler.upsertRuleGroup.mock.calls[0][3] as GeneratedRuleGroup;
@@ -135,6 +136,58 @@ describe('handleCreatePrometheusRule — shared group merge', () => {
     expect(upserted.rules.map((r) => r.name).sort()).toEqual(['HighErrorRate', 'OtherRule']);
     const updated = upserted.rules.find((r) => r.name === 'HighErrorRate');
     expect(updated?.expr).toBe(basePayload.query);
+  });
+
+  it('rejects a create that collides with an existing same-named rule (no overwrite)', async () => {
+    const ruler = makeRulerClient({
+      groupName: 'team-rules',
+      interval: 60,
+      rules: [{ type: 'alerting', name: 'HighErrorRate', expr: 'old_expr', for: '1m' } as any],
+    });
+    await expect(
+      handleCreatePrometheusRule(ruler as any, mockClient, mockDatasource, {
+        ...basePayload,
+        groupName: 'team-rules',
+      })
+    ).rejects.toMatchObject({ kind: 'conflict' });
+    // Must NOT have written anything — the existing rule is untouched.
+    expect(ruler.upsertRuleGroup).not.toHaveBeenCalled();
+  });
+
+  it('reads and writes the given namespace override (defaults to the user namespace otherwise)', async () => {
+    const ruler = makeRulerClient(null);
+    const result = await handleCreatePrometheusRule(ruler as any, mockClient, mockDatasource, {
+      ...basePayload,
+      groupName: 'team-rules',
+      namespace: 'custom-ns',
+    });
+
+    expect(result.namespace).toBe('custom-ns');
+    // Both the collision read and the write target the overridden namespace.
+    expect(ruler.getRuleGroup).toHaveBeenCalledWith(
+      mockClient,
+      mockDatasource,
+      'custom-ns',
+      'team-rules'
+    );
+    expect(ruler.upsertRuleGroup.mock.calls[0][2]).toBe('custom-ns');
+  });
+
+  it('allows a create with a distinct name to merge into an existing group', async () => {
+    const ruler = makeRulerClient({
+      groupName: 'team-rules',
+      interval: 60,
+      rules: [{ type: 'alerting', name: 'OtherRule', expr: 'up == 0', for: '1m' } as any],
+    });
+    // basePayload.name differs from OtherRule → no collision, no overwrite needed.
+    await handleCreatePrometheusRule(ruler as any, mockClient, mockDatasource, {
+      ...basePayload,
+      groupName: 'team-rules',
+    });
+    const upserted = ruler.upsertRuleGroup.mock.calls[0][3] as GeneratedRuleGroup;
+    expect(upserted.rules.map((r) => r.name).sort()).toEqual(
+      ['OtherRule', basePayload.name].sort()
+    );
   });
 });
 
@@ -182,6 +235,26 @@ describe('handleDeletePrometheusRule — per-rule splice', () => {
       mockClient,
       mockDatasource,
       USER_RULES_NAMESPACE,
+      'team-rules'
+    );
+  });
+
+  it('deletes from the given namespace override', async () => {
+    const ruler = makeRulerClient(null);
+    await handleDeletePrometheusRule(
+      ruler as any,
+      mockClient,
+      mockDatasource,
+      'team-rules',
+      undefined,
+      undefined,
+      'custom-ns'
+    );
+
+    expect(ruler.deleteRuleGroup).toHaveBeenCalledWith(
+      mockClient,
+      mockDatasource,
+      'custom-ns',
       'team-rules'
     );
   });

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -28,6 +28,7 @@ import {
 } from '../../services/alerting';
 import { DirectQueryPrometheusBackend } from '../../services/alerting/directquery_prometheus_backend';
 import { MonitorMutationService } from '../../services/alerting/monitor_mutation_service';
+import { stripTrailingComparison } from '../../services/alerting/alert_utils';
 import { registerAlertingMutationRoutes } from './mutations';
 import { toErrorBody, toHandlerResult } from './route_utils';
 import { isAlertManagerError } from '../../services/alerting';
@@ -928,6 +929,85 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
             req.params.dsId,
             logger
           );
+        })
+    );
+
+    // POST /api/alerting/prometheus/{dsId}/preview — run an ad-hoc PromQL range
+    // query so the "Create alert rule" flyout can show a real preview chart of
+    // the current expression (replacing the former hardcoded sample series).
+    // Reuses the same `promBackend.queryRange` path the rule-detail condition
+    // preview uses (see alert_preview.ts:fetchPromPreviewData).
+    router.post(
+      {
+        path: '/api/alerting/prometheus/{dsId}/preview',
+        validate: {
+          params: schema.object({ dsId: alertingIdSchema }),
+          body: schema.object({
+            query: schema.string({ minLength: 1, maxLength: 4096 }),
+            // Epoch seconds; default to the last hour at a 60s step. Bounded so
+            // a hand-crafted request can't ask the upstream for an enormous
+            // window at fine resolution (the point budget below is the real
+            // guard; these keep individual fields sane). 1s..1d step.
+            start: schema.maybe(schema.number({ min: 0 })),
+            end: schema.maybe(schema.number({ min: 0 })),
+            step: schema.maybe(schema.number({ min: 1, max: 86400 })),
+          }),
+        },
+      },
+      async (ctx, req, res) =>
+        runHandler(res, async () => {
+          const promDs = await resolvePrometheusDatasource(
+            ctx as AlertingHandlerContext,
+            req.params.dsId
+          );
+          if (!promDs) {
+            return {
+              status: 404,
+              body: { message: `Prometheus datasource not found: ${req.params.dsId}` },
+            };
+          }
+          const now = Math.floor(Date.now() / 1000);
+          // Clamp end to now (no future ranges) and default to a last-hour /
+          // 60s window when the caller omits them.
+          const end = Math.min(req.body.end ?? now, now);
+          const start = req.body.start ?? end - 3600;
+          const step = req.body.step ?? 60;
+          if (start >= end) {
+            return { status: 400, body: { message: 'start must be earlier than end.' } };
+          }
+          // Cap the requested resolution so a preview can't fan out into a
+          // huge range query. 1500 points comfortably covers any chart width.
+          const MAX_PREVIEW_POINTS = 1500;
+          if ((end - start) / step > MAX_PREVIEW_POINTS) {
+            return {
+              status: 400,
+              body: {
+                message: `Preview range too large for step ${step}s (max ${MAX_PREVIEW_POINTS} points); widen the step or shorten the range.`,
+              },
+            };
+          }
+          // Strip a trailing comparison so we chart the metric series, not the
+          // boolean alert condition (shared with the rule-detail preview).
+          const metricQuery = stripTrailingComparison(req.body.query);
+          // Use `queryRangeMatrix` (not `queryRange`) deliberately: it throws on
+          // a bad query / unreachable upstream instead of swallowing to [], so
+          // the client can tell a real failure apart from a genuinely empty
+          // result, and it caps points per series. Forward the inbound request
+          // so the datasource read uses the caller's credentials. Flatten to
+          // the first series — the preview is a single line.
+          const series = await promBackend.queryRangeMatrix(
+            ctx,
+            promDs,
+            metricQuery,
+            start,
+            end,
+            step,
+            { sourceRequest: req }
+          );
+          const points = series[0]?.values ?? [];
+          // Return the effective (stripped) query so the UI caption reflects
+          // exactly what was plotted rather than the full alert condition.
+          return { status: 200, body: { points, query: metricQuery } };
         })
     );
   }

--- a/server/routes/alerting/index.ts
+++ b/server/routes/alerting/index.ts
@@ -935,8 +935,10 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
     // POST /api/alerting/prometheus/{dsId}/preview — run an ad-hoc PromQL range
     // query so the "Create alert rule" flyout can show a real preview chart of
     // the current expression (replacing the former hardcoded sample series).
-    // Reuses the same `promBackend.queryRange` path the rule-detail condition
-    // preview uses (see alert_preview.ts:fetchPromPreviewData).
+    // Uses `promBackend.queryRangeMatrix` (throws on bad/unreachable queries
+    // rather than swallowing to [], and caps points per series), the same
+    // datasource read path the rule-detail condition preview uses
+    // (see alert_preview.ts:fetchPromPreviewData, which calls queryRange).
     router.post(
       {
         path: '/api/alerting/prometheus/{dsId}/preview',
@@ -1006,8 +1008,10 @@ export function registerAlertingRoutes(router: IRouter, deps: AlertingRoutesDeps
           );
           const points = series[0]?.values ?? [];
           // Return the effective (stripped) query so the UI caption reflects
-          // exactly what was plotted rather than the full alert condition.
-          return { status: 200, body: { points, query: metricQuery } };
+          // exactly what was plotted rather than the full alert condition, plus
+          // the total number of matching series so the UI can be honest that a
+          // multi-series expression is only charting the first one.
+          return { status: 200, body: { points, query: metricQuery, seriesCount: series.length } };
         })
     );
   }

--- a/server/routes/alerting/mutations/prometheus_handlers.ts
+++ b/server/routes/alerting/mutations/prometheus_handlers.ts
@@ -13,6 +13,7 @@
 import type { AlertingOSClient, Datasource, Logger } from '../../../../common/types/alerting';
 import type { GeneratedRule, GeneratedRuleGroup } from '../../../../common/slo/slo_types';
 import type { RulerClient } from '../../../services/slo/ruler_client';
+import { createConflictError } from '../../../services/alerting/errors';
 
 /** The namespace under which user-created alerting rules are stored in the ruler. */
 export const USER_RULES_NAMESPACE = 'observability-alerting';
@@ -33,6 +34,20 @@ export interface PrometheusRulePayload {
   enabled: boolean;
   /** Optional group name override. Defaults to the rule name. */
   groupName?: string;
+  /**
+   * Optional Cortex namespace override. Defaults to `USER_RULES_NAMESPACE`.
+   * Rules are identified by the full (namespace, group, name) tuple; the
+   * flyout currently pins this to the one user namespace, but threading it
+   * explicitly keeps the create/delete guard correct if a future surface
+   * writes to a different namespace.
+   */
+  namespace?: string;
+  /**
+   * When false (default), a create that collides with an existing same-named
+   * rule in the target group is rejected (409) rather than silently replacing
+   * it. Edit flows that intend to replace pass `true`.
+   */
+  overwrite?: boolean;
 }
 
 /**
@@ -92,6 +107,10 @@ export async function handleCreatePrometheusRule(
   logger?: Logger
 ): Promise<{ success: boolean; groupName: string; namespace: string }> {
   const group = buildRuleGroup(payload);
+  // Rules are identified by the full (namespace, group, name) tuple. Default
+  // to the single user namespace, but honor an explicit override so the guard
+  // below compares within the right namespace.
+  const namespace = payload.namespace ?? USER_RULES_NAMESPACE;
 
   // Rule groups are shared: multiple rules may live in the same group, and
   // the ruler's POST is create-or-replace on (namespace, groupName). Merge with
@@ -103,13 +122,19 @@ export async function handleCreatePrometheusRule(
   // can still lose an update (the second upsert wins). This protects against
   // the common single-writer clobber; true concurrent safety would need
   // server-side coordination in the ruler itself.
-  const existing = await rulerClient.getRuleGroup(
-    client,
-    datasource,
-    USER_RULES_NAMESPACE,
-    group.groupName
-  );
+  const existing = await rulerClient.getRuleGroup(client, datasource, namespace, group.groupName);
   if (existing && existing.rules.length > 0) {
+    // Guard against silently clobbering an existing same-named rule. A create
+    // (overwrite=false) that collides is a conflict; only an explicit edit
+    // (overwrite=true) may replace. This is the primary protection for the
+    // Metrics-page create flow, which has no client-side duplicate check.
+    if (!payload.overwrite && existing.rules.some((r) => r.name === payload.name)) {
+      throw createConflictError(
+        `A rule named "${payload.name}" already exists in group "${group.groupName}". ` +
+          `Choose a different rule name or group.`,
+        payload.name
+      );
+    }
     const siblings = existing.rules.filter((r) => r.name !== payload.name);
     group.rules = [...siblings, ...group.rules];
     // The evaluation interval is a group-level property shared by all rules.
@@ -120,11 +145,11 @@ export async function handleCreatePrometheusRule(
     }
   }
 
-  await rulerClient.upsertRuleGroup(client, datasource, USER_RULES_NAMESPACE, group);
+  await rulerClient.upsertRuleGroup(client, datasource, namespace, group);
   logger?.info(
-    `alerting: createPrometheusRule success — ds=${datasource.id} group=${group.groupName} rules=${group.rules.length}`
+    `alerting: createPrometheusRule success — ds=${datasource.id} ns=${namespace} group=${group.groupName} rules=${group.rules.length}`
   );
-  return { success: true, groupName: group.groupName, namespace: USER_RULES_NAMESPACE };
+  return { success: true, groupName: group.groupName, namespace };
 }
 
 export async function handleDeletePrometheusRule(
@@ -133,35 +158,36 @@ export async function handleDeletePrometheusRule(
   datasource: Datasource,
   groupName: string,
   logger?: Logger,
-  ruleName?: string
+  ruleName?: string,
+  namespaceOverride?: string
 ): Promise<{ success: boolean }> {
+  // Identity is (namespace, group, name); default to the single user
+  // namespace but honor an explicit override for symmetry with create.
+  const namespace = namespaceOverride ?? USER_RULES_NAMESPACE;
   // When a ruleName is provided, splice just that rule out of the group so
   // sibling rules in a shared group are preserved. The whole group is only
   // deleted when it would become empty (or no ruleName was given).
   // Same non-atomicity caveat as the create-merge above: no CAS on the
   // ruler, so concurrent writers to one group can race.
   if (ruleName) {
-    const existing = await rulerClient.getRuleGroup(
-      client,
-      datasource,
-      USER_RULES_NAMESPACE,
-      groupName
-    );
+    const existing = await rulerClient.getRuleGroup(client, datasource, namespace, groupName);
     if (existing) {
       const remaining = existing.rules.filter((r) => r.name !== ruleName);
       if (remaining.length > 0) {
-        await rulerClient.upsertRuleGroup(client, datasource, USER_RULES_NAMESPACE, {
+        await rulerClient.upsertRuleGroup(client, datasource, namespace, {
           ...existing,
           rules: remaining,
         });
         logger?.info(
-          `alerting: deletePrometheusRule spliced rule=${ruleName} from group=${groupName} — ds=${datasource.id} remaining=${remaining.length}`
+          `alerting: deletePrometheusRule spliced rule=${ruleName} from group=${groupName} — ds=${datasource.id} ns=${namespace} remaining=${remaining.length}`
         );
         return { success: true };
       }
     }
   }
-  await rulerClient.deleteRuleGroup(client, datasource, USER_RULES_NAMESPACE, groupName);
-  logger?.info(`alerting: deletePrometheusRule success — ds=${datasource.id} group=${groupName}`);
+  await rulerClient.deleteRuleGroup(client, datasource, namespace, groupName);
+  logger?.info(
+    `alerting: deletePrometheusRule success — ds=${datasource.id} ns=${namespace} group=${groupName}`
+  );
   return { success: true };
 }

--- a/server/routes/alerting/mutations/prometheus_routes.ts
+++ b/server/routes/alerting/mutations/prometheus_routes.ts
@@ -55,7 +55,15 @@ const prometheusRuleBodySchema = schema.object({
     defaultValue: {},
   }),
   enabled: schema.boolean({ defaultValue: true }),
-  groupName: schema.maybe(schema.string()),
+  groupName: schema.maybe(schema.string({ minLength: 1, maxLength: 256 })),
+  // Optional Cortex namespace. Defaults server-side to the single user
+  // namespace; accepted here so a future surface can target another namespace
+  // without a schema change (identity is the full namespace/group/name tuple).
+  namespace: schema.maybe(schema.string({ minLength: 1, maxLength: 256 })),
+  // When false (the default), creating a rule whose name already exists in the
+  // target group is rejected with 409 instead of silently replacing it. Edit
+  // flows that intend to replace an existing rule pass `overwrite: true`.
+  overwrite: schema.boolean({ defaultValue: false }),
 });
 
 export function registerPrometheusRuleRoutes(
@@ -113,6 +121,7 @@ export function registerPrometheusRuleRoutes(
         }),
         query: schema.object({
           ruleName: schema.maybe(schema.string({ minLength: 1 })),
+          namespace: schema.maybe(schema.string({ minLength: 1, maxLength: 256 })),
         }),
       },
     },
@@ -125,7 +134,8 @@ export function registerPrometheusRuleRoutes(
           datasource,
           req.params.groupName,
           logger,
-          req.query.ruleName
+          req.query.ruleName,
+          req.query.namespace
         );
         return res.ok({ body: result });
       } catch (e: unknown) {

--- a/server/services/alerting/__tests__/alert_utils.test.ts
+++ b/server/services/alerting/__tests__/alert_utils.test.ts
@@ -22,8 +22,46 @@ import {
   osMonitorToUnifiedRuleSummary,
   promEpisodeToUnified,
   runtimeStateToMonitorStatus,
+  stripTrailingComparison,
 } from '../alert_utils';
 import type { MonitorStatus, OSMonitor } from '../../../../common/types/alerting';
+
+describe('stripTrailingComparison', () => {
+  it('strips a simple trailing comparison', () => {
+    expect(stripTrailingComparison('rate(http_requests_total[5m]) > 0.5')).toBe(
+      'rate(http_requests_total[5m])'
+    );
+  });
+
+  it('strips every comparison operator', () => {
+    expect(stripTrailingComparison('up >= 1')).toBe('up');
+    expect(stripTrailingComparison('up <= 1')).toBe('up');
+    expect(stripTrailingComparison('up < 1')).toBe('up');
+    expect(stripTrailingComparison('up == 0')).toBe('up');
+    expect(stripTrailingComparison('up != 0')).toBe('up');
+  });
+
+  it('handles scientific-notation and negative thresholds', () => {
+    expect(stripTrailingComparison('foo > 1e3')).toBe('foo');
+    expect(stripTrailingComparison('foo > 1.5e-3')).toBe('foo');
+    expect(stripTrailingComparison('foo > -0.5')).toBe('foo');
+  });
+
+  it('leaves a compound / multi-comparison expression unchanged rather than mangling it', () => {
+    // Stripping only the trailing `> 2` would yield the nonsensical
+    // `a > 1 and b`; the residual comparison is detected so the whole
+    // expression is preserved instead.
+    const compound = 'a > 1 and b > 2';
+    expect(stripTrailingComparison(compound)).toBe(compound);
+  });
+
+  it('returns the original when the expression is only a comparison / avoids empty output', () => {
+    // A metric-less expression trims to empty after the strip; fall back to the
+    // original so we never issue an empty query.
+    expect(stripTrailingComparison('   ')).toBe('');
+    expect(stripTrailingComparison('up')).toBe('up');
+  });
+});
 
 describe('promEpisodeToUnified', () => {
   const START = Date.UTC(2024, 0, 15, 12, 0, 0);

--- a/server/services/alerting/alert_preview.ts
+++ b/server/services/alerting/alert_preview.ts
@@ -31,6 +31,7 @@ import {
   extractClusterMetricValue,
   extractTimestampField,
   stripRangeFilters,
+  stripTrailingComparison,
   substituteMustacheTemplates,
 } from './alert_utils';
 
@@ -278,7 +279,7 @@ export async function fetchPromPreviewData(
 ): Promise<Array<{ timestamp: number; value: number }>> {
   if (promBackend?.queryRange && ctx) {
     try {
-      const metricQuery = query.replace(/\s*(>|<|>=|<=|==|!=)\s*[\d.]+\s*$/, '').trim();
+      const metricQuery = stripTrailingComparison(query);
       const now = Math.floor(Date.now() / 1000);
       const oneHourAgo = now - 3600;
       const step = 60;

--- a/server/services/alerting/alert_utils.ts
+++ b/server/services/alerting/alert_utils.ts
@@ -49,6 +49,33 @@ import {
 // ============================================================================
 
 /**
+ * Strip a single trailing comparison (`> 0.5`, `>= 1e3`, `!= -2`, …) off a
+ * PromQL alert expression so a preview can chart the underlying metric series
+ * rather than the boolean 0/1 the full alert condition would produce.
+ *
+ * Best-effort by design: it only removes the LAST trailing comparison, so a
+ * compound condition like `a > 1 and b > 2` is intentionally left unchanged
+ * (the metric expression can't be safely recovered) rather than mangled into
+ * `a > 1 and b`. Handles integers, decimals, scientific notation and negative
+ * thresholds. Shared by the Prometheus preview route and the rule-detail
+ * condition preview so both strip identically.
+ */
+export function stripTrailingComparison(query: string): string {
+  const trimmed = (query || '').trim();
+  const stripped = trimmed
+    .replace(/\s*(>=|<=|!=|==|>|<)\s*-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\s*$/, '')
+    .trim();
+  // No trailing comparison matched, or stripping emptied the query → leave as-is.
+  if (!stripped || stripped === trimmed) return trimmed;
+  // If the remainder still contains a comparison operator, the original was a
+  // compound condition (e.g. `a > 1 and b > 2`) — stripping only the tail would
+  // produce a nonsensical `a > 1 and b`, so preserve the original instead of
+  // charting a mangled expression.
+  if (/(>=|<=|!=|==|>|<)/.test(stripped)) return trimmed;
+  return stripped;
+}
+
+/**
  * Extract the timestamp field name from a query's range filter.
  * Inspects `bool.filter` and `bool.must` arrays for a `range` clause.
  * Returns the field name if found, or undefined.


### PR DESCRIPTION
### Description

Fixes two issues with **Create alert rule** from the Explore **Metrics (PromQL)** page and hardens the surrounding experience.

**A. The Explore query is now copied into the metrics rule flyout.**
Previously the flyout opened with an empty query. It now pre-fills a new, visible/editable **PromQL expression** field from the Explore editor — using the committed query, and falling back to the live `QueryStringManager` value so a not-yet-run query still copies (the metrics multi-query editor isn't wired to the shared `queryInEditor` buffer). The point-and-click builder still assists and writes into the same field.

**B. The preview now shows a real chart instead of hardcoded sample data.**
New server route `POST /api/alerting/prometheus/{dsId}/preview` runs a real range query via the DirectQuery Prometheus backend; `QueryPreviewResults` renders the live series (loading / error / empty / chart). Wired into both the metrics flyout and the Alert Manager "Create metrics rule" flyout, keyed on an explicit **Run preview** token.

**Unified Rules view freshness.** A rule created elsewhere (e.g. from the Metrics page) previously stayed invisible in the Alerts → Rules list until a manual filter toggle, because the list fetched once on mount and Cortex's querier lags the create. The view now refetches when the Rules tab is activated and on window focus, and gains a manual **Refresh** button.

### Hardening (from adversarial review)

- Preview fetch is keyed on the Run-preview token + datasource (snapshots the query) — no per-keystroke range queries.
- Preview uses the non-swallowing `queryRangeMatrix` so real failures surface as an error callout (instead of a misleading "no data"); empty-state copy reworded to not over-claim.
- Preview route bounds inputs: min step, clamp `end` to now, reject `start >= end`, and cap resolution to 1500 points to prevent oversized range queries.
- Shared `stripTrailingComparison` helper (handles `>=`, scientific notation, negatives; preserves compound conditions) used by both the preview route and the rule-detail preview; the route returns the effective plotted query so the caption is accurate.
- Throttled the focus/visibilitychange refetch to dedupe the double-fire.

### Testing

- Jest unit tests: query-seeding, unified-rules refetch on tab activation, `stripTrailingComparison`, updated preview/route-count tests (all green).
- New Cypress API-contract spec (`alerting_test/metrics_rule_preview_api.spec.js`) pinning the preview route against the real Cortex backend, wired into the `cypress-slo-cortex` workflow.
- Manually validated end-to-end against a local Metrics/PromQL datasource: query copies (incl. pre-submit), preview renders real points with the comparison correctly stripped, rule creates, and appears in the unified Rules view after refresh.

### Check List
- [x] All tests pass
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using `--signoff`

_Draft: opened for review; screenshots/GIFs to be attached in a follow-up comment._

---

### Update — immediacy, audit fixes, and a UI test

**Rules-list immediacy.** Beyond refetch-on-tab-activate / focus / manual Refresh, the Rules tab now **silently background-polls every 15s** (no spinner, no error-banner clobber), so a rule created here or from the Metrics page appears on its own within ~15s of Cortex's querier loading it. True zero-latency isn't possible (the unified list reads Cortex's querier, which lags the create by up to the rule's eval interval); this closes the gap without a manual reload.

**Audit fixes (metrics flyout):**
- **WYSIWYG (was a real bug):** the Rule Preview (YAML) and the save payload now share `materializeLabels`/`materializeAnnotations`, so an empty-value label/annotation can no longer be silently written while hidden from the preview.
- Reject an expression that starts with a comparison operator (no series) in the validity check.
- Trim rule name / group name before saving.
- Stop the PromQL builder re-emitting (and normalizing whitespace of) a seeded query on mount — that spuriously marked the form dirty; ownership is still tracked so clearing the metric clears a builder-authored query.

**Deferred (documented, not in this PR):** server-side overwrite-guard for a same-named metric rule created from the Metrics page (pre-existing create-or-replace semantics; needs cross-flow design + tests); group-scoped duplicate-name check; preview honoring the Explore time picker; builder-clobber-of-hand-typed-expression confirm; YAML preview group/interval header; datasource-picker selected-state.

**UI test.** Adds `alerting_test/metrics_create_alert_rule_ui.spec.js` (query-copy + real preview) and a dedicated **workspace-enabled** `cypress-metrics-alerting-ui` Cortex job (the Explore metrics page is workspace-gated, which conflicts with the SLO specs' workspace-off job). The job creates a workspace and best-effort-associates the Prometheus datasource; the spec skips gracefully if the flyout isn't reachable, so the workspace/datasource-association step can be iterated on CI without hard failures. The deterministic preview-route API spec runs in the SLO job regardless.


---

## Before / After

Before = `origin/main`, after = this PR. Changes outlined in red.

### 1. Explore PromQL query is copied into the metrics rule flyout
![query copy before vs after](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2862-media/.pr-media/cmp_query_copy.png)

The flyout now has a **Builder / Code toggle** — a copied query lands in **Code** mode as-is, so the point-and-click builder can no longer silently overwrite it (audit finding **#7**). Switching to Builder with a non-representable expression warns first:

![code vs builder mode](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2862-media/.pr-media/cmp_query_modes.png)

### 2. Real preview instead of hardcoded sample data
![preview before vs after](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2862-media/.pr-media/cmp_preview.png)
<sub>The preview also now runs over the Explore time picker's window instead of a fixed last hour (#5) — behavioral, no separate screenshot.</sub>

### 3. Unified Rules — Refresh button + 15s auto-refresh
![refresh before vs after](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2862-media/.pr-media/cmp_refresh.png)

### 4. Rule Preview (YAML) shows namespace, rule group & evaluation interval (#10)
The preview now renders the full rule-group that gets written (namespace → group → rule, including the group-level `interval`), instead of just the rule body.
![yaml before vs after](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2862-media/.pr-media/cmp_yaml.png)

### 5. Datasource picker marks the active selection (#11)
![datasource picker before vs after](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2862-media/.pr-media/cmp_datasource_picker.png)

### Full "Create alert rule from Metrics" workflow

**After (this PR)** — query copied, real preview:

![after workflow gif](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2862-media/.pr-media/gif_metrics_after.gif)

**Before (`origin/main`)** — empty query, fake sample data:

![before workflow gif](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2862-media/.pr-media/gif_metrics_before.gif)

<sub>Media hosted on the `pr-2862-media` asset branch of the fork (not part of this PR's diff).</sub>

---

### Corrections to the notes above
- **#2 (overwrite guard) and #3 (group-scoped duplicate check) are now implemented in this PR** — they are no longer deferred. Creating a metric rule whose name already exists in the target group returns a 409 (edit passes `overwrite:true`); the duplicate-name check is keyed on (datasource, group, name).
- The **metrics Create-alert-rule UI Cypress job/spec has been removed from this PR** and deferred to a follow-up (the workspace↔datasource association needs CI iteration). The deterministic `metrics_rule_preview_api.spec.js` remains wired into the SLO Cortex job.


