### PR TITLE
fix(alerting): clone + edit monitors in the unified Alerts view

### DIFF
--- a/common/types/alerting/opensearch_types.ts
+++ b/common/types/alerting/opensearch_types.ts
@@ -319,6 +319,13 @@ export interface OpenSearchBackend {
   // Monitors — read-only methods.
   getMonitors(client: AlertingOSClient): Promise<OSMonitor[]>;
   getMonitor(client: AlertingOSClient, monitorId: string): Promise<OSMonitor | null>;
+  // Returns the narrowed `monitor` projection AND the faithful upstream `source`
+  // document (real monitor_type + wrapped triggers) — used by the clone flow so
+  // it can re-create a monitor without the lossy `mapMonitor` projection.
+  getMonitorWithSource(
+    client: AlertingOSClient,
+    monitorId: string
+  ): Promise<{ monitor: OSMonitor; source: Record<string, unknown> } | null>;
   runMonitor(client: AlertingOSClient, monitorId: string, dryRun?: boolean): Promise<unknown>;
   searchQuery(
     client: AlertingOSClient,

--- a/public/components/alerting/__tests__/alarms_page.test.tsx
+++ b/public/components/alerting/__tests__/alarms_page.test.tsx
@@ -639,6 +639,168 @@ describe('AlarmsPage', () => {
     expect((inner.actions as Array<Record<string, unknown>>)[0].id).toBeUndefined();
   });
 
+  it('strips server-owned / response-derived fields from the clone payload', async () => {
+    // The faithful upstream doc carries identity/audit/ownership/principal
+    // fields and GET-only enrichments that must NOT be re-POSTed on create.
+    const fakeRaw = {
+      id: 'mon-strip',
+      name: 'Strip Mon',
+      type: 'monitor',
+      monitor_type: 'query_level_monitor',
+      inputs: [{ search: { indices: ['logs-*'], query: {} } }],
+      triggers: [{ query_level_trigger: { id: 't', name: 't', actions: [] } }],
+      // fields that must be dropped:
+      version: 7,
+      last_update_time: 123,
+      enabled_time: 456,
+      schema_version: 5,
+      owner: 'alerting',
+      user: { name: 'creator', backend_roles: ['admin'], roles: ['all_access'] },
+      data_sources: { tenant: 't1' },
+      item_type: 'query_level_monitor',
+      associated_workflows: [{ id: 'wf1' }],
+      associatedCompositeMonitorCnt: 2,
+      last_run_context: { lastFired: 0 },
+    };
+    mockGetRuleDetail.mockResolvedValue({ raw: fakeRaw });
+    mockCreateMonitor.mockResolvedValue({ id: 'new-strip' });
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0] as {
+      onClone: (monitor: unknown) => Promise<void>;
+    };
+    await act(async () => {
+      await tableProps.onClone({
+        id: 'mon-strip',
+        name: 'Strip Mon',
+        datasourceId: 'ds-1',
+        definitionType: 'monitor',
+      });
+    });
+
+    const payload = mockCreateMonitor.mock.calls[0][0] as Record<string, unknown>;
+    for (const stripped of [
+      'id',
+      'version',
+      'last_update_time',
+      'enabled_time',
+      'schema_version',
+      'owner',
+      'user',
+      'data_sources',
+      'item_type',
+      'associated_workflows',
+      'associatedCompositeMonitorCnt',
+      'last_run_context',
+    ]) {
+      expect(payload[stripped]).toBeUndefined();
+    }
+    // …while legitimate create fields still round-trip.
+    expect(payload.monitor_type).toBe('query_level_monitor');
+    expect(payload.type).toBe('monitor');
+  });
+
+  it('clones a doc-level monitor preserving the document_level_trigger + doc-only fields', async () => {
+    const fakeRaw = {
+      id: 'mon-doc',
+      name: 'Doc Mon',
+      type: 'monitor',
+      monitor_type: 'doc_level_monitor',
+      // doc-level create-time fields that MUST survive in ...rest:
+      delete_query_index_in_every_run: true,
+      should_create_single_alert_for_findings: false,
+      inputs: [
+        {
+          doc_level_input: {
+            description: '',
+            indices: ['logs-*'],
+            queries: [{ id: 'q1', name: 'q1', query: 'x:1' }],
+          },
+        },
+      ],
+      triggers: [
+        {
+          document_level_trigger: {
+            id: 'trig-doc',
+            name: 'd1',
+            severity: '2',
+            condition: { script: { source: 'true', lang: 'painless' } },
+            actions: [{ id: 'act-doc', name: 'notify' }],
+          },
+        },
+      ],
+    };
+    mockGetRuleDetail.mockResolvedValue({ raw: fakeRaw });
+    mockCreateMonitor.mockResolvedValue({ id: 'new-doc' });
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0] as {
+      onClone: (monitor: unknown) => Promise<void>;
+    };
+    await act(async () => {
+      await tableProps.onClone({
+        id: 'mon-doc',
+        name: 'Doc Mon',
+        datasourceId: 'ds-1',
+        definitionType: 'monitor',
+      });
+    });
+
+    const payload = mockCreateMonitor.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.monitor_type).toBe('doc_level_monitor');
+    // doc-only create fields preserved
+    expect(payload.delete_query_index_in_every_run).toBe(true);
+    expect(payload.should_create_single_alert_for_findings).toBe(false);
+    const inner = (payload.triggers as Array<Record<string, unknown>>)[0]
+      .document_level_trigger as Record<string, unknown>;
+    expect(inner).toBeDefined();
+    expect(inner.id).toBeUndefined();
+    expect((inner.actions as Array<Record<string, unknown>>)[0].id).toBeUndefined();
+  });
+
+  it('gives distinct names to two clones fired before the list refetches (in-flight dedup)', async () => {
+    // Regression for the double-clone race: the first clone is not yet in
+    // `rules` (no refetch has landed), so the dedup must remember the name it
+    // just issued and hand the second clone `(Copy 2)`.
+    const fakeRaw = {
+      id: 'mon-race',
+      name: 'Race Mon',
+      type: 'monitor',
+      monitor_type: 'query_level_monitor',
+      inputs: [{ search: { indices: ['logs-*'], query: {} } }],
+      triggers: [{ query_level_trigger: { id: 't', name: 't', actions: [] } }],
+    };
+    mockGetRuleDetail.mockResolvedValue({ raw: fakeRaw });
+    mockCreateMonitor.mockResolvedValue({ id: 'new-race' });
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0] as {
+      onClone: (monitor: unknown) => Promise<void>;
+    };
+    const rule = {
+      id: 'mon-race',
+      name: 'Race Mon',
+      datasourceId: 'ds-1',
+      definitionType: 'monitor',
+    };
+    await act(async () => {
+      await tableProps.onClone(rule);
+      await tableProps.onClone(rule);
+    });
+
+    const names = mockCreateMonitor.mock.calls.map((c) => (c[0] as Record<string, unknown>).name);
+    expect(names).toEqual(['Race Mon (Copy)', 'Race Mon (Copy 2)']);
+  });
+
   it('gives an OpenSearch clone a unique name when the copy already exists', async () => {
     // A prior clone of the same monitor already sits in the list, so the bare
     // ` (Copy)` name is taken — the next clone must fall through to ` (Copy 2)`

--- a/public/components/alerting/__tests__/alarms_page.test.tsx
+++ b/public/components/alerting/__tests__/alarms_page.test.tsx
@@ -531,6 +531,97 @@ describe('AlarmsPage', () => {
     );
   });
 
+  it('clones a cluster-metrics monitor with a valid cluster_metrics_monitor type', async () => {
+    // The server's `mapMonitor` normalizes a cluster-metrics monitor's wire
+    // type down to `query_level_monitor`, so `detail.raw.monitor_type` arrives
+    // coerced. Re-POSTing that value would store the clone as a query-level
+    // monitor with a `uri` input, and the classic editor then crashes on edit
+    // (reads `inputs[0].search.indices`) → blank page. The clone path must
+    // restore `cluster_metrics_monitor` from the `uri` input shape.
+    const fakeRaw = {
+      id: 'mon-cm',
+      name: 'Cluster Health',
+      type: 'monitor',
+      monitor_type: 'query_level_monitor',
+      last_update_time: 123,
+      schema_version: 1,
+      inputs: [{ uri: { api_type: 'CLUSTER_HEALTH', path: '/_cluster/health' } }],
+      triggers: [{ query_level_trigger: { id: 'trig-1', name: 'Red', actions: [] } }],
+    };
+    mockGetRuleDetail.mockResolvedValue({ raw: fakeRaw });
+    mockCreateMonitor.mockResolvedValue({ id: 'new-mon-cm' });
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0] as {
+      onClone: (monitor: unknown) => Promise<void>;
+    };
+    await act(async () => {
+      await tableProps.onClone({
+        id: 'mon-cm',
+        name: 'Cluster Health',
+        datasourceId: 'ds-1',
+        definitionType: 'monitor',
+      });
+    });
+
+    expect(mockCreateMonitor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Cluster Health (Copy)',
+        monitor_type: 'cluster_metrics_monitor',
+      }),
+      'ds-1'
+    );
+  });
+
+  it('gives an OpenSearch clone a unique name when the copy already exists', async () => {
+    // A prior clone of the same monitor already sits in the list, so the bare
+    // ` (Copy)` name is taken — the next clone must fall through to ` (Copy 2)`
+    // instead of producing a second identical name.
+    mockUseRulesData.mockReturnValue({
+      ...emptyRulesHookResult,
+      rules: [
+        { id: 'mon-1', name: 'Test Monitor', datasourceId: 'ds-1' },
+        { id: 'mon-1-copy', name: 'Test Monitor (Copy)', datasourceId: 'ds-1' },
+      ],
+    });
+    const fakeRaw = {
+      id: 'mon-1',
+      name: 'Test Monitor',
+      type: 'monitor',
+      monitor_type: 'query_level_monitor',
+      inputs: [{ search: { indices: ['logs-*'], query: {} } }],
+      triggers: [],
+    };
+    mockGetRuleDetail.mockResolvedValue({ raw: fakeRaw });
+    mockCreateMonitor.mockResolvedValue({ id: 'new-mon-2' });
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0] as {
+      onClone: (monitor: unknown) => Promise<void>;
+    };
+    await act(async () => {
+      await tableProps.onClone({
+        id: 'mon-1',
+        name: 'Test Monitor',
+        datasourceId: 'ds-1',
+        definitionType: 'monitor',
+      });
+    });
+
+    expect(mockCreateMonitor).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Test Monitor (Copy 2)' }),
+      'ds-1'
+    );
+  });
+
   it.each([
     {
       definitionType: 'detector',

--- a/public/components/alerting/__tests__/alarms_page.test.tsx
+++ b/public/components/alerting/__tests__/alarms_page.test.tsx
@@ -701,6 +701,8 @@ describe('AlarmsPage', () => {
     // …while legitimate create fields still round-trip.
     expect(payload.monitor_type).toBe('query_level_monitor');
     expect(payload.type).toBe('monitor');
+    // Clones start disabled regardless of the source's enabled state.
+    expect(payload.enabled).toBe(false);
   });
 
   it('clones a doc-level monitor preserving the document_level_trigger + doc-only fields', async () => {

--- a/public/components/alerting/__tests__/alarms_page.test.tsx
+++ b/public/components/alerting/__tests__/alarms_page.test.tsx
@@ -532,17 +532,18 @@ describe('AlarmsPage', () => {
   });
 
   it('clones a cluster-metrics monitor with a valid cluster_metrics_monitor type', async () => {
-    // The server's `mapMonitor` normalizes a cluster-metrics monitor's wire
-    // type down to `query_level_monitor`, so `detail.raw.monitor_type` arrives
-    // coerced. Re-POSTing that value would store the clone as a query-level
-    // monitor with a `uri` input, and the classic editor then crashes on edit
-    // (reads `inputs[0].search.indices`) → blank page. The clone path must
-    // restore `cluster_metrics_monitor` from the `uri` input shape.
+    // `detail.raw` is now the faithful upstream document (getOSRuleDetail no
+    // longer returns the lossy `mapMonitor` projection), so it carries the real
+    // `cluster_metrics_monitor` type. Re-POSTing the normalized
+    // `query_level_monitor` used to store the clone as a query-level monitor
+    // with a `uri` input, and the classic editor then crashed on edit (read
+    // `inputs[0].search.indices`) → blank page. The clone must preserve the
+    // real type verbatim.
     const fakeRaw = {
       id: 'mon-cm',
       name: 'Cluster Health',
       type: 'monitor',
-      monitor_type: 'query_level_monitor',
+      monitor_type: 'cluster_metrics_monitor',
       last_update_time: 123,
       schema_version: 1,
       inputs: [{ uri: { api_type: 'CLUSTER_HEALTH', path: '/_cluster/health' } }],
@@ -575,6 +576,67 @@ describe('AlarmsPage', () => {
       }),
       'ds-1'
     );
+  });
+
+  it('clones a bucket-level monitor preserving its wrapped trigger + type', async () => {
+    // Regression: `mapMonitor` used to FLATTEN the `bucket_level_trigger`
+    // wrapper (dropping `parent_bucket_path` / `buckets_path`) and expose that
+    // in `raw`, so the clone re-POSTed a bare trigger → the backend rejected it
+    // with "Incompatible trigger for monitor type [bucket_level_monitor]".
+    // Now `raw` is faithful: the wrapper + its condition survive, and the clone
+    // only strips the trigger id (and any nested action ids).
+    const fakeRaw = {
+      id: 'mon-bkt',
+      name: 'Bucket Mon',
+      type: 'monitor',
+      monitor_type: 'bucket_level_monitor',
+      inputs: [{ search: { indices: ['logs-*'], query: {} } }],
+      triggers: [
+        {
+          bucket_level_trigger: {
+            id: 'trig-bkt',
+            name: 'b1',
+            severity: '1',
+            condition: {
+              parent_bucket_path: 'composite_agg',
+              buckets_path: { _count: '_count' },
+              script: { source: 'params._count > 0', lang: 'painless' },
+            },
+            actions: [{ id: 'act-bkt', name: 'notify' }],
+          },
+        },
+      ],
+    };
+    mockGetRuleDetail.mockResolvedValue({ raw: fakeRaw });
+    mockCreateMonitor.mockResolvedValue({ id: 'new-mon-bkt' });
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0] as {
+      onClone: (monitor: unknown) => Promise<void>;
+    };
+    await act(async () => {
+      await tableProps.onClone({
+        id: 'mon-bkt',
+        name: 'Bucket Mon',
+        datasourceId: 'ds-1',
+        definitionType: 'monitor',
+      });
+    });
+
+    const payload = mockCreateMonitor.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.monitor_type).toBe('bucket_level_monitor');
+    expect(payload.name).toBe('Bucket Mon (Copy)');
+    const trigger = (payload.triggers as Array<Record<string, unknown>>)[0];
+    const inner = trigger.bucket_level_trigger as Record<string, unknown>;
+    // Wrapper + bucket-specific condition preserved; ids stripped.
+    expect(inner).toBeDefined();
+    expect(inner.id).toBeUndefined();
+    expect((inner.condition as Record<string, unknown>).parent_bucket_path).toBe('composite_agg');
+    expect((inner.actions as Array<Record<string, unknown>>)[0].id).toBeUndefined();
   });
 
   it('gives an OpenSearch clone a unique name when the copy already exists', async () => {

--- a/public/components/alerting/__tests__/prometheus_rule_lifecycle.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_rule_lifecycle.test.tsx
@@ -172,6 +172,8 @@ describe('Prometheus rule clone', () => {
         name: 'HighMemory-copy',
         forDuration: '120s',
         evaluationInterval: '60s',
+        // Clones start disabled so they don't fire before the user reviews them.
+        enabled: false,
       }),
       'ds-1'
     );

--- a/public/components/alerting/__tests__/prometheus_rule_lifecycle.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_rule_lifecycle.test.tsx
@@ -38,6 +38,25 @@ jest.mock('../hooks/use_alerts', () => ({
   useAlerts: (args: unknown) => mockUseAlerts(args),
 }));
 
+// Mock the rules-data hook so clone-name uniqueness tests can seed the list
+// the duplicate-name check reads. Defaults to an empty list, which matches the
+// prior (unmocked) behavior for the other tests in this file.
+const mockUseRulesData = jest.fn();
+const emptyRulesHookResult = {
+  rules: [],
+  rulesTotal: 0,
+  isLoading: false,
+  error: null,
+  warnings: [],
+  setRules: jest.fn(),
+  setRulesTotal: jest.fn(),
+  refetch: jest.fn(),
+  backgroundRefetch: jest.fn(),
+};
+jest.mock('../hooks/use_rules_data', () => ({
+  useRulesData: (args: unknown) => mockUseRulesData(args),
+}));
+
 const mockMonitorsTable = jest.fn();
 jest.mock('../monitors_table', () => ({
   MonitorsTable: (props: unknown) => {
@@ -98,6 +117,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   jest.useFakeTimers();
   mockUseAlerts.mockReturnValue(emptyHookResult);
+  mockUseRulesData.mockReturnValue(emptyRulesHookResult);
   window.location.hash = '';
 });
 
@@ -200,6 +220,52 @@ describe('Prometheus rule clone', () => {
 
     expect(mockCreatePrometheusRule).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'TestRule-copy' }),
+      'ds-1'
+    );
+  });
+
+  it('gives a Prometheus clone a unique name when -copy already exists', async () => {
+    // A `TestRule-copy` already sits in the list, so the next clone of
+    // `TestRule` must fall through to `-copy-2` rather than colliding.
+    mockUseRulesData.mockReturnValue({
+      ...emptyRulesHookResult,
+      rules: [
+        { id: 'ds-1-TestRule-TestRule', name: 'TestRule', datasourceId: 'ds-1' },
+        { id: 'ds-1-TestRule-copy', name: 'TestRule-copy', datasourceId: 'ds-1' },
+      ],
+    });
+    mockGetRuleDetail.mockResolvedValue({
+      datasourceType: 'prometheus',
+      name: 'TestRule',
+      query: 'up == 0',
+      pendingPeriod: '60s',
+      evaluationInterval: '30s',
+      threshold: { operator: '==', value: 0 },
+      labels: {},
+      annotations: {},
+      raw: { type: 'alerting', name: 'TestRule', query: 'up == 0', duration: 60 },
+    });
+    mockCreatePrometheusRule.mockResolvedValue({ success: true });
+
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0] as {
+      onClone: (monitor: unknown) => Promise<void>;
+    };
+    await act(async () => {
+      await tableProps.onClone({
+        id: 'ds-1-TestRule-TestRule',
+        name: 'TestRule',
+        datasourceId: 'ds-1',
+        datasourceType: 'prometheus',
+      });
+    });
+
+    expect(mockCreatePrometheusRule).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'TestRule-copy-2' }),
       'ds-1'
     );
   });

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -194,6 +194,39 @@ function buildPrometheusRulePayload(opts: {
   };
 }
 
+/**
+ * Build a clone name that doesn't collide with an existing rule on the same
+ * datasource. Tries the bare suffix first (`makeSuffix(1)`, e.g. ` (Copy)`),
+ * then numbered variants (`makeSuffix(2)` → ` (Copy 2)`, …) until it finds a
+ * name the `isTaken` predicate reports as free. Each candidate is capped at
+ * `maxLen` by trimming the BASE name — never the suffix — so the disambiguator
+ * is always preserved. A bounded attempt count guarantees termination even
+ * against a pathological set of existing names; the final fallback appends a
+ * timestamp to stay unique.
+ */
+function buildUniqueCloneName(
+  baseName: string,
+  makeSuffix: (n: number) => string,
+  isTaken: (candidate: string) => boolean,
+  maxLen: number
+): string {
+  const withSuffix = (suffix: string): string => {
+    const base =
+      baseName.length + suffix.length > maxLen
+        ? baseName.slice(0, Math.max(0, maxLen - suffix.length))
+        : baseName;
+    return `${base}${suffix}`;
+  };
+  const MAX_ATTEMPTS = 1000;
+  for (let n = 1; n <= MAX_ATTEMPTS; n++) {
+    const candidate = withSuffix(makeSuffix(n));
+    if (!isTaken(candidate)) return candidate;
+  }
+  // Practically unreachable — a thousand same-named clones on one datasource.
+  // Guarantee a unique name rather than loop forever.
+  return withSuffix(`${makeSuffix(1)}-${Date.now()}`);
+}
+
 export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   datasources,
   datasourcesLoading,
@@ -942,13 +975,17 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       // OpenSearch Alerting monitor API (which requires `schedule`).
       if (detail.datasourceType === 'prometheus') {
         // Use a suffix that's safe for the ruleId regex [A-Za-z0-9_-]+
-        // (no spaces or parentheses).
-        const suffix = '-copy';
-        const baseName =
-          monitor.name.length + suffix.length > PPL_MONITOR_NAME_MAX
-            ? monitor.name.slice(0, PPL_MONITOR_NAME_MAX - suffix.length)
-            : monitor.name;
-        const clonedName = `${baseName}${suffix}`;
+        // (no spaces or parentheses), and disambiguate against existing rules
+        // so cloning the same rule twice yields `-copy`, `-copy-2`, … instead
+        // of two identical names. Prometheus rule identity is scoped by group,
+        // but the clone POST omits the group (server defaults it to the rule
+        // name), so we check datasource-wide to keep display names distinct.
+        const clonedName = buildUniqueCloneName(
+          monitor.name,
+          (n) => (n === 1 ? '-copy' : `-copy-${n}`),
+          (candidate) => isRuleNameTaken(candidate, monitor.datasourceId, undefined),
+          PPL_MONITOR_NAME_MAX
+        );
 
         // Extract rule details from the unified shape + raw
         const rawDetail: unknown = detail.raw ?? {};
@@ -1044,15 +1081,36 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         }
         return cleaned;
       });
-      const suffix = ' (Copy)';
-      const baseName =
-        monitor.name.length + suffix.length > PPL_MONITOR_NAME_MAX
-          ? monitor.name.slice(0, PPL_MONITOR_NAME_MAX - suffix.length)
-          : monitor.name;
+      // Disambiguate the clone name so cloning the same monitor twice yields
+      // `X (Copy)`, `X (Copy 2)`, … rather than two identical `X (Copy)`.
+      // OpenSearch monitors have no group, so the check is datasource-wide.
+      const clonedName = buildUniqueCloneName(
+        monitor.name,
+        (n) => (n === 1 ? ' (Copy)' : ` (Copy ${n})`),
+        (candidate) => isRuleNameTaken(candidate, monitor.datasourceId, undefined),
+        PPL_MONITOR_NAME_MAX
+      );
+      // Rebuild the create-time `monitor_type`. The server's `mapMonitor`
+      // normalizes every non-PPL/bucket/doc monitor down to
+      // `query_level_monitor` (cluster-metrics monitors share that wire type),
+      // so `rest.monitor_type` here is the normalized value, not the real one.
+      // Re-POSTing it would store a cluster-metrics monitor (whose input is a
+      // `uri`, not a `search`) as a plain query-level monitor; the classic
+      // editor then reads `inputs[0].search.indices` on edit and throws,
+      // rendering a blank page. Detect the cluster-metrics shape from the input
+      // and restore the correct `cluster_metrics_monitor` type; all other types
+      // already round-trip correctly through `rest.monitor_type`.
+      const inputs = Array.isArray(rest.inputs) ? (rest.inputs as unknown[]) : [];
+      const isClusterMetrics =
+        !!inputs[0] && typeof inputs[0] === 'object' && 'uri' in (inputs[0] as object);
+      const clonedMonitorType = isClusterMetrics
+        ? 'cluster_metrics_monitor'
+        : ((rest.monitor_type as string | undefined) ?? 'query_level_monitor');
       const payload: Record<string, unknown> = {
         ...rest,
+        monitor_type: clonedMonitorType,
         triggers: cleanTriggers,
-        name: `${baseName}${suffix}`,
+        name: clonedName,
         type: 'monitor',
       };
       await mutations.createMonitor(payload, monitor.datasourceId);

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -214,10 +214,13 @@ function buildUniqueCloneName(
     // Trim by CODE POINTS, not UTF-16 units, so a boundary that falls inside a
     // surrogate pair (emoji / astral CJK) doesn't split the character into a
     // lone half (which renders as U+FFFD). `[...str]` iterates code points.
+    // Measure the suffix in code points too so the budget stays consistent (all
+    // current suffixes are ASCII, so this is defensive against future ones).
     const codePoints = [...baseName];
+    const suffixLen = [...suffix].length;
     const base =
-      codePoints.length + suffix.length > maxLen
-        ? codePoints.slice(0, Math.max(0, maxLen - suffix.length)).join('')
+      codePoints.length + suffixLen > maxLen
+        ? codePoints.slice(0, Math.max(0, maxLen - suffixLen)).join('')
         : baseName;
     return `${base}${suffix}`;
   };
@@ -984,11 +987,20 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   useEffect(() => {
     const set = inFlightCloneNamesRef.current;
     if (set.size === 0) return;
-    const present = new Set(rules.map((r) => cloneNameKey(r.datasourceId, r.name)));
+    // Mirror `isRuleNameTaken`'s soft-delete filter: a deleted rule can linger
+    // in `rules` (delete only marks `deletedRuleIds`, no immediate refetch), and
+    // `isRuleNameTaken` ignores it — so we must NOT treat its name as "present"
+    // here either, or we'd release the reservation while the name still reads as
+    // free, re-opening the duplicate-name window.
+    const present = new Set(
+      rules
+        .filter((r) => !deletedRuleIds.has(r.id))
+        .map((r) => cloneNameKey(r.datasourceId, r.name))
+    );
     set.forEach((key) => {
       if (present.has(key)) set.delete(key);
     });
-  }, [rules]);
+  }, [rules, deletedRuleIds]);
   // Build a unique clone name that also avoids names reserved by in-flight
   // clones this session, then reserve the chosen name.
   const takeUniqueCloneName = (

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -978,6 +978,9 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   // reserved until the refetch surfaces it in `rules` (which then covers it),
   // at which point the reconcile effect below drops it.
   const inFlightCloneNamesRef = useRef<Set<string>>(new Set());
+  // Normalized `trim().toLowerCase()` to match `isRuleNameTaken` (which is
+  // itself case-insensitive) — both sides compare names the same way, so a
+  // name differing only by case can't slip past the dedup.
   const cloneNameKey = (dsId: string, name: string) => `${dsId}\n${name.trim().toLowerCase()}`;
   // Once a reserved clone name lands in the fetched `rules`, `isRuleNameTaken`
   // covers it, so drop it from the reservation set. This bounds the set to
@@ -1076,7 +1079,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
           evaluationInterval: evalInterval,
           labels: rawLabels,
           annotations: rawAnnotations,
-          enabled: true,
+          // Start the clone DISABLED: enabling it immediately would spin up a
+          // second live rule firing the same notifications before the user has
+          // reviewed/renamed it. The user enables it explicitly afterwards.
+          enabled: false,
         };
         await mutations.createPrometheusRule(payload, monitor.datasourceId);
         // Optimistic pending row — the clone POST has no groupName, so the
@@ -1180,6 +1186,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         triggers: cleanTriggers,
         name: clonedName,
         type: 'monitor',
+        // Start the clone DISABLED (overriding the source's inherited `enabled`
+        // in `...rest`): a freshly-cloned monitor shouldn't fire the same alerts
+        // before the user reviews it. Matches the Prometheus clone path.
+        enabled: false,
       };
       await mutations.createMonitor(payload, monitor.datasourceId);
       addToast(

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -211,9 +211,13 @@ function buildUniqueCloneName(
   maxLen: number
 ): string {
   const withSuffix = (suffix: string): string => {
+    // Trim by CODE POINTS, not UTF-16 units, so a boundary that falls inside a
+    // surrogate pair (emoji / astral CJK) doesn't split the character into a
+    // lone half (which renders as U+FFFD). `[...str]` iterates code points.
+    const codePoints = [...baseName];
     const base =
-      baseName.length + suffix.length > maxLen
-        ? baseName.slice(0, Math.max(0, maxLen - suffix.length))
+      codePoints.length + suffix.length > maxLen
+        ? codePoints.slice(0, Math.max(0, maxLen - suffix.length)).join('')
         : baseName;
     return `${base}${suffix}`;
   };
@@ -961,7 +965,38 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
     }
   };
 
+  // Names of clones issued this session but not yet reconciled into `rules` by
+  // a refetch. `isRuleNameTaken` only sees the fetched list, so cloning the
+  // same rule twice in quick succession (before the background refetch lands)
+  // would otherwise re-pick the same suffix and mint a duplicate name — the
+  // very bug the unique-naming aims to prevent. This ref bridges that window;
+  // entries are keyed by (datasourceId, lowercased name). A reserved name is
+  // released only if the create fails (see the catch) — on success it stays
+  // reserved until the refetch surfaces it in `rules` (which then covers it).
+  const inFlightCloneNamesRef = useRef<Set<string>>(new Set());
+  const cloneNameKey = (dsId: string, name: string) => `${dsId}\n${name.trim().toLowerCase()}`;
+  // Build a unique clone name that also avoids names reserved by in-flight
+  // clones this session, then reserve the chosen name.
+  const takeUniqueCloneName = (
+    baseName: string,
+    makeSuffix: (n: number) => string,
+    dsId: string
+  ): string => {
+    const name = buildUniqueCloneName(
+      baseName,
+      makeSuffix,
+      (candidate) =>
+        isRuleNameTaken(candidate, dsId, undefined) ||
+        inFlightCloneNamesRef.current.has(cloneNameKey(dsId, candidate)),
+      PPL_MONITOR_NAME_MAX
+    );
+    inFlightCloneNamesRef.current.add(cloneNameKey(dsId, name));
+    return name;
+  };
+
   const handleCloneRule = async (monitor: UnifiedRuleSummary) => {
+    // Tracked so a failed create can release the reserved clone name.
+    let reservedCloneName: string | null = null;
     try {
       // Fetch the full rule detail to get the raw backend payload — the
       // summary shape doesn't carry the wire format needed for re-creation.
@@ -980,12 +1015,12 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         // of two identical names. Prometheus rule identity is scoped by group,
         // but the clone POST omits the group (server defaults it to the rule
         // name), so we check datasource-wide to keep display names distinct.
-        const clonedName = buildUniqueCloneName(
+        const clonedName = takeUniqueCloneName(
           monitor.name,
           (n) => (n === 1 ? '-copy' : `-copy-${n}`),
-          (candidate) => isRuleNameTaken(candidate, monitor.datasourceId, undefined),
-          PPL_MONITOR_NAME_MAX
+          monitor.datasourceId
         );
+        reservedCloneName = clonedName;
 
         // Extract rule details from the unified shape + raw
         const rawDetail: unknown = detail.raw ?? {};
@@ -1053,12 +1088,16 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       // wrapped, type-specific triggers we need for a valid re-create. Strip
       // the server-owned / response-derived fields that must NOT be re-POSTed:
       // identity + audit stamps (`id`, `*_time`, `schema_version`, `version`),
-      // ownership/routing (`owner`, `data_sources`), and the read-only
-      // enrichments the alerting API adds on GET (`item_type`,
+      // ownership/principal/routing (`owner`, `user`, `data_sources`), and the
+      // read-only enrichments the alerting API adds on GET (`item_type`,
       // `associated_workflows`, `associatedCompositeMonitorCnt`,
-      // `last_run_context`). Legit create-time fields (e.g. the doc-level
-      // `delete_query_index_in_every_run` / `should_create_single_alert_for_findings`)
-      // fall through in `...rest`.
+      // `last_run_context`). `user` (the security principal: name/backend_roles)
+      // is stripped for parity with `owner` so the clone is attributed to and
+      // access-scoped by the CALLER — the alerting plugin re-assigns it from the
+      // request's auth context — rather than inheriting the original creator's
+      // roles on any config that doesn't override it. Legit create-time fields
+      // (e.g. the doc-level `delete_query_index_in_every_run` /
+      // `should_create_single_alert_for_findings`) fall through in `...rest`.
       const {
         id: _id,
         last_update_time: _t,
@@ -1066,6 +1105,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         schema_version: _sv,
         version: _v,
         owner: _ow,
+        user: _user,
         data_sources: _ds,
         item_type: _it,
         associated_workflows: _aw,
@@ -1100,12 +1140,12 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       // Disambiguate the clone name so cloning the same monitor twice yields
       // `X (Copy)`, `X (Copy 2)`, … rather than two identical `X (Copy)`.
       // OpenSearch monitors have no group, so the check is datasource-wide.
-      const clonedName = buildUniqueCloneName(
+      const clonedName = takeUniqueCloneName(
         monitor.name,
         (n) => (n === 1 ? ' (Copy)' : ` (Copy ${n})`),
-        (candidate) => isRuleNameTaken(candidate, monitor.datasourceId, undefined),
-        PPL_MONITOR_NAME_MAX
+        monitor.datasourceId
       );
+      reservedCloneName = clonedName;
       // `rest.monitor_type` is the real upstream type (e.g.
       // `cluster_metrics_monitor`, `bucket_level_monitor`), so it round-trips
       // as-is — no reconstruction needed now that `raw` is faithful.
@@ -1123,6 +1163,10 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       );
       refetchRules();
     } catch (e: unknown) {
+      // The create failed, so free the reserved name for the next attempt.
+      if (reservedCloneName) {
+        inFlightCloneNamesRef.current.delete(cloneNameKey(monitor.datasourceId, reservedCloneName));
+      }
       addToast(
         i18n.translate('observability.alerting.alarmsPage.toast.cloneMonitorFailed', {
           defaultMessage: 'Failed to clone alert rule',

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -972,9 +972,23 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
   // very bug the unique-naming aims to prevent. This ref bridges that window;
   // entries are keyed by (datasourceId, lowercased name). A reserved name is
   // released only if the create fails (see the catch) — on success it stays
-  // reserved until the refetch surfaces it in `rules` (which then covers it).
+  // reserved until the refetch surfaces it in `rules` (which then covers it),
+  // at which point the reconcile effect below drops it.
   const inFlightCloneNamesRef = useRef<Set<string>>(new Set());
   const cloneNameKey = (dsId: string, name: string) => `${dsId}\n${name.trim().toLowerCase()}`;
+  // Once a reserved clone name lands in the fetched `rules`, `isRuleNameTaken`
+  // covers it, so drop it from the reservation set. This bounds the set to
+  // genuinely in-flight names (no unbounded per-session growth) and frees a
+  // name for reuse if that clone is later deleted (it left `rules`, so it's no
+  // longer reserved either).
+  useEffect(() => {
+    const set = inFlightCloneNamesRef.current;
+    if (set.size === 0) return;
+    const present = new Set(rules.map((r) => cloneNameKey(r.datasourceId, r.name)));
+    set.forEach((key) => {
+      if (present.has(key)) set.delete(key);
+    });
+  }, [rules]);
   // Build a unique clone name that also avoids names reserved by in-flight
   // clones this session, then reserve the chosen name.
   const takeUniqueCloneName = (

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -1048,13 +1048,29 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
 
       const rawDetail: unknown = detail.raw ?? {};
       const raw = rawDetail as Record<string, unknown>;
+      // `detail.raw` is the faithful upstream monitor document (see
+      // getOSRuleDetail), so it carries the real `monitor_type` and the fully
+      // wrapped, type-specific triggers we need for a valid re-create. Strip
+      // the server-owned / response-derived fields that must NOT be re-POSTed:
+      // identity + audit stamps (`id`, `*_time`, `schema_version`, `version`),
+      // ownership/routing (`owner`, `data_sources`), and the read-only
+      // enrichments the alerting API adds on GET (`item_type`,
+      // `associated_workflows`, `associatedCompositeMonitorCnt`,
+      // `last_run_context`). Legit create-time fields (e.g. the doc-level
+      // `delete_query_index_in_every_run` / `should_create_single_alert_for_findings`)
+      // fall through in `...rest`.
       const {
         id: _id,
         last_update_time: _t,
         enabled_time: _et,
         schema_version: _sv,
+        version: _v,
         owner: _ow,
         data_sources: _ds,
+        item_type: _it,
+        associated_workflows: _aw,
+        associatedCompositeMonitorCnt: _acmc,
+        last_run_context: _lrc,
         ...rest
       } = raw;
       // Strip trigger IDs so the backend assigns fresh ones. Triggers live
@@ -1090,25 +1106,11 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         (candidate) => isRuleNameTaken(candidate, monitor.datasourceId, undefined),
         PPL_MONITOR_NAME_MAX
       );
-      // Rebuild the create-time `monitor_type`. The server's `mapMonitor`
-      // normalizes every non-PPL/bucket/doc monitor down to
-      // `query_level_monitor` (cluster-metrics monitors share that wire type),
-      // so `rest.monitor_type` here is the normalized value, not the real one.
-      // Re-POSTing it would store a cluster-metrics monitor (whose input is a
-      // `uri`, not a `search`) as a plain query-level monitor; the classic
-      // editor then reads `inputs[0].search.indices` on edit and throws,
-      // rendering a blank page. Detect the cluster-metrics shape from the input
-      // and restore the correct `cluster_metrics_monitor` type; all other types
-      // already round-trip correctly through `rest.monitor_type`.
-      const inputs = Array.isArray(rest.inputs) ? (rest.inputs as unknown[]) : [];
-      const isClusterMetrics =
-        !!inputs[0] && typeof inputs[0] === 'object' && 'uri' in (inputs[0] as object);
-      const clonedMonitorType = isClusterMetrics
-        ? 'cluster_metrics_monitor'
-        : ((rest.monitor_type as string | undefined) ?? 'query_level_monitor');
+      // `rest.monitor_type` is the real upstream type (e.g.
+      // `cluster_metrics_monitor`, `bucket_level_monitor`), so it round-trips
+      // as-is — no reconstruction needed now that `raw` is faithful.
       const payload: Record<string, unknown> = {
         ...rest,
-        monitor_type: clonedMonitorType,
         triggers: cleanTriggers,
         name: clonedName,
         type: 'monitor',

--- a/public/components/alerting/alerting.scss
+++ b/public/components/alerting/alerting.scss
@@ -240,12 +240,16 @@
 .altFacetCount {
   display: inline-block;
   line-height: 18px;
-  // Logical (RTL-safe) separation from the label, using the EUI spacing token
-  // rather than a magic pixel value. The label + count share a flex container
-  // (the facet-group button) whose inter-node whitespace collapses to zero, so
-  // a plain space would render no gap — the margin is required, not cosmetic.
+}
+
+// Count next to a facet-GROUP KEY (the collapsible header button) only. The
+// label + count share the button's flex content, whose inter-node whitespace
+// collapses to zero, so a plain space renders no gap — an explicit, RTL-safe,
+// token-based margin is required. Scoped to this modifier so it does NOT touch
+// the per-OPTION count, whose row already supplies its own `gap`.
+.altFacetGroupCount {
   margin-inline-start: $euiSizeXS;
-  // Never let the count be squeezed out when the label truncates.
+  // Never let the count be squeezed out when the key label truncates.
   flex-shrink: 0;
 }
 

--- a/public/components/alerting/alerting.scss
+++ b/public/components/alerting/alerting.scss
@@ -240,6 +240,13 @@
 .altFacetCount {
   display: inline-block;
   line-height: 18px;
+  // Logical (RTL-safe) separation from the label, using the EUI spacing token
+  // rather than a magic pixel value. The label + count share a flex container
+  // (the facet-group button) whose inter-node whitespace collapses to zero, so
+  // a plain space would render no gap — the margin is required, not cosmetic.
+  margin-inline-start: $euiSizeXS;
+  // Never let the count be squeezed out when the label truncates.
+  flex-shrink: 0;
 }
 
 // Monitors table wrapper — keeps the table content scrollable horizontally

--- a/public/components/alerting/create_ad_rule_flyout.tsx
+++ b/public/components/alerting/create_ad_rule_flyout.tsx
@@ -2691,22 +2691,38 @@ export const CreateAdRuleFlyout: React.FC<CreateAdRuleFlyoutProps> = ({
           hint={i18n.translate('observability.alerting.createAdRuleFlyout.nameHint', {
             defaultMessage: 'Specify a unique and descriptive name that is easy to recognize.',
           })}
-          helpText={i18n.translate('observability.alerting.createAdRuleFlyout.nameHelpText', {
-            defaultMessage:
-              'Detector name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period).',
-          })}
+          helpText={
+            isDetector
+              ? i18n.translate('observability.alerting.createAdRuleFlyout.detectorNameHelpText', {
+                  defaultMessage:
+                    'Detector name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period).',
+                })
+              : i18n.translate('observability.alerting.createAdRuleFlyout.forecasterNameHelpText', {
+                  defaultMessage:
+                    'Forecaster name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period).',
+                })
+          }
           isInvalid={!!visibleErrors.name}
           error={visibleErrors.name}
         >
           <EuiFieldText
             value={form.name}
             onChange={(e) => updateForm('name', e.target.value)}
-            placeholder={i18n.translate(
-              'observability.alerting.createAdRuleFlyout.detectorNamePlaceholder',
-              {
-                defaultMessage: 'Enter detector name',
-              }
-            )}
+            placeholder={
+              isDetector
+                ? i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.detectorNamePlaceholder',
+                    {
+                      defaultMessage: 'Enter detector name',
+                    }
+                  )
+                : i18n.translate(
+                    'observability.alerting.createAdRuleFlyout.forecasterNamePlaceholder',
+                    {
+                      defaultMessage: 'Enter forecaster name',
+                    }
+                  )
+            }
             data-test-subj="alertManagerCreateAdRuleName"
           />
         </AdFormattedFormRow>

--- a/public/components/alerting/facet_filter_panel.tsx
+++ b/public/components/alerting/facet_filter_panel.tsx
@@ -287,7 +287,7 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
               // button's flex content, so the margin is required.
               <EuiTextColor
                 color="subdued"
-                className="altFacetCount"
+                className="altFacetCount altFacetGroupCount"
                 data-test-subj={`facetGroup-${id}-optionCount`}
               >
                 ({options.length})

--- a/public/components/alerting/facet_filter_panel.tsx
+++ b/public/components/alerting/facet_filter_panel.tsx
@@ -281,16 +281,14 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
               // Parenthesize the option count so it reads as a count and
               // matches the per-option `({count})` style below — a bare
               // trailing number (e.g. "severity 2") looked like a
-              // superscript/typo next to the label. The label + count sit in a
-              // flex container (the button content), which collapses inter-node
-              // whitespace to zero, so a plain `{' '}` produced no visible gap
-              // ("severity(2)"). Use an explicit left margin for reliable
-              // separation, and never let the count shrink.
+              // superscript/typo next to the label. Spacing + flex-shrink live
+              // in the `.altFacetCount` SCSS rule (RTL-safe `margin-inline-start:
+              // $euiSizeXS`) — a plain `{' '}` collapses to zero inside the
+              // button's flex content, so the margin is required.
               <EuiTextColor
                 color="subdued"
                 className="altFacetCount"
                 data-test-subj={`facetGroup-${id}-optionCount`}
-                style={{ marginLeft: 4, flexShrink: 0 }}
               >
                 ({options.length})
               </EuiTextColor>

--- a/public/components/alerting/facet_filter_panel.tsx
+++ b/public/components/alerting/facet_filter_panel.tsx
@@ -282,9 +282,11 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
               // matches the per-option `({count})` style below — a bare
               // trailing number (e.g. "severity 2") looked like a
               // superscript/typo next to the label. Spacing + flex-shrink live
-              // in the `.altFacetCount` SCSS rule (RTL-safe `margin-inline-start:
-              // $euiSizeXS`) — a plain `{' '}` collapses to zero inside the
-              // button's flex content, so the margin is required.
+              // in the KEY-only `.altFacetGroupCount` SCSS modifier (RTL-safe
+              // `margin-inline-start: $euiSizeXS`) — a plain `{' '}` collapses to
+              // zero inside the button's flex content, so the margin is required
+              // here; the per-option count keeps plain `.altFacetCount` (its row
+              // supplies its own gap) to avoid a double margin.
               <EuiTextColor
                 color="subdued"
                 className="altFacetCount altFacetGroupCount"

--- a/public/components/alerting/facet_filter_panel.tsx
+++ b/public/components/alerting/facet_filter_panel.tsx
@@ -268,18 +268,32 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
             aria-controls={isCollapsed ? undefined : `facetGroup-${id}-region`}
             data-test-subj={`facetGroup-${id}-toggle`}
           >
-            <strong>{label}</strong>
+            {/* A long facet key (e.g. "deployment_environment") gets clipped
+                by the narrow filter panel. Render it through `TruncatedLabel`
+                so it ellipsis-truncates AND shows the full name in a hover
+                tooltip — matching the option rows. `minWidth: 0` lets the bold
+                wrapper shrink inside the button's flex content so truncation
+                kicks in instead of overflowing. */}
+            <strong style={{ minWidth: 0, overflow: 'hidden' }}>
+              <TruncatedLabel text={label} />
+            </strong>
             {showOptionCount && (
-              <>
-                {' '}
-                <EuiTextColor
-                  color="subdued"
-                  className="altFacetCount"
-                  data-test-subj={`facetGroup-${id}-optionCount`}
-                >
-                  {options.length}
-                </EuiTextColor>
-              </>
+              // Parenthesize the option count so it reads as a count and
+              // matches the per-option `({count})` style below — a bare
+              // trailing number (e.g. "severity 2") looked like a
+              // superscript/typo next to the label. The label + count sit in a
+              // flex container (the button content), which collapses inter-node
+              // whitespace to zero, so a plain `{' '}` produced no visible gap
+              // ("severity(2)"). Use an explicit left margin for reliable
+              // separation, and never let the count shrink.
+              <EuiTextColor
+                color="subdued"
+                className="altFacetCount"
+                data-test-subj={`facetGroup-${id}-optionCount`}
+                style={{ marginLeft: 4, flexShrink: 0 }}
+              >
+                ({options.length})
+              </EuiTextColor>
             )}
           </EuiButtonEmpty>
         </EuiFlexItem>

--- a/public/components/alerting/monitors_table/monitors_table_columns.tsx
+++ b/public/components/alerting/monitors_table/monitors_table_columns.tsx
@@ -43,6 +43,7 @@ import {
   STATUS_COLORS,
   TYPE_LABELS,
 } from '../shared_constants';
+import { TruncatedLabel } from '../../common/truncated_label';
 import { DEFAULT_WIDTHS } from './resizable_columns';
 import { isPending } from './pending_rules';
 
@@ -301,7 +302,12 @@ export function buildTableColumns({
         sortable: (r: UnifiedRuleSummary) =>
           (dsNameMap.get(r.datasourceId) || r.datasourceId).toLowerCase(),
         width: w('datasource'),
-        render: (id: string) => dsNameMap.get(id) || id,
+        // A bare string cell wraps mid-word for long datasource names (e.g.
+        // "ObservabilityStack_Prometheus"). EUI's `truncateText` doesn't
+        // single-line a plain-text render in this table, so use the shared
+        // `TruncatedLabel` (single-line ellipsis + instant full-text tooltip),
+        // matching the datasource facet in the filter panel.
+        render: (id: string) => <TruncatedLabel text={dsNameMap.get(id) || id} />,
       });
     } else if (colId === 'createdBy') {
       cols.push({

--- a/public/components/common/truncated_label/__tests__/truncated_label.test.tsx
+++ b/public/components/common/truncated_label/__tests__/truncated_label.test.tsx
@@ -22,4 +22,65 @@ describe('TruncatedLabel', () => {
     fireEvent.mouseEnter(screen.getByText('short'));
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
+
+  // jsdom has no layout, so force the "clipped" condition the component checks
+  // (scrollWidth > clientWidth) on the inner label span.
+  const forceTruncated = (text: string) => {
+    const span = screen.getByText(text);
+    Object.defineProperty(span, 'scrollWidth', { configurable: true, value: 200 });
+    Object.defineProperty(span, 'clientWidth', { configurable: true, value: 50 });
+  };
+
+  it('reveals on keyboard focus of a focusable ANCESTOR (facet-group key button) and Esc dismisses', () => {
+    const LONG = 'deployment_environment';
+    render(
+      <button type="button">
+        <TruncatedLabel text={LONG} />
+      </button>
+    );
+    forceTruncated(LONG);
+    const btn = screen.getByRole('button');
+    fireEvent.focus(btn);
+    expect(screen.getByRole('tooltip')).toHaveTextContent(LONG);
+    // WCAG 1.4.13 dismissable — Esc on the focused control hides it.
+    fireEvent.keyDown(btn, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    // blur also hides.
+    fireEvent.focus(btn);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    fireEvent.blur(btn);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('does NOT reveal when the only ancestor is a tabindex="-1" wrapper (EuiAccordion childWrapper)', () => {
+    const LONG = 'deployment_environment';
+    render(
+      <div tabIndex={-1} data-test-subj="wrapper">
+        <TruncatedLabel text={LONG} />
+      </div>
+    );
+    forceTruncated(LONG);
+    fireEvent.focus(screen.getByTestId('wrapper'));
+    // Regression guard: focusing the auto-focused accordion wrapper must not
+    // pop the tooltip (it previously fired on every truncated row at once).
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('reveals via the associated control of an enclosing label (checkbox option row)', () => {
+    const LONG = 'ObservabilityStack_Prometheus';
+    render(
+      <div>
+        <input id="cb" type="checkbox" />
+        <label htmlFor="cb">
+          <TruncatedLabel text={LONG} />
+        </label>
+      </div>
+    );
+    forceTruncated(LONG);
+    const input = document.getElementById('cb') as HTMLInputElement;
+    fireEvent.focus(input);
+    expect(screen.getByRole('tooltip')).toHaveTextContent(LONG);
+    fireEvent.blur(input);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
 });

--- a/public/components/common/truncated_label/truncated_label.tsx
+++ b/public/components/common/truncated_label/truncated_label.tsx
@@ -79,13 +79,14 @@ export const TruncatedLabel: React.FC<TruncatedLabelProps> = ({ text, fontSize, 
   useEffect(() => {
     const el = ref.current;
     if (!el) return undefined;
-    let control: Element | null = el.closest(
-      'button, a, [role="button"], [tabindex]:not([tabindex="-1"])'
-    );
-    if (!control) {
-      const label = el.closest('label');
-      control = (label && (label as HTMLLabelElement).control) || null;
-    }
+    // Resolve the focusable control once into a `const` so the cleanup closure
+    // provably detaches from the same node (no reassignment, no null-narrowing
+    // ambiguity): the nearest genuine tab stop, else the enclosing label's
+    // associated control.
+    const control =
+      el.closest('button, a, [role="button"], [tabindex]:not([tabindex="-1"])') ??
+      (el.closest('label') as HTMLLabelElement | null)?.control ??
+      null;
     if (!control) return undefined;
     const onKeyDown = (e: Event) => {
       if ((e as KeyboardEvent).key === 'Escape') hide();

--- a/public/components/common/truncated_label/truncated_label.tsx
+++ b/public/components/common/truncated_label/truncated_label.tsx
@@ -62,36 +62,46 @@ export const TruncatedLabel: React.FC<TruncatedLabelProps> = ({ text, fontSize, 
 
   // Reveal on keyboard focus too, not just mouse hover (WCAG 1.4.13): when this
   // label sits inside a focusable control (e.g. a collapsible facet-group
-  // button), a keyboard-only or screen-magnifier user must be able to read the
-  // clipped full text. Focus lands on the ANCESTOR control, not this span, and
-  // native focus/blur don't bubble — so `onFocus`/`onBlur` on the wrap alone
-  // wouldn't fire. Attach directly to the nearest focusable ancestor. When the
-  // label isn't inside a focusable control (e.g. a plain table cell) there's no
-  // ancestor and this is a no-op. Esc dismisses (dismissable requirement).
+  // button, or a checkbox facet-option row), a keyboard-only or screen-magnifier
+  // user must be able to read the clipped full text. Focus/blur/keydown land on
+  // the focusable CONTROL, not this span, and native focus/blur don't bubble —
+  // so wiring the handlers onto the wrap span wouldn't fire. Resolve the real
+  // control and attach there:
+  //   - nearest focusable ANCESTOR, but only a genuine tab stop. We must EXCLUDE
+  //     `tabindex="-1"` wrappers: OUI's `EuiAccordion` gives its content a
+  //     `tabIndex=-1` childWrapper and auto-`.focus()`es it on expand, which
+  //     would otherwise fire `reveal` on every truncated row at once.
+  //   - else the control ASSOCIATED with an enclosing `<label>` (the checkbox
+  //     `<input>` is a SIBLING, not an ancestor, of an option-row label).
+  // Esc dismisses (WCAG 1.4.13 "dismissable"); the listener lives on the same
+  // control so it actually receives the keydown. A plain table cell has no
+  // focusable control → no-op (hover still works).
   useEffect(() => {
-    const focusable = ref.current?.closest('button, a, [role="button"], [tabindex]');
-    if (!focusable) return undefined;
-    focusable.addEventListener('focus', reveal);
-    focusable.addEventListener('blur', hide);
+    const el = ref.current;
+    if (!el) return undefined;
+    let control: Element | null = el.closest(
+      'button, a, [role="button"], [tabindex]:not([tabindex="-1"])'
+    );
+    if (!control) {
+      const label = el.closest('label');
+      control = (label && (label as HTMLLabelElement).control) || null;
+    }
+    if (!control) return undefined;
+    const onKeyDown = (e: Event) => {
+      if ((e as KeyboardEvent).key === 'Escape') hide();
+    };
+    control.addEventListener('focus', reveal);
+    control.addEventListener('blur', hide);
+    control.addEventListener('keydown', onKeyDown);
     return () => {
-      focusable.removeEventListener('focus', reveal);
-      focusable.removeEventListener('blur', hide);
+      control.removeEventListener('focus', reveal);
+      control.removeEventListener('blur', hide);
+      control.removeEventListener('keydown', onKeyDown);
     };
   }, [reveal, hide, text]);
 
-  const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') hide();
-  };
-
   return (
-    <span
-      className="obsTruncatedLabelWrap"
-      onMouseEnter={reveal}
-      onMouseLeave={hide}
-      onFocus={reveal}
-      onBlur={hide}
-      onKeyDown={onKeyDown}
-    >
+    <span className="obsTruncatedLabelWrap" onMouseEnter={reveal} onMouseLeave={hide}>
       <span ref={ref} className="obsTruncatedLabel" style={labelStyle}>
         {text}
       </span>

--- a/public/components/common/truncated_label/truncated_label.tsx
+++ b/public/components/common/truncated_label/truncated_label.tsx
@@ -29,7 +29,7 @@
  * `min-width: 0`); this component fills its parent and truncates within it.
  */
 
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import './truncated_label.scss';
 
@@ -51,17 +51,47 @@ export const TruncatedLabel: React.FC<TruncatedLabelProps> = ({ text, fontSize, 
   if (fontSize !== undefined) labelStyle.fontSize = fontSize;
   if (lineHeight !== undefined) labelStyle.lineHeight = `${lineHeight}px`;
 
-  const onEnter = () => {
+  const reveal = useCallback(() => {
     const el = ref.current;
     // Only show the tooltip when the text is actually clipped right now.
     if (!el || el.scrollWidth <= el.clientWidth) return;
     const rect = el.getBoundingClientRect();
     setTooltipPos({ top: rect.top - 28, left: rect.left });
+  }, []);
+  const hide = useCallback(() => setTooltipPos(null), []);
+
+  // Reveal on keyboard focus too, not just mouse hover (WCAG 1.4.13): when this
+  // label sits inside a focusable control (e.g. a collapsible facet-group
+  // button), a keyboard-only or screen-magnifier user must be able to read the
+  // clipped full text. Focus lands on the ANCESTOR control, not this span, and
+  // native focus/blur don't bubble — so `onFocus`/`onBlur` on the wrap alone
+  // wouldn't fire. Attach directly to the nearest focusable ancestor. When the
+  // label isn't inside a focusable control (e.g. a plain table cell) there's no
+  // ancestor and this is a no-op. Esc dismisses (dismissable requirement).
+  useEffect(() => {
+    const focusable = ref.current?.closest('button, a, [role="button"], [tabindex]');
+    if (!focusable) return undefined;
+    focusable.addEventListener('focus', reveal);
+    focusable.addEventListener('blur', hide);
+    return () => {
+      focusable.removeEventListener('focus', reveal);
+      focusable.removeEventListener('blur', hide);
+    };
+  }, [reveal, hide, text]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') hide();
   };
-  const onLeave = () => setTooltipPos(null);
 
   return (
-    <span className="obsTruncatedLabelWrap" onMouseEnter={onEnter} onMouseLeave={onLeave}>
+    <span
+      className="obsTruncatedLabelWrap"
+      onMouseEnter={reveal}
+      onMouseLeave={hide}
+      onFocus={reveal}
+      onBlur={hide}
+      onKeyDown={onKeyDown}
+    >
       <span ref={ref} className="obsTruncatedLabel" style={labelStyle}>
         {text}
       </span>

--- a/server/services/alerting/__tests__/alert_service.mutations.test.ts
+++ b/server/services/alerting/__tests__/alert_service.mutations.test.ts
@@ -46,6 +46,7 @@ const mockDsSvc = {
 const mockOsBackend = {
   getMonitors: jest.fn(async () => []),
   getMonitor: jest.fn(),
+  getMonitorWithSource: jest.fn(),
   createMonitor: jest.fn(),
   updateMonitor: jest.fn(),
   deleteMonitor: jest.fn(),
@@ -127,7 +128,10 @@ describe('MultiBackendAlertService — mutations + detail', () => {
   });
 
   it('getRuleDetail returns enriched OS rule with alertHistory', async () => {
-    mockOsBackend.getMonitor.mockResolvedValueOnce(sampleOSMonitor);
+    mockOsBackend.getMonitorWithSource.mockResolvedValueOnce({
+      monitor: sampleOSMonitor,
+      source: { ...sampleOSMonitor },
+    });
     mockOsBackend.getAlerts.mockResolvedValueOnce({ alerts: [sampleOSAlert], totalAlerts: 1 });
     mockOsBackend.getDestinations.mockResolvedValueOnce({
       destinations: [sampleOSDestination],
@@ -145,7 +149,10 @@ describe('MultiBackendAlertService — mutations + detail', () => {
   });
 
   it('getRuleDetail bounds the alert history with limit + start_time desc sort', async () => {
-    mockOsBackend.getMonitor.mockResolvedValueOnce(sampleOSMonitor);
+    mockOsBackend.getMonitorWithSource.mockResolvedValueOnce({
+      monitor: sampleOSMonitor,
+      source: { ...sampleOSMonitor },
+    });
     mockOsBackend.getAlerts.mockResolvedValueOnce({ alerts: [], totalAlerts: 0, truncated: false });
     mockOsBackend.searchQuery.mockResolvedValueOnce({
       aggregations: { time_buckets: { buckets: [] } },

--- a/server/services/alerting/__tests__/opensearch_backend.test.ts
+++ b/server/services/alerting/__tests__/opensearch_backend.test.ts
@@ -164,6 +164,54 @@ describe('HttpOpenSearchBackend', () => {
     });
   });
 
+  describe('getMonitorWithSource', () => {
+    it('returns the mapped projection AND the faithful upstream source', async () => {
+      // A bucket-level monitor: the mapped projection flattens the trigger
+      // wrapper (dropping `parent_bucket_path`), but the clone flow needs the
+      // untouched document. `source` must keep the wrapper + its fields.
+      const bucketSource = {
+        type: 'monitor',
+        monitor_type: 'bucket_level_monitor',
+        name: 'Bucket',
+        enabled: true,
+        schedule: { period: { interval: 1, unit: 'MINUTES' } },
+        inputs: [{ search: { indices: ['logs-*'], query: {} } }],
+        triggers: [
+          {
+            bucket_level_trigger: {
+              id: 't-bkt',
+              name: 'b',
+              severity: 1,
+              condition: { parent_bucket_path: 'agg', buckets_path: { _count: '_count' } },
+              actions: [],
+            },
+          },
+        ],
+        owner: 'alerting',
+        data_sources: {},
+      };
+      const { client } = makeClient([{ body: { _id: 'mon-bkt', monitor: bucketSource } }]);
+
+      const result = await backend.getMonitorWithSource(client, 'mon-bkt');
+      expect(result).not.toBeNull();
+      // Mapped projection: narrowed type, id attached.
+      expect(result!.monitor.id).toBe('mon-bkt');
+      // Faithful source: real type + wrapped trigger with bucket-only fields.
+      expect(result!.source.monitor_type).toBe('bucket_level_monitor');
+      expect(result!.source.id).toBe('mon-bkt');
+      const trig = (result!.source.triggers as Array<Record<string, unknown>>)[0];
+      const inner = trig.bucket_level_trigger as Record<string, unknown>;
+      expect(inner).toBeDefined();
+      expect((inner.condition as Record<string, unknown>).parent_bucket_path).toBe('agg');
+    });
+
+    it('returns null when the monitor is missing (statusCode 404)', async () => {
+      const err = Object.assign(new Error('not found'), { statusCode: 404 });
+      const { client } = makeClient([err]);
+      expect(await backend.getMonitorWithSource(client, 'missing')).toBeNull();
+    });
+  });
+
   describe('getAlerts', () => {
     it('paginates and returns mapped alerts plus totalAlerts', async () => {
       const { client, request } = makeClient([

--- a/server/services/alerting/__tests__/opensearch_backend.test.ts
+++ b/server/services/alerting/__tests__/opensearch_backend.test.ts
@@ -18,9 +18,7 @@ const mockLogger: Logger = {
  * sequence. Each call in `responses` is either the body object (wrapped as
  * `{ body }`) or a rejected Error.
  */
-function makeClient(
-  responses: Array<{ body: unknown } | Error>
-): {
+function makeClient(responses: Array<{ body: unknown } | Error>): {
   client: AlertingOSClient;
   request: jest.Mock;
 } {
@@ -30,7 +28,7 @@ function makeClient(
     else request.mockResolvedValueOnce(r);
   });
   return {
-    client: ({ transport: { request } } as unknown) as AlertingOSClient,
+    client: { transport: { request } } as unknown as AlertingOSClient,
     request,
   };
 }
@@ -872,14 +870,14 @@ describe('HttpOpenSearchBackend — updateMonitor round-trip', () => {
       { body: { _id: 'mon-1', monitor: upstreamSource } },
     ]);
 
-    await backend.updateMonitor(client, 'mon-1', ({
+    await backend.updateMonitor(client, 'mon-1', {
       name: 'renamed',
       // Hostile input: try to clobber tenant scoping + ownership + state.
       data_sources: { tenant: 'evil-tenant' },
       last_run_context: { lastFiredAt: 0 },
       owner: 'attacker',
       enabled_time: 0,
-    } as unknown) as Parameters<typeof backend.updateMonitor>[2]);
+    } as unknown as Parameters<typeof backend.updateMonitor>[2]);
 
     const putBody = captureBody(request, 1);
     expect(putBody.data_sources).toEqual({ tenant: 'tenant-a' });

--- a/server/services/alerting/__tests__/opensearch_backend.test.ts
+++ b/server/services/alerting/__tests__/opensearch_backend.test.ts
@@ -186,7 +186,8 @@ describe('HttpOpenSearchBackend', () => {
           },
         ],
         owner: 'alerting',
-        data_sources: {},
+        user: { name: 'creator', backend_roles: ['admin'], roles: ['all_access'] },
+        data_sources: { tenant: 'tenant-a' },
       };
       const { client } = makeClient([{ body: { _id: 'mon-bkt', monitor: bucketSource } }]);
 
@@ -201,6 +202,11 @@ describe('HttpOpenSearchBackend', () => {
       const inner = trig.bucket_level_trigger as Record<string, unknown>;
       expect(inner).toBeDefined();
       expect((inner.condition as Record<string, unknown>).parent_bucket_path).toBe('agg');
+      // SECURITY: RBAC/tenant principal fields must be stripped from the source
+      // (never transmitted to the browser as UnifiedRule.raw).
+      expect(result!.source.user).toBeUndefined();
+      expect(result!.source.owner).toBeUndefined();
+      expect(result!.source.data_sources).toBeUndefined();
     });
 
     it('returns null when the monitor is missing (statusCode 404)', async () => {

--- a/server/services/alerting/alert_detail.ts
+++ b/server/services/alerting/alert_detail.ts
@@ -204,8 +204,13 @@ export async function getOSRuleDetail(
   ds: Datasource,
   monitorId: string
 ): Promise<UnifiedRule | null> {
-  const monitor = await osBackend.getMonitor(client, monitorId);
-  if (!monitor) return null;
+  const fetched = await osBackend.getMonitorWithSource(client, monitorId);
+  if (!fetched) return null;
+  // `monitor` is the narrowed projection used for summary/description/preview
+  // rendering; `source` is the faithful upstream document exposed as `raw` so
+  // the clone flow can re-create the monitor without losing its real
+  // `monitor_type` or wrapped triggers.
+  const { monitor, source } = fetched;
 
   const summary = osMonitorToUnifiedRuleSummary(monitor, ds.id);
 
@@ -287,7 +292,9 @@ export async function getOSRuleDetail(
     notificationRouting: [],
     // Suppression rules from the in-memory service (not from OS API)
     suppressionRules: [],
-    raw: monitor,
+    // Faithful upstream document (not the lossy `mapMonitor` projection) so
+    // the clone flow re-creates the exact monitor_type + wrapped triggers.
+    raw: (source as unknown) as UnifiedRule['raw'],
   };
 }
 

--- a/server/services/alerting/alert_detail.ts
+++ b/server/services/alerting/alert_detail.ts
@@ -302,7 +302,7 @@ export async function getOSRuleDetail(
     // is therefore a deliberate shape assertion, not a true type match: treat
     // `raw` for OS rules as an opaque backend document and re-derive fields
     // rather than reading `raw.triggers[i].severity` as if it were flat.
-    raw: (source as unknown) as UnifiedRule['raw'],
+    raw: source as unknown as UnifiedRule['raw'],
   };
 }
 

--- a/server/services/alerting/alert_detail.ts
+++ b/server/services/alerting/alert_detail.ts
@@ -292,8 +292,16 @@ export async function getOSRuleDetail(
     notificationRouting: [],
     // Suppression rules from the in-memory service (not from OS API)
     suppressionRules: [],
-    // Faithful upstream document (not the lossy `mapMonitor` projection) so
-    // the clone flow re-creates the exact monitor_type + wrapped triggers.
+    // Faithful upstream monitor document (not the lossy `mapMonitor`
+    // projection) so the clone flow re-creates the exact monitor_type +
+    // wrapped triggers. CAUTION: the declared type `UnifiedRule['raw']`
+    // (OSMonitor) models triggers in the FLATTENED shape, but for OpenSearch
+    // rules this value is the UNTOUCHED upstream doc — `monitor_type` is the
+    // real value (e.g. `cluster_metrics_monitor`) and `triggers[]` are still
+    // WRAPPED (`query_level_trigger`/`bucket_level_trigger`/…). The double-cast
+    // is therefore a deliberate shape assertion, not a true type match: treat
+    // `raw` for OS rules as an opaque backend document and re-derive fields
+    // rather than reading `raw.triggers[i].severity` as if it were flat.
     raw: (source as unknown) as UnifiedRule['raw'],
   };
 }

--- a/server/services/alerting/opensearch_backend.ts
+++ b/server/services/alerting/opensearch_backend.ts
@@ -194,7 +194,13 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
         ...safeMonitor
       } = resp.body.monitor as Record<string, unknown>;
       const source: Record<string, unknown> = { ...safeMonitor, id: resp.body._id };
-      return { monitor: this.mapMonitor(resp.body._id, resp.body.monitor), source };
+      // Build BOTH returned values from the sanitized body so neither can carry
+      // the principal fields. `mapMonitor` is a fixed-field projection today
+      // (it doesn't read user/owner/data_sources), so this is defensive — it
+      // keeps the "server-side removal is authoritative" guarantee true even if
+      // `mapMonitor` ever starts spreading unknown keys.
+      const monitor = this.mapMonitor(resp.body._id, safeMonitor as unknown as OSMonitorSource);
+      return { monitor, source };
     } catch (err) {
       if (this.is404(err)) return null;
       throw err;

--- a/server/services/alerting/opensearch_backend.ts
+++ b/server/services/alerting/opensearch_backend.ts
@@ -164,8 +164,18 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
    * projection is right for list/summary rendering, but callers that need to
    * faithfully RE-CREATE the monitor (clone) must have the untouched document
    * — otherwise the re-POST is rejected ("Incompatible trigger for monitor
-   * type …") or silently mistyped. `source` is that untouched document, with
-   * the OpenSearch `_id` attached for parity with the projection.
+   * type …") or silently mistyped. `source` is that document with the
+   * OpenSearch `_id` attached for parity with the projection.
+   *
+   * SECURITY: the upstream document also carries the RBAC/tenant principal
+   * (`user.name` / `user.backend_roles` / `user.roles`, `owner`, and
+   * `data_sources.tenant`). `source` is surfaced to the browser as
+   * `UnifiedRule.raw`, and the clone flow does NOT need those fields (it
+   * re-creates the monitor under the caller's own auth context). Strip them
+   * HERE so RBAC role assignments are never transmitted to the frontend —
+   * closing the information-disclosure surface that shipping the full document
+   * would otherwise open. (The client also drops them before the clone re-POST;
+   * this server-side removal is the authoritative guard.)
    */
   async getMonitorWithSource(
     client: AlertingOSClient,
@@ -177,10 +187,13 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
         'GET',
         `/_plugins/_alerting/monitors/${encodeURIComponent(monitorId)}`
       );
-      const source: Record<string, unknown> = {
-        ...(resp.body.monitor as Record<string, unknown>),
-        id: resp.body._id,
-      };
+      const {
+        user: _user,
+        owner: _owner,
+        data_sources: _dataSources,
+        ...safeMonitor
+      } = resp.body.monitor as Record<string, unknown>;
+      const source: Record<string, unknown> = { ...safeMonitor, id: resp.body._id };
       return { monitor: this.mapMonitor(resp.body._id, resp.body.monitor), source };
     } catch (err) {
       if (this.is404(err)) return null;

--- a/server/services/alerting/opensearch_backend.ts
+++ b/server/services/alerting/opensearch_backend.ts
@@ -152,6 +152,42 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
     }
   }
 
+  /**
+   * Like {@link getMonitor}, but also returns the FAITHFUL upstream monitor
+   * document alongside the narrowed {@link OSMonitor} projection.
+   *
+   * `mapMonitor` is lossy by design — it coerces `monitor_type` to a small
+   * union (so `cluster_metrics_monitor` becomes `query_level_monitor`) and
+   * FLATTENS each type-specific trigger wrapper (`bucket_level_trigger`,
+   * `document_level_trigger`, …) into a bare trigger, dropping wrapper-only
+   * fields like a bucket trigger's `parent_bucket_path` / `buckets_path`. That
+   * projection is right for list/summary rendering, but callers that need to
+   * faithfully RE-CREATE the monitor (clone) must have the untouched document
+   * — otherwise the re-POST is rejected ("Incompatible trigger for monitor
+   * type …") or silently mistyped. `source` is that untouched document, with
+   * the OpenSearch `_id` attached for parity with the projection.
+   */
+  async getMonitorWithSource(
+    client: AlertingOSClient,
+    monitorId: string
+  ): Promise<{ monitor: OSMonitor; source: Record<string, unknown> } | null> {
+    try {
+      const resp = await this.req<OSGetMonitorResponse>(
+        client,
+        'GET',
+        `/_plugins/_alerting/monitors/${encodeURIComponent(monitorId)}`
+      );
+      const source: Record<string, unknown> = {
+        ...(resp.body.monitor as Record<string, unknown>),
+        id: resp.body._id,
+      };
+      return { monitor: this.mapMonitor(resp.body._id, resp.body.monitor), source };
+    } catch (err) {
+      if (this.is404(err)) return null;
+      throw err;
+    }
+  }
+
   async createMonitor(
     client: AlertingOSClient,
     monitor: Omit<OSMonitor, 'id'>

--- a/server/services/alerting/opensearch_backend.ts
+++ b/server/services/alerting/opensearch_backend.ts
@@ -250,7 +250,7 @@ export class HttpOpenSearchBackend implements OpenSearchBackend {
     // `...input` spread. Re-spreading the originals from `rawUpstream`
     // after `input` makes the precedence explicit: client cannot edit
     // these fields through this route.
-    const rawUpstream = (getResp.body.monitor as unknown) as Record<string, unknown>;
+    const rawUpstream = getResp.body.monitor as unknown as Record<string, unknown>;
     const preserved: Record<string, unknown> = {};
     for (const key of PLUGIN_OWNED_KEYS) {
       if (key in rawUpstream) preserved[key] = rawUpstream[key];


### PR DESCRIPTION
## Summary

Fixes bugs in the unified Alerts view (Alert Manager → **Rules** tab) around **cloning and editing monitors**, hardens the clone flow across every OpenSearch monitor type, and includes small filter-panel/table UI polish. Scoped to the `dashboards-observability` alerting UI + its server rule-detail path.

## Changes

### Bug fixes
1. **Blank edit page after cloning an OpenSearch monitor.** Cloning a cluster-metrics monitor and clicking **Edit** opened a blank classic-editor page. Root cause: the server rule-detail returned `raw` as the lossy `mapMonitor` projection, which coerces `monitor_type` (→ `query_level_monitor`) and flattens type-specific trigger wrappers; re-POSTing that shape on clone stored an invalid monitor, and the classic editor then crashed reading `inputs[0].search.indices`.
2. **Cloning any per-bucket / per-document monitor failed** with "Incompatible trigger for monitor type …" — same lossy-`raw` root cause (the `bucket_level_trigger` / `document_level_trigger` wrapper + its `parent_bucket_path`/`buckets_path` were dropped).
3. **Duplicate clone names.** Cloning the same monitor twice produced two identically-named copies.

**Fix:** `getOSRuleDetail` now returns the **faithful upstream monitor document** (new `OpenSearchBackend.getMonitorWithSource`, added to the interface + impl), so the clone re-creates the exact `monitor_type` + wrapped triggers for **every** OpenSearch monitor type (query / bucket / doc / ppl / cluster-metrics). The clone strips server-owned / response-derived fields that must not be re-POSTed (`id`, `version`, `owner`, `user`, `data_sources`, `item_type`, `associated_workflows`, `associatedCompositeMonitorCnt`, `last_run_context`, timestamps). `buildUniqueCloneName` yields `(Copy)`, `(Copy 2)`, … (and `-copy`, `-copy-2`, … for Prometheus), de-duped against existing rules **and** names issued in-flight this session (reconcile-based pruning, soft-delete aware), and trims by code points so a length cap can't split a surrogate pair.

### UI polish (unified Alerts view)
- **Forecaster** create/edit flyout showed **"Detector name"** help text/placeholder → now branches on rule type ("Forecaster name").
- Rules table **Datasource** column wrapped a long name mid-word → single-line ellipsis + full-name hover tooltip via the shared `TruncatedLabel`.
- Filter-panel **label-facet counts** read like a superscript (`severity2`) → now `severity (2)` (RTL-safe `margin-inline-start: $euiSizeXS`).
- Long filter **facet keys** (e.g. `deployment_environment`) clipped with no tooltip → now truncate + reveal the full name on hover **and keyboard focus** (WCAG 1.4.13; Esc dismisses; excludes `tabindex=-1` accordion wrappers).

### Under the hood
- Server: `getMonitorWithSource` returns the narrowed projection **and** the faithful upstream doc; `getOSRuleDetail` exposes the latter as `raw` (documented cast — OS `raw` carries wrapped triggers).
- Clone-name reservation set is bounded and reconciled against the fetched rules (mirrors `isRuleNameTaken`'s soft-delete filter).

## Visual evidence

Matched viewport/route/workspace. **BEFORE = `origin/main`, AFTER = this branch.**

### 1. Editing a cloned OpenSearch monitor
_BEFORE: the Edit page is blank (classic editor crashes). AFTER: the full monitor editor renders with the clone's fields._

![Before/after — cloned monitor edit renders](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2871-media/composite_bug1.png)

| Before flow (origin/main) | After flow (this PR) |
|---|---|
| ![before flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2871-media/before_bug1_flow.gif) | ![after flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2871-media/after_bug1_flow.gif) |

### 2. Cloning the same monitor twice
_BEFORE: every clone is "… (Copy)" — indistinguishable duplicates. AFTER: unique names — "(Copy)", "(Copy 2)", …_

![Before/after — unique clone names](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2871-media/composite_bug2.png)

| Before flow (origin/main) | After flow (this PR) |
|---|---|
| ![before flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2871-media/before_bug2_flow.gif) | ![after flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2871-media/after_bug2_flow.gif) |

### 3. Filter-panel & table polish
_BEFORE: label-facet counts hug the label ("severity2") and long datasource names wrap mid-word. AFTER: spaced "(n)" counts, and single-line datasource names with a hover/keyboard tooltip._

![Before/after — filter-panel & table polish](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr-2871-media/composite_bug3.png)

## Testing
- Unit: full alerting + shared-component + server suites green (Jest + react-testing-library). Added coverage for the cloned-monitor edit target, all-OS-type clone (wrapped triggers + strip-list), doc-level clone, clone-name uniqueness + in-flight dedup, `getMonitorWithSource`, and `TruncatedLabel` keyboard reveal (ancestor focus, `tabindex=-1` exclusion, `label.control`, Esc).
- Manual: verified in the running dev app across cluster-metrics / query / bucket / doc / PPL / Prometheus rules — clone, edit-after-clone (editor renders), delete, and the create-from-Explore (Logs + Metrics) flows.

## Checklist
- [x] All commits DCO signed-off
- [x] Unit tests added/updated and passing
- [x] Screenshots / visual evidence attached (above)
- [x] Changes are backwards compatible
