### PR TITLE
fix(notebooks): bind sample notebook paragraphs to the selected data

### DIFF
--- a/public/components/notebooks/components/main.tsx
+++ b/public/components/notebooks/components/main.tsx
@@ -408,7 +408,7 @@ export class Main extends React.Component<MainProps, MainState> {
         });
       await this.props.http
         .post(`${NOTEBOOKS_API_PREFIX}/note/savedNotebook/addSampleNotebooks`, {
-          body: JSON.stringify({ visIds }),
+          body: JSON.stringify({ visIds, dataSourceMDSId, dataSourceMDSLabel }),
         })
         .then((res) => {
           const newData = res.body.map((notebook: any) => ({

--- a/server/adaptors/notebooks/saved_objects_notebooks_router.tsx
+++ b/server/adaptors/notebooks/saved_objects_notebooks_router.tsx
@@ -68,13 +68,31 @@ export function renameNotebook(noteBookObj: { name: string; noteId: string }) {
 
 export async function addSampleNotes(
   opensearchNotebooksClient: SavedObjectsClientContract,
-  visIds: string[]
+  visIds: string[],
+  dataSourceMDSId?: string,
+  dataSourceMDSLabel?: string
 ) {
   const notebooks = getSampleNotebooks(visIds);
   const sampleNotebooks = [];
   try {
+    // Without a stored binding, each code block's selector falls back to the default data
+    // source rather than the one the sample data was just installed against.
     for (const item of notebooks) {
-      const createdNotebooks = await opensearchNotebooksClient.create(NOTEBOOK_SAVED_OBJECT, item);
+      const notebook = {
+        ...item,
+        savedNotebook: {
+          ...item.savedNotebook,
+          paragraphs: item.savedNotebook.paragraphs.map((paragraph) => ({
+            ...paragraph,
+            dataSourceMDSId: dataSourceMDSId ?? '',
+            dataSourceMDSLabel: dataSourceMDSLabel ?? '',
+          })),
+        },
+      };
+      const createdNotebooks = await opensearchNotebooksClient.create(
+        NOTEBOOK_SAVED_OBJECT,
+        notebook
+      );
       sampleNotebooks.push({
         dateCreated: createdNotebooks.attributes.savedNotebook.dateCreated,
         dateModified: createdNotebooks.attributes.savedNotebook.dateModified,

--- a/server/routes/notebooks/noteRouter.ts
+++ b/server/routes/notebooks/noteRouter.ts
@@ -237,6 +237,8 @@ export function registerNoteRoute(router: IRouter) {
       validate: {
         body: schema.object({
           visIds: schema.arrayOf(schema.string()),
+          dataSourceMDSId: schema.maybe(schema.string({ defaultValue: '' })),
+          dataSourceMDSLabel: schema.maybe(schema.string({ defaultValue: '' })),
         }),
       },
     },
@@ -250,7 +252,9 @@ export function registerNoteRoute(router: IRouter) {
       try {
         const sampleNotebooks = await addSampleNotes(
           opensearchNotebooksClient,
-          request.body.visIds
+          request.body.visIds,
+          request.body.dataSourceMDSId,
+          request.body.dataSourceMDSLabel
         );
         return response.ok({
           body: sampleNotebooks,

--- a/server/routes/notebooks/noteRouter.ts
+++ b/server/routes/notebooks/noteRouter.ts
@@ -237,8 +237,8 @@ export function registerNoteRoute(router: IRouter) {
       validate: {
         body: schema.object({
           visIds: schema.arrayOf(schema.string()),
-          dataSourceMDSId: schema.maybe(schema.string({ defaultValue: '' })),
-          dataSourceMDSLabel: schema.maybe(schema.string({ defaultValue: '' })),
+          dataSourceMDSId: schema.maybe(schema.string()),
+          dataSourceMDSLabel: schema.maybe(schema.string()),
         }),
       },
     },


### PR DESCRIPTION
### Description

`Add sample notebooks` does not honor the data source selected in its modal. The sample data installs against the chosen data source correctly, but every code block inside the created notebooks points at whichever data source is configured as the default.

**Root cause.** The selected id is dropped at the persistence boundary. `main.tsx` posts only `visIds`, and `addSampleNotes` accepts only `visIds`, so the generated paragraphs are written with no `dataSourceMDSId` and no `dataSourceMDSLabel`:

```ts
body: JSON.stringify({ visIds }),
```

The per-paragraph selector gates its `defaultOption` on `paradataSourceMDSId !== undefined`. With nothing stored that is `false`, so `DataSourceSelector` falls through to `handleDefaultDataSource` and resolves the default data source instead of the one picked. On a real multi-cluster setup the sample data lands on one cluster while the notebook queries another, so the PPL and SQL paragraphs hit a cluster with no sample indices.

**Fix.** Thread the id and label from the modal through the route into `addSampleNotes`, which stamps both onto every paragraph before create. The fields, the writer on paragraph run, and the reader in `default_parser.tsx` all already existed. Only the sample creation path never populated them.

**Notes for reviewers**

1. **Existing sample notebooks are not repaired**, since the missing binding is already persisted. Delete and re-add them, as re-adding creates duplicates rather than replacing.
2. **No unit test, verified manually instead**, with a before and after recording below. A three-case test on `addSampleNotes` was written and validated red then green, can add if necessary.
3. **The empty string fallback is deliberate.** `notebook.tsx` blanks a `QUERY` paragraph's output and raises a danger toast when `dataSourceMDSId` is truthy while multiple data sources are disabled. Local cluster's id is already the empty string, so defaulting to `''` keeps Local cluster and non-MDS installs on their existing path.
4. **Complementary to #2861, not dependent on it.** That fix only changes behavior when the id is falsy while the label is truthy, which is only the Local cluster case. For a real data source both are truthy and the visualization title search string is identical either way. Either can land first.

**Testing.** Verified with MDS enabled inside a workspace holding a wizard-created data source. Before the fix every paragraph across all four sample notebooks had `dataSourceMDSId` and `dataSourceMDSLabel` null. After, every paragraph carries the selected id and label, confirmed by querying the `observability-notebook` saved objects directly. Jest suites for `public/components/notebooks` and `server` pass, lint clean.

**Before**


https://github.com/user-attachments/assets/eb348ca4-1760-43f7-ae28-cf2e6ac370ae


**After**


https://github.com/user-attachments/assets/a1c06392-8724-4ff3-8a80-69e2a60f6370




### Issues Resolved

Fixes #2454


### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
