### PR TITLE
feat(alerting): optimistic pending-rule cache for the metrics rules list

### DIFF
--- a/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
@@ -389,8 +389,13 @@ describe('CreateMetricsMonitor', () => {
     expect(body).not.toHaveProperty('operator');
     expect(body).not.toHaveProperty('threshold');
 
-    // Should call onSave and show success toast
+    // Should call onSave and show success toast, including the querier-lag
+    // note as the toast body (Prometheus creates take ~a minute to appear).
     expect(onSave).toHaveBeenCalled();
-    expect(addToast).toHaveBeenCalledWith(expect.any(String), 'success');
+    expect(addToast).toHaveBeenCalledWith(
+      expect.any(String),
+      'success',
+      expect.stringContaining('take up to a minute')
+    );
   });
 });

--- a/public/components/alerting/__tests__/monitor_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/monitor_detail_flyout.test.tsx
@@ -162,6 +162,52 @@ describe('MonitorDetailFlyout', () => {
     labels: { monitor_kind: 'composite', composite_delegates: 'mon-a,mon-b' },
   };
 
+  it('disables Edit / Clone / Delete / Enable for a pending optimistic rule', async () => {
+    const onClone = jest.fn();
+    const onDelete = jest.fn();
+    const onEdit = jest.fn();
+    // ppl/metric OS monitor would normally be editable + toggleable in place;
+    // the synthetic new- id + pending status must gate every mutating action.
+    const pendingMonitor: UnifiedRuleSummary = {
+      ...mockMonitor,
+      id: 'new-1-0',
+      status: 'pending',
+      monitorType: 'ppl',
+    };
+    const { getByText, queryByTestId } = render(
+      <MonitorDetailFlyout
+        monitor={pendingMonitor}
+        onClose={jest.fn()}
+        onDelete={onDelete}
+        onClone={onClone}
+        onEdit={onEdit}
+        onToggleEnabled={jest.fn()}
+      />
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const editBtn = getByText('Edit').closest('button');
+    const cloneBtn = getByText('Clone').closest('button');
+    const deleteBtn = getByText('Delete').closest('button');
+    expect(editBtn).toBeDisabled();
+    expect(cloneBtn).toBeDisabled();
+    expect(deleteBtn).toBeDisabled();
+    // Enable/Disable footer button is disabled (no active toggle control).
+    expect(getByText('Disable rule').closest('button')).toBeDisabled();
+    expect(queryByTestId('alertManagerMonitorDetailToggleEnabled')).toBeNull();
+    // Not the clickable classic-edit redirect either.
+    expect(queryByTestId('alertManagerMonitorDetailEditRedirect')).toBeNull();
+
+    fireEvent.click(editBtn!);
+    fireEvent.click(cloneBtn!);
+    fireEvent.click(deleteBtn!);
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(onClone).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
   it('renders composite monitors with the member list and gates Clone/Delete', async () => {
     // Composite detail 404s on the monitors endpoint by design — reject so we
     // also assert the error banner is suppressed for composites.

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -239,4 +239,32 @@ describe('MonitorsTable', () => {
     expect(onDatasourceChange).toHaveBeenCalledWith([]);
     expect(searchInput.value).toBe('');
   });
+
+  // ---- Pending optimistic rows -------------------------------------------
+  describe('pending optimistic rows', () => {
+    const pendingRule = () =>
+      sampleRule({ id: 'new-123-0', name: 'PendingRule', status: 'pending' as const });
+
+    it('renders the pending badge instead of the status health pill', () => {
+      const { container } = render(<MonitorsTable {...defaultProps} rules={[pendingRule()]} />);
+      expect(container.querySelector('[data-test-subj="pendingRuleBadge"]')).toBeInTheDocument();
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+    });
+
+    it('disables the checkbox for a pending row (not selectable)', () => {
+      render(<MonitorsTable {...defaultProps} rules={[pendingRule()]} />);
+      expect(screen.getByLabelText('Select PendingRule')).toBeDisabled();
+    });
+
+    it('keeps a confirmed row selectable alongside a pending row', () => {
+      render(
+        <MonitorsTable
+          {...defaultProps}
+          rules={[pendingRule(), sampleRule({ id: 'r2', name: 'ConfirmedRule' })]}
+        />
+      );
+      expect(screen.getByLabelText('Select PendingRule')).toBeDisabled();
+      expect(screen.getByLabelText('Select ConfirmedRule')).not.toBeDisabled();
+    });
+  });
 });

--- a/public/components/alerting/__tests__/toast_helpers.test.tsx
+++ b/public/components/alerting/__tests__/toast_helpers.test.tsx
@@ -80,6 +80,21 @@ describe('showMonitorCreatedToast', () => {
     expect(opts.path).toContain('ds=ds-with-dash');
   });
 
+  it('appends the propagation note only when pending is set (Prometheus creates)', () => {
+    // Without pending: no note.
+    showMonitorCreatedToast({ monitorName: 'os-mon', dsId: 'ds-1' });
+    const noPending = render(<>{mockAddSuccess.mock.calls[0][0].text}</>);
+    expect(noPending.queryByText(/take up to a minute/i)).toBeNull();
+    noPending.unmount();
+
+    // With pending: note is present alongside the View rule link.
+    mockAddSuccess.mockReset();
+    showMonitorCreatedToast({ monitorName: 'prom-mon', dsId: 'ds-1', pending: true });
+    const withPending = render(<>{mockAddSuccess.mock.calls[0][0].text}</>);
+    expect(withPending.getByText(/take up to a minute/i)).toBeInTheDocument();
+    expect(withPending.getByTestId('alertManagerToastViewRule')).toBeInTheDocument();
+  });
+
   it('no-ops gracefully when the toasts service is unavailable', () => {
     // Re-mock coreRefs without `toasts` for this test only.
     jest.isolateModules(() => {

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -568,8 +568,14 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       name: string,
       origin: PendingEntry['origin']
     ) => {
+      const entryKey = pendingRuleKey(dsId, group, name);
+      // Re-adding this key means a fresh create (e.g. a retry after a timeout);
+      // `pendingRulesStore.add` resets its clock, so clear any prior "didn't
+      // show up" warning too — otherwise a second timeout for the same rule
+      // would be silently suppressed by the once-per-key guard below.
+      warnedPendingKeysRef.current.delete(entryKey);
       addPending({
-        key: pendingRuleKey(dsId, group, name),
+        key: entryKey,
         dsId,
         optimisticRule: { ...rule, datasourceId: dsId, group, status: 'pending' },
         attempts: 0,
@@ -996,9 +1002,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             defaultMessage: 'Monitor cloned',
           })
         );
-        // Immediate refetch so a fast-propagating rule confirms on the next
-        // tick; otherwise the background poll reconciles the pending row.
-        refetchRules();
+        // Background refetch: the optimistic pending row is already showing, so
+        // reconcile silently (no spinner, keeps any warning banner); the poll
+        // reconciles too if the rule is slow to propagate.
+        backgroundRefetchRules();
         return;
       }
 
@@ -1195,10 +1202,19 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       setShowCreateMonitor(false);
       setCreateBackendType(null);
       setPplSubmitError(null);
-      // Optimistic pending row keeps the UI instant; the immediate refetch (and
-      // the background poll) reconcile it against the canonical querier row.
-      addOptimisticPending(newRule, dsId, optimisticGroup, formState.name, 'create');
-      refetchRules();
+      if (isProm) {
+        // Prometheus lags the querier ~60s: layer an optimistic pending row so
+        // the UI is instant, then reconcile it via a BACKGROUND refetch — no
+        // spinner over the row that's already showing, and any cross-datasource
+        // warning banner survives — plus the ongoing poll.
+        addOptimisticPending(newRule, dsId, optimisticGroup, formState.name, 'create');
+        backgroundRefetchRules();
+      } else {
+        // OpenSearch confirms immediately (no querier lag), so no optimistic
+        // pending row — one would wrongly render as a disabled spinner. A
+        // foreground refetch shows the loading state until the real row lands.
+        refetchRules();
+      }
     } catch (e: unknown) {
       const message = extractServerErrorMessage(e);
       const pplError = extractPplValidationError(message);
@@ -1281,7 +1297,8 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       form.monitorName,
       'metrics'
     );
-    refetchRules();
+    // Optimistic row is showing — reconcile silently via background refetch + poll.
+    backgroundRefetchRules();
   };
 
   const handleEditMonitor = async (formState: MonitorFormState, ruleId: string) => {
@@ -1386,9 +1403,9 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           values: { count: succeededRules.length },
         })
       );
-      for (const r of succeededRules) {
-        addOptimisticPending(r, r.datasourceId, r.group, r.name, 'batch');
-      }
+      // Batch create is OpenSearch-only (`createMonitor`), which confirms with
+      // no querier lag — so no optimistic pending rows (they'd wrongly render as
+      // disabled spinners). The foreground refetch surfaces the new rows.
       refetchRules();
     }
     // Don't close flyout — AI wizard shows its own summary step and "Done" button
@@ -1407,10 +1424,15 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     {
       id: 'rules' as TabId,
       name:
+        // Count what the table actually renders — `visibleRules` includes the
+        // optimistic pending rows (and drops optimistically-deleted ones), so
+        // the badge stays in sync with the list during the confirm window.
+        // `rulesTotal` (querier length) is used only for the not-yet-loaded
+        // sentinel: -1 → show "Rules" with no count.
         rulesTotal >= 0
           ? i18n.translate('observability.alerting.alarmsPage.tabs.rulesCount', {
               defaultMessage: 'Rules ({count})',
-              values: { count: rulesTotal },
+              values: { count: visibleRules.length },
             })
           : i18n.translate('observability.alerting.alarmsPage.tabs.rules', {
               defaultMessage: 'Rules',

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -76,6 +76,8 @@ import {
   formStateToRule,
   resolveDatasourceTokens,
 } from './alarms_page_helpers';
+import { usePendingRules } from './hooks/use_pending_rules';
+import { key as pendingRuleKey, PendingEntry } from './monitors_table/pending_rules';
 
 // ============================================================================
 // Main Page Component
@@ -273,12 +275,6 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   // value — that way cross-tab deep-links inside the same app (alert
   // flyout's "Open monitor") still re-apply.
   const lastAppliedDsRef = useRef<string | undefined>(undefined);
-  const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => {
-    return () => {
-      if (refetchTimerRef.current) clearTimeout(refetchTimerRef.current);
-    };
-  }, []);
   useEffect(() => {
     const dsId = deepLink.ds;
     if (!dsId) return;
@@ -529,6 +525,61 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   const [selectedAlert, setSelectedAlert] = useState<UnifiedAlertSummary | null>(null);
   const { setToast: addToast } = useToast();
 
+  // Optimistic "pending rule" cache. A freshly-created Prometheus/metrics rule
+  // is persisted synchronously but only appears in the querier-backed list
+  // ~60s+ later; this layers an optimistic row on top and reconciles it against
+  // each background poll / refetch (no dedicated timer). A poll that hasn't
+  // seen the rule means "not propagated yet", so eviction on timeout warns
+  // softly rather than reporting a failure.
+  const warnedPendingKeysRef = useRef<Set<string>>(new Set());
+  const { mergedRules, addPending, dropPendingOutsideDsIds } = usePendingRules({
+    rules,
+    deletedRuleIds,
+    selectedDsIds,
+    onEvictWarning: (entry) => {
+      // One warning per key — reconcile can surface the same eviction on the
+      // same tick from multiple triggers.
+      if (warnedPendingKeysRef.current.has(entry.key)) return;
+      warnedPendingKeysRef.current.add(entry.key);
+      addToast(
+        i18n.translate('observability.alerting.alarmsPage.toast.pendingRuleUnconfirmed.title', {
+          defaultMessage: "'{name}' isn't showing up yet",
+          values: { name: entry.optimisticRule.name },
+        }),
+        'warning',
+        i18n.translate('observability.alerting.alarmsPage.toast.pendingRuleUnconfirmed.body', {
+          defaultMessage:
+            "The rule was submitted but the querier hasn't confirmed it after 2 minutes. It may still appear — click Refresh, or check the datasource is reachable.",
+        })
+      );
+    },
+  });
+
+  // Register an optimistic pending row after a successful create/clone POST.
+  // The row is keyed on the create payload's (dsId, group, name) so it lines up
+  // with the eventual querier row; forcing `status: 'pending'` makes it render
+  // as the pending badge and keeps its actions disabled (its synthetic id would
+  // 404). See `pending_rules.ts`.
+  const addOptimisticPending = useCallback(
+    (
+      rule: UnifiedRuleSummary,
+      dsId: string,
+      group: string | undefined,
+      name: string,
+      origin: PendingEntry['origin']
+    ) => {
+      addPending({
+        key: pendingRuleKey(dsId, group, name),
+        dsId,
+        optimisticRule: { ...rule, datasourceId: dsId, group, status: 'pending' },
+        attempts: 0,
+        createdAt: Date.now(),
+        origin,
+      });
+    },
+    [addPending]
+  );
+
   const handleNavigateToDetectorResults = useCallback((href: string) => {
     if (coreRefs.application?.navigateToUrl) {
       coreRefs.application.navigateToUrl(href);
@@ -537,7 +588,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     window.location.assign(href);
   }, []);
 
-  const visibleRules = rules.filter((r) => !deletedRuleIds.has(r.id));
+  const visibleRules = useMemo(
+    () => mergedRules.filter((r) => !deletedRuleIds.has(r.id)),
+    [mergedRules, deletedRuleIds]
+  );
 
   // Fires when a user tries to select past `maxDatasources`. Pops a warning
   // toast with an in-toast link to the Advanced Settings entry so they can
@@ -615,8 +669,11 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     (ids: string[]) => {
       setSelectedDsIds(ids);
       setDeletedRuleIds(new Set());
+      // Drop pending rows whose datasource is no longer selected (but keep the
+      // rest — this is a scope change, not a blanket clear).
+      dropPendingOutsideDsIds(ids);
     },
-    [setSelectedDsIds]
+    [setSelectedDsIds, dropPendingOutsideDsIds]
   );
 
   // ---- Handlers ----
@@ -918,7 +975,8 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           enabled: true,
         };
         await mutations.createPrometheusRule(payload, monitor.datasourceId);
-        // Optimistic insert — show the cloned rule immediately in the UI
+        // Optimistic pending row — the clone POST has no groupName, so the
+        // server defaults the group to the (cloned) rule name.
         const optimisticClone: UnifiedRuleSummary = {
           ...monitor,
           id: `new-clone-${Date.now()}`,
@@ -926,15 +984,21 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           group: clonedName,
           status: 'pending',
         };
-        setRules((prev) => [optimisticClone, ...prev]);
-        setRulesTotal((prev) => prev + 1);
+        addOptimisticPending(
+          optimisticClone,
+          monitor.datasourceId,
+          clonedName,
+          clonedName,
+          'clone'
+        );
         addToast(
           i18n.translate('observability.alerting.alarmsPage.toast.monitorCloned', {
             defaultMessage: 'Monitor cloned',
           })
         );
-        // Background refetch to reconcile with Prometheus once it propagates
-        refetchTimerRef.current = setTimeout(() => refetchRules(), 15000);
+        // Immediate refetch so a fast-propagating rule confirms on the next
+        // tick; otherwise the background poll reconciles the pending row.
+        refetchRules();
         return;
       }
 
@@ -1092,13 +1156,19 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     const dsId = resolveDatasourceId(formState);
     if (!dsId) return;
     const newRule = buildOptimisticRule(formState);
+    const isProm = formState.datasourceType === 'prometheus';
+    // Group the optimistic pending row is keyed on. Prometheus rules carry a
+    // group (from the _ruleGroup transport label or the rule name); OpenSearch
+    // monitors have none.
+    let optimisticGroup: string | undefined;
     try {
-      if (formState.datasourceType === 'prometheus') {
+      if (isProm) {
         // Prometheus rules go to the Prometheus ruler API
         const promForm = formState as PrometheusFormState;
         // _ruleGroup is a form-transport metadata label, not a real Prometheus
         // label — extract it into groupName and strip it from persisted labels.
         const ruleGroupLabel = promForm.labels.find((l) => l.key === '_ruleGroup')?.value;
+        optimisticGroup = ruleGroupLabel || promForm.name;
         const payload = buildPrometheusRulePayload({
           name: promForm.name,
           query: promForm.query,
@@ -1113,26 +1183,21 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             promForm.annotations.filter((a) => a.key && a.value).map((a) => [a.key, a.value])
           ),
           enabled: promForm.enabled,
-          groupName: ruleGroupLabel || promForm.name,
+          groupName: optimisticGroup,
         });
         await mutations.createPrometheusRule(payload, dsId);
-
-        // Prometheus has eventual consistency (~30-60s propagation). Use
-        // optimistic pattern: close flyout immediately, show toast, and
-        // schedule a background refetch after 15s to sync the list.
-        refetchTimerRef.current = setTimeout(() => refetchRules(), 15000);
       } else {
         await mutations.createMonitor(buildPayload(formState), dsId);
       }
-      showMonitorCreatedToast({ monitorName: formState.name, dsId });
+      // Prometheus creates lag the querier (~30-60s), so hint at the delay;
+      // OpenSearch monitors confirm immediately.
+      showMonitorCreatedToast({ monitorName: formState.name, dsId, pending: isProm });
       setShowCreateMonitor(false);
       setCreateBackendType(null);
       setPplSubmitError(null);
-      // Refetch rules so the new monitor (with backend-assigned id /
-      // last_update_time) shows up in the list. Optimistic insert is kept
-      // for the UI to feel instant; the refetch reconciles.
-      setRules((prev) => [newRule, ...prev]);
-      setRulesTotal((prev) => prev + 1);
+      // Optimistic pending row keeps the UI instant; the immediate refetch (and
+      // the background poll) reconcile it against the canonical querier row.
+      addOptimisticPending(newRule, dsId, optimisticGroup, formState.name, 'create');
       refetchRules();
     } catch (e: unknown) {
       const message = extractServerErrorMessage(e);
@@ -1207,10 +1272,16 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     const newRule = buildOptimisticRule(promForm);
     setShowCreateMonitor(false);
     setCreateBackendType(null);
-    setRules((prev) => [newRule, ...prev]);
-    setRulesTotal((prev) => prev + 1);
+    // The flyout persisted the rule itself with groupName `form.groupName ||
+    // form.monitorName` — key the optimistic pending row on the same tuple.
+    addOptimisticPending(
+      newRule,
+      form.datasourceId,
+      form.groupName || form.monitorName,
+      form.monitorName,
+      'metrics'
+    );
     refetchRules();
-    refetchTimerRef.current = setTimeout(() => refetchRules(), 15000);
   };
 
   const handleEditMonitor = async (formState: MonitorFormState, ruleId: string) => {
@@ -1261,8 +1332,9 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             // Orphaned old rule — harmless, user can delete manually
           }
         }
-        // Background refetch to reconcile with Prometheus once it propagates
-        refetchTimerRef.current = setTimeout(() => refetchRules(), 15000);
+        // Immediate refetch; the background poll continues to reconcile once
+        // Prometheus propagates the edited rule.
+        refetchRules();
       } else {
         await mutations.updateMonitor(ruleId, buildPayload(formState), dsId);
         // Immediate refetch for OpenSearch monitors (no propagation delay)
@@ -1314,8 +1386,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           values: { count: succeededRules.length },
         })
       );
-      setRules((prev) => [...succeededRules, ...prev]);
-      setRulesTotal((prev) => prev + succeededRules.length);
+      for (const r of succeededRules) {
+        addOptimisticPending(r, r.datasourceId, r.group, r.name, 'batch');
+      }
+      refetchRules();
     }
     // Don't close flyout — AI wizard shows its own summary step and "Done" button
   };

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -1056,7 +1056,13 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
         i18n.translate('observability.alerting.createMetricsMonitor.toast.created', {
           defaultMessage: 'Alert rule created successfully.',
         }),
-        'success'
+        'success',
+        // Prometheus/Cortex creates persist synchronously but the querier-backed
+        // list lags ~a minute; tell the user so a not-yet-visible row doesn't
+        // read as a failure. (The list also shows an optimistic "Pending" row.)
+        i18n.translate('observability.alerting.createMetricsMonitor.toast.createdPendingNote', {
+          defaultMessage: 'It may take up to a minute to appear in the list.',
+        })
       );
       onSave(form);
     } catch (err) {

--- a/public/components/alerting/hooks/__tests__/use_pending_rules.test.ts
+++ b/public/components/alerting/hooks/__tests__/use_pending_rules.test.ts
@@ -100,11 +100,12 @@ describe('usePendingRules', () => {
     expect(onEvictWarning).not.toHaveBeenCalled();
   });
 
-  it('warns once when an entry is evicted for exhausting its attempts', () => {
+  it('warns once when an entry is evicted for aging past its ttl', () => {
     const onEvictWarning = jest.fn();
     const { result, rerender } = setup({ rules: [], onEvictWarning });
-    // One attempt short of the cap so the next poll evicts it as exhausted.
-    act(() => result.current.addPending(entry({ attempts: 6 })));
+    // Created well over the ttl ago (default 120s), so the next reconcile evicts
+    // it as expired.
+    act(() => result.current.addPending(entry({ createdAt: Date.now() - 200_000 })));
 
     // Two refetches (empty querier) — should only warn on the first eviction.
     act(() =>
@@ -126,7 +127,7 @@ describe('usePendingRules', () => {
     expect(onEvictWarning).toHaveBeenCalledTimes(1);
     expect(onEvictWarning).toHaveBeenCalledWith(
       expect.objectContaining({ key: entry().key }),
-      'exhausted'
+      'expired'
     );
   });
 

--- a/public/components/alerting/hooks/__tests__/use_pending_rules.test.ts
+++ b/public/components/alerting/hooks/__tests__/use_pending_rules.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * use_pending_rules hook tests — the singleton store + React wiring around the
+ * pure `reconcilePending`. Covers: an added optimistic row shows immediately
+ * (no `rules` change needed), a querier refetch that reveals the rule evicts it
+ * silently, and a timeout fires the warning callback exactly once.
+ */
+import { act, renderHook } from '@testing-library/react';
+import type { UnifiedRuleSummary } from '../../../../../common/types/alerting';
+import { pendingRulesStore, usePendingRules } from '../use_pending_rules';
+import { key, PendingEntry } from '../../monitors_table/pending_rules';
+
+const rule = (over: Partial<UnifiedRuleSummary> = {}): UnifiedRuleSummary => ({
+  id: 'ds1-g-HighCpu',
+  datasourceId: 'ds1',
+  datasourceType: 'prometheus',
+  name: 'HighCpu',
+  enabled: true,
+  severity: 'critical',
+  query: 'up == 0',
+  condition: '> 0',
+  group: 'g',
+  labels: {},
+  annotations: {},
+  monitorType: 'metric',
+  status: 'active',
+  healthStatus: 'healthy',
+  createdBy: 'system',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastModified: '2026-01-01T00:00:00.000Z',
+  notificationDestinations: [],
+  evaluationInterval: '60s',
+  pendingPeriod: '5m',
+  ...over,
+});
+
+const entry = (over: Partial<PendingEntry> = {}): PendingEntry => ({
+  key: key('ds1', 'g', 'HighCpu'),
+  dsId: 'ds1',
+  optimisticRule: rule({ id: 'new-1-0', status: 'pending' }),
+  attempts: 0,
+  createdAt: Date.now(),
+  origin: 'metrics',
+  ...over,
+});
+
+const setup = (initial: {
+  rules?: UnifiedRuleSummary[];
+  deletedRuleIds?: Set<string>;
+  selectedDsIds?: string[];
+  onEvictWarning?: jest.Mock;
+}) =>
+  renderHook(
+    (props: {
+      rules: UnifiedRuleSummary[];
+      deletedRuleIds: Set<string>;
+      selectedDsIds: string[];
+    }) =>
+      usePendingRules({
+        ...props,
+        onEvictWarning: initial.onEvictWarning ?? jest.fn(),
+      }),
+    {
+      initialProps: {
+        rules: initial.rules ?? [],
+        deletedRuleIds: initial.deletedRuleIds ?? new Set<string>(),
+        selectedDsIds: initial.selectedDsIds ?? ['ds1'],
+      },
+    }
+  );
+
+beforeEach(() => {
+  act(() => pendingRulesStore._reset());
+});
+
+describe('usePendingRules', () => {
+  it('shows an added optimistic row immediately, without a rules change', () => {
+    const { result } = setup({ rules: [] });
+    expect(result.current.mergedRules).toHaveLength(0);
+    act(() => result.current.addPending(entry()));
+    expect(result.current.mergedRules).toHaveLength(1);
+    expect(result.current.mergedRules[0].id).toBe('new-1-0');
+  });
+
+  it('evicts the pending row silently once the querier confirms it', () => {
+    const onEvictWarning = jest.fn();
+    const { result, rerender } = setup({ rules: [], onEvictWarning });
+    act(() => result.current.addPending(entry()));
+    expect(result.current.mergedRules).toHaveLength(1);
+
+    // A refetch that now includes the canonical row confirms + evicts.
+    act(() => rerender({ rules: [rule()], deletedRuleIds: new Set(), selectedDsIds: ['ds1'] }));
+    expect(result.current.mergedRules).toHaveLength(1);
+    expect(result.current.mergedRules[0].id).toBe('ds1-g-HighCpu');
+    expect(pendingRulesStore.getSnapshot()).toHaveLength(0);
+    expect(onEvictWarning).not.toHaveBeenCalled();
+  });
+
+  it('warns once when an entry is evicted for exhausting its attempts', () => {
+    const onEvictWarning = jest.fn();
+    const { result, rerender } = setup({ rules: [], onEvictWarning });
+    // One attempt short of the cap so the next poll evicts it as exhausted.
+    act(() => result.current.addPending(entry({ attempts: 6 })));
+
+    // Two refetches (empty querier) — should only warn on the first eviction.
+    act(() =>
+      rerender({
+        rules: [rule({ name: 'Other', id: 'x' })],
+        deletedRuleIds: new Set(),
+        selectedDsIds: ['ds1'],
+      })
+    );
+    act(() =>
+      rerender({
+        rules: [rule({ name: 'Other2', id: 'y' })],
+        deletedRuleIds: new Set(),
+        selectedDsIds: ['ds1'],
+      })
+    );
+
+    expect(pendingRulesStore.getSnapshot()).toHaveLength(0);
+    expect(onEvictWarning).toHaveBeenCalledTimes(1);
+    expect(onEvictWarning).toHaveBeenCalledWith(
+      expect.objectContaining({ key: entry().key }),
+      'exhausted'
+    );
+  });
+
+  it('drops pending entries outside the retained datasource ids', () => {
+    const { result } = setup({ rules: [] });
+    act(() => {
+      result.current.addPending(entry());
+      result.current.addPending(
+        entry({
+          key: key('ds2', 'g', 'X'),
+          dsId: 'ds2',
+          optimisticRule: rule({ id: 'new-2-0', datasourceId: 'ds2', status: 'pending' }),
+        })
+      );
+    });
+    expect(pendingRulesStore.getSnapshot()).toHaveLength(2);
+    act(() => result.current.dropPendingOutsideDsIds(['ds1']));
+    expect(pendingRulesStore.getSnapshot()).toHaveLength(1);
+    expect(pendingRulesStore.getSnapshot()[0].dsId).toBe('ds1');
+  });
+});

--- a/public/components/alerting/hooks/use_monitor_detail.ts
+++ b/public/components/alerting/hooks/use_monitor_detail.ts
@@ -26,6 +26,14 @@ export interface UseMonitorDetailParams {
   dsId: string;
   ruleId: string;
   definitionType?: UnifiedDefinitionType;
+  /**
+   * Skip the fetch entirely when false — used for optimistic pending rows whose
+   * synthetic `new-` id the backend doesn't know yet, so `getRuleDetail` would
+   * be a guaranteed 404. Defaults to true (fetch). When false the hook stays in
+   * a resolved, empty state (no loading, no error) and the flyout renders
+   * against its summary props.
+   */
+  enabled?: boolean;
 }
 
 export interface UseMonitorDetailResult {
@@ -38,6 +46,7 @@ export function useMonitorDetail({
   dsId,
   ruleId,
   definitionType,
+  enabled = true,
 }: UseMonitorDetailParams): UseMonitorDetailResult {
   const osService = useMemo(() => new AlertingOpenSearchService(), []);
   const [detail, setDetail] = useState<UnifiedRule | null>(null);
@@ -46,6 +55,15 @@ export function useMonitorDetail({
 
   useEffect(() => {
     let cancelled = false;
+    // Disabled (e.g. an optimistic pending row): nothing to fetch — drop into a
+    // resolved, empty state so the flyout renders its summary props instead of a
+    // permanent spinner or a doomed 404 request.
+    if (!enabled) {
+      setDetail(null);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
     // Reset detail alongside error so a switch from rule A to rule B
     // doesn't render A's history/preview behind the loading indicator
     // until B's fetch resolves.
@@ -69,7 +87,7 @@ export function useMonitorDetail({
     return () => {
       cancelled = true;
     };
-  }, [dsId, ruleId, definitionType, osService]);
+  }, [dsId, ruleId, definitionType, osService, enabled]);
 
   return { detail, isLoading, error };
 }

--- a/public/components/alerting/hooks/use_pending_rules.ts
+++ b/public/components/alerting/hooks/use_pending_rules.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * React glue + module-level singleton for the optimistic pending-rule cache.
+ *
+ * The store is an in-memory module singleton (the `coreRefs` precedent), NOT
+ * sessionStorage: a module singleton survives the client-side Explore→Alerts
+ * navigation within the same SPA tab — the real cross-surface case, since both
+ * create flyouts live in this plugin — while a hard reload cleanly falls back
+ * to the poll (safe) instead of resurrecting a possibly-dead row (zombie risk).
+ *
+ * The reconcile that increments attempts / evicts / warns runs exactly once per
+ * querier refetch — the effect below keys on `rules` alone, so an `addPending`
+ * (which mutates the store, not `rules`) can never spuriously bump attempts or
+ * loop. The rendered view is a separate pure derivation over `[rules, pending,
+ * …]`, so a freshly-added optimistic row appears immediately.
+ */
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+import type { UnifiedRuleSummary } from '../../../../common/types/alerting';
+import {
+  DEFAULT_PENDING_RULES_CONFIG,
+  EvictReason,
+  mergePending,
+  PendingEntry,
+  PendingRulesConfig,
+  reconcilePending,
+} from '../monitors_table/pending_rules';
+
+// ============================================================================
+// Singleton store
+// ============================================================================
+
+type Listener = () => void;
+
+let entries: PendingEntry[] = [];
+const listeners = new Set<Listener>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+export const pendingRulesStore = {
+  getSnapshot: (): PendingEntry[] => entries,
+  subscribe: (l: Listener): (() => void) => {
+    listeners.add(l);
+    return () => {
+      listeners.delete(l);
+    };
+  },
+  /**
+   * Add (or replace, by key) a pending entry. Replacing on key collision means
+   * re-creating the same (ds, group, name) — e.g. after a failed-then-retried
+   * save — resets the clock rather than stacking duplicate rows.
+   */
+  add: (entry: PendingEntry): void => {
+    entries = [...entries.filter((e) => e.key !== entry.key), entry];
+    emit();
+  },
+  /** Commit the post-reconcile survivor set. */
+  replace: (next: PendingEntry[]): void => {
+    entries = next;
+    emit();
+  },
+  /** Drop entries whose datasource is not in `keepDsIds` (datasource-change scope). */
+  dropOutsideDsIds: (keepDsIds: string[]): void => {
+    const keep = new Set(keepDsIds);
+    const filtered = entries.filter((e) => keep.has(e.dsId));
+    if (filtered.length !== entries.length) {
+      entries = filtered;
+      emit();
+    }
+  },
+  /** Test-only reset. */
+  _reset: (): void => {
+    entries = [];
+    emit();
+  },
+};
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export interface UsePendingRulesParams {
+  /** Canonical querier rows from `useRulesData`. */
+  rules: UnifiedRuleSummary[];
+  /** Ids the user has optimistically deleted (page-level overlay). */
+  deletedRuleIds: Set<string>;
+  /** Currently selected datasource ids — scopes which pending rows are shown. */
+  selectedDsIds: string[];
+  /**
+   * Fired once per entry that timed out (expired / attempts exhausted). The
+   * page shows a soft WARNING toast — a timeout means "not propagated yet",
+   * not "creation failed".
+   */
+  onEvictWarning: (
+    entry: PendingEntry,
+    reason: Extract<EvictReason, 'expired' | 'exhausted'>
+  ) => void;
+  config?: PendingRulesConfig;
+}
+
+export interface UsePendingRulesResult {
+  /** Querier rows with unconfirmed optimistic rows layered on top. */
+  mergedRules: UnifiedRuleSummary[];
+  /** Register an optimistic row (call right after a successful create POST). */
+  addPending: (entry: PendingEntry) => void;
+  /** Drop pending entries outside the given datasource ids (on selection change). */
+  dropPendingOutsideDsIds: (keepDsIds: string[]) => void;
+}
+
+export function usePendingRules({
+  rules,
+  deletedRuleIds,
+  selectedDsIds,
+  onEvictWarning,
+  config = DEFAULT_PENDING_RULES_CONFIG,
+}: UsePendingRulesParams): UsePendingRulesResult {
+  const pending = useSyncExternalStore(pendingRulesStore.subscribe, pendingRulesStore.getSnapshot);
+
+  // Keep the newest closures/values available to the rules-keyed effect without
+  // widening its dependency list (which would re-run the reconcile — and bump
+  // attempts — on every selection change).
+  const onEvictWarningRef = useRef(onEvictWarning);
+  onEvictWarningRef.current = onEvictWarning;
+  const deletedRef = useRef(deletedRuleIds);
+  deletedRef.current = deletedRuleIds;
+  const selectedRef = useRef(selectedDsIds);
+  selectedRef.current = selectedDsIds;
+
+  useEffect(() => {
+    const snapshot = pendingRulesStore.getSnapshot();
+    if (snapshot.length === 0) return; // nothing to reconcile — stay idle
+    const { nextPending, evicted } = reconcilePending(
+      rules,
+      snapshot,
+      deletedRef.current,
+      Date.now(),
+      selectedRef.current,
+      config
+    );
+    pendingRulesStore.replace(nextPending);
+    for (const ev of evicted) {
+      if (ev.reason === 'expired' || ev.reason === 'exhausted') {
+        onEvictWarningRef.current(ev.entry, ev.reason);
+      }
+    }
+    // Reconcile rides the querier refetch: `rules` identity changes once per
+    // poll / refetch. Intentionally NOT keyed on pending/selection/deleted.
+  }, [rules, config]);
+
+  const mergedRules = useMemo(
+    () => mergePending(rules, pending, deletedRuleIds, selectedDsIds),
+    [rules, pending, deletedRuleIds, selectedDsIds]
+  );
+
+  const addPending = useCallback((entry: PendingEntry) => pendingRulesStore.add(entry), []);
+  const dropPendingOutsideDsIds = useCallback(
+    (keepDsIds: string[]) => pendingRulesStore.dropOutsideDsIds(keepDsIds),
+    []
+  );
+
+  return { mergedRules, addPending, dropPendingOutsideDsIds };
+}

--- a/public/components/alerting/hooks/use_pending_rules.ts
+++ b/public/components/alerting/hooks/use_pending_rules.ts
@@ -92,14 +92,11 @@ export interface UsePendingRulesParams {
   /** Currently selected datasource ids — scopes which pending rows are shown. */
   selectedDsIds: string[];
   /**
-   * Fired once per entry that timed out (expired / attempts exhausted). The
-   * page shows a soft WARNING toast — a timeout means "not propagated yet",
-   * not "creation failed".
+   * Fired once per entry that timed out (aged past `ttlMs`). The page shows a
+   * soft WARNING toast — a timeout means "not propagated yet", not "creation
+   * failed".
    */
-  onEvictWarning: (
-    entry: PendingEntry,
-    reason: Extract<EvictReason, 'expired' | 'exhausted'>
-  ) => void;
+  onEvictWarning: (entry: PendingEntry, reason: Extract<EvictReason, 'expired'>) => void;
   config?: PendingRulesConfig;
 }
 
@@ -144,7 +141,7 @@ export function usePendingRules({
     );
     pendingRulesStore.replace(nextPending);
     for (const ev of evicted) {
-      if (ev.reason === 'expired' || ev.reason === 'exhausted') {
+      if (ev.reason === 'expired') {
         onEvictWarningRef.current(ev.entry, ev.reason);
       }
     }

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -50,6 +50,7 @@ import { humanizeCondition } from './monitor_detail/humanize_condition';
 import { normalizeDuration } from './utils/duration';
 import { observabilityAlertingID } from '../../../common/constants/shared';
 import { coreRefs } from '../../framework/core_refs';
+import { isPending } from './monitors_table/pending_rules';
 
 import { SEVERITY_COLORS, STATE_COLORS, STATUS_COLORS, HEALTH_COLORS } from './shared_constants';
 
@@ -128,10 +129,23 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showEditRedirectConfirm, setShowEditRedirectConfirm] = useState(false);
   const [isTogglingEnabled, setIsTogglingEnabled] = useState(false);
+  // Optimistic rows we injected while the querier catches up carry a synthetic
+  // `new-` id the backend doesn't know yet, so every mutating action (edit,
+  // clone, delete, enable/disable) would 404 — gate them all off until the
+  // rule confirms.
+  const pending = isPending(monitor);
+  const pendingActionTooltip = i18n.translate(
+    'observability.alerting.monitorDetailFlyout.pendingActionTooltip',
+    {
+      defaultMessage:
+        'This rule is still being confirmed by the querier. Actions are available once it appears in the list.',
+    }
+  );
   // Mirror the Edit-button gate (PPL only). Non-PPL types stay read-only;
   // the existing tooltip surfaces explains the limitation.
   // Prometheus rules cannot be disabled via the OS Alerting API.
   const canToggleEnabled =
+    !pending &&
     !!onToggleEnabled &&
     monitor.datasourceType !== 'prometheus' &&
     (monitor.monitorType === 'ppl' || monitor.monitorType === 'metric');
@@ -203,12 +217,12 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
   // flyout, so rather than disable Edit we send the user to the classic
   // alerting app after a heads-up confirmation.
   const canEditInPlace =
-    !!onEdit && (monitor.monitorType === 'ppl' || monitor.monitorType === 'metric');
+    !pending && !!onEdit && (monitor.monitorType === 'ppl' || monitor.monitorType === 'metric');
   // Only OpenSearch monitors have a real `_id` + monitor_type the classic
   // editor understands; detectors/forecasters/Prometheus rules do not.
   const isOpenSearchMonitor =
     (monitor.definitionType ?? 'monitor') === 'monitor' && monitor.datasourceType === 'opensearch';
-  const canRedirectToClassicEdit = !canEditInPlace && isOpenSearchMonitor;
+  const canRedirectToClassicEdit = !pending && !canEditInPlace && isOpenSearchMonitor;
   // The classic `monitorType` param is advisory (the classic app re-derives
   // the form from the fetched monitor body), but we send the best value we
   // have. Cluster-metrics monitors are stored as `query_level_monitor` and
@@ -372,12 +386,13 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                 </EuiToolTip>
               ) : (
                 <EuiToolTip
-                  content={i18n.translate(
-                    'observability.alerting.monitorDetailFlyout.editTooltip',
-                    {
-                      defaultMessage: 'Editing is only supported for PPL alert rules',
-                    }
-                  )}
+                  content={
+                    pending
+                      ? pendingActionTooltip
+                      : i18n.translate('observability.alerting.monitorDetailFlyout.editTooltip', {
+                          defaultMessage: 'Editing is only supported for PPL alert rules',
+                        })
+                  }
                 >
                   <EuiButtonEmpty size="s" iconType="pencil" isDisabled>
                     <FormattedMessage
@@ -389,8 +404,8 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
               )}
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              {isComposite ? (
-                <EuiToolTip content={compositeActionTooltip}>
+              {isComposite || pending ? (
+                <EuiToolTip content={pending ? pendingActionTooltip : compositeActionTooltip}>
                   <EuiButtonEmpty size="s" iconType="copy" isDisabled>
                     <FormattedMessage
                       id="observability.alerting.monitorDetailFlyout.cloneButton"
@@ -408,8 +423,8 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
               )}
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              {isComposite ? (
-                <EuiToolTip content={compositeActionTooltip}>
+              {isComposite || pending ? (
+                <EuiToolTip content={pending ? pendingActionTooltip : compositeActionTooltip}>
                   <EuiButtonEmpty size="s" iconType="trash" color="danger" isDisabled>
                     <FormattedMessage
                       id="observability.alerting.monitorDetailFlyout.deleteButton"
@@ -1088,12 +1103,17 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
                     </EuiButton>
                   ) : (
                     <EuiToolTip
-                      content={i18n.translate(
-                        'observability.alerting.monitorDetailFlyout.enableDisableTooltip',
-                        {
-                          defaultMessage: 'Enable/disable is only supported for PPL alert rules.',
-                        }
-                      )}
+                      content={
+                        pending
+                          ? pendingActionTooltip
+                          : i18n.translate(
+                              'observability.alerting.monitorDetailFlyout.enableDisableTooltip',
+                              {
+                                defaultMessage:
+                                  'Enable/disable is only supported for PPL alert rules.',
+                              }
+                            )
+                      }
                     >
                       <EuiButton size="s" isDisabled>
                         {monitor.enabled === false

--- a/public/components/alerting/monitor_detail_flyout.tsx
+++ b/public/components/alerting/monitor_detail_flyout.tsx
@@ -153,6 +153,10 @@ export const MonitorDetailFlyout: React.FC<MonitorDetailFlyoutProps> = ({
     dsId: monitor.datasourceId,
     ruleId: monitor.id,
     definitionType: monitor.definitionType || 'monitor',
+    // A pending optimistic row carries a synthetic `new-` id the backend can't
+    // resolve — skip the detail fetch so it doesn't 404 on every open; the
+    // flyout falls back to the summary props until the rule confirms.
+    enabled: !pending,
   });
   const { detail, isLoading: detailLoading, error: detailError } = detailState;
 

--- a/public/components/alerting/monitors_table/__tests__/pending_rules.test.ts
+++ b/public/components/alerting/monitors_table/__tests__/pending_rules.test.ts
@@ -137,7 +137,7 @@ describe('reconcilePending', () => {
     expect(evicted[0].reason).toBe('confirmed');
   });
 
-  it('(e) retains an unconfirmed entry and increments attempts + keeps pending status', () => {
+  it('(d) retains an unconfirmed entry and increments attempts + keeps pending status', () => {
     const { merged, nextPending, evicted } = reconcile([], [entry({ attempts: 2 })]);
     expect(evicted).toHaveLength(0);
     expect(nextPending).toHaveLength(1);
@@ -147,15 +147,18 @@ describe('reconcilePending', () => {
     expect(isPending(merged[0])).toBe(true);
   });
 
-  it('(d) evicts as exhausted when attempts reach maxAttempts', () => {
-    const { nextPending, evicted } = reconcile([], [entry({ attempts: 6 })]);
-    expect(nextPending).toHaveLength(0);
-    expect(evicted).toEqual([
-      { entry: expect.objectContaining({ attempts: 6 }), reason: 'exhausted' },
-    ]);
+  it('never evicts on attempt count alone — a high-attempt but recent entry is retained', () => {
+    // attempts no longer drive eviction (only wall-clock ttl does), so an entry
+    // that has ridden many focus/visibility refetches within the ttl survives.
+    const { nextPending, evicted } = reconcile([], [entry({ attempts: 99, createdAt: 1_000 })], {
+      now: 1_500,
+    });
+    expect(evicted).toHaveLength(0);
+    expect(nextPending).toHaveLength(1);
+    expect(nextPending[0].attempts).toBe(100);
   });
 
-  it('(c) evicts as expired when age exceeds ttl even if attempts are under the cap', () => {
+  it('(c) evicts as expired when age exceeds ttl regardless of attempt count', () => {
     const { nextPending, evicted } = reconcile([], [entry({ attempts: 0, createdAt: 1_000 })], {
       now: 1_000 + DEFAULT_PENDING_RULES_CONFIG.ttlMs + 1,
     });
@@ -174,7 +177,7 @@ describe('reconcilePending', () => {
     expect(pass2.nextPending).toHaveLength(0);
   });
 
-  it('prioritizes confirm over delete/ttl/attempts', () => {
+  it('prioritizes confirm over delete/ttl', () => {
     const confirmed = rule();
     const { evicted } = reconcile([confirmed], [entry({ attempts: 99, createdAt: 0 })], {
       deleted: new Set(['new-100-0']),

--- a/public/components/alerting/monitors_table/__tests__/pending_rules.test.ts
+++ b/public/components/alerting/monitors_table/__tests__/pending_rules.test.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { UnifiedRuleSummary } from '../../../../../common/types/alerting';
+import {
+  DEFAULT_PENDING_RULES_CONFIG,
+  isPending,
+  key,
+  mergePending,
+  PendingEntry,
+  reconcilePending,
+} from '../pending_rules';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const rule = (over: Partial<UnifiedRuleSummary> = {}): UnifiedRuleSummary => ({
+  id: 'ds1-g-HighCpu',
+  datasourceId: 'ds1',
+  datasourceType: 'prometheus',
+  name: 'HighCpu',
+  enabled: true,
+  severity: 'critical',
+  query: 'up == 0',
+  condition: '> 0',
+  group: 'g',
+  labels: {},
+  annotations: {},
+  monitorType: 'metric',
+  status: 'active',
+  healthStatus: 'healthy',
+  createdBy: 'system',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastModified: '2026-01-01T00:00:00.000Z',
+  notificationDestinations: [],
+  evaluationInterval: '60s',
+  pendingPeriod: '5m',
+  ...over,
+});
+
+const optimistic = (over: Partial<UnifiedRuleSummary> = {}): UnifiedRuleSummary =>
+  rule({ id: 'new-100-0', status: 'pending', ...over });
+
+const entry = (over: Partial<PendingEntry> = {}): PendingEntry => ({
+  key: key('ds1', 'g', 'HighCpu'),
+  dsId: 'ds1',
+  optimisticRule: optimistic(),
+  attempts: 0,
+  createdAt: 1_000,
+  origin: 'metrics',
+  ...over,
+});
+
+const reconcile = (
+  querier: UnifiedRuleSummary[],
+  pending: PendingEntry[],
+  opts: {
+    deleted?: Set<string>;
+    now?: number;
+    selected?: string[];
+    config?: typeof DEFAULT_PENDING_RULES_CONFIG;
+  } = {}
+) =>
+  reconcilePending(
+    querier,
+    pending,
+    opts.deleted ?? new Set<string>(),
+    opts.now ?? 2_000,
+    opts.selected ?? ['ds1'],
+    opts.config ?? DEFAULT_PENDING_RULES_CONFIG
+  );
+
+// ---------------------------------------------------------------------------
+// key()
+// ---------------------------------------------------------------------------
+
+describe('key', () => {
+  it('is case- and whitespace-insensitive on group and name', () => {
+    expect(key('ds1', '  G  ', '  HighCpu  ')).toBe(key('ds1', 'g', 'highcpu'));
+    expect(key('ds1', 'Group', 'Rule')).toBe('ds1|group|rule');
+  });
+
+  it('degrades to an empty group segment for group-less monitors', () => {
+    expect(key('ds1', undefined, 'Mon')).toBe('ds1||mon');
+    expect(key('ds1', '', 'Mon')).toBe('ds1||mon');
+    expect(key('ds1', undefined, 'Mon')).toBe(key('ds1', '', 'Mon'));
+  });
+
+  it('keeps the datasource segment distinct', () => {
+    expect(key('ds1', 'g', 'n')).not.toBe(key('ds2', 'g', 'n'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPending()
+// ---------------------------------------------------------------------------
+
+describe('isPending', () => {
+  it('is true only for a synthetic new- id with pending status', () => {
+    expect(isPending(optimistic())).toBe(true);
+  });
+
+  it('is false for a real Cortex rule whose querier state is pending', () => {
+    expect(isPending(rule({ id: 'ds1-g-HighCpu', status: 'pending' }))).toBe(false);
+  });
+
+  it('is false for a new- id that is no longer pending', () => {
+    expect(isPending(optimistic({ status: 'active' }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcilePending()
+// ---------------------------------------------------------------------------
+
+describe('reconcilePending', () => {
+  it('(a) evicts a confirmed entry silently with no duplicate row', () => {
+    const confirmed = rule(); // key ds1|g|highcpu, canonical id
+    const { merged, nextPending, evicted } = reconcile([confirmed], [entry()]);
+    expect(nextPending).toHaveLength(0);
+    expect(evicted).toEqual([
+      { entry: expect.objectContaining({ key: key('ds1', 'g', 'HighCpu') }), reason: 'confirmed' },
+    ]);
+    // Deduped: exactly one row, and it's the canonical one (not the new- id).
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe('ds1-g-HighCpu');
+  });
+
+  it('confirms across a group name whose case/whitespace differs (group-mismatch regression)', () => {
+    const confirmed = rule({ group: 'g', name: 'HighCpu' });
+    const pendingEntry = entry({ key: key('ds1', '  G ', ' highcpu ') });
+    const { nextPending, evicted } = reconcile([confirmed], [pendingEntry]);
+    expect(nextPending).toHaveLength(0);
+    expect(evicted[0].reason).toBe('confirmed');
+  });
+
+  it('(e) retains an unconfirmed entry and increments attempts + keeps pending status', () => {
+    const { merged, nextPending, evicted } = reconcile([], [entry({ attempts: 2 })]);
+    expect(evicted).toHaveLength(0);
+    expect(nextPending).toHaveLength(1);
+    expect(nextPending[0].attempts).toBe(3);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].status).toBe('pending');
+    expect(isPending(merged[0])).toBe(true);
+  });
+
+  it('(d) evicts as exhausted when attempts reach maxAttempts', () => {
+    const { nextPending, evicted } = reconcile([], [entry({ attempts: 6 })]);
+    expect(nextPending).toHaveLength(0);
+    expect(evicted).toEqual([
+      { entry: expect.objectContaining({ attempts: 6 }), reason: 'exhausted' },
+    ]);
+  });
+
+  it('(c) evicts as expired when age exceeds ttl even if attempts are under the cap', () => {
+    const { nextPending, evicted } = reconcile([], [entry({ attempts: 0, createdAt: 1_000 })], {
+      now: 1_000 + DEFAULT_PENDING_RULES_CONFIG.ttlMs + 1,
+    });
+    expect(nextPending).toHaveLength(0);
+    expect(evicted[0].reason).toBe('expired');
+  });
+
+  it('(b) evicts a user-deleted optimistic row and does not resurrect it on the next pass', () => {
+    const deleted = new Set<string>(['new-100-0']);
+    const pass1 = reconcile([], [entry()], { deleted });
+    expect(pass1.evicted[0].reason).toBe('deleted');
+    expect(pass1.nextPending).toHaveLength(0);
+    // Next pass over the (now empty) survivor set can't bring it back.
+    const pass2 = reconcile([], pass1.nextPending, { deleted });
+    expect(pass2.merged).toHaveLength(0);
+    expect(pass2.nextPending).toHaveLength(0);
+  });
+
+  it('prioritizes confirm over delete/ttl/attempts', () => {
+    const confirmed = rule();
+    const { evicted } = reconcile([confirmed], [entry({ attempts: 99, createdAt: 0 })], {
+      deleted: new Set(['new-100-0']),
+      now: 10 ** 12,
+    });
+    expect(evicted[0].reason).toBe('confirmed');
+  });
+
+  it('excludes a pending row whose datasource is not selected, without evicting it', () => {
+    const e = entry({
+      dsId: 'ds2',
+      key: key('ds2', 'g', 'HighCpu'),
+      optimisticRule: optimistic({ datasourceId: 'ds2' }),
+    });
+    const { merged, nextPending } = reconcile([], [e], { selected: ['ds1'] });
+    expect(merged).toHaveLength(0); // hidden
+    expect(nextPending).toHaveLength(1); // but retained
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergePending()
+// ---------------------------------------------------------------------------
+
+describe('mergePending', () => {
+  it('appends only unconfirmed, selected, non-deleted optimistic rows', () => {
+    const confirmed = rule({ id: 'ds1-g2-Other', group: 'g2', name: 'Other' });
+    const merged = mergePending([confirmed], [entry()], new Set(), ['ds1']);
+    expect(merged.map((r) => r.id)).toEqual(['ds1-g2-Other', 'new-100-0']);
+  });
+
+  it('never appends a pending row once its key appears in the querier response', () => {
+    const merged = mergePending([rule()], [entry()], new Set(), ['ds1']);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe('ds1-g-HighCpu');
+  });
+
+  it('hides a pending row whose optimistic id was deleted', () => {
+    const merged = mergePending([], [entry()], new Set(['new-100-0']), ['ds1']);
+    expect(merged).toHaveLength(0);
+  });
+});

--- a/public/components/alerting/monitors_table/index.tsx
+++ b/public/components/alerting/monitors_table/index.tsx
@@ -23,6 +23,7 @@ import { Datasource, UnifiedRuleSummary } from '../../../../common/types/alertin
 import { useFacetCollapse } from '../facet_filter_panel';
 import { isStandardOpenSearchDatasource } from '../shared_constants';
 import { buildTableColumns, DEFAULT_VISIBLE } from './monitors_table_columns';
+import { isPending } from './pending_rules';
 import {
   buildSuggestions,
   collectLabelKeys,
@@ -229,7 +230,13 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
     () => rules.filter((r) => matchesSearch(r, searchQuery) && matchesFilters(r, filters)),
     [rules, searchQuery, filters]
   );
-  const selectableIds = useMemo(() => new Set(rules.map((r) => r.id)), [rules]);
+  // Pending (optimistic, unconfirmed) rows carry a synthetic id the backend
+  // doesn't know yet, so they must not be checkbox-selectable — a bulk delete
+  // against a `new-` id would 404.
+  const selectableIds = useMemo(
+    () => new Set(rules.filter((r) => !isPending(r)).map((r) => r.id)),
+    [rules]
+  );
   useEffect(() => {
     setSelectedIds((prev) => {
       const next = new Set(Array.from(prev).filter((id) => selectableIds.has(id)));
@@ -268,7 +275,7 @@ export const MonitorsTable: React.FC<MonitorsTableProps> = ({
     setSelectedIds(next);
   };
   const toggleSelectAll = () => {
-    const selectableFiltered = filtered;
+    const selectableFiltered = filtered.filter((r) => selectableIds.has(r.id));
     const allSelected =
       selectableFiltered.length > 0 && selectableFiltered.every((r) => selectedIds.has(r.id));
     const next = new Set(selectedIds);

--- a/public/components/alerting/monitors_table/monitors_table_columns.tsx
+++ b/public/components/alerting/monitors_table/monitors_table_columns.tsx
@@ -23,7 +23,9 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiHealth,
+  EuiLoadingSpinner,
   EuiTextColor,
+  EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import {
@@ -42,6 +44,7 @@ import {
   TYPE_LABELS,
 } from '../shared_constants';
 import { DEFAULT_WIDTHS } from './resizable_columns';
+import { isPending } from './pending_rules';
 
 // ============================================================================
 // Column Definitions
@@ -105,7 +108,9 @@ export function buildTableColumns({
   setSelectedMonitor,
 }: BuildTableColumnsParams): Array<Record<string, unknown>> {
   const w = (id: string) => `${columnWidths[id] || DEFAULT_WIDTHS[id] || 120}px`;
-  const selectable = filtered;
+  // Pending optimistic rows aren't selectable (their synthetic id would 404),
+  // so exclude them when deciding the header's "all selected" state.
+  const selectable = filtered.filter((item) => !isPending(item));
   const allSelectableSelected =
     selectable.length > 0 && selectable.every((item) => selectedIds.has(item.id));
 
@@ -132,6 +137,7 @@ export function buildTableColumns({
           <input
             type="checkbox"
             checked={selectedIds.has(item.id)}
+            disabled={isPending(item)}
             onChange={() => toggleSelect(item.id)}
             aria-label={i18n.translate(
               'observability.alerting.monitorsTable.columns.selectRowAriaLabel',
@@ -199,9 +205,35 @@ export function buildTableColumns({
         }),
         sortable: true,
         width: w('status'),
-        render: (s: MonitorStatus) => (
-          <EuiHealth color={STATUS_COLORS[s] || 'subdued'}>{s}</EuiHealth>
-        ),
+        render: (s: MonitorStatus, item: UnifiedRuleSummary) => {
+          // Optimistic rows we injected while the querier catches up render a
+          // distinct spinner badge so it's clear the rule is submitted but not
+          // yet confirmed (its actions are disabled — the id would 404).
+          if (isPending(item)) {
+            return (
+              <EuiToolTip
+                content={i18n.translate(
+                  'observability.alerting.monitorsTable.columns.pendingTooltip',
+                  { defaultMessage: 'Waiting for the querier to confirm this rule' }
+                )}
+              >
+                <EuiBadge color="hollow" data-test-subj="pendingRuleBadge">
+                  <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+                    <EuiFlexItem grow={false}>
+                      <EuiLoadingSpinner size="s" />
+                    </EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      {i18n.translate('observability.alerting.monitorsTable.columns.pending', {
+                        defaultMessage: 'Pending',
+                      })}
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiBadge>
+              </EuiToolTip>
+            );
+          }
+          return <EuiHealth color={STATUS_COLORS[s] || 'subdued'}>{s}</EuiHealth>;
+        },
       });
     } else if (colId === 'severity') {
       cols.push({

--- a/public/components/alerting/monitors_table/pending_rules.ts
+++ b/public/components/alerting/monitors_table/pending_rules.ts
@@ -70,7 +70,12 @@ export interface PendingEntry {
   dsId: string;
   /** The row rendered while the rule is unconfirmed (status `pending`, `new-` id). */
   optimisticRule: UnifiedRuleSummary;
-  /** Number of reconcile passes this entry has survived (one per querier refetch). */
+  /**
+   * Number of reconcile passes this entry has survived (one per querier
+   * refetch). Informational only — eviction is driven purely by `ttlMs` so a
+   * healthy-but-slow rule isn't dropped early just because focus/visibility
+   * refetches bumped the pass count faster than wall-clock time elapsed.
+   */
   attempts: number;
   /** Epoch ms the entry was added — drives the TTL eviction. */
   createdAt: number;
@@ -78,18 +83,15 @@ export interface PendingEntry {
 }
 
 export interface PendingRulesConfig {
-  /** Max reconcile passes before giving up and warning. */
-  maxAttempts: number;
   /** Wall-clock budget (ms) before giving up and warning. */
   ttlMs: number;
 }
 
 export const DEFAULT_PENDING_RULES_CONFIG: PendingRulesConfig = {
-  maxAttempts: 6,
   ttlMs: 120_000,
 };
 
-export type EvictReason = 'confirmed' | 'deleted' | 'expired' | 'exhausted';
+export type EvictReason = 'confirmed' | 'deleted' | 'expired';
 
 export interface EvictedEntry {
   entry: PendingEntry;
@@ -143,8 +145,7 @@ export function mergePending(
  *   (a) key present in the querier → evict (confirmed), silent.
  *   (b) optimistic id in `deletedRuleIds` → evict (deleted), never resurrected.
  *   (c) age past `ttlMs` → evict (expired), warn.
- *   (d) attempts at `maxAttempts` → evict (exhausted), warn.
- *   (e) otherwise keep and increment attempts.
+ *   (d) otherwise keep and increment attempts (informational).
  *
  * `selectedDsIds` only scopes which surviving rows are appended to `merged`
  * (an entry on a currently-unselected datasource stays pending but is hidden);
@@ -176,15 +177,11 @@ export function reconcilePending(
       evicted.push({ entry, reason: 'deleted' });
       continue;
     }
-    // Age is checked before attempts so a slow-but-recent entry that has simply
-    // ridden many polls isn't reported as "expired" (and vice-versa the age
-    // gate fires even when attempts are still under the cap).
+    // Eviction is purely wall-clock: a rule that's simply slow to propagate
+    // shouldn't be dropped just because many focus/visibility/poll refetches
+    // bumped the pass count. Only elapsed time past `ttlMs` gives up (and warns).
     if (now - entry.createdAt > config.ttlMs) {
       evicted.push({ entry, reason: 'expired' });
-      continue;
-    }
-    if (entry.attempts >= config.maxAttempts) {
-      evicted.push({ entry, reason: 'exhausted' });
       continue;
     }
     nextPending.push({ ...entry, attempts: entry.attempts + 1 });

--- a/public/components/alerting/monitors_table/pending_rules.ts
+++ b/public/components/alerting/monitors_table/pending_rules.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Optimistic "pending rule" cache — pure core.
+ *
+ * A newly-created Prometheus/metrics alert rule is persisted synchronously to
+ * Cortex's ruler CONFIG store (a 2xx from the create POST means "persisted"),
+ * but the unified rules list reads the QUERIER (`/api/v1/rules`), which only
+ * surfaces the rule once the ruler poll (~60s) + one evaluation interval have
+ * elapsed. Between those two moments the rule genuinely exists but is invisible
+ * to the list.
+ *
+ * This module lets the page carry an optimistic row for that window and
+ * reconcile it against each querier refetch WITHOUT a dedicated timer — the
+ * reconcile rides the existing 15s background poll + tab-activate + window-focus
+ * refetches. A poll that hasn't yet seen the rule means "not propagated yet",
+ * NOT "creation failed" — so eviction on timeout warns (soft), never errors.
+ *
+ * Everything here is PURE (no React, no module state, no clock) so it can be
+ * exhaustively unit-tested; the singleton store + React glue live in
+ * `../hooks/use_pending_rules.ts`.
+ */
+import type { UnifiedRuleSummary } from '../../../../common/types/alerting';
+
+// ============================================================================
+// Identity
+// ============================================================================
+
+/**
+ * The single match key used everywhere a pending row must line up with its
+ * eventual querier row: `${dsId}|${group}|${name}`, group + name trimmed and
+ * lower-cased. This mirrors the (datasource, group, name) tuple the create-time
+ * duplicate check uses (case-insensitive + trimmed) and the server's canonical
+ * id `${dsId}-${group}-${name}` (`promRuleToUnified`) — but keyed off the
+ * rule's `group`/`name` FIELDS rather than by parsing the id, so it degrades
+ * cleanly for OpenSearch/PPL monitors (no group → empty middle segment).
+ *
+ * CRITICAL: at create time build the key from the create PAYLOAD's groupName
+ * (`ruleGroupLabel || name`, or `form.groupName || form.monitorName`), never
+ * from `formStateToRule` output — the latter carries no group, so its key
+ * would never match the confirmed row.
+ */
+export function key(dsId: string, group: string | undefined, name: string): string {
+  const g = (group ?? '').trim().toLowerCase();
+  const n = (name ?? '').trim().toLowerCase();
+  return `${dsId}|${g}|${n}`;
+}
+
+/**
+ * True for an optimistic pending row this cache injected — status `pending`
+ * AND a synthetic `new-` id. Both conditions are required: a real Cortex rule
+ * whose querier state is `pending` (evaluating, not yet firing) also carries
+ * status `pending`, but has a canonical id, so it must NOT be treated as one
+ * of our optimistic rows (its actions work; ours would 404).
+ */
+export function isPending(rule: UnifiedRuleSummary): boolean {
+  return rule.status === 'pending' && typeof rule.id === 'string' && rule.id.startsWith('new-');
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PendingEntry {
+  /** `key(dsId, group, name)` — the match key against querier rows. */
+  key: string;
+  dsId: string;
+  /** The row rendered while the rule is unconfirmed (status `pending`, `new-` id). */
+  optimisticRule: UnifiedRuleSummary;
+  /** Number of reconcile passes this entry has survived (one per querier refetch). */
+  attempts: number;
+  /** Epoch ms the entry was added — drives the TTL eviction. */
+  createdAt: number;
+  origin: 'create' | 'clone' | 'metrics' | 'batch';
+}
+
+export interface PendingRulesConfig {
+  /** Max reconcile passes before giving up and warning. */
+  maxAttempts: number;
+  /** Wall-clock budget (ms) before giving up and warning. */
+  ttlMs: number;
+}
+
+export const DEFAULT_PENDING_RULES_CONFIG: PendingRulesConfig = {
+  maxAttempts: 6,
+  ttlMs: 120_000,
+};
+
+export type EvictReason = 'confirmed' | 'deleted' | 'expired' | 'exhausted';
+
+export interface EvictedEntry {
+  entry: PendingEntry;
+  reason: EvictReason;
+}
+
+export interface ReconcileResult {
+  /** Querier rows with surviving pending rows appended (deduped by key). */
+  merged: UnifiedRuleSummary[];
+  /** Entries to keep for the next pass (attempts incremented). */
+  nextPending: PendingEntry[];
+  /** Entries removed this pass, with the reason. */
+  evicted: EvictedEntry[];
+}
+
+// ============================================================================
+// Merge (pure, no mutation) — used for render on every rules/pending change
+// ============================================================================
+
+/**
+ * Build the view: querier rows first, then each still-pending optimistic row
+ * whose datasource is currently selected and whose key hasn't yet appeared in
+ * the querier response (and whose optimistic row wasn't user-deleted). Deduping
+ * by key BEFORE appending guarantees there's never a two-row flash during the
+ * confirm window.
+ */
+export function mergePending(
+  querierRules: UnifiedRuleSummary[],
+  pending: PendingEntry[],
+  deletedRuleIds: Set<string>,
+  selectedDsIds: string[]
+): UnifiedRuleSummary[] {
+  const querierKeys = new Set(querierRules.map((r) => key(r.datasourceId, r.group, r.name)));
+  const selected = new Set(selectedDsIds);
+  const appended = pending
+    .filter(
+      (e) =>
+        selected.has(e.dsId) && !querierKeys.has(e.key) && !deletedRuleIds.has(e.optimisticRule.id)
+    )
+    .map((e) => e.optimisticRule);
+  return [...querierRules, ...appended];
+}
+
+// ============================================================================
+// Reconcile (pure) — runs once per querier refetch
+// ============================================================================
+
+/**
+ * Reconcile the pending set against a fresh querier response. Per entry, in
+ * priority order:
+ *   (a) key present in the querier → evict (confirmed), silent.
+ *   (b) optimistic id in `deletedRuleIds` → evict (deleted), never resurrected.
+ *   (c) age past `ttlMs` → evict (expired), warn.
+ *   (d) attempts at `maxAttempts` → evict (exhausted), warn.
+ *   (e) otherwise keep and increment attempts.
+ *
+ * `selectedDsIds` only scopes which surviving rows are appended to `merged`
+ * (an entry on a currently-unselected datasource stays pending but is hidden);
+ * it never causes eviction — that's the datasource-change handler's job.
+ *
+ * Note: the approved design lists this as `(querierRules, pending,
+ * deletedRuleIds, now, config)`; `selectedDsIds` is threaded in ahead of
+ * `config` because `merged` needs it (the design body references
+ * `dsId ∈ selectedDsIds`).
+ */
+export function reconcilePending(
+  querierRules: UnifiedRuleSummary[],
+  pending: PendingEntry[],
+  deletedRuleIds: Set<string>,
+  now: number,
+  selectedDsIds: string[],
+  config: PendingRulesConfig = DEFAULT_PENDING_RULES_CONFIG
+): ReconcileResult {
+  const querierKeys = new Set(querierRules.map((r) => key(r.datasourceId, r.group, r.name)));
+  const nextPending: PendingEntry[] = [];
+  const evicted: EvictedEntry[] = [];
+
+  for (const entry of pending) {
+    if (querierKeys.has(entry.key)) {
+      evicted.push({ entry, reason: 'confirmed' });
+      continue;
+    }
+    if (deletedRuleIds.has(entry.optimisticRule.id)) {
+      evicted.push({ entry, reason: 'deleted' });
+      continue;
+    }
+    // Age is checked before attempts so a slow-but-recent entry that has simply
+    // ridden many polls isn't reported as "expired" (and vice-versa the age
+    // gate fires even when attempts are still under the cap).
+    if (now - entry.createdAt > config.ttlMs) {
+      evicted.push({ entry, reason: 'expired' });
+      continue;
+    }
+    if (entry.attempts >= config.maxAttempts) {
+      evicted.push({ entry, reason: 'exhausted' });
+      continue;
+    }
+    nextPending.push({ ...entry, attempts: entry.attempts + 1 });
+  }
+
+  const merged = mergePending(querierRules, nextPending, deletedRuleIds, selectedDsIds);
+  return { merged, nextPending, evicted };
+}

--- a/public/components/alerting/toast_helpers.tsx
+++ b/public/components/alerting/toast_helpers.tsx
@@ -57,6 +57,11 @@ export function navigateToRuleInAlarmsPage(monitorName: string, dsId: string): v
  * "View rule" inline link that lands on the alarms page Rules tab,
  * filtered to the new monitor.
  *
+ * `pending` appends a note that the rule may take up to a minute to appear —
+ * set it ONLY for Prometheus/Cortex creates, whose querier lags the create by
+ * the ruler poll + one eval interval. OpenSearch monitors confirm immediately,
+ * so the note would be misleading there.
+ *
  * No-ops gracefully when the toasts service hasn't been wired yet — same
  * shape as the existing `useToast` helper, so the create flow can call
  * this even on unusual init paths without throwing.
@@ -64,9 +69,11 @@ export function navigateToRuleInAlarmsPage(monitorName: string, dsId: string): v
 export function showMonitorCreatedToast({
   monitorName,
   dsId,
+  pending = false,
 }: {
   monitorName: string;
   dsId: string;
+  pending?: boolean;
 }): void {
   const toasts = coreRefs?.toasts;
   if (!toasts) return;
@@ -76,14 +83,23 @@ export function showMonitorCreatedToast({
       defaultMessage: 'Alert rule created',
     }),
     text: toMountPoint(
-      <EuiLink
-        onClick={() => navigateToRuleInAlarmsPage(monitorName, dsId)}
-        data-test-subj="alertManagerToastViewRule"
-      >
-        {i18n.translate('observability.alerting.toast.monitorCreated.link', {
-          defaultMessage: 'View rule',
-        })}
-      </EuiLink>
+      <>
+        {pending && (
+          <p>
+            {i18n.translate('observability.alerting.toast.monitorCreated.pendingNote', {
+              defaultMessage: 'It may take up to a minute to appear in the list.',
+            })}
+          </p>
+        )}
+        <EuiLink
+          onClick={() => navigateToRuleInAlarmsPage(monitorName, dsId)}
+          data-test-subj="alertManagerToastViewRule"
+        >
+          {i18n.translate('observability.alerting.toast.monitorCreated.link', {
+            defaultMessage: 'View rule',
+          })}
+        </EuiLink>
+      </>
     ),
     toastLifeTimeMs: TOAST_LIFETIME_MS,
   });


### PR DESCRIPTION
> ✅ **#2862 merged; this PR was rebased onto `main` (commit d484847c).** The diff is now just the optimistic pending-rule cache — client-side only, no server/route changes.

### Problem
A newly-created Prometheus/metrics alert rule is persisted **synchronously** to Cortex's ruler config store (a 2xx = "persisted"), but the unified rules list reads the **querier** (`/api/v1/rules`), which only surfaces the rule ~60s+ later (ruler poll + one eval interval). Two bugs made it flicker/disappear:

1. The optimistic insert built the row with a throwaway `new-<ts>` id and **no group**, so it never matched the server's canonical id `${dsId}-${group}-${name}`.
2. `useRulesData.fetchRules` **full-replaces** the list on every refetch (15s poll, tab-activate, focus, manual Refresh) — dropping the optimistic row before propagation, and the ad-hoc `setTimeout(refetchRules, 15000)` calls actively triggered the drop.

A poll timeout means **"not propagated yet"**, not "creation failed" — so timeout warns softly, never errors.

### Approach
An optimistic **pending-rule cache** that carries the row for that window and reconciles against each querier refetch — **no new timer** (rides the existing poll + tab-activate + focus refetches).

- **Pure core** `monitors_table/pending_rules.ts`: one match `key` (`dsId|group|name`, trimmed + lowercased, built from the create *payload's* groupName), `isPending` (status `pending` **and** synthetic `new-` id — so a real Cortex-pending rule isn't mistaken for ours), `mergePending`, and `reconcilePending` (evict on confirm / user-delete / TTL 120s / maxAttempts 6; dedupe-before-append so no two-row flash).
- **State** `hooks/use_pending_rules.ts`: in-memory **module singleton** (the `coreRefs` precedent — survives the Explore→Alerts SPA nav; **no** sessionStorage, so a hard reload cleanly falls back to the poll rather than resurrecting a dead row) + a `useSyncExternalStore` hook. Reconcile runs **once per querier refetch** (effect keyed on `rules` alone); the rendered view is a separate pure derivation so an added row appears immediately.
- **Wiring** in `alarms_page.tsx`: layer `mergedRules` into `visibleRules`; route create/clone/metrics/batch through `addPending`; **retire** `refetchTimerRef` + all four `setTimeout(refetchRules, 15000)` (keep the immediate refetch after each create); scope pending to the selection on datasource change; soft **warning** toast (deduped per key) on timeout.
- **UX**: spinner `pendingRuleBadge` in the status cell; Edit/Delete/Clone/Enable disabled in the detail flyout + pending rows excluded from checkbox selection (their synthetic id would 404); Prometheus create toast gains a "may take up to a minute" note.

### Out of scope (future follow-up)
Config-API positive confirmation (`RulerClient.getRuleGroup`) for lag-free confirm + honest write-failed vs querier-lag distinction. v1 is poll-only.

### Tests
- Heavy branch coverage on the pure `reconcilePending` / `key` / `isPending` / `mergePending` (incl. group case/whitespace-insensitivity, confirm-vs-delete/ttl/attempts priority, no-resurrection, ds-scoping).
- Hook tests: immediate display on add, silent evict on confirm, warn-once on timeout, drop-on-datasource-change.
- Thin component tests: pending badge renders, actions disabled, pending row not selectable, Prom-only toast note.

All 465 alerting suites pass; `yarn lint --fix` clean via the pre-commit hook.
