### PR TITLE
fix(observability): duplicated dashboard cannot be deleted

### DIFF
--- a/public/components/custom_panels/__tests__/custom_panel_table.test.tsx
+++ b/public/components/custom_panels/__tests__/custom_panel_table.test.tsx
@@ -124,6 +124,12 @@ describe('Panels Table Component', () => {
     await waitFor(() => {
       expect(coreRefs.savedObjectsClient.create).toHaveBeenCalledTimes(1);
     });
+
+    // The copy must not carry the source id, otherwise it shares the original's
+    // row id and selection and deletion act on the wrong dashboard.
+    const [, attributes] = coreRefs.savedObjectsClient.create.mock.calls[0];
+    expect(attributes).not.toHaveProperty('id');
+    expect(attributes.title).toBe('copy');
   });
 
   it('rename a custom panel', async () => {

--- a/public/components/custom_panels/custom_panel_table.tsx
+++ b/public/components/custom_panels/custom_panel_table.tsx
@@ -48,6 +48,7 @@ import { CustomPanelListType, CustomPanelType } from '../../../common/types/cust
 import { getSampleDataModal } from '../common/helpers/add_sample_modal';
 import { DeleteModal } from '../common/helpers/delete_modal';
 import {
+  clonePanel,
   createPanel,
   deletePanels,
   fetchPanels,
@@ -154,12 +155,7 @@ export const CustomPanelTable = ({
           sourcePanel = legacyFetchResult.operationalPanel;
         }
 
-        const { ...newPanel } = {
-          ...sourcePanel,
-          title: newName,
-        };
-
-        dispatch(createPanel(newPanel));
+        dispatch(clonePanel(sourcePanel, newName));
       } catch (err) {
         setToast(
           'Error cloning Observability Dashboard, please make sure you have the correct permission.',

--- a/public/components/custom_panels/redux/__tests__/panel_slice.test.ts
+++ b/public/components/custom_panels/redux/__tests__/panel_slice.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { applyMiddleware, createStore } from '@reduxjs/toolkit';
+import thunk from 'redux-thunk';
+import { coreRefs } from '../../../../framework/core_refs';
+import { rootReducer } from '../../../../framework/redux/reducers';
+import { fetchPanels, selectPanelList } from '../panel_slice';
+
+describe('Panel slice', () => {
+  const store = createStore(rootReducer, applyMiddleware(thunk));
+
+  it('keeps the saved object id when attributes carry a stale id', async () => {
+    coreRefs.savedObjectsClient.find = jest.fn(() =>
+      Promise.resolve({
+        savedObjects: [
+          {
+            id: 'real-id',
+            type: 'observability-panel',
+            attributes: { id: 'stale-source-id', title: 'test (copy)' },
+          },
+        ],
+      })
+    );
+    coreRefs.http.get = jest.fn(() => Promise.resolve({ panels: [] }));
+
+    await store.dispatch(fetchPanels());
+
+    const [panel] = selectPanelList(store.getState());
+    expect(panel.id).toBe('real-id');
+    expect(panel.objectId).toBe('observability-panel:real-id');
+    expect(panel.title).toBe('test (copy)');
+  });
+});

--- a/public/components/custom_panels/redux/panel_slice.ts
+++ b/public/components/custom_panels/redux/panel_slice.ts
@@ -133,33 +133,34 @@ const updateLegacyPanel = (panel: CustomPanelType) =>
 
 const updateSavedObjectPanel = (panel: CustomPanelType) => savedObjectPanelsClient.update(panel);
 
-export const uuidRx = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
+export const uuidRx =
+  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
 
 export const isUuid = (id) => !!id.match(uuidRx);
 
-export const updatePanel = (
-  panel: CustomPanelType,
-  successMsg: string,
-  failureMsg: string
-) => async (dispatch, getState) => {
-  const { toasts } = coreRefs;
+export const updatePanel =
+  (panel: CustomPanelType, successMsg: string, failureMsg: string) =>
+  async (dispatch, getState) => {
+    const { toasts } = coreRefs;
 
-  try {
-    if (isUuid(panel.id)) await updateSavedObjectPanel(panel);
-    else await updateLegacyPanel(panel);
-    if (successMsg) {
-      toasts!.add(successMsg);
+    try {
+      if (isUuid(panel.id)) await updateSavedObjectPanel(panel);
+      else await updateLegacyPanel(panel);
+      if (successMsg) {
+        toasts!.add(successMsg);
+      }
+      dispatch(setPanel(panel));
+      const panelList = getState().customPanel.panelList.map((p) =>
+        p.id === panel.id ? panel : p
+      );
+      dispatch(setPanelList(panelList));
+    } catch (e) {
+      if (failureMsg) {
+        toasts!.addDanger(failureMsg);
+      }
+      console.error(e);
     }
-    dispatch(setPanel(panel));
-    const panelList = getState().customPanel.panelList.map((p) => (p.id === panel.id ? panel : p));
-    dispatch(setPanelList(panelList));
-  } catch (e) {
-    if (failureMsg) {
-      toasts!.addDanger(failureMsg);
-    }
-    console.error(e);
-  }
-};
+  };
 
 export const addVizToPanels = (panels, vizId) => async (dispatch, getState) => {
   forEach(panels, (oldPanel) => {
@@ -203,26 +204,24 @@ export const addMultipleVizToPanels = async (panels, vizIds) => {
   );
 };
 
-export const replaceVizInPanel = (oldPanel, oldVizId, vizId, newVisualizationTitle) => async (
-  dispatch,
-  getState
-) => {
-  const panel = getState().customPanel.panelList.find((p) => p.id === oldPanel.id);
+export const replaceVizInPanel =
+  (oldPanel, oldVizId, vizId, newVisualizationTitle) => async (dispatch, getState) => {
+    const panel = getState().customPanel.panelList.find((p) => p.id === oldPanel.id);
 
-  const allVisualizations = panel!.visualizations;
+    const allVisualizations = panel!.visualizations;
 
-  const visualizationsWithNewPanel = addVisualizationPanel(vizId, oldVizId, allVisualizations);
+    const visualizationsWithNewPanel = addVisualizationPanel(vizId, oldVizId, allVisualizations);
 
-  const updatedPanel = { ...panel, visualizations: visualizationsWithNewPanel };
+    const updatedPanel = { ...panel, visualizations: visualizationsWithNewPanel };
 
-  dispatch(
-    updatePanel(
-      updatedPanel,
-      `Visualization ${newVisualizationTitle} successfully added!`,
-      `Error in adding ${newVisualizationTitle} visualization to the panel`
-    )
-  );
-};
+    dispatch(
+      updatePanel(
+        updatedPanel,
+        `Visualization ${newVisualizationTitle} successfully added!`,
+        `Error in adding ${newVisualizationTitle} visualization to the panel`
+      )
+    );
+  };
 
 const deletePanelSO = (customPanelIdList: string[]) => {
   const soPanelIds = customPanelIdList.filter((id) => isUuid(id));
@@ -338,20 +337,18 @@ const saveRenamedPanelSO = async (id, name) => {
 };
 
 // Renames an existing CustomPanel
-export const renameCustomPanel = (editedCustomPanelName: string, id: string) => async (
-  dispatch,
-  getState
-) => {
-  const panel = getState().customPanel.panelList.find((p) => p.id === id);
-  const updatedPanel = { ...panel, title: editedCustomPanelName };
-  dispatch(
-    updatePanel(
-      updatedPanel,
-      `Operational Panel successfully renamed into "${editedCustomPanelName}"`,
-      'Error renaming Operational Panel, please make sure you have the correct permission.'
-    )
-  );
-};
+export const renameCustomPanel =
+  (editedCustomPanelName: string, id: string) => async (dispatch, getState) => {
+    const panel = getState().customPanel.panelList.find((p) => p.id === id);
+    const updatedPanel = { ...panel, title: editedCustomPanelName };
+    dispatch(
+      updatePanel(
+        updatedPanel,
+        `Operational Panel successfully renamed into "${editedCustomPanelName}"`,
+        'Error renaming Operational Panel, please make sure you have the correct permission.'
+      )
+    );
+  };
 
 /*
  ** UTILITY FUNCTIONS

--- a/public/components/custom_panels/redux/panel_slice.ts
+++ b/public/components/custom_panels/redux/panel_slice.ts
@@ -357,10 +357,11 @@ export const renameCustomPanel = (editedCustomPanelName: string, id: string) => 
  ** UTILITY FUNCTIONS
  */
 const savedObjectToCustomPanel = (so: SimpleSavedObject<PanelType>): CustomPanelType => ({
-  id: so.id,
+  ...so.attributes,
+  // Spread first so stale copies of these in attributes cannot shadow the real values.
   type: so.type,
   objectId: so.type + ':' + so.id,
-  ...so.attributes,
+  id: so.id,
   savedObject: true,
 });
 


### PR DESCRIPTION
### Description

Duplicating an Observability Dashboard produced a copy that could not be deleted. Selecting either row selected all of them, deleting the copy deleted the original instead, and a second delete attempt failed with `Error deleting Observability Dashboards, please make sure you have the correct permission.`

**Root cause.** `onClone` built the new panel from the source with its `id` intact, so the source id was persisted as a saved object attribute. `savedObjectToCustomPanel` then spread those attributes over the real saved object id.

```diff
 const savedObjectToCustomPanel = (so: SimpleSavedObject<PanelType>): CustomPanelType => ({
-  id: so.id,                          // a stale `id` in attributes wins over this
-  type: so.type,
-  objectId: so.type + ':' + so.id,
-  ...so.attributes,
+  ...so.attributes,
+  type: so.type,
+  objectId: so.type + ':' + so.id,
+  id: so.id,                          // spread first, so the real id always wins
   savedObject: true,
 });
```

So every copy took the original's id as its row id. The table keys selection on that id, hence one click selecting all copies. Delete then targeted the original, and the follow-up delete hit a document that no longer existed, which the catch block reports as a permission error.

The stale id is not a uuid, so `isUuid` routed copies down the legacy branch. Editing a copy posted its updates to the original, and duplicating navigated to the original rather than the new copy.

**Fix.** `onClone` now dispatches the existing `clonePanel` thunk, which already strips the id and is what both panel view pages use. `savedObjectToCustomPanel` spreads attributes first so `type`, `objectId`, and `id` are authoritative.

**Notes for reviewers**

1. **Two regression tests ship with this.** Both were verified red against the pre-fix code and green after. One asserts the clone payload carries no `id`, the other that a stale `id` in attributes cannot shadow the real saved object id.
2. **Copies now get their own timestamps.** `clonePanel` sets `dateCreated` and `dateModified`, which the previous table path did not, so a duplicate no longer inherits the original's Last updated value in a table sorted on that column.

**Before**


https://github.com/user-attachments/assets/67540dda-c229-47bc-8da3-45c3547d4725



**After**

https://github.com/user-attachments/assets/4ef6015d-8bd0-4eeb-b4a2-56d5194c3184



### Issues Resolved

Fixes #2477


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
