### PR TITLE
fix(alerting): stop clone/edit from corrupting Prometheus rule expressions

### DIFF
--- a/public/components/alerting/__tests__/prometheus_rule_lifecycle.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_rule_lifecycle.test.tsx
@@ -403,6 +403,17 @@ describe('Prometheus rule edit — overwrite only for an in-place edit', () => {
     // Rename removes the old copy after the new one is created.
     expect(mockDeletePrometheusRule).toHaveBeenCalledWith('ds-1', 'OldName', 'OldName');
   });
+
+  it('does NOT overwrite (and does not delete) when the edited rule is not in the loaded list', async () => {
+    // Edge (stale list / background-refetch race): if `rules.find(id)` misses,
+    // we must default to the SAFE path — no overwrite (avoid clobbering a rule
+    // that occupies the target name) and no delete (a guessed old-name delete
+    // could remove the rule we just created).
+    seedRule({ id: 'someOtherRule', name: 'Unrelated', group: 'Unrelated', datasourceId: 'ds-1' });
+    const payload = await editAndGetPayload(promForm('GhostRule'), 'missing-id');
+    expect(payload.overwrite).toBeUndefined();
+    expect(mockDeletePrometheusRule).not.toHaveBeenCalled();
+  });
 });
 
 describe('Prometheus rule delete', () => {

--- a/public/components/alerting/__tests__/prometheus_rule_lifecycle.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_rule_lifecycle.test.tsx
@@ -72,7 +72,13 @@ jest.mock('../notification_routing_panel', () => ({
   NotificationRoutingPanel: () => <div data-test-subj="routingPanel" />,
 }));
 jest.mock('../create_monitor', () => ({ CreateMonitor: () => null }));
-jest.mock('../create_monitor/edit_monitor', () => ({ EditMonitor: () => null }));
+const mockEditMonitor = jest.fn();
+jest.mock('../create_monitor/edit_monitor', () => ({
+  EditMonitor: (props: unknown) => {
+    mockEditMonitor(props);
+    return <div data-test-subj="editMonitor" />;
+  },
+}));
 jest.mock('../alert_detail_flyout', () => ({ AlertDetailFlyout: () => null }));
 
 const mockGetRuleDetail = jest.fn();
@@ -270,6 +276,132 @@ describe('Prometheus rule clone', () => {
       expect.objectContaining({ name: 'TestRule-copy-2' }),
       'ds-1'
     );
+  });
+});
+
+describe('Prometheus rule clone — expression is preserved verbatim', () => {
+  const cloneAndGetPayload = async (detail: Record<string, unknown>) => {
+    mockGetRuleDetail.mockResolvedValue(detail);
+    mockCreatePrometheusRule.mockResolvedValue({ success: true });
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0] as {
+      onClone: (monitor: unknown) => Promise<void>;
+    };
+    await act(async () => {
+      await tableProps.onClone({
+        id: `ds-1-${detail.name}-${detail.name}`,
+        name: detail.name,
+        datasourceId: 'ds-1',
+        datasourceType: 'prometheus',
+      });
+    });
+    return mockCreatePrometheusRule.mock.calls[0][0] as Record<string, unknown>;
+  };
+
+  const promDetail = (name: string, query: string, threshold: unknown) => ({
+    datasourceType: 'prometheus',
+    name,
+    query,
+    pendingPeriod: '60s',
+    evaluationInterval: '30s',
+    threshold,
+    labels: {},
+    annotations: {},
+    raw: { type: 'alerting', name, query, duration: 60, labels: {}, annotations: {} },
+  });
+
+  it('clones an expression with NO comparison without appending a spurious "> 0"', async () => {
+    // Regression: the old strip/re-append path turned this into `... > 0`,
+    // changing when the rule fires. It must be cloned unchanged.
+    const payload = await cloneAndGetPayload(
+      promDetail('NoCmp', 'sum(rate(gen_ai_tokens_total[5m]))', undefined)
+    );
+    expect(payload.query).toBe('sum(rate(gen_ai_tokens_total[5m]))');
+    // The verbatim path no longer sends operator/threshold.
+    expect(payload).not.toHaveProperty('operator');
+    expect(payload).not.toHaveProperty('threshold');
+  });
+
+  it('clones an interior-comparison expression without rewriting the trailing threshold', async () => {
+    // Regression: strip-last + reparse-first turned the trailing `> 0` into the
+    // first-parsed `> 0.8`, corrupting the second condition.
+    const query = '(queue_size / queue_capacity) > 0.8 and queue_capacity > 0';
+    const payload = await cloneAndGetPayload(
+      promDetail('Interior', query, { operator: '>', value: 0.8 })
+    );
+    expect(payload.query).toBe(query);
+  });
+
+  it('clones a scientific-notation threshold without mangling it', async () => {
+    // Regression: parseThreshold read `1e-05` as `1`, so the clone fired at a
+    // 100000x-different threshold.
+    const payload = await cloneAndGetPayload(
+      promDetail('Sci', 'errors_total > 1e-05', { operator: '>', value: 1e-5 })
+    );
+    expect(payload.query).toBe('errors_total > 1e-05');
+  });
+});
+
+describe('Prometheus rule edit — overwrite only for an in-place edit', () => {
+  const seedRule = (rule: Record<string, unknown>) =>
+    mockUseRulesData.mockReturnValue({ ...emptyRulesHookResult, rules: [rule] });
+
+  const editAndGetPayload = async (
+    formState: Record<string, unknown>,
+    ruleId: string
+  ): Promise<Record<string, unknown>> => {
+    mockCreatePrometheusRule.mockResolvedValue({ success: true });
+    mockDeletePrometheusRule.mockResolvedValue({ success: true });
+    await act(async () => {
+      render(<AlarmsPage {...defaultProps} />);
+    });
+    fireEvent.click(screen.getByTestId('alertManagerTabs-rules'));
+    const tableProps = mockMonitorsTable.mock.calls[mockMonitorsTable.mock.calls.length - 1][0] as {
+      onEdit: (monitor: unknown) => void;
+    };
+    act(() => {
+      tableProps.onEdit({ id: ruleId, datasourceId: 'ds-1', name: formState.name });
+    });
+    const editProps = mockEditMonitor.mock.calls[mockEditMonitor.mock.calls.length - 1][0] as {
+      onSave: (form: unknown, ruleId: string) => Promise<void>;
+    };
+    await act(async () => {
+      await editProps.onSave(formState, ruleId);
+    });
+    return mockCreatePrometheusRule.mock.calls[0][0] as Record<string, unknown>;
+  };
+
+  const promForm = (name: string) => ({
+    name,
+    datasourceId: 'ds-1',
+    datasourceType: 'prometheus' as const,
+    query: 'up > 0',
+    threshold: { operator: '>', value: 0, unit: '', forDuration: '5m' },
+    evaluationInterval: '1m',
+    labels: [{ key: 'severity', value: 'warning' }],
+    annotations: [],
+    enabled: true,
+  });
+
+  it('forces overwrite when the (group, name) is unchanged (self-replace)', async () => {
+    seedRule({ id: 'r1', name: 'MyRule', group: 'MyRule', datasourceId: 'ds-1' });
+    const payload = await editAndGetPayload(promForm('MyRule'), 'r1');
+    expect(payload.overwrite).toBe(true);
+    // In-place edit must NOT delete the "old" copy.
+    expect(mockDeletePrometheusRule).not.toHaveBeenCalled();
+  });
+
+  it('does NOT overwrite on rename, so a name collision surfaces instead of clobbering', async () => {
+    // Regression: unconditional overwrite let a rename silently destroy a
+    // different, pre-existing rule occupying the new name.
+    seedRule({ id: 'r1', name: 'OldName', group: 'OldName', datasourceId: 'ds-1' });
+    const payload = await editAndGetPayload(promForm('NewName'), 'r1');
+    expect(payload.overwrite).toBeUndefined();
+    // Rename removes the old copy after the new one is created.
+    expect(mockDeletePrometheusRule).toHaveBeenCalledWith('ds-1', 'OldName', 'OldName');
   });
 });
 

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -1066,15 +1066,19 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             : String(raw.for || detail.pendingPeriod || '5m');
         const evalInterval = detail.evaluationInterval || '1m';
 
-        // Parse threshold from expression (e.g. "up == 0" → operator "==", threshold 0)
-        const parsed = detail.threshold || { operator: '>', value: 0 };
-
+        // Clone the stored PromQL expression VERBATIM. The expression itself is
+        // the complete alert condition, and the create/edit paths already send
+        // `query` unchanged for the server to use as-is. The clone path used to
+        // strip a trailing comparison and re-append a separately-parsed
+        // operator/threshold, which corrupted any expression whose trailing
+        // comparison differed from the first one — or had none at all. Examples
+        // that broke: `(a) > 0.8 and cap > 0` became `... and cap > 0.8`;
+        // `sum(rate(x[5m]))` gained a spurious `> 0`; `errors > 1e-05` became
+        // `errors > 1`. Sending `expr` as-is keeps the clone identical to its
+        // source.
         const payload = {
           name: clonedName,
-          query:
-            expr.replace(/\s*(>|>=|<|<=|==|!=)\s*[\d.]+(?:[eE][+-]?\d+)?\s*$/, '').trim() || expr,
-          operator: parsed.operator || '>',
-          threshold: parsed.value ?? 0,
+          query: expr,
           forDuration: duration,
           evaluationInterval: evalInterval,
           labels: rawLabels,
@@ -1452,6 +1456,23 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         // _ruleGroup is a form-transport metadata label — extract it into
         // groupName and strip it from persisted labels.
         const ruleGroupLabel = promForm.labels.find((l) => l.key === '_ruleGroup')?.value;
+
+        // Resolve the rule's ORIGINAL identity (group, name) before building the
+        // payload so we can tell an in-place edit from a rename/group move.
+        // `ruleId` is the rule the user opened from the table, so it is always
+        // present in the loaded `rules`.
+        const originalRule = rules.find((r) => r.id === ruleId);
+        const originalName = originalRule?.name || promForm.name;
+        const originalGroupName = originalRule?.group || originalName;
+        const newGroupName = ruleGroupLabel || promForm.name;
+        // Only overwrite when the edit keeps the SAME (group, name): that is the
+        // rule replacing itself, which the server's create-collision guard would
+        // otherwise reject with a 409. For a rename or group move we must NOT
+        // force overwrite — doing so lets the create silently destroy a
+        // DIFFERENT, pre-existing rule that happens to occupy the new
+        // (group, name). Leaving overwrite off makes the server return 409 so the
+        // collision surfaces as an error instead of silent data loss.
+        const isInPlaceEdit = originalGroupName === newGroupName && originalName === promForm.name;
         const payload = buildPrometheusRulePayload({
           name: promForm.name,
           query: promForm.query,
@@ -1466,23 +1487,17 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             promForm.annotations.filter((a) => a.key && a.value).map((a) => [a.key, a.value])
           ),
           enabled: promForm.enabled,
-          groupName: ruleGroupLabel || promForm.name,
-          // Edit intends to replace the existing rule (same name+group) —
-          // opt into overwrite so the server's create-collision guard allows it.
-          overwrite: true,
+          groupName: newGroupName,
+          overwrite: isInPlaceEdit,
         });
         // Create new rule first, then delete old on success (prevents data loss
         // if create fails — worst case is a harmless duplicate).
         await mutations.createPrometheusRule(payload, dsId);
 
-        const originalRule = rules.find((r) => r.id === ruleId);
-        const originalName = originalRule?.name || promForm.name;
-        const originalGroupName = originalRule?.group || originalName;
-        const newGroupName = ruleGroupLabel || promForm.name;
         // If the rule was renamed or moved to a different group, remove the
         // old copy. The rule-level delete splices it out of the old group,
         // preserving any sibling rules that share the group.
-        if (originalGroupName !== newGroupName || originalName !== promForm.name) {
+        if (!isInPlaceEdit) {
           try {
             await mutations.deletePrometheusRule(dsId, originalGroupName, originalName);
           } catch {

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -73,6 +73,7 @@ import type { OpenSearchFormState } from './create_monitor/create_monitor_types'
 import {
   extractPplValidationError,
   extractServerErrorMessage,
+  extractServerErrorStatus,
   formStateToRule,
   resolveDatasourceTokens,
 } from './alarms_page_helpers';
@@ -1457,22 +1458,25 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         // groupName and strip it from persisted labels.
         const ruleGroupLabel = promForm.labels.find((l) => l.key === '_ruleGroup')?.value;
 
-        // Resolve the rule's ORIGINAL identity (group, name) before building the
-        // payload so we can tell an in-place edit from a rename/group move.
-        // `ruleId` is the rule the user opened from the table, so it is always
-        // present in the loaded `rules`.
+        // Resolve the rule's ORIGINAL identity (group, name) so we can tell an
+        // in-place edit from a rename/group move. `ruleId` is normally the row
+        // the user opened, so the rule is in the loaded `rules` — but a stale
+        // list or a background-refetch race could miss it, which we treat as the
+        // unsafe case (see below).
         const originalRule = rules.find((r) => r.id === ruleId);
-        const originalName = originalRule?.name || promForm.name;
-        const originalGroupName = originalRule?.group || originalName;
         const newGroupName = ruleGroupLabel || promForm.name;
-        // Only overwrite when the edit keeps the SAME (group, name): that is the
-        // rule replacing itself, which the server's create-collision guard would
-        // otherwise reject with a 409. For a rename or group move we must NOT
-        // force overwrite — doing so lets the create silently destroy a
-        // DIFFERENT, pre-existing rule that happens to occupy the new
-        // (group, name). Leaving overwrite off makes the server return 409 so the
-        // collision surfaces as an error instead of silent data loss.
-        const isInPlaceEdit = originalGroupName === newGroupName && originalName === promForm.name;
+        // Overwrite ONLY for a confirmed in-place edit: the rule was found AND
+        // its (group, name) is unchanged — the rule replacing itself, which the
+        // server's create-collision guard would otherwise reject with a 409. For
+        // a rename, a group move, OR when the original rule can't be resolved, we
+        // must NOT force overwrite: doing so could let the create silently
+        // destroy a DIFFERENT rule already occupying the target (group, name).
+        // Without overwrite the server returns 409 and the collision surfaces as
+        // an error instead of causing silent data loss.
+        const isInPlaceEdit =
+          !!originalRule &&
+          (originalRule.group || originalRule.name) === newGroupName &&
+          originalRule.name === promForm.name;
         const payload = buildPrometheusRulePayload({
           name: promForm.name,
           query: promForm.query,
@@ -1494,10 +1498,14 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
         // if create fails — worst case is a harmless duplicate).
         await mutations.createPrometheusRule(payload, dsId);
 
-        // If the rule was renamed or moved to a different group, remove the
-        // old copy. The rule-level delete splices it out of the old group,
-        // preserving any sibling rules that share the group.
-        if (!isInPlaceEdit) {
+        // Remove the old copy only when we KNOW the original identity AND it
+        // changed (rename/group move). The rule-level delete splices it out of
+        // the old group, preserving siblings. When the original rule wasn't
+        // resolved we skip the delete entirely — deleting a guessed name could
+        // remove the rule we just created.
+        if (originalRule && !isInPlaceEdit) {
+          const originalName = originalRule.name;
+          const originalGroupName = originalRule.group || originalRule.name;
           try {
             await mutations.deletePrometheusRule(dsId, originalGroupName, originalName);
           } catch {
@@ -1523,10 +1531,22 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
       const message = extractServerErrorMessage(e);
       const pplError = extractPplValidationError(message);
       if (pplError) setPplSubmitError(pplError);
+      // A rename/group-move that lands on an existing rule now reaches the user
+      // as a 409 (the edit no longer force-overwrites). Special-case it into an
+      // actionable title instead of the generic failure, keeping the raw server
+      // message as the toast detail.
+      const isNameCollision =
+        extractServerErrorStatus(e) === 409 || /already exists/i.test(message);
       addToast(
-        i18n.translate('observability.alerting.alarmsPage.toast.updateMonitorFailed', {
-          defaultMessage: 'Failed to update alert rule',
-        }),
+        isNameCollision
+          ? i18n.translate('observability.alerting.alarmsPage.toast.updateMonitorNameCollision', {
+              defaultMessage:
+                'A rule named "{name}" already exists in this group. Rename it or pick a different group.',
+              values: { name: formState.name },
+            })
+          : i18n.translate('observability.alerting.alarmsPage.toast.updateMonitorFailed', {
+              defaultMessage: 'Failed to update alert rule',
+            }),
         'danger',
         message
       );

--- a/public/components/alerting/alarms_page_helpers.ts
+++ b/public/components/alerting/alarms_page_helpers.ts
@@ -298,6 +298,18 @@ export function extractPplValidationError(message: string): string | null {
  * one level deeper. Prefer `body.message` and fall back through a few
  * other shapes before settling on the bare message.
  */
+/**
+ * The HTTP status of a failed request, when the error carries one. OSD's
+ * `HttpFetchError` exposes `response.status`; some paths surface
+ * `body.statusCode`. Returns `undefined` when neither is present.
+ */
+export function extractServerErrorStatus(e: unknown): number | undefined {
+  if (e == null || typeof e !== 'object') return undefined;
+  const errorish = e as { response?: { status?: unknown }; body?: { statusCode?: unknown } };
+  const status = errorish.response?.status ?? errorish.body?.statusCode;
+  return typeof status === 'number' ? status : undefined;
+}
+
 export function extractServerErrorMessage(e: unknown): string {
   if (e == null) return 'Unknown error';
   if (typeof e === 'string') return e;


### PR DESCRIPTION
### Description

The unified Alerts view could silently change or destroy a Prometheus rule's definition while reporting success. Two fixes:

**1. Clone rewrote the PromQL expression.** `handleCloneRule` stripped a trailing comparison off the stored expression and re-appended a separately-parsed operator/threshold. Because the strip matched the *last* comparison while the parse read the *first* (or fell back to `> 0`), any non-trivial expression was corrupted:

| Source expression | Old clone produced |
|---|---|
| `sum(rate(x[5m]))` (no comparison) | `sum(rate(x[5m])) > 0` |
| `(a) > 0.8 and cap > 0` | `(a) > 0.8 and cap > 0.8` |
| `errors > 1e-05` | `errors > 1` |

Clone now sends the stored expression **verbatim**, matching the create/edit paths (the PromQL expression is itself the complete alert condition).

**2. Edit always set `overwrite: true`.** Renaming a rule onto a name already used by a *different* rule in the same group silently overwrote that other rule. Edit now sets `overwrite` only for an **in-place edit** (unchanged group + name — the rule replacing itself). A rename or group move sends no overwrite, so the server's collision guard returns 409 and the conflict surfaces instead of causing silent data loss.

### Before / after evidence

Reproduced on a live Prometheus datasource by cloning `genairule` (`sum(rate(gen_ai_client_token_usage_total[4m]))`) and reading the clone's stored expression back from the rule detail (and the ruler API).

**1. Cloning a Prometheus rule — the stored PromQL expression.** BEFORE (origin/main) the clone gains a spurious `> 0`; AFTER (this PR) it is preserved verbatim.

![clone before/after](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/2877-clone-edit/clone_composite.png)

**Flow — BEFORE (origin/main):** clone appends `> 0`.

![before flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/2877-clone-edit/before_flow.gif)

**Flow — AFTER (this PR):** clone preserves the expression.

![after flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/2877-clone-edit/after_flow.gif)

> The edit `overwrite` fix has no clean single-screen visual (it prevents a cross-datasource collision from silently clobbering a different rule). It is verified at the API layer — an `overwrite: true` re-POST replaces a same-named rule (`up == 1` → `up == 2`) while a non-overwrite collision correctly returns **409** — and by the regression tests below.

### Testing

`prometheus_rule_lifecycle.test.tsx` — added regression tests:
- Clone preserves an expression with no comparison (no spurious `> 0`), an interior-comparison expression (trailing threshold unchanged), and a scientific-notation threshold.
- Edit overwrites for an in-place edit; a rename does **not** overwrite and removes the old copy.

All alerting suites pass; typecheck + lint clean.

### Follow-ups

- #2878 — Prometheus create/edit/clone only round-trip a fixed field set (unmodeled ruler fields like `keep_firing_for` are dropped). Out of scope here; the expression corruption is fixed in this PR.

### Check List
- [x] All tests pass
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`
- [x] Screenshots/GIFs of before & after included
