### PR TITLE
fix(alerting): pin Prometheus rule routes to the user namespace

### DIFF
--- a/server/routes/alerting/__tests__/prometheus_handlers.test.ts
+++ b/server/routes/alerting/__tests__/prometheus_handlers.test.ts
@@ -154,23 +154,25 @@ describe('handleCreatePrometheusRule — shared group merge', () => {
     expect(ruler.upsertRuleGroup).not.toHaveBeenCalled();
   });
 
-  it('reads and writes the given namespace override (defaults to the user namespace otherwise)', async () => {
+  it('ignores a client-supplied namespace and always uses the user namespace', async () => {
     const ruler = makeRulerClient(null);
+    // A crafted `namespace` field (not part of the payload contract) must not
+    // let a caller target another namespace of the ruler — the create is pinned
+    // to USER_RULES_NAMESPACE for both the collision read and the write.
     const result = await handleCreatePrometheusRule(ruler as any, mockClient, mockDatasource, {
       ...basePayload,
       groupName: 'team-rules',
       namespace: 'custom-ns',
-    });
+    } as any);
 
-    expect(result.namespace).toBe('custom-ns');
-    // Both the collision read and the write target the overridden namespace.
+    expect(result.namespace).toBe(USER_RULES_NAMESPACE);
     expect(ruler.getRuleGroup).toHaveBeenCalledWith(
       mockClient,
       mockDatasource,
-      'custom-ns',
+      USER_RULES_NAMESPACE,
       'team-rules'
     );
-    expect(ruler.upsertRuleGroup.mock.calls[0][2]).toBe('custom-ns');
+    expect(ruler.upsertRuleGroup.mock.calls[0][2]).toBe(USER_RULES_NAMESPACE);
   });
 
   it('allows a create with a distinct name to merge into an existing group', async () => {
@@ -239,24 +241,33 @@ describe('handleDeletePrometheusRule — per-rule splice', () => {
     );
   });
 
-  it('deletes from the given namespace override', async () => {
-    const ruler = makeRulerClient(null);
+  it('pins deletes to the user namespace (no client-controllable namespace)', async () => {
+    // The splice path (ruleName leaves siblings) must also target only
+    // USER_RULES_NAMESPACE — this route can never touch another namespace.
+    const ruler = makeRulerClient({
+      groupName: 'team-rules',
+      interval: 60,
+      rules: [
+        { type: 'alerting', name: 'RuleA', expr: 'up == 0', for: '1m' } as any,
+        { type: 'alerting', name: 'RuleB', expr: 'up == 1', for: '1m' } as any,
+      ],
+    });
     await handleDeletePrometheusRule(
       ruler as any,
       mockClient,
       mockDatasource,
       'team-rules',
       undefined,
-      undefined,
-      'custom-ns'
+      'RuleA'
     );
 
-    expect(ruler.deleteRuleGroup).toHaveBeenCalledWith(
+    expect(ruler.getRuleGroup).toHaveBeenCalledWith(
       mockClient,
       mockDatasource,
-      'custom-ns',
+      USER_RULES_NAMESPACE,
       'team-rules'
     );
+    expect(ruler.upsertRuleGroup.mock.calls[0][2]).toBe(USER_RULES_NAMESPACE);
   });
 
   it('deletes the whole group when no ruleName is provided', async () => {

--- a/server/routes/alerting/mutations/prometheus_handlers.ts
+++ b/server/routes/alerting/mutations/prometheus_handlers.ts
@@ -35,14 +35,6 @@ export interface PrometheusRulePayload {
   /** Optional group name override. Defaults to the rule name. */
   groupName?: string;
   /**
-   * Optional Cortex namespace override. Defaults to `USER_RULES_NAMESPACE`.
-   * Rules are identified by the full (namespace, group, name) tuple; the
-   * flyout currently pins this to the one user namespace, but threading it
-   * explicitly keeps the create/delete guard correct if a future surface
-   * writes to a different namespace.
-   */
-  namespace?: string;
-  /**
    * When false (default), a create that collides with an existing same-named
    * rule in the target group is rejected (409) rather than silently replacing
    * it. Edit flows that intend to replace pass `true`.
@@ -107,10 +99,12 @@ export async function handleCreatePrometheusRule(
   logger?: Logger
 ): Promise<{ success: boolean; groupName: string; namespace: string }> {
   const group = buildRuleGroup(payload);
-  // Rules are identified by the full (namespace, group, name) tuple. Default
-  // to the single user namespace, but honor an explicit override so the guard
-  // below compares within the right namespace.
-  const namespace = payload.namespace ?? USER_RULES_NAMESPACE;
+  // Rules created through this route always live in the single user namespace.
+  // The namespace is intentionally NOT client-controllable: exposing it would
+  // let any caller of this route read/merge/overwrite rule groups in other
+  // namespaces of the same ruler (e.g. SLO or recording-rule groups). Pinning
+  // it here keeps this route scoped to user-authored alerting rules.
+  const namespace = USER_RULES_NAMESPACE;
 
   // Rule groups are shared: multiple rules may live in the same group, and
   // the ruler's POST is create-or-replace on (namespace, groupName). Merge with
@@ -158,12 +152,12 @@ export async function handleDeletePrometheusRule(
   datasource: Datasource,
   groupName: string,
   logger?: Logger,
-  ruleName?: string,
-  namespaceOverride?: string
+  ruleName?: string
 ): Promise<{ success: boolean }> {
-  // Identity is (namespace, group, name); default to the single user
-  // namespace but honor an explicit override for symmetry with create.
-  const namespace = namespaceOverride ?? USER_RULES_NAMESPACE;
+  // Deletes are pinned to the single user namespace — not client-controllable,
+  // so this route can never delete rule groups in other namespaces of the same
+  // ruler (e.g. SLO groups). Mirrors the create handler.
+  const namespace = USER_RULES_NAMESPACE;
   // When a ruleName is provided, splice just that rule out of the group so
   // sibling rules in a shared group are preserved. The whole group is only
   // deleted when it would become empty (or no ruleName was given).

--- a/server/routes/alerting/mutations/prometheus_routes.ts
+++ b/server/routes/alerting/mutations/prometheus_routes.ts
@@ -56,10 +56,10 @@ const prometheusRuleBodySchema = schema.object({
   }),
   enabled: schema.boolean({ defaultValue: true }),
   groupName: schema.maybe(schema.string({ minLength: 1, maxLength: 256 })),
-  // Optional Cortex namespace. Defaults server-side to the single user
-  // namespace; accepted here so a future surface can target another namespace
-  // without a schema change (identity is the full namespace/group/name tuple).
-  namespace: schema.maybe(schema.string({ minLength: 1, maxLength: 256 })),
+  // Note: the Cortex namespace is intentionally NOT a client input — it is
+  // pinned server-side to the single user namespace (see prometheus_handlers).
+  // Accepting it here would let a caller target arbitrary namespaces of the
+  // same ruler (e.g. SLO/recording-rule groups).
   // When false (the default), creating a rule whose name already exists in the
   // target group is rejected with 409 instead of silently replacing it. Edit
   // flows that intend to replace an existing rule pass `overwrite: true`.
@@ -121,7 +121,8 @@ export function registerPrometheusRuleRoutes(
         }),
         query: schema.object({
           ruleName: schema.maybe(schema.string({ minLength: 1 })),
-          namespace: schema.maybe(schema.string({ minLength: 1, maxLength: 256 })),
+          // No `namespace` input — deletes are pinned server-side to the user
+          // namespace so this route can't remove other namespaces' rule groups.
         }),
       },
     },
@@ -134,8 +135,7 @@ export function registerPrometheusRuleRoutes(
           datasource,
           req.params.groupName,
           logger,
-          req.query.ruleName,
-          req.query.namespace
+          req.query.ruleName
         );
         return res.ok({ body: result });
       } catch (e: unknown) {


### PR DESCRIPTION
### What
The `Code-Diff-Analyzer` flagged the Prometheus rule mutation routes (added in #2862). This PR resolves the two **HIGH** findings and explains why the **MEDIUM** is intentionally left as-is.

### HIGH — client-controllable Cortex `namespace` (fixed)
`POST /api/alerting/prometheus/{dsId}/rules` (body) and `DELETE …/rules/{groupName}` (query) accepted a `namespace` param with no allowlist and forwarded it verbatim to the ruler. The ruler client is **shared across features** (SLO / recording rules live in *other* namespaces of the same ruler), and OSD is the authz boundary — so any authenticated caller could read/merge/overwrite or delete rule groups **outside** the intended `observability-alerting` namespace.

The UI never sends `namespace` (create payloads omit it; the flyout's namespace field only drives the YAML preview) — it was dead client input with real blast radius. **Fix:** removed it as a client input and pinned both handlers to `USER_RULES_NAMESPACE`. Zero UX impact. The two override unit tests are repurposed as regressions asserting a crafted `namespace` is ignored.

### MEDIUM — `overwrite` flag (intentionally not changed)
`overwrite` is the **edit** mechanism (edit = `POST /rules` with `overwrite:true` to replace a rule). It grants no capability beyond delete-then-create, which the same caller can already perform on this route (arbitrary `groupName` + create), so it is **not a privilege escalation** — the 409 it bypasses is an accidental-clobber UX guard, not a security control. Removing it would break editing Prometheus rules, so it's kept and documented.

### Tests
`server/routes/alerting` — 167/167 pass (incl. the two rewritten regression tests).

### Relation to #2866
Independent, server-only. #2866 (optimistic pending-rule cache) is client-only and doesn't touch these routes.