### PR TITLE
feat(alerting): point-and-click condition builder for Prometheus metric rules

### DIFF
--- a/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
@@ -24,21 +24,22 @@ jest.mock('../promql_editor', () => ({
 jest.mock('../metric_browser', () => ({
   MetricBrowser: () => <div data-test-subj="metricBrowserMock" />,
 }));
-// Stub the shared builder with a button that emits a query, so tests can
-// simulate an explicit builder selection (the form seeds query: '' and the
-// Create button stays disabled until the builder produces one)
-jest.mock('../create_monitor/prom_query_builder', () => ({
-  PromQueryBuilder: ({ onQueryChange }: { onQueryChange: (q: string) => void }) => (
-    <button data-test-subj="mockBuilderSetQuery" onClick={() => onQueryChange('up{job="api"}')} />
-  ),
-  // Lightweight stand-in: builder-representable = a bare metric or metric{...};
-  // anything else (rates, comparisons) returns null. Used by the Query section
-  // to decide the "builder will overwrite your expression" warning.
-  parseBuilderQuery: (q: string) => {
-    const m = (q || '').trim().match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?$/);
-    return m ? { metric: m[1] } : null;
-  },
-}));
+// Stub the shared builder *component* with a button that emits a query, but keep
+// the REAL parse/compose core (from prom_condition) so representability decisions
+// in these tests match what the component actually does. Using a hand-rolled
+// stand-in `parseExpr` here previously diverged from the real one (it only
+// recognised bare selectors), which made "non-representable" fixtures pass for
+// the wrong reason. `up{job="api"}` (a bare selector) is builder-representable.
+jest.mock('../create_monitor/prom_query_builder', () => {
+  const realCore = jest.requireActual('../create_monitor/prom_condition');
+  return {
+    PromQueryBuilder: ({ onQueryChange }: { onQueryChange: (q: string) => void }) => (
+      <button data-test-subj="mockBuilderSetQuery" onClick={() => onQueryChange('up{job="api"}')} />
+    ),
+    parseExpr: realCore.parseExpr,
+    buildExpr: realCore.buildExpr,
+  };
+});
 
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
@@ -152,22 +153,22 @@ describe('CreateMetricsMonitor', () => {
   });
 
   it('seeds the query from initialQuery copied off the Explore Metrics page', () => {
+    // A copied expression the builder cannot represent (histogram_quantile) opens
+    // in Code mode, pre-filled, visible/editable — never hidden-yet-submittable.
     render(
       <CreateMetricsMonitor
         onCancel={jest.fn()}
         onSave={jest.fn()}
         datasourceId="prom-1"
-        initialQuery="rate(http_requests_total[5m])"
+        initialQuery="histogram_quantile(0.9, rate(http_requests_total[5m]))"
       />
     );
 
-    // The pre-filled expression is visible/editable (not hidden), so a complex
-    // expression the builder can't represent is never hidden-yet-submittable.
     const expr = document.querySelector(
       '[data-test-subj="metricsMonitorPromQlExpression"]'
     ) as HTMLTextAreaElement;
     expect(expr).not.toBeNull();
-    expect(expr.value).toBe('rate(http_requests_total[5m])');
+    expect(expr.value).toBe('histogram_quantile(0.9, rate(http_requests_total[5m]))');
 
     // With the query seeded, Create enables as soon as a name is entered — no
     // separate builder selection required.
@@ -179,14 +180,15 @@ describe('CreateMetricsMonitor', () => {
     expect(createBtn.disabled).toBe(false);
   });
 
-  it('defaults to Code mode when a query is copied in, Builder mode when empty', () => {
-    // Copied query -> Code mode: raw expression shown, builder hidden.
+  it('defaults to Builder mode, but Code mode for a copied query the builder cannot represent', () => {
+    // Copied query the real parser can't represent (histogram_quantile) -> Code
+    // mode so it shows as-is and is never clobbered.
     const { unmount } = render(
       <CreateMetricsMonitor
         onCancel={jest.fn()}
         onSave={jest.fn()}
         datasourceId="prom-1"
-        initialQuery="rate(http_requests_total[5m]) > 0.5"
+        initialQuery="histogram_quantile(0.9, rate(http_requests_total[5m]))"
       />
     );
     expect(
@@ -195,7 +197,20 @@ describe('CreateMetricsMonitor', () => {
     expect(document.querySelector('[data-test-subj="mockBuilderSetQuery"]')).toBeNull();
     unmount();
 
-    // Empty flyout -> Builder mode: builder shown, raw expression hidden.
+    // A copied query the builder CAN represent (rate + comparison) opens in
+    // Builder mode — the real parseExpr recognises it, so it isn't stuck in Code.
+    const rep = render(
+      <CreateMetricsMonitor
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+        datasourceId="prom-1"
+        initialQuery="rate(http_requests_total[5m]) > 0.5"
+      />
+    );
+    expect(document.querySelector('[data-test-subj="mockBuilderSetQuery"]')).not.toBeNull();
+    rep.unmount();
+
+    // Empty flyout opens in Builder mode (the default point-and-click experience).
     render(<CreateMetricsMonitor onCancel={jest.fn()} onSave={jest.fn()} datasourceId="prom-1" />);
     expect(document.querySelector('[data-test-subj="mockBuilderSetQuery"]')).not.toBeNull();
     expect(document.querySelector('[data-test-subj="metricsMonitorPromQlExpression"]')).toBeNull();
@@ -207,7 +222,7 @@ describe('CreateMetricsMonitor', () => {
         onCancel={jest.fn()}
         onSave={jest.fn()}
         datasourceId="prom-1"
-        initialQuery="rate(http_requests_total[5m]) > 0.5"
+        initialQuery="histogram_quantile(0.9, rate(http_requests_total[5m]))"
       />
     );
     // Starts in Code mode — no overwrite warning yet.
@@ -354,9 +369,11 @@ describe('CreateMetricsMonitor', () => {
     );
 
     // Fill in required fields: monitorName + an explicit builder selection
-    // (the form seeds query: '' — no invisible default expression)
+    // (the form seeds query: '' — no invisible default expression). The flyout
+    // opens in Code mode now, so switch to Builder to reach the mock builder.
     const nameInput = document.querySelector('input[aria-label="Rule name"]') as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: 'my-test-rule' } });
+    fireEvent.click(screen.getByText('Builder'));
     fireEvent.click(document.querySelector('[data-test-subj="mockBuilderSetQuery"]')!);
 
     // Click Create button

--- a/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
+++ b/public/components/alerting/__tests__/create_metrics_monitor.test.tsx
@@ -369,8 +369,9 @@ describe('CreateMetricsMonitor', () => {
     );
 
     // Fill in required fields: monitorName + an explicit builder selection
-    // (the form seeds query: '' — no invisible default expression). The flyout
-    // opens in Code mode now, so switch to Builder to reach the mock builder.
+    // (the form seeds query: '' — no invisible default expression). An empty
+    // flyout already defaults to Builder mode; the Builder click below is
+    // defensive (a no-op if already selected) before the mock builder emits.
     const nameInput = document.querySelector('input[aria-label="Rule name"]') as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: 'my-test-rule' } });
     fireEvent.click(screen.getByText('Builder'));

--- a/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
@@ -18,7 +18,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { PrometheusFormSection } from '../create_monitor/prometheus_form_section';
-import { parseBuilderQuery } from '../create_monitor/prom_query_builder';
+import { parseExpr } from '../create_monitor/prom_query_builder';
 import type { PrometheusFormState } from '../create_monitor/create_monitor_types';
 
 // Mock dependencies that PrometheusFormSection uses
@@ -77,7 +77,13 @@ describe('PrometheusFormSection — simplified layout', () => {
     // combo box placeholder text
     expect(screen.getAllByText('Label name').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Label value').length).toBeGreaterThan(0);
-    expect(screen.getByText('Select a metric to start.')).toBeInTheDocument();
+    // The Function + Aggregate + Condition rows render too.
+    expect(screen.getByText('Function')).toBeInTheDocument();
+    expect(screen.getByText('Aggregate')).toBeInTheDocument();
+    expect(screen.getByText('Condition')).toBeInTheDocument();
+    // baseForm's `up == 0` is now builder-representable, so it seeds the metric
+    // and the IS-EQUAL-TO condition rather than leaving the builder inert.
+    expect(screen.getByText('up')).toBeInTheDocument();
   });
 
   it('does not render Code mode, Trigger condition, or Evaluation Settings', () => {
@@ -387,13 +393,13 @@ describe('PrometheusFormSection — YAML preview', () => {
   });
 });
 
-describe('parseBuilderQuery — edit-mode builder seeding', () => {
+describe('parseExpr — edit-mode builder seeding', () => {
   it('parses a bare metric', () => {
-    expect(parseBuilderQuery('up')).toEqual({ metric: 'up' });
+    expect(parseExpr('up')).toMatchObject({ metric: 'up', conditionOp: 'none', func: 'none' });
   });
 
   it('parses a metric with a single label matcher', () => {
-    expect(parseBuilderQuery('up{instance="host-1"}')).toEqual({
+    expect(parseExpr('up{instance="host-1"}')).toMatchObject({
       metric: 'up',
       labelName: 'instance',
       labelOperator: '=',
@@ -402,7 +408,7 @@ describe('parseBuilderQuery — edit-mode builder seeding', () => {
   });
 
   it('unescapes quotes and backslashes in the label value', () => {
-    expect(parseBuilderQuery('up{path="C:\\\\dir\\"x\\""}')).toEqual({
+    expect(parseExpr('up{path="C:\\\\dir\\"x\\""}')).toMatchObject({
       metric: 'up',
       labelName: 'path',
       labelOperator: '=',
@@ -410,11 +416,30 @@ describe('parseBuilderQuery — edit-mode builder seeding', () => {
     });
   });
 
+  it('now parses a simple comparison the builder can represent', () => {
+    expect(parseExpr('up == 0')).toMatchObject({
+      metric: 'up',
+      conditionOp: 'eq',
+      thresholdA: 0,
+    });
+  });
+
+  it('now parses an aggregation-over-function expression the builder can represent', () => {
+    expect(parseExpr('sum(rate(http_requests_total[5m])) > 0.05')).toMatchObject({
+      metric: 'http_requests_total',
+      func: 'rate',
+      window: '5m',
+      aggOp: 'sum',
+      conditionOp: 'gt',
+      thresholdA: 0.05,
+    });
+  });
+
   it('returns null for expressions the builder cannot represent', () => {
-    expect(parseBuilderQuery('sum(rate(http_requests_total[5m])) > 0.05')).toBeNull();
-    expect(parseBuilderQuery('up == 0')).toBeNull();
-    expect(parseBuilderQuery('up{a="1",b="2"}')).toBeNull();
-    expect(parseBuilderQuery('')).toBeNull();
+    // Nested aggregation / functions the builder does not model.
+    expect(parseExpr('histogram_quantile(0.9, rate(http_requests_total[5m]))')).toBeNull();
+    expect(parseExpr('up{a="1",b="2"}')).toBeNull();
+    expect(parseExpr('')).toBeNull();
   });
 });
 
@@ -471,19 +496,20 @@ describe('PrometheusFormSection — edit mode seeding', () => {
     expect(onUpdate).not.toHaveBeenCalledWith('query', expect.anything());
   });
 
-  it('does not clobber a complex seeded query on mount', () => {
+  it('does not clobber a non-representable seeded query on mount', () => {
     const onUpdate = jest.fn();
     render(
       <PrometheusFormSection
-        form={{ ...baseForm, query: 'sum(rate(http_requests_total[5m])) > 0.05' }}
+        form={{ ...baseForm, query: 'histogram_quantile(0.9, rate(http_requests_total[5m]))' }}
         onUpdate={onUpdate}
         validationErrors={{}}
         hasSubmitted={false}
       />
     );
 
-    // Builder is unseeded (query not representable), so the builder→query
-    // sync must stay inert — no query updates on mount
+    // This query genuinely can't be represented by the builder (parseExpr → null),
+    // so the builder stays inert and its builder→query sync must never fire —
+    // the hand-written expression is preserved, no query updates on mount.
     expect(onUpdate).not.toHaveBeenCalledWith('query', expect.anything());
   });
 });

--- a/public/components/alerting/alerting.scss
+++ b/public/components/alerting/alerting.scss
@@ -37,7 +37,13 @@
 }
 
 .altResizableContainer {
-  min-height: calc(100vh - 140px);
+  /* Cap (not floor) the table region to the viewport so the inner
+   * `.monitors-table-wrapper` scrolls internally instead of the whole page
+   * growing past the viewport (double-scroll regression from #2686, which used
+   * `min-height` here). `min-height: 0` lets the flex children shrink so the
+   * inner overflow engages. */
+  height: calc(100vh - 140px);
+  min-height: 0;
 }
 
 .altFiltersPanel {
@@ -50,6 +56,20 @@
   overflow-y: auto;
 }
 
+/*
+ * FacetFilterGroup's header title (the toggle button's `flush="left"`
+ * EuiButtonEmpty) had no truncation of its own. In this ~182px-wide column,
+ * a long facet label — or even a short one once the active-count badge +
+ * "Clear" link are showing alongside it — didn't fit, and the non-wrapping
+ * header row overflowed the panel instead of the title shrinking. Fixed via
+ * `contentProps`/`textProps`/EuiFlexItem `style` inline styles in
+ * facet_filter_panel.tsx rather than here — the `min-width: 0` + ellipsis
+ * cascade needs to reach through several EUI-internal elements (the flex
+ * item, the button, its content span, its text span) that this file isn't
+ * allowed to select (`no_modifying_global_selectors` — alerting.scss has no
+ * approved-file entry for `.eui*`).
+ */
+
 .altFiltersBody {
   margin-top: 8px;
 }
@@ -61,15 +81,31 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+
+  /* Allow the column to shrink so its flex:1 table child can bound its own
+   * scroll region rather than expanding to content height. */
+  min-height: 0;
 }
 
 .altTablePanel {
   flex: 1;
+  min-height: 0;
+
+  /* Column so the title/search/count stay fixed and the table fills the rest
+   * and scrolls internally — one scroll region, page doesn't overflow.
+   * (Alerts-tab only; the Rules tab uses .altContentPanel + its own wrapper.) */
+  display: flex;
+  flex-direction: column;
 }
 
 .altAlertsTable {
   min-width: 0;
   overflow-x: auto;
+  overflow-y: auto;
+
+  /* Fill the remaining panel height so the table body — not the page — scrolls. */
+  flex: 1;
+  min-height: 0;
 
   .euiTable {
     table-layout: fixed;
@@ -80,6 +116,23 @@
     min-width: 0;
     overflow: hidden;
   }
+
+  /*
+   * EuiBasicTable's own footer (rows-per-page + pagination) renders an
+   * EuiFlexGroup with `gutterSize="l"`. EUI implements that gutter via
+   * `padding: 12px` on each flex item counteracted by `margin: -12px` on the
+   * group itself — a trick that assumes the surrounding panel already has
+   * >=12px of padding to absorb the negative margin. This scroll wrapper has
+   * none, so the -12px bleeds 12px past the right edge and manufactures a
+   * permanent phantom horizontal scrollbar even when the table content
+   * itself fits (`scrollWidth` includes the bled-out footer even though
+   * nothing is visibly clipped). Reserving that same 12px back as padding
+   * absorbs the bleed inside the box instead of past its edge, without
+   * touching any EUI-internal selector. `overflow-x: auto` above still
+   * engages a real scrollbar once the table's own min-width genuinely
+   * doesn't fit.
+   */
+  padding-right: 12px;
 }
 
 .altAlertCell {
@@ -258,6 +311,12 @@
       border-right: none;
     }
   }
+
+  /* Same EuiBasicTable footer negative-margin bleed as `.altAlertsTable`'s
+   * `padding-right` — see that rule's comment for the full explanation.
+   * Absorbing it here too so the Rules table doesn't grow a phantom ~12px
+   * horizontal scrollbar. */
+  padding-right: 12px;
 }
 
 // PPL preview panel — column-share layout that prevents trace ids and

--- a/public/components/alerting/create_metrics_monitor.tsx
+++ b/public/components/alerting/create_metrics_monitor.tsx
@@ -43,13 +43,14 @@ import {
   EuiToolTip,
   EuiPopover,
   EuiIcon,
-  EuiBetaBadge,
+  EuiFormLabel,
   EuiConfirmModal,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { coreRefs } from '../../framework/core_refs';
 import { classifiedToastColor, classifiedToastText, extractClassifiedError } from '../common/error';
-import { PromQueryBuilder, parseBuilderQuery } from './create_monitor/prom_query_builder';
+import { PromQueryBuilder, parseExpr } from './create_monitor/prom_query_builder';
+import { isAlwaysFiring } from './create_monitor/prom_condition';
 import { RuleGroupSelector } from './create_monitor/rule_group_selector';
 import { QueryPreviewResults } from './query_preview_results';
 // Shared label editor + entry types keep both flyouts' Labels sections in sync
@@ -379,8 +380,18 @@ const QuerySection = React.memo<{
     // A non-empty expression the builder cannot represent (e.g. a copied
     // `rate(...) > 0.5`). Switching to the builder and picking a metric would
     // replace it — warn instead of silently clobbering (audit finding #7).
-    const builderWouldOverwrite =
-      form.query.trim() !== '' && parseBuilderQuery(form.query) === null;
+    const parsedCondition = parseExpr(form.query);
+    const builderWouldOverwrite = form.query.trim() !== '' && parsedCondition === null;
+    // Feed the parsed threshold to the preview so it draws the threshold line +
+    // "would fire now" badge. Undefined for condition-less or unparseable exprs.
+    const previewCondition =
+      parsedCondition && parsedCondition.conditionOp !== 'none'
+        ? {
+            op: parsedCondition.conditionOp,
+            thresholdA: parsedCondition.thresholdA,
+            thresholdB: parsedCondition.thresholdB,
+          }
+        : undefined;
 
     // With an explicit datasource list (Alert Manager) the picker offers all
     // Prometheus datasources; otherwise it is pinned to the Explore page's
@@ -472,14 +483,18 @@ const QuerySection = React.memo<{
         <EuiPanel paddingSize="s" hasBorder style={{ borderRadius: 4 }}>
           <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
             <EuiFlexItem grow={false}>
-              <EuiBetaBadge
-                label="PromQL"
-                tooltipContent={i18n.translate(
+              {/* Neutral language tag — a BetaBadge would wrongly imply the
+                feature is experimental; this just labels the query language. */}
+              <EuiToolTip
+                content={i18n.translate(
                   'observability.alerting.createMetricsMonitor.promqlTooltip',
-                  { defaultMessage: 'Prometheus Query Language' }
+                  {
+                    defaultMessage: 'Prometheus Query Language',
+                  }
                 )}
-                size="s"
-              />
+              >
+                <EuiBadge color="hollow">PromQL</EuiBadge>
+              </EuiToolTip>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiPopover
@@ -532,6 +547,16 @@ const QuerySection = React.memo<{
               </EuiPopover>
             </EuiFlexItem>
             <EuiFlexItem grow={false} style={{ marginLeft: 'auto' }}>
+              <EuiFormLabel>
+                {i18n.translate(
+                  'observability.alerting.createMetricsMonitor.queryModeEditorLabel',
+                  {
+                    defaultMessage: 'Editor',
+                  }
+                )}
+              </EuiFormLabel>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
               {/* Builder ⇄ Code toggle. Only one editor shows at a time, so a
                 copied PromQL expression (Code) is never silently overwritten by
                 the builder's output — the two no longer share a visible field. */}
@@ -578,7 +603,7 @@ const QuerySection = React.memo<{
                 'observability.alerting.createMetricsMonitor.expressionHelpText',
                 {
                   defaultMessage:
-                    'The complete alert condition — it fires for every series the expression returns. A bare series (e.g. "up") is always-firing; add a comparison/threshold (e.g. "> 0.5") for a conditional alert. Switch to Builder to construct a simple metric/label query.',
+                    'The complete PromQL alert condition — it fires for every series the expression returns.',
                 }
               )}
               fullWidth
@@ -593,6 +618,9 @@ const QuerySection = React.memo<{
                 rows={2}
                 fullWidth
                 compressed
+                // Monospace so brackets/labels align and it reads as a query,
+                // not a comment box (EUI code font token, no custom font).
+                style={{ fontFamily: 'var(--euiCodeFontFamily)' }}
                 aria-label={i18n.translate(
                   'observability.alerting.createMetricsMonitor.expressionAriaLabel',
                   { defaultMessage: 'PromQL expression' }
@@ -625,6 +653,29 @@ const QuerySection = React.memo<{
                 datasourceId={form.datasourceId}
                 query={form.query}
                 onQueryChange={(q) => onUpdate({ query: q })}
+              />
+            </>
+          )}
+
+          {/* Always-firing guard (both modes): a valid expression with no
+            comparison returns samples whenever the series exists, so the alert
+            fires continuously. Non-blocking — a condition-less rule is legal
+            PromQL — but surfaced so it isn't created by accident. */}
+          {isAlwaysFiring(form.query) && (
+            <>
+              <EuiSpacer size="s" />
+              <EuiCallOut
+                size="s"
+                color="warning"
+                iconType="alert"
+                title={i18n.translate(
+                  'observability.alerting.createMetricsMonitor.alwaysFiringWarning',
+                  {
+                    defaultMessage:
+                      'This expression has no condition, so the alert fires whenever the series exists. Add a comparison (e.g. “> 0.5”) — or a Condition in the builder — for a conditional alert.',
+                  }
+                )}
+                data-test-subj="metricsMonitorAlwaysFiringWarning"
               />
             </>
           )}
@@ -671,6 +722,7 @@ const QuerySection = React.memo<{
               datasourceId={form.datasourceId}
               timeRange={previewTimeRange}
               runToken={previewToken}
+              condition={previewCondition}
             />
           </>
         )}
@@ -949,11 +1001,14 @@ export const CreateMetricsMonitor: React.FC<CreateMetricsMonitorProps> = ({
     labels: [{ key: 'severity', value: 'warning', isDynamic: false }],
     annotations: [],
   });
-  // Default to Code mode when a query was copied in (so it shows as-is and the
-  // builder can't overwrite it); an empty flyout starts in Builder mode.
-  const [queryMode, setQueryMode] = useState<QueryMode>(() =>
-    (initialQuery ?? '').trim() ? 'code' : 'builder'
-  );
+  // Default to Builder (point-and-click) — the primary experience on both the
+  // Explore Metrics "Create alert rule" flow and the Alerts page Rules tab.
+  // Exception: a query copied in that the builder can't represent opens in Code
+  // so it's shown as-is and never clobbered. Users can toggle either way.
+  const [queryMode, setQueryMode] = useState<QueryMode>(() => {
+    const seeded = (initialQuery ?? '').trim();
+    return seeded && parseExpr(seeded) === null ? 'code' : 'builder';
+  });
   const [showPreview, setShowPreview] = useState(false);
   // Bumped on each "Run preview" click so QueryPreviewResults re-runs the
   // range query even when the panel is already open.

--- a/public/components/alerting/create_monitor/__tests__/prom_condition.test.ts
+++ b/public/components/alerting/create_monitor/__tests__/prom_condition.test.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  buildExpr,
+  ConditionBuilderState,
+  DEFAULT_WINDOW,
+  isAlwaysFiring,
+  isRangeOp,
+  parseExpr,
+} from '../prom_condition';
+
+const state = (over: Partial<ConditionBuilderState> = {}): ConditionBuilderState => ({
+  metric: 'cpu_usage',
+  func: 'none',
+  window: DEFAULT_WINDOW,
+  aggOp: 'none',
+  aggGrouping: 'none',
+  aggLabels: [],
+  conditionOp: 'none',
+  ...over,
+});
+
+describe('buildExpr', () => {
+  it('returns empty string until a metric is chosen', () => {
+    expect(buildExpr(state({ metric: '' }))).toBe('');
+    expect(buildExpr(state({ metric: '   ' }))).toBe('');
+  });
+
+  it('builds a bare selector', () => {
+    expect(buildExpr(state())).toBe('cpu_usage');
+  });
+
+  it('omits the comparison when a chosen operator has no threshold yet', () => {
+    // A chosen operator with a blank/NaN threshold must NOT emit a surprise
+    // `… > 0`; it yields the pre-condition expression (still valid, and the
+    // always-firing warning then nudges the user to enter a value).
+    expect(buildExpr(state({ conditionOp: 'gt' }))).toBe('cpu_usage');
+    expect(buildExpr(state({ func: 'rate', window: '5m', aggOp: 'sum', conditionOp: 'gt' }))).toBe(
+      'sum(rate(cpu_usage[5m]))'
+    );
+    // Range ops need BOTH bounds; a missing bound also falls back to no condition.
+    expect(buildExpr(state({ conditionOp: 'outside', thresholdA: 10 }))).toBe('cpu_usage');
+    // With the threshold present, the comparison is emitted as usual.
+    expect(buildExpr(state({ conditionOp: 'gt', thresholdA: 0 }))).toBe('cpu_usage > 0');
+  });
+
+  it('builds a labelled selector, escaping the value', () => {
+    expect(buildExpr(state({ labelName: 'host', labelOperator: '=', labelValue: 'web"1' }))).toBe(
+      'cpu_usage{host="web\\"1"}'
+    );
+  });
+
+  it('wraps in an over-time function over the window', () => {
+    expect(buildExpr(state({ func: 'avg_over_time', window: '10m' }))).toBe(
+      'avg_over_time(cpu_usage[10m])'
+    );
+  });
+
+  it('wraps in a rate function', () => {
+    expect(buildExpr(state({ func: 'rate', window: '4m' }))).toBe('rate(cpu_usage[4m])');
+  });
+
+  it('applies a plain aggregation across series', () => {
+    expect(buildExpr(state({ aggOp: 'sum' }))).toBe('sum(cpu_usage)');
+  });
+
+  it('applies an aggregation with by-grouping', () => {
+    expect(
+      buildExpr(state({ aggOp: 'sum', aggGrouping: 'by', aggLabels: ['job', 'instance'] }))
+    ).toBe('sum by (job, instance) (cpu_usage)');
+  });
+
+  it('applies an aggregation with without-grouping', () => {
+    expect(buildExpr(state({ aggOp: 'avg', aggGrouping: 'without', aggLabels: ['pod'] }))).toBe(
+      'avg without (pod) (cpu_usage)'
+    );
+  });
+
+  it('drops grouping when no labels are given', () => {
+    expect(buildExpr(state({ aggOp: 'sum', aggGrouping: 'by', aggLabels: [] }))).toBe(
+      'sum(cpu_usage)'
+    );
+  });
+
+  it('stacks aggregation over a function (the sum(rate(...)) shape)', () => {
+    expect(buildExpr(state({ func: 'rate', window: '4m', aggOp: 'sum' }))).toBe(
+      'sum(rate(cpu_usage[4m]))'
+    );
+  });
+
+  it('builds the full sum(rate(...)) > N expression from the question', () => {
+    expect(
+      buildExpr(
+        state({
+          metric: 'gen_ai_client_token_usage_total',
+          func: 'rate',
+          window: '4m',
+          aggOp: 'sum',
+          conditionOp: 'gt',
+          thresholdA: 6,
+        })
+      )
+    ).toBe('sum(rate(gen_ai_client_token_usage_total[4m])) > 6');
+  });
+
+  it.each([
+    ['gt', 'cpu_usage > 0.5'],
+    ['gte', 'cpu_usage >= 0.5'],
+    ['lt', 'cpu_usage < 0.5'],
+    ['lte', 'cpu_usage <= 0.5'],
+    ['eq', 'cpu_usage == 0.5'],
+    ['neq', 'cpu_usage != 0.5'],
+  ] as const)('applies the %s comparison', (op, expected) => {
+    expect(buildExpr(state({ conditionOp: op, thresholdA: 0.5 }))).toBe(expected);
+  });
+
+  it('builds an OUTSIDE RANGE condition', () => {
+    expect(buildExpr(state({ conditionOp: 'outside', thresholdA: 10, thresholdB: 90 }))).toBe(
+      '(cpu_usage < 10 or cpu_usage > 90)'
+    );
+  });
+
+  it('builds a WITHIN RANGE condition', () => {
+    expect(buildExpr(state({ conditionOp: 'within', thresholdA: 10, thresholdB: 90 }))).toBe(
+      '(cpu_usage >= 10 and cpu_usage <= 90)'
+    );
+  });
+
+  it('never emits NaN for a threshold', () => {
+    // A finite threshold renders normally; a missing one drops the comparison
+    // entirely (see "omits the comparison when a chosen operator has no threshold
+    // yet") rather than emitting `NaN` or a surprise `> 0`.
+    expect(buildExpr(state({ conditionOp: 'gt', thresholdA: 0 }))).toBe('cpu_usage > 0');
+    expect(buildExpr(state({ conditionOp: 'gt' }))).not.toContain('NaN');
+  });
+});
+
+describe('parseExpr round-trips buildExpr', () => {
+  const cases: ConditionBuilderState[] = [
+    state(),
+    state({ labelName: 'host', labelOperator: '=', labelValue: 'web-1' }),
+    state({ labelName: 'host', labelOperator: '=~', labelValue: 'web.*' }),
+    state({ labelName: 'host', labelOperator: '!=', labelValue: 'web-1' }),
+    state({ labelName: 'host', labelOperator: '!~', labelValue: 'web.*' }),
+    state({ func: 'avg_over_time', window: '10m' }),
+    state({ func: 'min_over_time', window: '3m' }),
+    state({ func: 'max_over_time', window: '3m' }),
+    state({ func: 'sum_over_time', window: '3m' }),
+    state({ func: 'count_over_time', window: '3m' }),
+    state({ func: 'last_over_time', window: '3m' }),
+    state({ func: 'rate', window: '4m' }),
+    state({ func: 'increase', window: '1h' }),
+    state({ func: 'delta', window: '30m' }),
+    // Day / week / year windows (parseable per RANGE_FN_RE + selectable in the UI).
+    state({ func: 'rate', window: '2d' }),
+    state({ func: 'increase', window: '1w' }),
+    state({ func: 'delta', window: '1y' }),
+    state({ aggOp: 'sum' }),
+    state({ aggOp: 'min' }),
+    state({ aggOp: 'max' }),
+    state({ aggOp: 'count' }),
+    // `count` aggregation vs the `count_over_time` function must stay distinct.
+    state({ func: 'count_over_time', window: '5m', aggOp: 'count' }),
+    state({ aggOp: 'sum', aggGrouping: 'by', aggLabels: ['job', 'instance'] }),
+    state({ aggOp: 'avg', aggGrouping: 'without', aggLabels: ['pod'] }),
+    state({ conditionOp: 'gte', thresholdA: 1000 }),
+    state({ conditionOp: 'lt', thresholdA: 0 }),
+    state({ func: 'rate', window: '4m', aggOp: 'sum', conditionOp: 'gt', thresholdA: 6 }),
+    state({ conditionOp: 'gt', thresholdA: 0.5 }),
+    state({ conditionOp: 'lte', thresholdA: -3.5 }),
+    state({ conditionOp: 'outside', thresholdA: 10, thresholdB: 90 }),
+    state({ conditionOp: 'within', thresholdA: 10, thresholdB: 90 }),
+    state({
+      metric: 'http_requests_total',
+      labelName: 'job',
+      labelOperator: '=',
+      labelValue: 'api',
+      func: 'rate',
+      window: '5m',
+      aggOp: 'sum',
+      aggGrouping: 'by',
+      aggLabels: ['code'],
+      conditionOp: 'gte',
+      thresholdA: 100,
+    }),
+  ];
+
+  it.each(cases)('round-trips %#', (s) => {
+    const expr = buildExpr(s);
+    const parsed = parseExpr(expr);
+    expect(parsed).not.toBeNull();
+    // Re-building from the parsed state yields the identical expression.
+    expect(buildExpr(parsed!)).toBe(expr);
+    // Stronger: the parsed state deep-equals the original (canonical) state, so a
+    // parser that mangled a field in a way that happened to re-serialize the same
+    // is still caught. (Undefined threshold keys are ignored by toEqual.)
+    expect(parsed).toEqual(s);
+  });
+});
+
+describe('parseExpr', () => {
+  it('returns null for an empty query', () => {
+    expect(parseExpr('')).toBeNull();
+    expect(parseExpr('   ')).toBeNull();
+  });
+
+  it('parses the sum(rate(...)) > N expression from the question', () => {
+    expect(parseExpr('sum(rate(gen_ai_client_token_usage_total[4m])) > 6')).toMatchObject({
+      metric: 'gen_ai_client_token_usage_total',
+      func: 'rate',
+      window: '4m',
+      aggOp: 'sum',
+      conditionOp: 'gt',
+      thresholdA: 6,
+    });
+  });
+
+  it('parses a scientific-notation threshold', () => {
+    expect(parseExpr('http_errors > 1e3')).toMatchObject({
+      metric: 'http_errors',
+      conditionOp: 'gt',
+      thresholdA: 1000,
+    });
+  });
+
+  it('parses an aggregation with by-grouping', () => {
+    expect(parseExpr('sum by (job, instance) (rate(cpu_usage[4m]))')).toMatchObject({
+      metric: 'cpu_usage',
+      func: 'rate',
+      aggOp: 'sum',
+      aggGrouping: 'by',
+      aggLabels: ['job', 'instance'],
+    });
+  });
+
+  it('returns null for an expression the builder cannot represent', () => {
+    // Nested aggregation the builder does not model.
+    expect(parseExpr('sum(sum(cpu_usage))')).toBeNull();
+    expect(parseExpr('histogram_quantile(0.9, rate(x[5m]))')).toBeNull();
+    expect(parseExpr('cpu_usage{a="1",b="2"}')).toBeNull(); // multiple matchers
+  });
+
+  it('does not confuse a range form for a simple comparison', () => {
+    expect(parseExpr('(cpu_usage < 10 or cpu_usage > 90)')).toMatchObject({
+      conditionOp: 'outside',
+      thresholdA: 10,
+      thresholdB: 90,
+    });
+  });
+
+  it('rejects a range whose two inner expressions differ', () => {
+    expect(parseExpr('(cpu_usage < 10 or mem_usage > 90)')).toBeNull();
+  });
+});
+
+describe('isAlwaysFiring', () => {
+  it('is false for empty input (nothing yet, not a footgun)', () => {
+    expect(isAlwaysFiring('')).toBe(false);
+  });
+
+  it('is true for a condition-less expression', () => {
+    expect(isAlwaysFiring('up')).toBe(true);
+    expect(isAlwaysFiring('cpu_usage{host="web-1"}')).toBe(true);
+    expect(isAlwaysFiring('sum(rate(cpu_usage[5m]))')).toBe(true);
+  });
+
+  it('is false once a comparison is present', () => {
+    expect(isAlwaysFiring('up == 0')).toBe(false);
+    expect(isAlwaysFiring('sum(rate(cpu_usage[4m])) > 6')).toBe(false);
+    expect(isAlwaysFiring('(cpu_usage < 10 or cpu_usage > 90)')).toBe(false);
+  });
+
+  it('is not fooled by a comparison-like character inside a label value', () => {
+    expect(isAlwaysFiring('cpu_usage{path="/a>b"}')).toBe(true);
+  });
+
+  it('is not fooled by a closing brace AND a comparison char inside a label value', () => {
+    // The label value contains `}` which used to end the label-matcher strip
+    // early, leaking the `>` and wrongly reporting a comparison. Bare selector →
+    // still always-firing.
+    expect(isAlwaysFiring('cpu_usage{path="a}>b"}')).toBe(true);
+    // A genuine comparison alongside a `}`-bearing value is still detected.
+    expect(isAlwaysFiring('cpu_usage{path="a}b"} > 5')).toBe(false);
+  });
+});
+
+describe('isRangeOp', () => {
+  it('is true only for range operators', () => {
+    expect(isRangeOp('outside')).toBe(true);
+    expect(isRangeOp('within')).toBe(true);
+    expect(isRangeOp('gt')).toBe(false);
+    expect(isRangeOp('none')).toBe(false);
+  });
+});

--- a/public/components/alerting/create_monitor/__tests__/prom_condition.test.ts
+++ b/public/components/alerting/create_monitor/__tests__/prom_condition.test.ts
@@ -129,6 +129,17 @@ describe('buildExpr', () => {
     );
   });
 
+  it('normalizes an inverted range so it is never always-true / never-true', () => {
+    // A > B entered by mistake must not silently produce an always-true `outside`
+    // or never-true `within`; the bounds are ordered (lo <= hi) on emit.
+    expect(buildExpr(state({ conditionOp: 'outside', thresholdA: 90, thresholdB: 10 }))).toBe(
+      '(cpu_usage < 10 or cpu_usage > 90)'
+    );
+    expect(buildExpr(state({ conditionOp: 'within', thresholdA: 90, thresholdB: 10 }))).toBe(
+      '(cpu_usage >= 10 and cpu_usage <= 90)'
+    );
+  });
+
   it('never emits NaN for a threshold', () => {
     // A finite threshold renders normally; a missing one drops the comparison
     // entirely (see "omits the comparison when a chosen operator has no threshold

--- a/public/components/alerting/create_monitor/prom_condition.ts
+++ b/public/components/alerting/create_monitor/prom_condition.ts
@@ -1,0 +1,330 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure composition + parsing core for the PromQL alert-condition
+ * builder. Kept free of React so the (fiddly) expression assembly and its
+ * inverse round-trip parser can be exhaustively unit-tested; the UI in
+ * `prom_query_builder.tsx` is a thin shell over these functions.
+ *
+ * The builder assembles a Prometheus alerting `expr` in four stacked layers:
+ *
+ *   1. Series selector  — `metric` or `metric{label OP "value"}`
+ *   2. Function (optional) — a range/over-time function applied over a window:
+ *        rate / increase / delta, or the reduce family avg|min|max|sum|count|
+ *        last `_over_time`. Emitted as `<fn>(<selector>[<window>])`.
+ *   3. Aggregate (optional) — an aggregation operator across series:
+ *        sum / avg / min / max / count, with optional `by (…)` / `without (…)`
+ *        grouping. Emitted as `<op>[ by|without (labels)](<inner>)`.
+ *   4. Condition — a comparison that makes the expr return samples ONLY when
+ *        the alert should fire: IS ABOVE `>`, ABOVE-OR-EQUAL `>=`, BELOW `<`,
+ *        BELOW-OR-EQUAL `<=`, EQUAL `==`, NOT EQUAL `!=`, and the range forms
+ *        OUTSIDE RANGE → `(<inner> < a or <inner> > b)`
+ *        WITHIN RANGE  → `(<inner> >= a and <inner> <= b)`
+ *
+ * `buildExpr` composes the layers inside-out; `parseExpr` peels them back off in
+ * reverse so switching Builder↔Code (or editing then re-opening) is lossless for
+ * any expression the builder itself could have produced (e.g.
+ * `sum(rate(metric[4m])) > 6`). Anything more complex parses to `null`, leaving
+ * the builder inert so a hand-written Code expression is never rewritten.
+ */
+
+/** Range / over-time function applied to the selector over a window. */
+export type RangeFn =
+  | 'none'
+  | 'rate'
+  | 'increase'
+  | 'delta'
+  | 'avg_over_time'
+  | 'min_over_time'
+  | 'max_over_time'
+  | 'sum_over_time'
+  | 'count_over_time'
+  | 'last_over_time';
+
+/** Aggregation operator across matching series. */
+export type AggOp = 'none' | 'sum' | 'avg' | 'min' | 'max' | 'count';
+
+/** Grouping modifier for the aggregation. */
+export type AggGrouping = 'none' | 'by' | 'without';
+
+export type ConditionOp =
+  'none' | 'gt' | 'gte' | 'lt' | 'lte' | 'eq' | 'neq' | 'outside' | 'within';
+
+export interface ConditionBuilderState {
+  /** Metric name — the only required field; empty means "no query yet". */
+  metric: string;
+  /** Optional single label matcher. */
+  labelName?: string;
+  /** Label match operator: `=`, `!=`, `=~`, `!~`. */
+  labelOperator?: string;
+  labelValue?: string;
+  /** Range/over-time function; `none` = raw instant selector. */
+  func: RangeFn;
+  /** Window for the function, e.g. `5m`. Ignored when `func === 'none'`. */
+  window: string;
+  /** Aggregation operator across series; `none` = no aggregation. */
+  aggOp: AggOp;
+  /** Grouping modifier; only meaningful when `aggOp !== 'none'`. */
+  aggGrouping: AggGrouping;
+  /** Labels for `by`/`without`; only meaningful when grouping is set. */
+  aggLabels: string[];
+  /** Alert condition; `none` = no comparison (an always-firing selector). */
+  conditionOp: ConditionOp;
+  /** Primary threshold (comparison RHS, or the LOW bound of a range). */
+  thresholdA?: number;
+  /** HIGH bound — only used by the `outside` / `within` range operators. */
+  thresholdB?: number;
+}
+
+export const DEFAULT_WINDOW = '5m';
+
+/** Functions that emit `<fn>(<selector>[<window>])` — every non-`none` RangeFn. */
+const RANGE_FNS: ReadonlyArray<Exclude<RangeFn, 'none'>> = [
+  'rate',
+  'increase',
+  'delta',
+  'avg_over_time',
+  'min_over_time',
+  'max_over_time',
+  'sum_over_time',
+  'count_over_time',
+  'last_over_time',
+];
+
+const AGG_OPS: ReadonlyArray<Exclude<AggOp, 'none'>> = ['sum', 'avg', 'min', 'max', 'count'];
+
+/** Single-comparison operator → PromQL symbol. */
+const SIMPLE_OP_TO_SYMBOL: Record<
+  Extract<ConditionOp, 'gt' | 'gte' | 'lt' | 'lte' | 'eq' | 'neq'>,
+  string
+> = {
+  gt: '>',
+  gte: '>=',
+  lt: '<',
+  lte: '<=',
+  eq: '==',
+  neq: '!=',
+};
+
+const SYMBOL_TO_SIMPLE_OP: Record<string, ConditionOp> = {
+  '>': 'gt',
+  '>=': 'gte',
+  '<': 'lt',
+  '<=': 'lte',
+  '==': 'eq',
+  '!=': 'neq',
+};
+
+/** True for the two-bound range operators. */
+export function isRangeOp(op: ConditionOp): boolean {
+  return op === 'outside' || op === 'within';
+}
+
+/** Render a number for embedding in PromQL (no locale separators, no `NaN`). */
+function num(n: number | undefined): string {
+  return Number.isFinite(n as number) ? String(n) : '0';
+}
+
+/** Escape a label value for a PromQL double-quoted string literal. */
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function unescapeLabelValue(value: string): string {
+  return value.replace(/\\(["\\])/g, '$1');
+}
+
+/** Layer 1 — the bare series selector. Empty metric → empty string. */
+function buildSelector(state: ConditionBuilderState): string {
+  const metric = (state.metric || '').trim();
+  if (!metric) return '';
+  if (state.labelName && state.labelValue !== undefined && state.labelValue !== '') {
+    const op = state.labelOperator || '=';
+    return `${metric}{${state.labelName}${op}"${escapeLabelValue(state.labelValue)}"}`;
+  }
+  return metric;
+}
+
+/**
+ * Compose the full PromQL expression from builder state. Returns `''` until a
+ * metric is chosen (nothing to preview / save yet).
+ */
+export function buildExpr(state: ConditionBuilderState): string {
+  const selector = buildSelector(state);
+  if (!selector) return '';
+
+  // Layer 2 — range / over-time function.
+  let inner = selector;
+  if (state.func !== 'none') {
+    const window = (state.window || DEFAULT_WINDOW).trim() || DEFAULT_WINDOW;
+    inner = `${state.func}(${selector}[${window}])`;
+  }
+
+  // Layer 3 — aggregation across series. With grouping we emit the canonical
+  // `op by (labels) (inner)` (space before the inner group); without grouping,
+  // `op(inner)`.
+  if (state.aggOp !== 'none') {
+    const labels = (state.aggLabels || []).map((l) => l.trim()).filter(Boolean);
+    inner =
+      state.aggGrouping !== 'none' && labels.length > 0
+        ? `${state.aggOp} ${state.aggGrouping} (${labels.join(', ')}) (${inner})`
+        : `${state.aggOp}(${inner})`;
+  }
+
+  // Layer 4 — condition. A chosen operator whose threshold(s) are still blank is
+  // treated as "no condition yet": we return the pre-condition expression rather
+  // than emitting a surprise `… > 0` the user never typed (which would otherwise
+  // save as a real threshold). The always-firing warning then correctly nudges
+  // them to enter a value.
+  const a = state.thresholdA;
+  const b = state.thresholdB;
+  switch (state.conditionOp) {
+    case 'none':
+      return inner;
+    case 'outside':
+      return Number.isFinite(a as number) && Number.isFinite(b as number)
+        ? `(${inner} < ${num(a)} or ${inner} > ${num(b)})`
+        : inner;
+    case 'within':
+      return Number.isFinite(a as number) && Number.isFinite(b as number)
+        ? `(${inner} >= ${num(a)} and ${inner} <= ${num(b)})`
+        : inner;
+    default:
+      return Number.isFinite(a as number)
+        ? `${inner} ${SIMPLE_OP_TO_SYMBOL[state.conditionOp]} ${num(a)}`
+        : inner;
+  }
+}
+
+const NUMBER = String.raw`-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?`;
+const SELECTOR_RE = new RegExp(
+  String.raw`^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*(=~|!~|!=|=)\s*"((?:[^"\\]|\\.)*)"\s*\})?$`
+);
+const RANGE_FN_RE = new RegExp(
+  String.raw`^(${RANGE_FNS.join('|')})\(\s*(.+?)\s*\[\s*(\d+[smhdwy])\s*\]\s*\)$`
+);
+// `<op>[ by|without (labels)] (<inner>)`
+const AGG_RE = new RegExp(
+  String.raw`^(${AGG_OPS.join('|')})(?:\s+(by|without)\s*\(([^)]*)\))?\s*\(\s*(.+?)\s*\)$`
+);
+const SIMPLE_CMP_RE = new RegExp(String.raw`^(.+?)\s*(>=|<=|==|!=|>|<)\s*(${NUMBER})$`);
+const OUTSIDE_RE = new RegExp(
+  String.raw`^\(\s*(.+?)\s*<\s*(${NUMBER})\s+or\s+(.+?)\s*>\s*(${NUMBER})\s*\)$`
+);
+const WITHIN_RE = new RegExp(
+  String.raw`^\(\s*(.+?)\s*>=\s*(${NUMBER})\s+and\s+(.+?)\s*<=\s*(${NUMBER})\s*\)$`
+);
+
+/** Parse a bare selector (`metric` / `metric{l OP "v"}`) into partial state. */
+function parseSelector(
+  selector: string
+): Pick<ConditionBuilderState, 'metric' | 'labelName' | 'labelOperator' | 'labelValue'> | null {
+  const m = selector.trim().match(SELECTOR_RE);
+  if (!m) return null;
+  const [, metric, labelName, labelOperator, escaped] = m;
+  if (!labelName) return { metric };
+  return { metric, labelName, labelOperator, labelValue: unescapeLabelValue(escaped) };
+}
+
+/**
+ * Inverse of {@link buildExpr}. Returns fully-populated builder state for any
+ * expression the builder could have emitted, or `null` for anything else (so
+ * the caller leaves the builder inert rather than clobbering a Code expression).
+ */
+export function parseExpr(query: string): ConditionBuilderState | null {
+  const q = (query || '').trim();
+  if (!q) return null;
+
+  let conditionOp: ConditionOp = 'none';
+  let thresholdA: number | undefined;
+  let thresholdB: number | undefined;
+  let inner = q;
+
+  // Layer 4 — range forms first (they wrap in parens), then a simple comparison.
+  const outside = q.match(OUTSIDE_RE);
+  const within = q.match(WITHIN_RE);
+  if (outside && outside[1].trim() === outside[3].trim()) {
+    conditionOp = 'outside';
+    inner = outside[1].trim();
+    thresholdA = Number(outside[2]);
+    thresholdB = Number(outside[4]);
+  } else if (within && within[1].trim() === within[3].trim()) {
+    conditionOp = 'within';
+    inner = within[1].trim();
+    thresholdA = Number(within[2]);
+    thresholdB = Number(within[4]);
+  } else {
+    const cmp = q.match(SIMPLE_CMP_RE);
+    if (cmp) {
+      conditionOp = SYMBOL_TO_SIMPLE_OP[cmp[2]];
+      inner = cmp[1].trim();
+      thresholdA = Number(cmp[3]);
+    }
+  }
+
+  // Layer 3 — aggregation.
+  let aggOp: AggOp = 'none';
+  let aggGrouping: AggGrouping = 'none';
+  let aggLabels: string[] = [];
+  const agg = inner.match(AGG_RE);
+  if (agg) {
+    aggOp = agg[1] as AggOp;
+    if (agg[2]) {
+      aggGrouping = agg[2] as AggGrouping;
+      aggLabels = agg[3]
+        .split(',')
+        .map((l) => l.trim())
+        .filter(Boolean);
+    }
+    inner = agg[4].trim();
+  }
+
+  // Layer 2 — range / over-time function.
+  let func: RangeFn = 'none';
+  let window = DEFAULT_WINDOW;
+  const fn = inner.match(RANGE_FN_RE);
+  if (fn) {
+    func = fn[1] as RangeFn;
+    inner = fn[2].trim();
+    window = fn[3];
+  }
+
+  // Layer 1 — selector.
+  const parsedSelector = parseSelector(inner);
+  if (!parsedSelector) return null;
+
+  return {
+    ...parsedSelector,
+    func,
+    window,
+    aggOp,
+    aggGrouping,
+    aggLabels,
+    conditionOp,
+    thresholdA,
+    thresholdB,
+  };
+}
+
+/**
+ * Heuristic used to warn about an always-firing rule: true when the expression
+ * carries no top-level comparison, so it returns samples whenever the series
+ * merely exists. Conservative by design — it strips label matchers and quoted
+ * strings first, so a real threshold (`… > 5`) is never flagged; only a bare
+ * selector (or function/aggregation with no comparison) trips it. Empty input is
+ * NOT always-firing (there's simply nothing yet).
+ */
+export function isAlwaysFiring(query: string): boolean {
+  const q = (query || '').trim();
+  if (!q) return false;
+  const stripped = q
+    // Strip quoted strings FIRST: a label value may contain a `}` (e.g.
+    // `metric{path="a}b"}`), which would otherwise make the label-matcher
+    // strip below stop early and leak a stray `>`/`<` from inside the value.
+    .replace(/"(?:[^"\\]|\\.)*"/g, '') // quoted strings (label values)
+    .replace(/\{[^}]*\}/g, ''); // then label matchers
+  return !/(>=|<=|==|!=|>|<)/.test(stripped);
+}

--- a/public/components/alerting/create_monitor/prom_condition.ts
+++ b/public/components/alerting/create_monitor/prom_condition.ts
@@ -184,14 +184,22 @@ export function buildExpr(state: ConditionBuilderState): string {
   switch (state.conditionOp) {
     case 'none':
       return inner;
-    case 'outside':
-      return Number.isFinite(a as number) && Number.isFinite(b as number)
-        ? `(${inner} < ${num(a)} or ${inner} > ${num(b)})`
-        : inner;
-    case 'within':
-      return Number.isFinite(a as number) && Number.isFinite(b as number)
-        ? `(${inner} >= ${num(a)} and ${inner} <= ${num(b)})`
-        : inner;
+    case 'outside': {
+      // Normalize the bounds (lo <= hi) so an inverted range entered as A > B
+      // can't silently emit an always-true `outside` (`x < hi or x > lo` matches
+      // everything). Same normalization for `within` below (which would
+      // otherwise be never-true). `parseExpr` reads the ordered bounds back.
+      if (!(Number.isFinite(a as number) && Number.isFinite(b as number))) return inner;
+      const lo = Math.min(a as number, b as number);
+      const hi = Math.max(a as number, b as number);
+      return `(${inner} < ${num(lo)} or ${inner} > ${num(hi)})`;
+    }
+    case 'within': {
+      if (!(Number.isFinite(a as number) && Number.isFinite(b as number))) return inner;
+      const lo = Math.min(a as number, b as number);
+      const hi = Math.max(a as number, b as number);
+      return `(${inner} >= ${num(lo)} and ${inner} <= ${num(hi)})`;
+    }
     default:
       return Number.isFinite(a as number)
         ? `${inner} ${SIMPLE_OP_TO_SYMBOL[state.conditionOp]} ${num(a)}`
@@ -203,6 +211,11 @@ const NUMBER = String.raw`-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?`;
 const SELECTOR_RE = new RegExp(
   String.raw`^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*(=~|!~|!=|=)\s*"((?:[^"\\]|\\.)*)"\s*\})?$`
 );
+// Only a single-unit integer duration (`\d+[smhdwy]`) seeds the builder. A
+// compound duration (`1h30m`) or a `ms` window parses to `null` here, dropping
+// the whole expression to Code mode — the safe direction (the builder never
+// silently mis-represents it). Prometheus still accepts `90m`, so a 90-minute
+// window has an escape hatch; only the builder's window picker is limited.
 const RANGE_FN_RE = new RegExp(
   String.raw`^(${RANGE_FNS.join('|')})\(\s*(.+?)\s*\[\s*(\d+[smhdwy])\s*\]\s*\)$`
 );
@@ -316,6 +329,12 @@ export function parseExpr(query: string): ConditionBuilderState | null {
  * strings first, so a real threshold (`… > 5`) is never flagged; only a bare
  * selector (or function/aggregation with no comparison) trips it. Empty input is
  * NOT always-firing (there's simply nothing yet).
+ *
+ * Known limitations (acceptable — the callout is a non-blocking hint, not a
+ * gate): the `bool` modifier (`up > bool 0`) always returns a 0/1 sample so it
+ * effectively always fires, but the `>` makes this heuristic stay quiet;
+ * conversely `absent(metric)` carries no comparison yet is a legitimate
+ * conditional alert, so it gets the warning. Neither is worth special-casing.
  */
 export function isAlwaysFiring(query: string): boolean {
   const q = (query || '').trim();

--- a/public/components/alerting/create_monitor/prom_query_builder.tsx
+++ b/public/components/alerting/create_monitor/prom_query_builder.tsx
@@ -4,23 +4,37 @@
  */
 
 /**
- * PromQueryBuilder — the shared point-and-click PromQL builder used by both
- * the Alert Manager "Create metrics rule" flyout and the Metrics page
- * "Create alert rule" flyout.
+ * PromQueryBuilder — the shared point-and-click PromQL alert-condition builder
+ * used by both the Alert Manager "Create metrics rule" flyout and the Metrics
+ * page "Create alert rule" flyout.
  *
- * Builds expressions of the shape `metric` or `metric{label OP "value"}`
- * from live metadata (metric names, label names/values) fetched from the
- * datasource. Seeds its selections from an existing query when that query
- * is builder-representable; complex expressions leave the builder empty and
- * inert so a seeded query is never clobbered unless the user explicitly
- * picks a new metric.
+ * It assembles the expression in four stacked layers (see `prom_condition.ts`
+ * for the pure composition/parse core):
+ *
+ *   1. Series    — metric + optional `{label OP "value"}` matcher
+ *   2. Function  — rate / increase / delta, or the `_over_time` reduce family,
+ *                  over a rolling window
+ *   3. Aggregate — sum / avg / min / max / count across series, optional
+ *                  `by (…)` / `without (…)` grouping
+ *   4. Condition — IS ABOVE / BELOW / EQUAL / … or a range, i.e. the comparison
+ *                  that makes the alert conditional rather than always-firing
+ *
+ * Metric names, label names, and label values are fetched live from the
+ * datasource. Selections are seeded from an existing query when that query is
+ * builder-representable (`parseExpr`); anything more complex leaves the builder
+ * empty and inert so a seeded Code expression is never clobbered unless the
+ * user explicitly picks a new metric.
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   EuiButtonIcon,
+  EuiCode,
   EuiComboBox,
+  EuiFieldNumber,
+  EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiFormLabel,
   EuiFormRow,
   EuiSelect,
   EuiSpacer,
@@ -28,35 +42,204 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import { AlertingPromResourcesService } from '../query_services/alerting_prom_resources_service';
+import {
+  AggGrouping,
+  AggOp,
+  buildExpr,
+  ConditionBuilderState,
+  ConditionOp,
+  DEFAULT_WINDOW,
+  isRangeOp,
+  parseExpr,
+  RangeFn,
+} from './prom_condition';
 
-interface ParsedBuilderQuery {
-  metric: string;
-  labelName?: string;
-  labelOperator?: string;
-  labelValue?: string;
-}
+/** Function options (value = PromQL function name). */
+const FUNCTION_OPTIONS: Array<{ value: RangeFn; text: string }> = [
+  {
+    value: 'none',
+    text: i18n.translate('observability.alerting.promQueryBuilder.fnNone', {
+      defaultMessage: 'None (instant value)',
+    }),
+  },
+  {
+    value: 'rate',
+    text: i18n.translate('observability.alerting.promQueryBuilder.fnRate', {
+      defaultMessage: 'Rate',
+    }),
+  },
+  {
+    value: 'increase',
+    text: i18n.translate('observability.alerting.promQueryBuilder.fnIncrease', {
+      defaultMessage: 'Increase',
+    }),
+  },
+  {
+    value: 'delta',
+    text: i18n.translate('observability.alerting.promQueryBuilder.fnDelta', {
+      defaultMessage: 'Delta',
+    }),
+  },
+  {
+    value: 'avg_over_time',
+    text: i18n.translate('observability.alerting.promQueryBuilder.fnAvgOverTime', {
+      defaultMessage: 'Avg over time',
+    }),
+  },
+  {
+    value: 'min_over_time',
+    text: i18n.translate('observability.alerting.promQueryBuilder.fnMinOverTime', {
+      defaultMessage: 'Min over time',
+    }),
+  },
+  {
+    value: 'max_over_time',
+    text: i18n.translate('observability.alerting.promQueryBuilder.fnMaxOverTime', {
+      defaultMessage: 'Max over time',
+    }),
+  },
+  {
+    value: 'sum_over_time',
+    text: i18n.translate('observability.alerting.promQueryBuilder.fnSumOverTime', {
+      defaultMessage: 'Sum over time',
+    }),
+  },
+  {
+    value: 'count_over_time',
+    text: i18n.translate('observability.alerting.promQueryBuilder.fnCountOverTime', {
+      defaultMessage: 'Count over time',
+    }),
+  },
+  {
+    value: 'last_over_time',
+    text: i18n.translate('observability.alerting.promQueryBuilder.fnLastOverTime', {
+      defaultMessage: 'Last over time',
+    }),
+  },
+];
 
-/**
- * Parse a PromQL expression back into builder selections, when the expression
- * has the exact shape the builder produces: `metric` or
- * `metric{label OP "value"}`. Returns null for anything more complex
- * (aggregations, comparisons, multiple matchers) — those cannot be
- * represented by the builder, so its fields stay empty and the builder→query
- * sync stays inert until the user makes a selection.
- */
-export function parseBuilderQuery(query: string): ParsedBuilderQuery | null {
-  const match = (query || '')
-    .trim()
-    .match(
-      /^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*(=~|!~|!=|=)\s*"((?:[^"\\]|\\.)*)"\s*\})?$/
-    );
-  if (!match) return null;
-  const [, metric, labelName, labelOperator, escapedValue] = match;
-  if (!labelName) return { metric };
-  // Reverse the escaping applied by the builder→query sync
-  const labelValue = escapedValue.replace(/\\(["\\])/g, '$1');
-  return { metric, labelName, labelOperator, labelValue };
-}
+/** Aggregation-operator options (value = PromQL aggregation keyword). */
+const AGG_OP_OPTIONS: Array<{ value: AggOp; text: string }> = [
+  {
+    value: 'none',
+    text: i18n.translate('observability.alerting.promQueryBuilder.aggNone', {
+      defaultMessage: 'None',
+    }),
+  },
+  {
+    value: 'sum',
+    text: i18n.translate('observability.alerting.promQueryBuilder.aggSum', {
+      defaultMessage: 'Sum',
+    }),
+  },
+  {
+    value: 'avg',
+    text: i18n.translate('observability.alerting.promQueryBuilder.aggAvg', {
+      defaultMessage: 'Average',
+    }),
+  },
+  {
+    value: 'min',
+    text: i18n.translate('observability.alerting.promQueryBuilder.aggMin', {
+      defaultMessage: 'Min',
+    }),
+  },
+  {
+    value: 'max',
+    text: i18n.translate('observability.alerting.promQueryBuilder.aggMax', {
+      defaultMessage: 'Max',
+    }),
+  },
+  {
+    value: 'count',
+    text: i18n.translate('observability.alerting.promQueryBuilder.aggCount', {
+      defaultMessage: 'Count',
+    }),
+  },
+];
+
+/** Grouping-modifier options for the aggregation. */
+const GROUPING_OPTIONS: Array<{ value: AggGrouping; text: string }> = [
+  {
+    value: 'none',
+    text: i18n.translate('observability.alerting.promQueryBuilder.groupingNone', {
+      defaultMessage: 'no grouping',
+    }),
+  },
+  {
+    value: 'by',
+    text: i18n.translate('observability.alerting.promQueryBuilder.groupingBy', {
+      defaultMessage: 'by',
+    }),
+  },
+  {
+    value: 'without',
+    text: i18n.translate('observability.alerting.promQueryBuilder.groupingWithout', {
+      defaultMessage: 'without',
+    }),
+  },
+];
+
+/** Condition-operator options (value → label). */
+const CONDITION_OP_OPTIONS: Array<{ value: ConditionOp; text: string }> = [
+  {
+    value: 'none',
+    text: i18n.translate('observability.alerting.promQueryBuilder.condNone', {
+      defaultMessage: 'No condition (always firing)',
+    }),
+  },
+  {
+    value: 'gt',
+    text: i18n.translate('observability.alerting.promQueryBuilder.condGt', {
+      defaultMessage: 'IS ABOVE',
+    }),
+  },
+  {
+    value: 'gte',
+    text: i18n.translate('observability.alerting.promQueryBuilder.condGte', {
+      defaultMessage: 'IS ABOVE OR EQUAL',
+    }),
+  },
+  {
+    value: 'lt',
+    text: i18n.translate('observability.alerting.promQueryBuilder.condLt', {
+      defaultMessage: 'IS BELOW',
+    }),
+  },
+  {
+    value: 'lte',
+    text: i18n.translate('observability.alerting.promQueryBuilder.condLte', {
+      defaultMessage: 'IS BELOW OR EQUAL',
+    }),
+  },
+  {
+    value: 'eq',
+    text: i18n.translate('observability.alerting.promQueryBuilder.condEq', {
+      defaultMessage: 'IS EQUAL TO',
+    }),
+  },
+  {
+    value: 'neq',
+    text: i18n.translate('observability.alerting.promQueryBuilder.condNeq', {
+      defaultMessage: 'IS NOT EQUAL TO',
+    }),
+  },
+  {
+    value: 'outside',
+    text: i18n.translate('observability.alerting.promQueryBuilder.condOutside', {
+      defaultMessage: 'IS OUTSIDE RANGE',
+    }),
+  },
+  {
+    value: 'within',
+    text: i18n.translate('observability.alerting.promQueryBuilder.condWithin', {
+      defaultMessage: 'IS WITHIN RANGE',
+    }),
+  },
+];
+
+/** Re-export so callers (the always-firing warning) parse from one place. */
+export { parseExpr, buildExpr } from './prom_condition';
 
 export const PromQueryBuilder: React.FC<{
   /** Datasource to fetch metric/label metadata from. */
@@ -66,21 +249,37 @@ export const PromQueryBuilder: React.FC<{
   /** Fired whenever builder selections produce (or clear) a query. */
   onQueryChange: (query: string) => void;
 }> = ({ datasourceId, query, onQueryChange }) => {
-  // Seeded once on mount — complex expressions yield null and an inert builder
-  const [seededBuilder] = useState(() => parseBuilderQuery(query));
+  // Seeded once on mount — complex expressions yield null and an inert builder.
+  const [seeded] = useState(() => parseExpr(query));
   const [metricOptions, setMetricOptions] = useState<Array<{ label: string }>>([]);
   const [selectedMetric, setSelectedMetric] = useState<Array<{ label: string }>>(
-    seededBuilder ? [{ label: seededBuilder.metric }] : []
+    seeded ? [{ label: seeded.metric }] : []
   );
   const [labelNameOptions, setLabelNameOptions] = useState<Array<{ label: string }>>([]);
   const [selectedLabelName, setSelectedLabelName] = useState<Array<{ label: string }>>(
-    seededBuilder?.labelName ? [{ label: seededBuilder.labelName }] : []
+    seeded?.labelName ? [{ label: seeded.labelName }] : []
   );
   const [labelValueOptions, setLabelValueOptions] = useState<Array<{ label: string }>>([]);
   const [selectedLabelValue, setSelectedLabelValue] = useState<Array<{ label: string }>>(
-    seededBuilder?.labelValue ? [{ label: seededBuilder.labelValue }] : []
+    seeded?.labelValue ? [{ label: seeded.labelValue }] : []
   );
-  const [labelOperator, setLabelOperator] = useState(seededBuilder?.labelOperator || '=');
+  const [labelOperator, setLabelOperator] = useState(seeded?.labelOperator || '=');
+
+  // Function + aggregate + condition layers.
+  const [func, setFunc] = useState<RangeFn>(seeded?.func ?? 'none');
+  const [window, setWindow] = useState(seeded?.window || DEFAULT_WINDOW);
+  const [aggOp, setAggOp] = useState<AggOp>(seeded?.aggOp ?? 'none');
+  const [aggGrouping, setAggGrouping] = useState<AggGrouping>(seeded?.aggGrouping ?? 'none');
+  const [aggLabels, setAggLabels] = useState((seeded?.aggLabels || []).join(', '));
+  const [conditionOp, setConditionOp] = useState<ConditionOp>(seeded?.conditionOp ?? 'none');
+  // Thresholds are held as strings so the field can be cleared / mid-typed; the
+  // pure core coerces a blank/NaN value to 0 when composing.
+  const [thresholdA, setThresholdA] = useState(
+    seeded?.thresholdA !== undefined ? String(seeded.thresholdA) : ''
+  );
+  const [thresholdB, setThresholdB] = useState(
+    seeded?.thresholdB !== undefined ? String(seeded.thresholdB) : ''
+  );
 
   // Fetch metric names when datasource changes. The `stale` flag guards
   // against out-of-order responses overwriting current options.
@@ -101,7 +300,7 @@ export const PromQueryBuilder: React.FC<{
     };
   }, [datasourceId]);
 
-  // Fetch label names when metric changes
+  // Fetch label names when metric changes.
   useEffect(() => {
     if (!datasourceId || selectedMetric.length === 0) {
       setLabelNameOptions([]);
@@ -122,7 +321,7 @@ export const PromQueryBuilder: React.FC<{
     };
   }, [datasourceId, selectedMetric]);
 
-  // Fetch label values when label name changes
+  // Fetch label values when label name changes.
   useEffect(() => {
     if (!datasourceId || selectedLabelName.length === 0) {
       setLabelValueOptions([]);
@@ -146,25 +345,45 @@ export const PromQueryBuilder: React.FC<{
   }, [datasourceId, selectedLabelName, selectedMetric]);
 
   // Tracks whether the current query was authored by the builder. Only then
-  // may clearing the metric clear the query — a complex seeded expression
-  // the builder never produced must not be wiped.
+  // may clearing the metric clear the query — a complex seeded expression the
+  // builder never produced must not be wiped.
   const builderOwnsQuery = useRef(false);
 
-  const syncBuilderToQuery = useCallback(() => {
-    if (selectedMetric.length === 0) return;
-    const metric = selectedMetric[0].label;
-    let next = metric;
-    if (selectedLabelName.length > 0 && selectedLabelValue.length > 0) {
-      // Escape backslashes and quotes so the value is a valid PromQL string literal
-      const escapedValue = selectedLabelValue[0].label.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      const labelFilter = `${selectedLabelName[0].label}${labelOperator}"${escapedValue}"`;
-      next = `${metric}{${labelFilter}}`;
-    }
-    builderOwnsQuery.current = true;
-    onQueryChange(next);
-  }, [selectedMetric, selectedLabelName, selectedLabelValue, labelOperator, onQueryChange]);
+  const currentState = useCallback(
+    (): ConditionBuilderState => ({
+      metric: selectedMetric.length > 0 ? selectedMetric[0].label : '',
+      labelName: selectedLabelName.length > 0 ? selectedLabelName[0].label : undefined,
+      labelOperator,
+      labelValue: selectedLabelValue.length > 0 ? selectedLabelValue[0].label : undefined,
+      func,
+      window,
+      aggOp,
+      aggGrouping,
+      aggLabels: aggLabels
+        .split(',')
+        .map((l) => l.trim())
+        .filter(Boolean),
+      conditionOp,
+      thresholdA: thresholdA === '' ? undefined : Number(thresholdA),
+      thresholdB: thresholdB === '' ? undefined : Number(thresholdB),
+    }),
+    [
+      selectedMetric,
+      selectedLabelName,
+      selectedLabelValue,
+      labelOperator,
+      func,
+      window,
+      aggOp,
+      aggGrouping,
+      aggLabels,
+      conditionOp,
+      thresholdA,
+      thresholdB,
+    ]
+  );
 
-  // Sync when builder field selections change; clearing the metric clears a
+  // Sync whenever any builder field changes; clearing the metric clears a
   // builder-authored query so the two stay consistent.
   const didMountRef = useRef(false);
   useEffect(() => {
@@ -172,24 +391,44 @@ export const PromQueryBuilder: React.FC<{
       didMountRef.current = true;
       // Seeded FROM the query on mount: mark ownership so a later clear can
       // reset it, but do NOT re-emit — re-emitting would normalize whitespace
-      // the user never touched (e.g. `foo{ bar = "x" }` → `foo{bar="x"}`) and
-      // spuriously mark the form dirty / pop the discard-changes modal.
-      if (seededBuilder) builderOwnsQuery.current = true;
+      // the user never touched and spuriously mark the form dirty.
+      if (seeded) builderOwnsQuery.current = true;
       return;
     }
     if (selectedMetric.length > 0) {
-      syncBuilderToQuery();
+      builderOwnsQuery.current = true;
+      onQueryChange(buildExpr(currentState()));
     } else if (builderOwnsQuery.current) {
       builderOwnsQuery.current = false;
       onQueryChange('');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedMetric, selectedLabelName, selectedLabelValue, labelOperator]);
+  }, [
+    selectedMetric,
+    selectedLabelName,
+    selectedLabelValue,
+    labelOperator,
+    func,
+    window,
+    aggOp,
+    aggGrouping,
+    aggLabels,
+    conditionOp,
+    thresholdA,
+    thresholdB,
+  ]);
+
+  const showRange = isRangeOp(conditionOp);
+  const numericWindow = window.replace(/[a-z]/gi, '');
+  const windowUnit = window.replace(/[0-9.]/g, '') || 'm';
 
   return (
     <>
+      {/* Layer 1 — series selector. Metric stands alone; the label matcher
+        (name / operator / value / clear) is one tight cluster so it reads as a
+        single `{name = value}` filter rather than three scattered fields. */}
       <EuiFlexGroup gutterSize="m" alignItems="flexEnd" responsive={false}>
-        <EuiFlexItem grow={3}>
+        <EuiFlexItem grow={2}>
           <EuiFormRow
             label={i18n.translate('observability.alerting.promQueryBuilder.metricLabel', {
               defaultMessage: 'Metric',
@@ -206,96 +445,373 @@ export const PromQueryBuilder: React.FC<{
               onChange={(opts) => {
                 setSelectedMetric(opts);
                 // Reset the label filter when the metric changes — a label
-                // name/value valid for the old metric can be invalid (or mean
-                // something different) for the new one, which would build an
-                // incorrect `newMetric{staleLabel="staleValue"}` query.
+                // name/value valid for the old metric can be invalid for the
+                // new one, building an incorrect `newMetric{staleLabel=…}`.
                 setSelectedLabelName([]);
                 setSelectedLabelValue([]);
               }}
               singleSelection={{ asPlainText: true }}
               compressed
               isClearable
+              data-test-subj="promBuilderMetric"
             />
           </EuiFormRow>
         </EuiFlexItem>
         <EuiFlexItem grow={3}>
           <EuiFormRow
-            label={i18n.translate('observability.alerting.promQueryBuilder.labelNameLabel', {
-              defaultMessage: 'Label name',
+            label={i18n.translate('observability.alerting.promQueryBuilder.labelFilterLabel', {
+              defaultMessage: 'Label filter — optional',
             })}
             display="rowCompressed"
           >
-            <EuiComboBox
-              placeholder={i18n.translate(
-                'observability.alerting.promQueryBuilder.labelNamePlaceholder',
-                { defaultMessage: 'Label name' }
-              )}
-              options={labelNameOptions}
-              selectedOptions={selectedLabelName}
-              onChange={(opts) => setSelectedLabelName(opts)}
-              singleSelection={{ asPlainText: true }}
-              compressed
-              isClearable
-            />
+            {/* xs gutter so name/op/value visually connect as one matcher. */}
+            <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+              <EuiFlexItem grow={3}>
+                <EuiComboBox
+                  placeholder={i18n.translate(
+                    'observability.alerting.promQueryBuilder.labelNamePlaceholder',
+                    { defaultMessage: 'Label name' }
+                  )}
+                  aria-label={i18n.translate(
+                    'observability.alerting.promQueryBuilder.labelNameLabel',
+                    { defaultMessage: 'Label name' }
+                  )}
+                  options={labelNameOptions}
+                  selectedOptions={selectedLabelName}
+                  onChange={(opts) => setSelectedLabelName(opts)}
+                  singleSelection={{ asPlainText: true }}
+                  compressed
+                  isClearable
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false} style={{ width: 68 }}>
+                <EuiSelect
+                  options={[
+                    { value: '=', text: '=' },
+                    { value: '!=', text: '!=' },
+                    { value: '=~', text: '=~' },
+                    { value: '!~', text: '!~' },
+                  ]}
+                  value={labelOperator}
+                  onChange={(e) => setLabelOperator(e.target.value)}
+                  compressed
+                  aria-label={i18n.translate(
+                    'observability.alerting.promQueryBuilder.labelOperatorAriaLabel',
+                    { defaultMessage: 'Label match operator' }
+                  )}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={3}>
+                <EuiComboBox
+                  placeholder={i18n.translate(
+                    'observability.alerting.promQueryBuilder.labelValuePlaceholder',
+                    { defaultMessage: 'Label value' }
+                  )}
+                  aria-label={i18n.translate(
+                    'observability.alerting.promQueryBuilder.labelValueLabel',
+                    { defaultMessage: 'Label value' }
+                  )}
+                  options={labelValueOptions}
+                  selectedOptions={selectedLabelValue}
+                  onChange={(opts) => setSelectedLabelValue(opts)}
+                  singleSelection={{ asPlainText: true }}
+                  compressed
+                  isClearable
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonIcon
+                  iconType="cross"
+                  aria-label={i18n.translate(
+                    'observability.alerting.promQueryBuilder.clearFilterAriaLabel',
+                    { defaultMessage: 'Clear filter' }
+                  )}
+                  color="subdued"
+                  onClick={() => {
+                    setSelectedLabelName([]);
+                    setSelectedLabelValue([]);
+                  }}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false} style={{ width: 60 }}>
-          <EuiFormRow label=" " display="rowCompressed">
-            <EuiSelect
-              options={[
-                { value: '=', text: '=' },
-                { value: '!=', text: '!=' },
-                { value: '=~', text: '=~' },
-                { value: '!~', text: '!~' },
-              ]}
-              value={labelOperator}
-              onChange={(e) => setLabelOperator(e.target.value)}
-              compressed
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={3}>
-          <EuiFormRow
-            label={i18n.translate('observability.alerting.promQueryBuilder.labelValueLabel', {
-              defaultMessage: 'Label value',
-            })}
-            display="rowCompressed"
-          >
-            <EuiComboBox
-              placeholder={i18n.translate(
-                'observability.alerting.promQueryBuilder.labelValuePlaceholder',
-                { defaultMessage: 'Label value' }
-              )}
-              options={labelValueOptions}
-              selectedOptions={selectedLabelValue}
-              onChange={(opts) => setSelectedLabelValue(opts)}
-              singleSelection={{ asPlainText: true }}
-              compressed
-              isClearable
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="cross"
-            aria-label={i18n.translate(
-              'observability.alerting.promQueryBuilder.clearFilterAriaLabel',
-              { defaultMessage: 'Clear filter' }
-            )}
-            color="subdued"
-            onClick={() => {
-              setSelectedLabelName([]);
-              setSelectedLabelValue([]);
-            }}
-          />
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer size="s" />
-      <EuiText size="xs" color="subdued">
-        {i18n.translate('observability.alerting.promQueryBuilder.helpText', {
-          defaultMessage: 'Select a metric to start.',
-        })}
-      </EuiText>
+
+      {/* Progressive disclosure: the transform + condition layers only appear
+        once a metric is chosen, so the empty state is a single clean row. */}
+      {selectedMetric.length > 0 && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiFormLabel>
+            {i18n.translate('observability.alerting.promQueryBuilder.transformSection', {
+              defaultMessage: 'Transform (optional)',
+            })}
+          </EuiFormLabel>
+          <EuiSpacer size="xs" />
+
+          {/* Layer 2 — function, and Layer 3 — aggregation. Wraps so the
+            compressed controls reflow instead of cramming on a narrow flyout. */}
+          <EuiFlexGroup gutterSize="m" alignItems="flexEnd" responsive={false} wrap>
+            <EuiFlexItem grow={false} style={{ minWidth: 150 }}>
+              <EuiFormRow
+                label={i18n.translate('observability.alerting.promQueryBuilder.functionLabel', {
+                  defaultMessage: 'Function',
+                })}
+                display="rowCompressed"
+              >
+                <EuiSelect
+                  options={FUNCTION_OPTIONS}
+                  value={func}
+                  onChange={(e) => setFunc(e.target.value as RangeFn)}
+                  compressed
+                  data-test-subj="promBuilderFunction"
+                  aria-label={i18n.translate(
+                    'observability.alerting.promQueryBuilder.functionAriaLabel',
+                    { defaultMessage: 'Range function' }
+                  )}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            {func !== 'none' && (
+              <>
+                <EuiFlexItem grow={false} style={{ width: 72 }}>
+                  <EuiFormRow
+                    label={i18n.translate('observability.alerting.promQueryBuilder.windowLabel', {
+                      defaultMessage: 'Window',
+                    })}
+                    display="rowCompressed"
+                  >
+                    <EuiFieldNumber
+                      value={numericWindow}
+                      min={1}
+                      step={1}
+                      onChange={(e) => {
+                        // Prometheus durations are integers only, and a bare unit
+                        // (e.g. `[m]`) is invalid PromQL. Keep digits only and,
+                        // when the field is cleared, emit '' so `buildExpr` falls
+                        // back to the default window instead of a unit-only value.
+                        const digits = e.target.value.replace(/[^0-9]/g, '');
+                        setWindow(digits ? `${digits}${windowUnit}` : '');
+                      }}
+                      compressed
+                      data-test-subj="promBuilderWindow"
+                      aria-label={i18n.translate(
+                        'observability.alerting.promQueryBuilder.windowAriaLabel',
+                        { defaultMessage: 'Function window' }
+                      )}
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false} style={{ width: 64 }}>
+                  {/* Unit as its own control — an `append` select gets clipped at
+                these compressed widths, hiding the current unit. */}
+                  <EuiFormRow label="&nbsp;" display="rowCompressed">
+                    <EuiSelect
+                      options={[
+                        { value: 's', text: 's' },
+                        { value: 'm', text: 'm' },
+                        { value: 'h', text: 'h' },
+                        { value: 'd', text: 'd' },
+                        { value: 'w', text: 'w' },
+                        { value: 'y', text: 'y' },
+                      ]}
+                      value={windowUnit}
+                      onChange={(e) => setWindow(`${numericWindow || '5'}${e.target.value}`)}
+                      compressed
+                      aria-label={i18n.translate(
+                        'observability.alerting.promQueryBuilder.windowUnitAriaLabel',
+                        { defaultMessage: 'Window unit' }
+                      )}
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+              </>
+            )}
+            <EuiFlexItem grow={false} style={{ minWidth: 150 }}>
+              <EuiFormRow
+                label={i18n.translate('observability.alerting.promQueryBuilder.aggregateLabel', {
+                  defaultMessage: 'Aggregate',
+                })}
+                display="rowCompressed"
+              >
+                <EuiSelect
+                  options={AGG_OP_OPTIONS}
+                  value={aggOp}
+                  onChange={(e) => setAggOp(e.target.value as AggOp)}
+                  compressed
+                  data-test-subj="promBuilderAggregate"
+                  aria-label={i18n.translate(
+                    'observability.alerting.promQueryBuilder.aggregateAriaLabel',
+                    { defaultMessage: 'Aggregation operator' }
+                  )}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            {aggOp !== 'none' && (
+              <>
+                <EuiFlexItem grow={false} style={{ width: 120 }}>
+                  <EuiFormRow
+                    label={i18n.translate('observability.alerting.promQueryBuilder.groupingLabel', {
+                      defaultMessage: 'Grouping',
+                    })}
+                    display="rowCompressed"
+                  >
+                    <EuiSelect
+                      options={GROUPING_OPTIONS}
+                      value={aggGrouping}
+                      onChange={(e) => setAggGrouping(e.target.value as AggGrouping)}
+                      compressed
+                      data-test-subj="promBuilderGrouping"
+                      aria-label={i18n.translate(
+                        'observability.alerting.promQueryBuilder.groupingAriaLabel',
+                        { defaultMessage: 'Aggregation grouping' }
+                      )}
+                    />
+                  </EuiFormRow>
+                </EuiFlexItem>
+                {aggGrouping !== 'none' && (
+                  <EuiFlexItem grow={false} style={{ minWidth: 160 }}>
+                    <EuiFormRow
+                      label={i18n.translate(
+                        'observability.alerting.promQueryBuilder.groupLabelsLabel',
+                        {
+                          defaultMessage: 'Labels',
+                        }
+                      )}
+                      display="rowCompressed"
+                    >
+                      <EuiFieldText
+                        placeholder={i18n.translate(
+                          'observability.alerting.promQueryBuilder.groupLabelsPlaceholder',
+                          { defaultMessage: 'e.g. job, instance' }
+                        )}
+                        value={aggLabels}
+                        onChange={(e) => setAggLabels(e.target.value)}
+                        compressed
+                        data-test-subj="promBuilderGroupLabels"
+                        aria-label={i18n.translate(
+                          'observability.alerting.promQueryBuilder.groupLabelsAriaLabel',
+                          { defaultMessage: 'Grouping labels (comma-separated)' }
+                        )}
+                      />
+                    </EuiFormRow>
+                  </EuiFlexItem>
+                )}
+              </>
+            )}
+          </EuiFlexGroup>
+
+          <EuiSpacer size="m" />
+
+          {/* Layer 4 — condition. No wrap: the operator and its value(s) must
+            stay on one line so the "IS ABOVE → 6" pairing reads as one decision. */}
+          <EuiFlexGroup gutterSize="m" alignItems="flexEnd" responsive={false}>
+            <EuiFlexItem grow={false} style={{ minWidth: 220 }}>
+              <EuiFormRow
+                label={i18n.translate('observability.alerting.promQueryBuilder.conditionLabel', {
+                  defaultMessage: 'Condition',
+                })}
+                display="rowCompressed"
+              >
+                <EuiSelect
+                  options={CONDITION_OP_OPTIONS}
+                  value={conditionOp}
+                  onChange={(e) => setConditionOp(e.target.value as ConditionOp)}
+                  compressed
+                  data-test-subj="promBuilderConditionOp"
+                  aria-label={i18n.translate(
+                    'observability.alerting.promQueryBuilder.conditionAriaLabel',
+                    { defaultMessage: 'Alert condition' }
+                  )}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            {conditionOp !== 'none' && (
+              <EuiFlexItem grow={false} style={{ width: 140 }}>
+                <EuiFormRow
+                  label={
+                    showRange
+                      ? i18n.translate('observability.alerting.promQueryBuilder.rangeLowLabel', {
+                          defaultMessage: 'From',
+                        })
+                      : i18n.translate('observability.alerting.promQueryBuilder.thresholdLabel', {
+                          defaultMessage: 'Value',
+                        })
+                  }
+                  display="rowCompressed"
+                >
+                  <EuiFieldNumber
+                    value={thresholdA}
+                    onChange={(e) => setThresholdA(e.target.value)}
+                    compressed
+                    data-test-subj="promBuilderThresholdA"
+                    aria-label={i18n.translate(
+                      'observability.alerting.promQueryBuilder.thresholdAAriaLabel',
+                      { defaultMessage: 'Threshold value' }
+                    )}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            )}
+            {showRange && (
+              <EuiFlexItem grow={false} style={{ width: 140 }}>
+                <EuiFormRow
+                  label={i18n.translate('observability.alerting.promQueryBuilder.rangeHighLabel', {
+                    defaultMessage: 'To',
+                  })}
+                  display="rowCompressed"
+                >
+                  <EuiFieldNumber
+                    value={thresholdB}
+                    onChange={(e) => setThresholdB(e.target.value)}
+                    compressed
+                    data-test-subj="promBuilderThresholdB"
+                    aria-label={i18n.translate(
+                      'observability.alerting.promQueryBuilder.thresholdBAriaLabel',
+                      { defaultMessage: 'Upper threshold value' }
+                    )}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        </>
+      )}
+
+      <EuiSpacer size="m" />
+      {selectedMetric.length === 0 ? (
+        <EuiText size="xs" color="subdued">
+          {i18n.translate('observability.alerting.promQueryBuilder.helpText', {
+            defaultMessage: 'Select a metric to start.',
+          })}
+        </EuiText>
+      ) : (
+        <>
+          {/* Live composed expression — the single source of truth the Code
+            editor also shows, so switching modes never surprises the user.
+            Inline EuiCode (not a block) keeps it one text node, and Code mode
+            already exposes the same string for copy/edit. */}
+          <EuiFormLabel>
+            {i18n.translate('observability.alerting.promQueryBuilder.expressionLabel', {
+              defaultMessage: 'Expression',
+            })}
+          </EuiFormLabel>
+          <EuiSpacer size="xs" />
+          <EuiCode data-test-subj="promBuilderExpression">{buildExpr(currentState())}</EuiCode>
+          {conditionOp === 'none' && (
+            <>
+              <EuiSpacer size="xs" />
+              <EuiText size="xs" color="subdued">
+                {i18n.translate('observability.alerting.promQueryBuilder.noConditionHint', {
+                  defaultMessage:
+                    'No condition set — this alert fires whenever the series exists. Add a condition to make it conditional.',
+                })}
+              </EuiText>
+            </>
+          )}
+        </>
+      )}
     </>
   );
 };

--- a/public/components/alerting/facet_filter_panel.tsx
+++ b/public/components/alerting/facet_filter_panel.tsx
@@ -244,7 +244,15 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
          * link is a SIBLING outside it (never a link nested inside a button),
          * which is why Clear no longer needs a stopPropagation workaround.
          */}
-        <EuiFlexItem grow={true}>
+        {/*
+         * `minWidth: 0` lets this item shrink below the title's intrinsic
+         * width — without it, the badge + "Clear" link (siblings below,
+         * fixed-width) push the header row wider than the ~182px facet
+         * column instead of the title truncating. See the `textProps`
+         * comment below for why this is inline style rather than a class in
+         * alerting.scss.
+         */}
+        <EuiFlexItem grow={true} style={{ minWidth: 0 }}>
           <EuiButtonEmpty
             size="xs"
             color="text"
@@ -254,8 +262,31 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
             // center`, which centers the arrow + title instead of leaving them
             // flush-left. Pin the content to the start so the header aligns
             // with the plain-text groups (e.g. "Labels") at every panel width.
-            // `flush="left"` only strips padding, not alignment.
-            contentProps={{ style: { justifyContent: 'flex-start', width: '100%' } }}
+            // `flush="left"` only strips padding, not alignment. `minWidth: 0`
+            // continues the shrink cascade from the EuiFlexItem above.
+            contentProps={{
+              style: { justifyContent: 'flex-start', width: '100%', minWidth: 0 },
+            }}
+            // The title text (plus the optional option-count suffix) has no
+            // truncation of its own, so a long facet label — or even a short
+            // one once the badge + "Clear" link are showing — overflows this
+            // narrow column instead of shrinking. `textProps` targets EUI's
+            // internal `.euiButtonEmpty__text` span directly (there's no
+            // approved-file entry for `.eui*` selectors in alerting.scss, so
+            // this has to be inline style rather than CSS); `flex`/`minWidth`
+            // let it shrink inside the content span above, and the rest is a
+            // plain single-line ellipsis truncation.
+            textProps={{
+              style: {
+                display: 'block',
+                flex: 1,
+                minWidth: 0,
+                maxWidth: '100%',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              },
+            }}
             iconType={isCollapsed ? 'arrowRight' : 'arrowDown'}
             iconSide="left"
             onClick={() => onToggleCollapse(id)}

--- a/public/components/alerting/query_preview_results.tsx
+++ b/public/components/alerting/query_preview_results.tsx
@@ -19,6 +19,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import {
   EuiAccordion,
+  EuiBadge,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
@@ -30,14 +31,58 @@ import { FormattedMessage } from '@osd/i18n/react';
 import { i18n } from '@osd/i18n';
 import { EchartsRender } from './echarts_render';
 import { AlertingPromResourcesService } from './query_services/alerting_prom_resources_service';
+import { ConditionOp } from './create_monitor/prom_condition';
 
 interface PreviewPoint {
   timestamp: number;
   value: number;
 }
 
+/** The alert condition parsed from the query, used to overlay the threshold. */
+export interface PreviewCondition {
+  op: ConditionOp;
+  thresholdA?: number;
+  thresholdB?: number;
+}
+
+/** The threshold value(s) to draw as horizontal marker line(s). */
+function thresholdValues(condition?: PreviewCondition): number[] {
+  if (!condition || condition.op === 'none') return [];
+  const a = condition.thresholdA;
+  if (condition.op === 'outside' || condition.op === 'within') {
+    return [a, condition.thresholdB].filter((v): v is number => Number.isFinite(v as number));
+  }
+  return Number.isFinite(a as number) ? [a as number] : [];
+}
+
+/** Would the alert fire, given the most recent sample value? */
+function conditionMet(value: number, condition: PreviewCondition): boolean {
+  const a = condition.thresholdA ?? 0;
+  const b = condition.thresholdB ?? 0;
+  switch (condition.op) {
+    case 'gt':
+      return value > a;
+    case 'gte':
+      return value >= a;
+    case 'lt':
+      return value < a;
+    case 'lte':
+      return value <= a;
+    case 'eq':
+      return value === a;
+    case 'neq':
+      return value !== a;
+    case 'outside':
+      return value < a || value > b;
+    case 'within':
+      return value >= a && value <= b;
+    default:
+      return false;
+  }
+}
+
 /** Build the echarts line-chart spec from live range-query points. */
-function buildChartOption(points: PreviewPoint[]): Record<string, unknown> {
+function buildChartOption(points: PreviewPoint[], thresholds: number[]): Record<string, unknown> {
   const timeLabels = points.map((p) =>
     new Date(p.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
   );
@@ -55,6 +100,24 @@ function buildChartOption(points: PreviewPoint[]): Record<string, unknown> {
         showSymbol: false,
         itemStyle: { color: '#006BB4' },
         areaStyle: { color: 'rgba(0,107,180,0.1)' },
+        // Dashed red threshold line(s) so the user sees where the condition
+        // trips relative to the plotted metric.
+        ...(thresholds.length > 0
+          ? {
+              markLine: {
+                silent: true,
+                symbol: 'none',
+                data: thresholds.map((v) => ({ yAxis: v })),
+                lineStyle: { color: '#BD271E', type: 'dashed' },
+                label: {
+                  formatter: i18n.translate(
+                    'observability.alerting.queryPreviewResults.thresholdLineLabel',
+                    { defaultMessage: 'threshold' }
+                  ),
+                },
+              },
+            }
+          : {}),
       },
     ],
   };
@@ -118,9 +181,15 @@ export const QueryPreviewResults: React.FC<{
   timeRange?: PreviewTimeRange;
   /** Bumped on each "Run preview" click to re-run the query. */
   runToken?: number;
+  /**
+   * Parsed alert condition (from the current query). When present, its
+   * threshold(s) are drawn on the chart and the latest sample is evaluated
+   * into a "would fire now" badge.
+   */
+  condition?: PreviewCondition;
   /** Unique accordion id — pass a distinct one per mount point. */
   id?: string;
-}> = ({ query, datasourceId, timeRange, runToken, id = 'prom-preview-results' }) => {
+}> = ({ query, datasourceId, timeRange, runToken, condition, id = 'prom-preview-results' }) => {
   const [state, setState] = useState<PreviewState>(EMPTY_STATE);
 
   // Snapshot the live query in a ref so editing it does NOT re-fire the range
@@ -183,6 +252,15 @@ export const QueryPreviewResults: React.FC<{
   // caption isn't mistaken for a threshold-applied series.
   const comparisonStripped = !!state.plottedQuery && state.plottedQuery !== state.requestedQuery;
 
+  const thresholds = thresholdValues(condition);
+  // Evaluate the most recent plotted sample against the condition for the
+  // "would fire now" badge. Only meaningful once we have data and a condition.
+  const latestValue = resultCount > 0 ? state.points[resultCount - 1].value : undefined;
+  const wouldFire =
+    condition && condition.op !== 'none' && latestValue !== undefined
+      ? conditionMet(latestValue, condition)
+      : undefined;
+
   return (
     <EuiAccordion
       id={id}
@@ -197,6 +275,22 @@ export const QueryPreviewResults: React.FC<{
               />
             </strong>
           </EuiFlexItem>
+          {wouldFire !== undefined && (
+            <EuiFlexItem grow={false}>
+              <EuiBadge
+                color={wouldFire ? 'danger' : 'hollow'}
+                data-test-subj="previewWouldFireBadge"
+              >
+                {wouldFire
+                  ? i18n.translate('observability.alerting.queryPreviewResults.wouldFire', {
+                      defaultMessage: 'Would fire now',
+                    })
+                  : i18n.translate('observability.alerting.queryPreviewResults.wouldNotFire', {
+                      defaultMessage: 'Would not fire',
+                    })}
+              </EuiBadge>
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
       }
       initialIsOpen
@@ -291,7 +385,7 @@ export const QueryPreviewResults: React.FC<{
           </EuiText>
         </EuiCallOut>
       ) : (
-        <EchartsRender spec={buildChartOption(state.points)} height={200} />
+        <EchartsRender spec={buildChartOption(state.points, thresholds)} height={200} />
       )}
     </EuiAccordion>
   );


### PR DESCRIPTION
## Summary

The metrics-rule **Builder** previously emitted only a bare series selector (`metric{label="x"}`), so a *conditional* alert (a comparison/threshold) could only be written by hand in **Code** mode — and Code mode silently allowed an always-firing, condition-less rule. This PR adds a first-class, point-and-click alert-condition experience.

### What changed
- **New pure core** `create_monitor/prom_condition.ts` composes the PromQL `expr` in stacked layers and provides a lossless inverse parser:
  1. **Series** — `metric` + optional `{label OP "value"}`
  2. **Function** — rate / increase / delta and the `_over_time` family (avg/min/max/sum/count/last) over a window
  3. **Aggregate** — sum / avg / min / max / count with optional `by` / `without` grouping
  4. **Condition** — IS ABOVE / BELOW / EQUAL / NOT EQUAL / ABOVE-OR-EQUAL / BELOW-OR-EQUAL / **OUTSIDE RANGE** / **WITHIN RANGE**
  - `buildExpr` ↔ `parseExpr` round-trip so switching Builder↔Code (or re-opening to edit) is lossless for anything the builder could produce; anything more complex (nested aggs, histogram_quantile, arithmetic between series, multi-label matchers) parses to `null`, leaving the builder inert so a hand-written expression is never clobbered. Covers e.g. `sum(rate(metric[4m])) > 6`.
- **`PromQueryBuilder`** gains Function + Aggregate + Condition rows on top of the metric/label picker, composing via the core, with a live composed `Expression` preview.
- **Always-firing guard** — a warning callout in **both** Builder and Code modes when the expression has no comparison. Non-blocking (a condition-less rule is legal PromQL), just surfaced so it isn't created by accident.
- **Preview** — the *Run preview* chart now draws the threshold line(s) and shows a **"Would fire now" / "Would not fire"** badge evaluated against the latest sample.

`parseExpr` supersedes the old `parseBuilderQuery` (now represents comparisons and ranges, not just bare selectors); callers and tests updated.

## Before / after

Same rule (`sum(rate(gen_ai_client_token_usage_total[5m])) > 6`), same viewport, from the unified **Alerts → Rules → Create metrics rule** flyout. Left = `origin/main`, right = this PR; orange box = area before, green box = same area after.

### 1. Point-and-click condition builder (the feature)
On `origin/main` the Builder stops at the metric/label picker and *For duration* — there is **no way to express a condition**, so a threshold alert has to be hand-typed in Code. This PR adds **Function / Aggregate / Condition** rows and a live composed **Expression**.

![builder before/after](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/condition-builder/condition-builder-evidence/ba_builder.png)

**Before — full flow (`origin/main`):** pick a metric → the Builder offers no condition → you must switch to Code and hand-write the PromQL.

![before flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/condition-builder/condition-builder-evidence/gif_before.gif)

**After — full flow (this PR):** pick a metric → set Function (rate) · Aggregate (sum) · Condition (IS ABOVE 6) → the Expression composes itself and Create enables. No raw PromQL required.

![after flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/condition-builder/condition-builder-evidence/gif_after.gif)

### 2. Rules table — internal scroll (fixes #2686 regression)
Before, the table grew past the viewport → the whole page scrolled and a nested table scrollbar appeared (double-scroll). After, the table region is capped to the viewport and scrolls internally with a sticky header.

![table before/after](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/condition-builder/condition-builder-evidence/ba_table.png)

### 3. No more horizontal "side" scroll
Before, the filters panel and the table each showed a spurious horizontal scrollbar. After, both are gone (a real x-scrollbar appears only when the table genuinely can't fit).

![side-scroll before/after](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/condition-builder/condition-builder-evidence/ba_side.png)

<sub>Captured at matched viewports (builder/flows 1440×900, table 1200×689). Composites/GIFs are hosted on the `evidence/condition-builder` fork branch and are not part of this PR's diff.</sub>

### On reusing the Discover/Explore metrics builder
The Discover/Explore metrics `PromQLBuilder` is **not cleanly reusable** from this plugin: it lives in explore's internal `application/` tree (not exported from any public contract — a deep import would violate cross-plugin import rules), and its `PrometheusClient` is constructed from `ExploreServices` + the query_enhancements-registered `prometheus` resource client. This builder deliberately matches its UX shape and its `onQueryChange(promql)` + seed-from-query contract, so it can be swapped for that component if explore ever exports it.

### Testing
- New `prom_condition.test.ts` — exhaustive build/parse/round-trip + always-firing heuristic.
- Updated `create_metrics_monitor.test.tsx` / `prometheus_form_sync.test.tsx` for the `parseExpr` semantics.
- All alerting suites pass locally; typecheck + lint clean.
- e2e-validated in both surfaces (unified Alerts Rules tab + Discover/Explore metrics "Create alert rule") — correct POST payloads for comparison + range conditions, static + dynamic labels, and templated annotations.

### Checklist
- [x] Unit tests added/updated
- [x] `Signed-off-by` (DCO)
- [x] Manual UI walkthrough / screenshots (before/after above)